### PR TITLE
Postgres - double quote identifiers

### DIFF
--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -223,6 +223,12 @@
       inQuote() {
         return false
       },
+      wrapIdentifier(value) {
+        if (value && this.connectionType === 'postgresql' && /[A-Z]/.test(value)) {
+          return `"${value.replace(/^"|"$/g, '')}"`
+        }
+        return value;
+      },
       maybeAutoComplete(editor, e) {
         // Currently this doesn't do anything.
         // BUGS:
@@ -316,21 +322,8 @@
             const { to, from, origin, text } = co;
             if (origin === 'complete') {
               let [tableName, colName] = text[0].split('.');
-              let replace = false;
-              if (/[A-Z]/.test(tableName)) {
-                tableName = tableName.replace(/^"|"$/g, '')
-                tableName = `"${tableName}"`;
-                replace = true;
-              }
-              if (/[A-Z]/.test(colName)) {
-                colName = colName.replace(/^"|"$/g, '')
-                colName = `"${colName}"`;
-                replace = true;
-              }
-              const newText = [[tableName, colName].filter(s => s).join('.')]
-              if (replace) {
-                co.update(from, to, newText, origin); 
-              }
+              const newText = [[this.wrapIdentifier(tableName), this.wrapIdentifier(colName)].filter(s => s).join('.')]
+              co.update(from, to, newText, origin); 
             }
           })
         }

--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -116,7 +116,7 @@ export async function selectTop(conn, table, offset, limit, orderBy, filters) {
 
   if (filters && filters.length > 0) {
     filterString = "WHERE " + filters.map((item, index) => {
-      return `${item.field} ${item.type} $${index + 1}`
+      return `${wrapIdentifier(item.field)} ${item.type} $${index + 1}`
     }).join(" AND ")
 
     params = filters.map((item) => {
@@ -125,7 +125,7 @@ export async function selectTop(conn, table, offset, limit, orderBy, filters) {
   }
 
   let baseSQL = `
-    FROM ${table}
+    FROM ${wrapIdentifier(table)}
     ${filterString}
   `
   let countQuery = `

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -101,6 +101,7 @@ const store = new Vuex.Store({
       const server = ConnectionProvider.for(config)
       const connection = await server.createConnection(config.defaultDatabase)
       await connection.connect()
+      connection.connectionType = config.connectionType;
       const usedConfig = new UsedConnection(config)
       await usedConfig.save()
       context.commit('newConnection', {config: usedConfig, server, connection})


### PR DESCRIPTION
Fixes #74 

Makes sure that postgres table and column names are surrounded in
double-quotes. This is needed when the table or column name contains
upper case letters.

Also, it adds some additional logic to the autocomplete functionality to
automatically surround postgres table and column names with
double-quotes after the complete event has fired.

In order for the autocomplete to show properly for tables that have
double quotes, it was necessary to add both an unquoted and quoted
variant of the table name to this hintOption object. This does clutter
the dialog a bit - it will show both:

tableNameWithQuotes
"tableNameWithQuotes"

without this, however, you will only get autocomplete when typing the
table name - you will not get column name autocompletion hints off that table
name without the quoted variant present as well.