### PR TITLE
don't extract character classes, take 2

### DIFF
--- a/src/lib/db/sql_tools.js
+++ b/src/lib/db/sql_tools.js
@@ -33,10 +33,10 @@ export function splitQueries(queryText) {
   return queries
 }
 
-const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+|\$\d+)(?:\W|$)/g
+const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+|\$\d+)(?:[^:]*?$)/g
 export function extractParams(query) {
   if (!query) return []
-  
+
   const result = Array.from(query.matchAll(extractRegex)).map(match => match[1])
   if (!result || result.length == 0) {
     return []

--- a/src/lib/db/sql_tools.js
+++ b/src/lib/db/sql_tools.js
@@ -33,13 +33,21 @@ export function splitQueries(queryText) {
   return queries
 }
 
-const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+|\$\d+)(?:[^:]*?$)/g
+const badMatch = /(:\w+:)/g
+const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+:?|\$\d+)(?:\W|$)/g
+
 export function extractParams(query) {
   if (!query) return []
 
-  const result = Array.from(query.matchAll(extractRegex)).map(match => match[1])
+  const result = Array.from(query.matchAll(extractRegex))
+    .map(match => match[1])
+    .filter(m => {
+      return Array.from(m.matchAll(badMatch)).length === 0
+    })
   if (!result || result.length == 0) {
     return []
   }
+
+
   return _.uniq(result)
 }

--- a/tests/unit/lib/db/sql_tool.spec.js
+++ b/tests/unit/lib/db/sql_tool.spec.js
@@ -56,8 +56,8 @@ describe("extractParams", () => {
 
   it("shouldn't extract character class params", () => {
     const testCases = {
-      ":foo:": [],
-      ": foo :": [],
+      ":one:": [],
+      ": two :": [],
       "SELECT 'a' REGEXP '^[[:alpha:]]'": []
     }
     Object.keys(testCases).forEach(query => {

--- a/tests/unit/lib/db/sql_tool.spec.js
+++ b/tests/unit/lib/db/sql_tool.spec.js
@@ -53,4 +53,16 @@ describe("extractParams", () => {
       expect(extractParams(query)).toStrictEqual(expected)
     })
   })
+
+  it("shouldn't extract character class params", () => {
+    const testCases = {
+      ":foo:": [],
+      ": foo :": [],
+      "SELECT 'a' REGEXP '^[[:alpha:]]'": []
+    }
+    Object.keys(testCases).forEach(query => {
+      const expected = testCases[query]
+      expect(extractParams(query)).toStrictEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
Reverts beekeeper-studio/beekeeper-studio#226

This regex isn't quite right, and broke an existing check, so lets try to fix it.

We're using db-style params right now, but we could use mustache-style params instead - {{ param }}, although that's not as good UX I don't think.