### PR TITLE
Use os.homedir to find user directory

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 The SQLECTRON Team
 
 import fs from 'fs';
+import {homedir} from 'os';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import pf from 'portfinder';
@@ -35,12 +36,6 @@ export function ctrlOrCmd(otherKey) {
     return `ctrl+${otherKey}`
   }
 }
-
-
-export function homedir() {
-  return process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'];
-}
-
 
 export function fileExists(filename) {
   return new Promise((resolve) => {


### PR DESCRIPTION
[`os.homedir()`](https://nodejs.org/api/os.html#os_os_homedir) has been in node since 2.3 and is probably better to use than a hand-rolled function.

The builtin function has two more methods to find a user's home directory if the environment variable does not exist. 