### PR TITLE
Fixed an issue if no default database is set

### DIFF
--- a/src/common/appdb/models/saved_connection.js
+++ b/src/common/appdb/models/saved_connection.js
@@ -138,7 +138,11 @@ export class DbConnectionBase extends ApplicationEntity {
     if (this.connectionType === 'sqlite') {
       return path.basename(this.defaultDatabase || "./unknown.db")
     } else {
-      return `${this.host}:${this.port}/${this.defaultDatabase}`
+      let connectionString = `${this.host}:${this.port}`;
+      if (this.defaultDatabase) {
+        connectionString += `/${this.defaultDatabase}`
+      }
+      return connectionString
     }
   }
 


### PR DESCRIPTION
This PR fix a issue with the connectionstring which is displayed in the  `ConnectionListItem` component.
If no databse is set, currently the string shows `null` as database.

![Bildschirmfoto von 2020-08-06 21-01-12](https://user-images.githubusercontent.com/13292481/89571673-5e439400-d828-11ea-92d0-145e1ae47458.png)

With this PR no database will be (obviously) shown.
![Bildschirmfoto von 2020-08-06 21-01-26](https://user-images.githubusercontent.com/13292481/89571751-7fa48000-d828-11ea-9229-99e04fa77f2a.png)
