### PR TITLE
Add Execute time to the status bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "core-js": "^3.4.4",
     "dateformat": "^3.0.3",
     "electron-util": "^0.14.1",
+    "humanize-duration": "^3.23.1",
     "jquery": "^3.5.0",
     "lodash": "^4.17.15",
     "material-icons": "^0.3.1",

--- a/src/assets/styles/app/query-editor.scss
+++ b/src/assets/styles/app/query-editor.scss
@@ -88,7 +88,7 @@
       .result-selector {
         margin-right: 10px;
       }
-      .affected-rows {
+      .affected-rows, .execute-time {
         padding-left: 10px;
       }
       select {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -368,14 +368,14 @@
           const query = this.deparameterizedQuery
           this.$modal.hide('parameters-modal')
 
-          const runningQuery = this.connection.query(query);
-          const queryStartTime = +new Date();
-          const results = await runningQuery.execute();
-          const queryEndTime = +new Date();
-          const queryExecutionTime = queryEndTime - queryStartTime;
+          const runningQuery = this.connection.query(query)
+          const queryStartTime = +new Date()
+          const results = await runningQuery.execute()
+          const queryEndTime = +new Date()
+          const queryExecutionTime = queryEndTime - queryStartTime
           let totalRows = 0
           results.forEach(result => {
-            result.executeTime = queryExecutionTime;
+            result.executeTime = queryExecutionTime
             result.rowCount = result.rowCount || 0
 
             // TODO (matthew): remove truncation logic somewhere sensible

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -142,7 +142,8 @@
         cursorIndex: null,
         marker: null,
         queryParameterValues: {},
-        queryForExecution: null
+        queryForExecution: null,
+        executeTime: 0
 
       }
     },
@@ -204,10 +205,10 @@
         return `${rows} ${Pluralize('row', rows)} affected`
       },
       executeTimeText() {
-        if (!this.result) {
+        if (!this.executeTime) {
           return null
         }
-        const executeTime = this.result.executeTime || 0
+        const executeTime = this.executeTime || 0
         return `${executeTime} ms`
       },
       rowCount() {
@@ -372,10 +373,9 @@
           const queryStartTime = +new Date()
           const results = await runningQuery.execute()
           const queryEndTime = +new Date()
-          const queryExecutionTime = queryEndTime - queryStartTime
+          this.executeTime = queryEndTime - queryStartTime
           let totalRows = 0
           results.forEach(result => {
-            result.executeTime = queryExecutionTime
             result.rowCount = result.rowCount || 0
 
             // TODO (matthew): remove truncation logic somewhere sensible

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -49,7 +49,7 @@
             <span class="truncated-rows" v-if="result && result.truncated"> &middot; only {{result.truncatedRowCount}} shown.</span>
           </div>
           <span class="affected-rows" v-if="affectedRowsText ">{{ affectedRowsText}}</span>
-          <span class="affected-rows" v-if="executeTimeText">{{executeTimeText}}</span>
+          <span class="execute-time" v-if="executeTimeText">{{executeTimeText}}</span>
         </template>
         <template v-else>
           No Data

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -49,6 +49,7 @@
             <span class="truncated-rows" v-if="result && result.truncated"> &middot; only {{result.truncatedRowCount}} shown.</span>
           </div>
           <span class="affected-rows" v-if="affectedRowsText ">{{ affectedRowsText}}</span>
+          <span class="affected-rows" v-if="executeTimeText">{{executeTimeText}}</span>
         </template>
         <template v-else>
           No Data
@@ -201,6 +202,13 @@
 
         const rows = this.result.affectedRows || 0
         return `${rows} ${Pluralize('row', rows)} affected`
+      },
+      executeTimeText() {
+        if (!this.result) {
+          return null
+        }
+        const executeTime = this.result.executeTime || 0
+        return `${executeTime} ms`
       },
       rowCount() {
         return this.result && this.result.rows ? this.result.rows.length : 0
@@ -361,9 +369,13 @@
           this.$modal.hide('parameters-modal')
 
           const runningQuery = this.connection.query(query);
-          const results = await runningQuery.execute()
+          const queryStartTime = +new Date();
+          const results = await runningQuery.execute();
+          const queryEndTime = +new Date();
+          const queryExecutionTime = queryEndTime - queryStartTime;
           let totalRows = 0
           results.forEach(result => {
+            result.executeTime = queryExecutionTime;
             result.rowCount = result.rowCount || 0
 
             // TODO (matthew): remove truncation logic somewhere sensible

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -119,6 +119,7 @@
   import { splitQueries, extractParams } from '../lib/db/sql_tools'
   import ProgressBar from './editor/ProgressBar'
   import ResultTable from './editor/ResultTable'
+  import humanizeDuration from 'humanize-duration'
 
   export default {
     // this.queryText holds the current editor value, always
@@ -209,7 +210,7 @@
           return null
         }
         const executeTime = this.executeTime || 0
-        return `${executeTime} ms`
+        return humanizeDuration(executeTime)
       },
       rowCount() {
         return this.result && this.result.rows ? this.result.rows.length : 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -6140,6 +6140,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+humanize-duration@^3.23.1:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/humanize-duration/-/humanize-duration-3.23.1.tgz#59cb8d01287479c1aa7cd5b1efc260d799bef89b"
+  integrity sha512-aoOEkomAETmVuQyBx4E7/LfPlC9s8pAA/USl7vFRQpDjepo3aiyvFfOhtXSDqPowdBVPFUZ7onG/KyuolX0qPg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
This is my first PR on this project. This pull request resolves #38. 

With this change, I have added the execute time to the status bar.

To make the execution time a bit more readable I have added HumanizeDuration.js (Thanks @rathboma)

There are a few things that should be considered as follow-ups (if the DB APIs allows us to do this) to use the real execution type instead of the time it takes to init the promise and the rest of the magic around the queries :).

