### PR TITLE
Use lsb_release to determine proper ubuntu version for install docs

### DIFF
--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -31,7 +31,7 @@ A repo is provided for Ubuntu 18.04+. To install the repo:
 wget --quiet -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
 
 # add our repo to your apt lists directory
-echo "deb https://dl.bintray.com/beekeeper-studio/releases disco main" | sudo tee /etc/apt/sources.list.d/beekeeper-studio.list
+echo "deb https://dl.bintray.com/beekeeper-studio/releases $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/beekeeper-studio.list
 
 # Update apt and install
 sudo apt update


### PR DESCRIPTION
Unless you only do actually provide the single apt list for dingo, it's better to use `lsb_release` to fill in the distro name dynamically so that way you do not have to keep updating your site. From the [man page](https://linux.die.net/man/1/lsb_release), the `-c` gives us the distro codename and `-s` prints it out in short form (as otherwise it would print `Codename:    bionic`).