### PR TITLE
Order columns using ordinal_position

### DIFF
--- a/src/lib/db/clients/mysql.js
+++ b/src/lib/db/clients/mysql.js
@@ -106,6 +106,7 @@ export async function listTableColumns(conn, database, table) {
     FROM information_schema.columns
     WHERE table_schema = database()
     AND table_name = ?
+    ORDER BY ordinal_position
   `;
 
   const params = [

--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -179,6 +179,7 @@ export async function listTableColumns(conn, database, table, schema) {
     FROM information_schema.columns
     WHERE table_schema = $1
     AND table_name = $2
+    ORDER BY ordinal_position
   `;
 
   const params = [

--- a/src/lib/db/clients/sqlserver.js
+++ b/src/lib/db/clients/sqlserver.js
@@ -38,7 +38,7 @@ export default async function (server, database) {
     query: (queryText) => query(conn, queryText),
     executeQuery: (queryText) => executeQuery(conn, queryText),
     listDatabases: (filter) => listDatabases(conn, filter),
-    selectTop: (table, offset, limit, orderBy, filters) => selectTop(conn, table, offset, limit, orderBy, filters),    
+    selectTop: (table, offset, limit, orderBy, filters) => selectTop(conn, table, offset, limit, orderBy, filters),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
     getViewCreateScript: (view) => getViewCreateScript(conn, view),
@@ -81,7 +81,7 @@ export async function selectTop(conn, table, offset, limit, orderBy, filters) {
     select count(*) as total ${baseSQL}
   `
   logger().debug(countQuery)
-  
+
   let query = `
     SELECT * ${baseSQL}
     ${orderByString}
@@ -242,6 +242,7 @@ export async function listTableColumns(conn, database, table) {
     SELECT column_name, data_type
     FROM information_schema.columns
     WHERE table_name = '${table}'
+    ORDER BY ordinal_position
   `;
 
   const { data } = await driverExecuteQuery(conn, { query: sql });


### PR DESCRIPTION
The ordering of columns is not correct if the rows in `information_schema.COLUMNS` are not in proper order (which is in no way guaranteed).

The note in [mysql docs](https://dev.mysql.com/doc/refman/5.6/en/columns-table.html) for pulling information about of `information_schema.COLUMNS`:

> The position of the column within the table. ORDINAL_POSITION is necessary because you might want to say ORDER BY ORDINAL_POSITION. Unlike SHOW COLUMNS, SELECT from the COLUMNS table does not have automatic ordering.

Not having the order by gives me the following result:
![Screenshot 2020-05-08 18 44 37](https://user-images.githubusercontent.com/1845314/81455050-aa822800-9196-11ea-93f8-4a5fa3d7f63e.png)

where I would expect `id` to be shown before `column1` and it's not.
