### PR TITLE
Add missing table_name alias in listTableColumns for mysql 8

### DIFF
--- a/src/lib/db/clients/mysql.js
+++ b/src/lib/db/clients/mysql.js
@@ -104,7 +104,7 @@ export async function listRoutines(conn) {
 export async function listTableColumns(conn, database, table) {
   const clause = table ? `AND table_name = ?` : ''
   const sql = `
-    SELECT table_name, column_name AS 'column_name', column_type AS 'data_type'
+    SELECT table_name AS 'table_name', column_name AS 'column_name', column_type AS 'data_type'
     FROM information_schema.columns
     WHERE table_schema = database()
     ${clause}


### PR DESCRIPTION
MySQL 8 has made it so that columns returned from querying `information_schema` tables are returned as capitalized, regardless of the capitalization you use in your query. Adding the alias here is necessary (like everywhere else in the client) to normalize it to lowercase for both MySQL 5 and 8.

Maybe will resolve problem in #253?