### PR TITLE
explicitly mark sql files under dev/ as SQL for GH linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dev/**/*.sql linguist-language=SQL


### PR DESCRIPTION
Several of the files were being marked as TSQL and PLpgSQL, which due to their length overshadowed every other file in the repo. This patch marks these files as explicitly SQL langauge which is ignored by GitHub for language statistics.

Here are the stats breakdown for this patch:

__BEFORE__
```
98.39%  TSQL
0.62%   JavaScript
0.37%   Vue
0.36%   PLpgSQL
0.24%   CSS
0.02%   HTML
0.00%   Shell
```

__AFTER__
```
49.42%  JavaScript
29.86%  Vue
19.28%  CSS
1.29%   HTML
0.15%   Shell
```

Also see https://github.com/MasterOdin/beekeeper-studio for what the language bar will look like post merge.