### PR TITLE
Import Connection URL

### DIFF
--- a/src/assets/styles/app/_flex-grid.scss
+++ b/src/assets/styles/app/_flex-grid.scss
@@ -88,6 +88,9 @@ $gutter: 1rem;
 .flex-center {
   justify-content: center;
 }
+.flex-between {
+  justify-content: space-between;
+}
 
 // Vertical Row Alignment
 .flex-top {

--- a/src/components/ConnectionInterface.vue
+++ b/src/components/ConnectionInterface.vue
@@ -7,7 +7,12 @@
       <div ref="content" class="connection-main page-content" id="page-content">
         <div class="small-wrap">
           <div class="card-flat padding">
-            <h3 class="card-title">{{pageTitle}}</h3>
+            <div class="flex flex-between">
+              <h3 class="card-title">{{pageTitle}}</h3>
+                <button class="btn btn-small btn-flat" @click.prevent="showImportUrl = !showImportUrl">
+                  <i class="material-icons">add</i>
+                </button>
+            </div>
             <div class="alert alert-danger" v-show="errors">
               <i class="material-icons">warning</i>
               <div>
@@ -17,6 +22,7 @@
                 </ul>
               </div>
             </div>
+            <ImportUrlForm :hide="!showImportUrl" :config="config"/>
             <form @action="submit" v-if="config">
               <div class="form-group">
                 <label for="connectionType">Connection Type</label>
@@ -81,20 +87,21 @@
 </template>
 
 <script>
-  import os from 'os'
-  import {SavedConnection} from '../entity/saved_connection'
-  import ColorPicker from './form/ColorPicker'
-  import ConnectionSidebar from './ConnectionSidebar'
-  import MysqlForm from './connection/MysqlForm'
-  import PostgresForm from './connection/PostgresForm'
-  import Sidebar from './Sidebar'
-  import SqliteForm from './connection/SqliteForm'
-  import SqlServerForm from './connection/SqlServerForm'
-  import Split from 'split.js'
-  import _ from 'lodash'
+  import os from 'os';
+  import {SavedConnection} from '../entity/saved_connection';
+  import ColorPicker from './form/ColorPicker';
+  import ConnectionSidebar from './ConnectionSidebar';
+  import MysqlForm from './connection/MysqlForm';
+  import PostgresForm from './connection/PostgresForm';
+  import Sidebar from './Sidebar';
+  import SqliteForm from './connection/SqliteForm';
+  import SqlServerForm from './connection/SqlServerForm';
+  import Split from 'split.js';
+  import _ from 'lodash';
+  import ImportUrlForm from './connection/ImportUrlForm';
 
   export default {
-    components: { ConnectionSidebar, MysqlForm, PostgresForm, Sidebar, SqliteForm, SqlServerForm, ColorPicker },
+    components: {ImportUrlForm, ConnectionSidebar, MysqlForm, PostgresForm, Sidebar, SqliteForm, SqlServerForm, ColorPicker },
     data() {
       return {
         defaultConfig: new SavedConnection(),
@@ -102,7 +109,8 @@
         errors: null,
         connectionError: null,
         testing: false,
-        split: null
+        split: null,
+        showImportUrl: false
       }
     },
     computed: {
@@ -199,7 +207,5 @@
         }
       }
     },
-
-
   }
 </script>

--- a/src/components/ConnectionInterface.vue
+++ b/src/components/ConnectionInterface.vue
@@ -22,7 +22,7 @@
                 </ul>
               </div>
             </div>
-            <ImportUrlForm :hide="!showImportUrl" :config="config"/>
+            <ImportUrlForm :hide="!showImportUrl" :config="config" @handleErrorMessage="handleErrorMessage"/>
             <form @action="submit" v-if="config">
               <div class="form-group">
                 <label for="connectionType">Connection Type</label>
@@ -204,6 +204,14 @@
         } catch (ex) {
           this.errors = [ex.message]
           this.$noty.error("Could not save connection information")
+        }
+      },
+      handleErrorMessage(message){
+        if (message){
+          this.errors = [message]
+          this.$noty.error("Could not parse connection URL.")
+        }else{
+          this.errors = null
         }
       }
     },

--- a/src/components/connection/ImportUrlForm.vue
+++ b/src/components/connection/ImportUrlForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <form @submit.prevent="parseUrl(connectionUrl)">
+    <form :class="{hide: hide}" @submit.prevent="parseUrl(connectionUrl)">
         <div class="row gutter">
             <div class="col s9 form-group">
                 <label for="connectionUrl">Connection URL</label>
