### PR TITLE
Add run buttons for selection text and current cursor query

### DIFF
--- a/src/assets/styles/app/query-editor.scss
+++ b/src/assets/styles/app/query-editor.scss
@@ -48,7 +48,11 @@
         padding: 0 $gutter-w;
         font-size: 0.85rem;
         min-width: 48px;
-      }
+
+        &.run-btn {
+          min-width: 100px;
+        }
+      } 
     }
   }
   .bottom-panel {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -6,9 +6,9 @@
       <div class="toolbar text-right">
         <div class="actions btn-group" ref="actions">
           <a @click.prevent="triggerSave" class="btn btn-flat">Save</a>
+
           <a href="" v-tooltip="'(shift + ctrl + enter)'" @click.prevent="submitCurrentQuery" class="btn btn-primary btn-disabled">Run Current</a>
-          <a href="" v-tooltip="'(ctrl + enter)'" @click.prevent="submitTabQuery" class="btn btn-primary">Run</a>
-          <a href="" v-tooltip="'(ctrl + alt + enter)'" :disabled="!hasSelectedText" @click.prevent="submitSelectedQuery" class="btn btn-primary btn-disabled">Run Selection</a>
+          <a href="" v-tooltip="'(ctrl + enter)'" @click.prevent="submitTabQuery" class="btn run-btn btn-primary btn-disabled">{{hasSelectedText ? 'Run Selected' : 'Run'}}</a>
         </div>
       </div>
     </div>
@@ -213,10 +213,11 @@
       },
       async submitCurrentQuery() {
         // Regex test: https://regex101.com/r/nnJdre
-        const regex = /^(?:[\n|\t])*.+?(?:[^;']|(?:'[^']+'))+;$/gm
+        const regex = /^(?:[\n|\t])*.+?(?:[^;']|(?:'[^']+'))+;?$/gm
         const cursorIndex = this.editor.getDoc().indexFromPos(this.editor.getCursor(true))
 
         let value = this.editor.getValue().trim()
+        
         if (value[value.length - 1] !== ';') {
           value += ';'
         }
@@ -246,15 +247,14 @@
         // TODO: Not sure if need to throw error in case no current query has been found
         if (currentQuery) {
           this.submitQuery(currentQuery)
-        }
-      },
-      async submitSelectedQuery() {
-        if (this.hasSelectedText) {
-          this.submitQuery(this.editor.getSelection())
+        } else {
+          this.results = []
+          this.error = 'No query to run'
         }
       },
       async submitTabQuery() {
-        this.submitQuery(this.editor.getValue())
+        const text = this.hasSelectedText ? this.editor.getSelection() : this.editor.getValue()
+        this.submitQuery(text)
       },
       async submitQuery(query) {
         this.running = true
@@ -361,10 +361,8 @@
         const runQueryKeyMap = {
           "Shift-Ctrl-Enter": this.submitCurrentQuery,
           "Shift-Cmd-Enter": this.submitCurrentQuery,
-          "Ctrl-Alt-Enter": this.submitSelectedQuery,
-          "Cmd-Alt-Enter": this.submitSelectedQuery,
-          "Ctrl-Enter": this.submitQuery,
-          "Cmd-Enter": this.submitQuery,
+          "Ctrl-Enter": this.submitTabQuery,
+          "Cmd-Enter": this.submitTabQuery,
           "Ctrl-S": this.triggerSave,
           "Cmd-S": this.triggerSave
         }

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -276,7 +276,7 @@
             }
           })
           this.results = results
-          this.$store.dispatch('logQuery', { text: this.editor.getValue(), rowCount: totalRows})
+          this.$store.dispatch('logQuery', { text: query, rowCount: totalRows})
         } catch (ex) {
           this.error = ex
         } finally {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -216,9 +216,9 @@
         const regex = /^(?:[\n|\t])*.+?(?:[^;']|(?:'[^']+'))+;?$/gm
         const cursorIndex = this.editor.getDoc().indexFromPos(this.editor.getCursor(true))
 
-        let value = this.editor.getValue().trim()
+        let value = this.editor.getValue()
         
-        if (value[value.length - 1] !== ';') {
+        if (!value.trim().endsWith(';')) {
           value += ';'
         }
 


### PR DESCRIPTION
Hi,

I'm interesting with this tool and would like to add the new features. 
- Run Selection (Ctrl-Alt-Enter): Run the selection query. If no selection, then the button is disabled as default and can do nothing when using shortcut keys.
- Run Current (Shift-Ctrl-Enter): Run on the current query under cursor.

![image](https://user-images.githubusercontent.com/3168632/83287025-25c18180-a20b-11ea-85aa-323fc1f39108.png)

I just done and test manually on Windows and didn't test shortcut keys on macOS yet. Please help if you can. Also, please take a look on this PR and give me your opinions if can. Thanks so much! 😃 

References: 
https://github.com/beekeeper-studio/beekeeper-studio/issues/152