### PR TITLE
Add ability to select and copy a cell value

### DIFF
--- a/src/assets/styles/app/vendor/tabulator.scss
+++ b/src/assets/styles/app/vendor/tabulator.scss
@@ -6,10 +6,16 @@ $errorColor: $brand-danger;
   width: min-content;
   min-width: 100%;
   .tabulator-cell {
-    border-right: 0;
+    border: 1px solid transparent;
     padding: 4px 8px;
     height: 28px!important;
     line-height: 20px;
+
+    &.active-cell {
+      background: $selection;
+      border-color: $input-highlight;
+      color: $db-select-text;
+    }
   }
   &:nth-child(odd) {
     background: transparent;

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -56,11 +56,13 @@
 import Tabulator from "tabulator-tables";
 import data_converter from "../../mixins/data_converter";
 import DataMutators from '../../mixins/data_mutators'
+
 export default {
   mixins: [data_converter, DataMutators],
   props: ["table", "connection"],
   data() {
     return {
+      currentCell: null, // Last clicked cell
       filterTypes: {
         equals: "=",
         "does not equal": "!=",
@@ -125,7 +127,26 @@ export default {
       ajaxFiltering: true,
       pagination: "remote",
       paginationSize: this.limit,
-      initialSort: this.initialSort
+      initialSort: this.initialSort,
+      cellClick: (e, cell) => {
+        // Remove focus and listener on other cell, if any
+        if (this.currentCell) {
+          this.currentCell.getElement().classList.remove('active-cell')
+          this.currentCell.getElement().removeEventListener('copy', () => {})
+        }
+
+        // Set cell style
+        cell.getElement().classList.add('active-cell')
+
+        // Connect listener
+        cell.getElement().addEventListener('copy', event => {
+          event.clipboardData.setData('text/plain', cell.getValue())
+          event.preventDefault()
+        })
+
+        // Override current cell
+        this.currentCell = cell
+      }
     });
   },
   methods: {


### PR DESCRIPTION
Unfortunately Tabulator does not support cell-selection, but only row selection. With this PR you can select a single cell and copy its value with Ctrl+C (or Cmd+C) without entering the "edit mode", like the default behaviour of Tabulator editable cells.  

Until it support row editing I think this could work.  

**Before**:

![before](https://user-images.githubusercontent.com/6277291/82060525-d25a1a00-96c7-11ea-9155-5c91c2633acf.gif)

**After**:

![after](https://user-images.githubusercontent.com/6277291/82060557-d7b76480-96c7-11ea-9a1d-c5b7dc4ba2e2.gif)