@@ -17,7 +17,13 @@
 <script>
   export default {
     name: 'ImportUrlForm',
-    props: ['config'],
+    props: {
+      config: Object,
+      hide: {
+        type: Boolean,
+        default: false
+      }
+    },
     data() {
       return {
         connectionUrl: null,
@@ -60,3 +66,8 @@
     },
   };
 </script>
+<style scoped>
+    .hide {
+        display: none;
+    }
+</style>

--- a/src/components/connection/ImportUrlForm.vue
+++ b/src/components/connection/ImportUrlForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <form @submit.prevent="parseUrl">
+    <form @submit.prevent="parseUrl(connectionUrl)">
         <div class="row gutter">
             <div class="col s9 form-group">
                 <label for="connectionUrl">Connection URL</label>
@@ -8,7 +8,7 @@
             </div>
             <div class="col s3 form-group">
                 <div class="flex flex-bottom">
-                    <button class="btn btn-primary btn-block" type="submit">Import</button>
+                    <button class="btn btn-primary btn-block" type="submit" :disabled="!connectionUrl">Import</button>
                 </div>
             </div>
         </div>
@@ -23,12 +23,20 @@
         connectionUrl: null,
       };
     },
+    watch: {
+      config: {
+        handler: function(config) {
+          this.parseUrl(config.host)
+        },
+        deep: true
+      }
+    },
     methods: {
-      parseUrl() {
-        if (this.connectionUrl.indexOf('://') < 0){
-          this.connectionUrl = 'https://' + this.connectionUrl
+      parseUrl(connectionUrl) {
+        if (!connectionUrl.includes('://')){
+          return;
         }
-        let url = new URL(this.connectionUrl);
+        let url = new URL(connectionUrl);
         this.config.connectionType = this.protocol(url.protocol)
         // set https as the protocol so URL interface can
         // correctly parse all necessary information
@@ -40,7 +48,7 @@
         this.config.password = url.password
       },
       protocol(protocol){
-        // Set MySQL as default when dealing with a http connection.
+        // Set MySQL as default when dealing with a http/s connections.
         if (protocol.startsWith('http')){
           return 'mysql';
         }

--- a/src/components/connection/ImportUrlForm.vue
+++ b/src/components/connection/ImportUrlForm.vue
@@ -1,0 +1,54 @@
+<template>
+    <form @submit.prevent="parseUrl">
+        <div class="row gutter">
+            <div class="col s9 form-group">
+                <label for="connectionUrl">Connection URL</label>
+                <input type="text" name="connectionUrl" id="connectionUrl"
+                       class="form-control" v-model="connectionUrl">
+            </div>
+            <div class="col s3 form-group">
+                <div class="flex flex-bottom">
+                    <button class="btn btn-primary btn-block" type="submit">Import</button>
+                </div>
+            </div>
+        </div>
+    </form>
+</template>
+<script>
+  export default {
+    name: 'ImportUrlForm',
+    props: ['config'],
+    data() {
+      return {
+        connectionUrl: null,
+      };
+    },
+    methods: {
+      parseUrl() {
+        if (this.connectionUrl.indexOf('://') < 0){
+          this.connectionUrl = 'https://' + this.connectionUrl
+        }
+        let url = new URL(this.connectionUrl);
+        this.config.connectionType = this.protocol(url.protocol)
+        // set https as the protocol so URL interface can
+        // correctly parse all necessary information
+        url.protocol = 'https'
+        this.config.host = url.hostname
+        this.config.port = url.port
+        this.config.defaultDatabase = url.pathname.slice(1, -1)
+        this.config.username = url.username
+        this.config.password = url.password
+      },
+      protocol(protocol){
+        // Set MySQL as default when dealing with a http connection.
+        if (protocol.startsWith('http')){
+          return 'mysql';
+        }
+        if (protocol.startsWith('postgres')){
+          return 'postgresql';
+        }
+        return protocol;
+      }
+    },
+  };
+</script>


### PR DESCRIPTION
I have added the functionality described in #178. Adds an import button at the top right for adding connections strings directly. Additionally, host field detects when a connection URL is added and automatically fills the necessary fields.    

I think the (+) button a the top would look better without the `btn` classes, but I am not sure.

Please let me know what you think and if I should make any changes!