### PR TITLE
Refresh icon added to databases dropdown.

### DIFF
--- a/src/components/DatabaseDropdown.vue
+++ b/src/components/DatabaseDropdown.vue
@@ -6,6 +6,9 @@
         <option selected :value="selectedDatabase">{{selectedDatabase}}</option>
         <option v-for="db in availableDatabases" v-bind:key="db" :value="db">{{db}}</option>
       </select>
+      <a @click.prevent="refreshDatabases" v-tooltip="'Refresh'">
+        <i class="material-icons">refresh</i>
+      </a>
     </div>
   </div>
 </template>
@@ -20,6 +23,11 @@
         currentDatabase: null,
         selectedDatabase: null,
         dbs: [],
+      }
+    },
+    methods: {
+      async refreshDatabases() {
+        this.dbs = await this.connection.listDatabases()
       }
     },
     async mounted() {


### PR DESCRIPTION
Refresh icon added to databases dropdown. This fixes #160

I'm so sorry, normally I don't like to share images like that;

![image](https://user-images.githubusercontent.com/4205423/83349597-b482eb00-a33e-11ea-9926-413b08693cf5.png)

But it seems like that and it works :)

Thanks