### PR TITLE
Revert "don't extract character classes"

### DIFF
--- a/src/lib/db/sql_tools.js
+++ b/src/lib/db/sql_tools.js
@@ -33,10 +33,10 @@ export function splitQueries(queryText) {
   return queries
 }
 
-const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+|\$\d+)(?:[^:]*?$)/g
+const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+|\$\d+)(?:\W|$)/g
 export function extractParams(query) {
   if (!query) return []
-
+  
   const result = Array.from(query.matchAll(extractRegex)).map(match => match[1])
   if (!result || result.length == 0) {
     return []

--- a/tests/unit/lib/db/sql_tool.spec.js
+++ b/tests/unit/lib/db/sql_tool.spec.js
@@ -53,16 +53,4 @@ describe("extractParams", () => {
       expect(extractParams(query)).toStrictEqual(expected)
     })
   })
-
-  it("shouldn't extract character class params", () => {
-    const testCases = {
-      ":foo:": [],
-      ": foo :": [],
-      "SELECT 'a' REGEXP '^[[:alpha:]]'": []
-    }
-    Object.keys(testCases).forEach(query => {
-      const expected = testCases[query]
-      expect(extractParams(query)).toStrictEqual(expected)
-    })
-  })
 })


### PR DESCRIPTION
Reverts beekeeper-studio/beekeeper-studio#223

This actually broke unit tests. But unit tests weren't run for the PR for some reason.