### PR TITLE
Use native filepicker dialog instead of input file

### DIFF
--- a/src/assets/styles/app/_layout.scss
+++ b/src/assets/styles/app/_layout.scss
@@ -37,6 +37,10 @@ i {
     -webkit-user-select: none;
             user-select: none;
 }
+.clickable,
+.cursor-pointer {
+  cursor: pointer;
+}
 
 // Material-icons
 .material-icons {
@@ -149,6 +153,11 @@ i {
   width: 100%;
   max-width: 250px;
 }
+.btn-small {
+  font-size: 10px;
+  padding: 0 .7rem;
+  min-width: 0;
+}
 .btn-block {
   display: flex;
   justify-content: center;
@@ -252,6 +261,35 @@ input, select, textarea {
   @extend .form-control;
   &:focus {
     border-color: $input-highlight;
+  }
+}
+.input-group {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  width: 100%;
+
+  > .form-control {
+    position: relative;
+    flex: 1 1 0%;
+    min-width: 0;
+    margin-bottom: 0;
+
+    &:not(:last-child) {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+
+  .input-group-append {
+    margin-left: -1px;
+    display: flex;
+
+    > .btn {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
   }
 }
 

--- a/src/components/connection/CommonAdvanced.vue
+++ b/src/components/connection/CommonAdvanced.vue
@@ -33,7 +33,12 @@
         </div>
         <div class="col s6 form-group">
           <label for="sshKeyfile">Private Key File</label>
-          <input class="form-control" type="file" @change="setKeyfile">
+          <div class="input-group" @click.prevent="openFilePickerDialog">
+            <input type="text" class="form-control clickable" placeholder="No file selected" :value="config.sshKeyfile" readonly>
+            <div class="input-group-append">
+              <button class="btn btn-small btn-flat">Choose file</button>
+            </div>
+          </div>
         </div>
         <div class="col s6 form-group">
           <label for="sshKeyfilePassword">Key File PassPhrase <span class="hint">(Optional)</span></label>
@@ -68,6 +73,8 @@
   </div>
 </template>
 <script>
+  import { remote } from 'electron'
+
   export default {
     props: ['config'],
     data() {
@@ -87,8 +94,14 @@
       setMode(option) {
         this.config.sshMode = option.mode
       },
-      setKeyfile(e) {
-        this.config.sshKeyfile = e.target.files[0].path
+      openFilePickerDialog() {
+        const file = remote.dialog.showOpenDialogSync({
+          properties: ['openFile', 'showHiddenFiles']
+        })
+
+        if (file) {
+          this.config.sshKeyfile = file
+        }
       }
     }
   }

--- a/src/components/connection/CommonAdvanced.vue
+++ b/src/components/connection/CommonAdvanced.vue
@@ -74,6 +74,7 @@
 </template>
 <script>
   import { remote } from 'electron'
+  import { join as pathJoin } from 'path'
 
   export default {
     props: ['config'],
@@ -96,6 +97,7 @@
       },
       openFilePickerDialog() {
         const file = remote.dialog.showOpenDialogSync({
+          defaultPath: pathJoin(remote.app.getPath('home'), '.ssh'),
           properties: ['openFile', 'showHiddenFiles']
         })
 

--- a/src/components/connection/CommonAdvanced.vue
+++ b/src/components/connection/CommonAdvanced.vue
@@ -33,12 +33,11 @@
         </div>
         <div class="col s6 form-group">
           <label for="sshKeyfile">Private Key File</label>
-          <div class="input-group" @click.prevent="openFilePickerDialog">
-            <input type="text" class="form-control clickable" placeholder="No file selected" :value="config.sshKeyfile" readonly>
-            <div class="input-group-append">
-              <button class="btn btn-small btn-flat">Choose file</button>
-            </div>
-          </div>
+          <file-picker
+            v-model="config.sshKeyfile"
+            :show-hidden-files="true"
+            :default-path="filePickerDefaultPath">
+          </file-picker>
         </div>
         <div class="col s6 form-group">
           <label for="sshKeyfilePassword">Key File PassPhrase <span class="hint">(Optional)</span></label>
@@ -73,17 +72,23 @@
   </div>
 </template>
 <script>
+  import FilePicker from '@/components/form/FilePicker'
+
   import { remote } from 'electron'
   import { join as pathJoin } from 'path'
 
   export default {
     props: ['config'],
+    components: {
+      FilePicker
+    },
     data() {
       return {
         sshModeOptions: [
           { label: "Key File", mode: 'keyfile' },
           { label: "Username & Password", mode: "userpass" }
-        ]
+        ],
+        filePickerDefaultPath: pathJoin(remote.app.getPath('home'), '.ssh')
       }
     },
     computed: {
@@ -94,16 +99,6 @@
     methods: {
       setMode(option) {
         this.config.sshMode = option.mode
-      },
-      openFilePickerDialog() {
-        const file = remote.dialog.showOpenDialogSync({
-          defaultPath: pathJoin(remote.app.getPath('home'), '.ssh'),
-          properties: ['openFile', 'showHiddenFiles']
-        })
-
-        if (file) {
-          this.config.sshKeyfile = file
-        }
       }
     }
   }

--- a/src/components/connection/SqliteForm.vue
+++ b/src/components/connection/SqliteForm.vue
@@ -4,7 +4,7 @@
       <div class="row gutter">
         <div class="col form-group">
           <label for="Database" required>Database File</label>
-          <input type="file" @change="setDatabaseFile">
+          <file-picker v-model="config.defaultDatabase"></file-picker>
         </div>
       </div>
     </div>
@@ -12,12 +12,11 @@
 </template>
 
 <script>
+  import FilePicker from '@/components/form/FilePicker'
   export default {
     props: ['config'],
-    methods: {
-      setDatabaseFile(event) {
-        this.config.defaultDatabase = event.target.files[0].path
-      }
+    components: {
+      FilePicker
     }
   }
 </script>

--- a/src/components/form/FilePicker.vue
+++ b/src/components/form/FilePicker.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="input-group" @click.prevent.stop="openFilePickerDialog">
+    <input type="text" class="form-control clickable" placeholder="No file selected" :value="value" readonly>
+    <div class="input-group-append">
+      <button class="btn btn-small btn-flat">Choose file</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { remote } from 'electron'
+
+export default {
+  props: {
+    value: {
+      type: String,
+      required: true
+    },
+    defaultPath: {
+      type: String,
+      required: false,
+      default: null
+    },
+    showHiddenFiles: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    options: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    }
+  },
+  methods: {
+    openFilePickerDialog() {
+      const dialogConfig = {
+        defaultPath: this.defaultPath,
+        properties: ['openFile']
+      }
+
+      if (this.showHiddenFiles) {
+        dialogConfig.properties.push('showHiddenFiles')
+      }
+
+      const file = remote.dialog.showOpenDialogSync({
+        ...dialogConfig,
+        ...this.options
+      })
+
+      if (file) {
+        this.$emit('input', file[0])
+      }
+    }
+  }
+}
+</script>

--- a/src/components/form/FilePicker.vue
+++ b/src/components/form/FilePicker.vue
@@ -13,13 +13,14 @@ import { remote } from 'electron'
 export default {
   props: {
     value: {
-      type: String,
-      required: true
+      required: true,
+      // Allow String or null
+      validator: prop => typeof prop === 'string' || prop === null
     },
     defaultPath: {
       type: String,
       required: false,
-      default: null
+      default: ''
     },
     showHiddenFiles: {
       type: Boolean,
@@ -35,14 +36,18 @@ export default {
   methods: {
     openFilePickerDialog() {
       const dialogConfig = {
-        defaultPath: this.defaultPath,
         properties: ['openFile']
+      }
+
+      if (this.defaultPath.toString().length > 0) {
+        dialogConfig.defaultPath = this.defaultPath
       }
 
       if (this.showHiddenFiles) {
         dialogConfig.properties.push('showHiddenFiles')
       }
 
+      // Show dialog extending default config with provided custom config
       const file = remote.dialog.showOpenDialogSync({
         ...dialogConfig,
         ...this.options

--- a/src/components/form/FilePicker.vue
+++ b/src/components/form/FilePicker.vue
@@ -14,8 +14,6 @@ export default {
   props: {
     value: {
       required: true,
-      // Allow String or null
-      validator: prop => typeof prop === 'string' || prop === null
     },
     defaultPath: {
       type: String,


### PR DESCRIPTION
With this PR when choosing a private key for SSH tunneling a native dialog will be used instead of the `input file` one.

**Added**:

- Native dialog filepicker for SSH private key
- Input group CSS
- When choosing a private key, it will open by default `.ssh` folder (if it does not exists, it will fallback on the home folder, at least on unix)

**Fixes**:

- Bug on my PC (Ubuntu 17.04) returning error "Access denied" when navigating to `.ssh` folder
- Probably #32 too

Read more: https://www.electronjs.org/docs/api/dialog