### PR TITLE
fix for postgresql driver for redshift

### DIFF
--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -19,7 +19,7 @@ let dataTypes = {}
 
 /**
  * Do not convert DATE types to JS date.
- * It gnores of applying a wrong timezone to the date.
+ * It ignores of applying a wrong timezone to the date.
  * TODO: do not convert as well these same types with array (types 1115, 1182, 1185)
  */
 pg.types.setTypeParser(1082, 'text', (val) => val); // date
@@ -27,22 +27,44 @@ pg.types.setTypeParser(1114, 'text', (val) => val); // timestamp without timezon
 pg.types.setTypeParser(1184, 'text', (val) => val); // timestamp
 
 
+/**
+ * Gets the version details for the connection.
+ *
+ * Example version strings:
+ * CockroachDB CCL v1.1.0 (linux amd64, built 2017/10/12 14:50:18, go1.8.3)
+ * CockroachDB CCL v20.1.1 (x86_64-unknown-linux-gnu, built 2020/05/19 14:46:06, go1.13.9)
+ *
+ * PostgreSQL 9.4.26 on x86_64-pc-linux-gnu (Debian 9.4.26-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit
+ * PostgreSQL 12.3 (Debian 12.3-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
+ *
+ * PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 3.4.2 20041017 (Red Hat 3.4.2-6.fc3), Redshift 1.0.12103
+ */
+async function getVersion(conn) {
+  const { version } = (await driverExecuteQuery(conn, {query: "select version()"})).rows[0]
+  if (!version) {
+    return {
+      version: '',
+      isPostgres: false,
+      number: 0
+    }
+  }
+
+  const isPostgres = version.toLowerCase().includes('postgresql')
+  return {
+    version,
+    isPostgres,
+    number: parseInt(
+      version.split(" ")[isPostgres ? 1 : 2].replace(/^v/i, '').split(".").map(s => s.padStart(2, "0")).join("").padEnd(6, "0"),
+      10
+    )
+  }
+}
 
 async function getTypes(conn) {
-  let data;
-  try {
-    const sql = `
-      SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
-      FROM        pg_type t
-      LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-      WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
-      AND     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
-      AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
-    `
-
-    data = await driverExecuteQuery(conn, { query: sql })
-  } catch (err) {
-    const sql = `
+  const version = await getVersion(conn)
+  let sql
+  if (version.isPostgres && version.number < 80300) {
+    sql = `
       SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
       FROM        pg_type t
       LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
@@ -50,10 +72,18 @@ async function getTypes(conn) {
       AND     t.typname !~ '^_'
       AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
     `
-
-    data = await driverExecuteQuery(conn, { query: sql })    
+  } else {
+    sql = `
+      SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
+      FROM        pg_type t
+      LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+      WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+      AND     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+      AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
+    `
   }
-  
+
+  const data = await driverExecuteQuery(conn, { query: sql })
   const result = {}
   data.rows.forEach((row) => {
     result[row.typeid] = row.typename
@@ -145,9 +175,14 @@ export async function listViews(conn, filter = { schema: 'public' }) {
 }
 
 export async function listMaterializedViews(conn, filter = { schema: 'public' }) {
+  const version = await getVersion(conn);
+  if (!version.isPostgres || version.number < 90003) {
+    return []
+  }
+
   const schemaFilter = buildSchemaFilter(filter, 'schemaname')
   const sql = `
-    SELECT 
+    SELECT
       schemaname as schema,
       matviewname as name
     FROM pg_matviews
@@ -155,17 +190,6 @@ export async function listMaterializedViews(conn, filter = { schema: 'public' })
     order by schemaname, matviewname;
   `
 
-  const isPostgres = (await driverExecuteQuery(conn, {query: "select version()"})).rows[0]
-
-  if(!isPostgres.version || !isPostgres.version.toLowerCase().includes("postgresql")) {
-    return []
-  }
-
-  const versionData = (await driverExecuteQuery(conn, {query: "show server_version_num"})).rows[0]
-
-    if (!versionData.server_version_num || versionData.server_version_num.toLowerCase() < "090003") {
-    return []
-  }
   const data = await driverExecuteQuery(conn, {query: sql});
   return data.rows;
 }
@@ -270,10 +294,10 @@ export async function listMaterializedViewColumns(conn, database, table, schema)
     FROM pg_attribute a
       JOIN pg_class t on a.attrelid = t.oid
       JOIN pg_namespace s on t.relnamespace = s.oid
-    WHERE a.attnum > 0 
+    WHERE a.attnum > 0
       AND NOT a.attisdropped
       AND s.nspname = $1
-      AND t.relname = $2 
+      AND t.relname = $2
     ORDER BY a.attnum;
   `
   const params = [schema, table]

--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -29,16 +29,32 @@ pg.types.setTypeParser(1184, 'text', (val) => val); // timestamp
 
 
 async function getTypes(conn) {
-  const sql = `
-    SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
-    FROM        pg_type t
-    LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-    WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
-    AND     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
-    AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
-  `
+  let data;
+  try {
+    const sql = `
+      SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
+      FROM        pg_type t
+      LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+      WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+      AND     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
+      AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
+    `
+
+    data = await driverExecuteQuery(conn, { query: sql })
+  } catch (err) {
+    const sql = `
+      SELECT      n.nspname as schema, t.typname as typename, t.oid::int4 as typeid
+      FROM        pg_type t
+      LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+      WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
+      AND     t.typname !~ '^_'
+      AND     n.nspname NOT IN ('pg_catalog', 'information_schema');
+    `
+
+    data = await driverExecuteQuery(conn, { query: sql })    
+  }
+  
   const result = {}
-  const data = await driverExecuteQuery(conn, { query: sql })
   data.rows.forEach((row) => {
     result[row.typeid] = row.typename
   })


### PR DESCRIPTION
Amazon Redshift is based on postgresql 8.0, and pg_catalog.pg_type.typarray was added in 8.3, meaning that the query would cause an exception to be thrown due to el.typarray not existing when used for Redshift. This change gives us a fallback in the case of an exception on the first query to use one that will work under pg 8.0. Like the original query, this is based on the sql that is executed when using \dT command within psql, with the addition of the clause on n.snpname which was added in later versions of psql for \dT.

Fixes #150