### PR TITLE
Feature/context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "v-hotkey": "^0.8.0",
     "v-tooltip": "^2.0.2",
     "vue": "^2.6.10",
+    "vue-context": "^6.0.0",
     "vue-js-modal": "^1.3.33",
     "vuejs-noty": "^0.1.3",
     "vuex": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "shortid": "^2.2.14",
     "simple-encryptor": "^3.0.0",
     "split.js": "^1.5.11",
+    "sql-formatter": "^2.3.3",
     "sql-query-identifier": "^1.1.0",
     "sqlite3": "^4.1.1",
     "ssh2": "beekeeper-studio/ssh2#electron-detection",

--- a/src/assets/styles/app/_all.scss
+++ b/src/assets/styles/app/_all.scss
@@ -11,4 +11,5 @@
 @import './connection-interface';
 @import './connection-labels';
 @import './preloader';
+@import './context-menu';
 

--- a/src/assets/styles/app/context-menu.scss
+++ b/src/assets/styles/app/context-menu.scss
@@ -1,0 +1,52 @@
+.v-context, .v-context ul {
+  background-color: $theme-bg;
+  background-clip: padding-box;
+  border-radius: .25rem;
+  border: 1px solid rgba(0, 0, 0, .15);
+  box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .2), 0 1px 5px 0 rgba(0, 0, 0, .12);
+  display: block;
+  margin: 0;
+  padding: 10px 0;
+  min-width: 10rem;
+  z-index: 1500;
+  position: fixed;
+  list-style: none;
+  box-sizing: border-box;
+  max-height: calc(100% - 50px);
+  overflow-y: auto
+}
+
+.v-context > li, .v-context ul > li {
+  margin: 0;
+  position: relative
+}
+
+.v-context > li > a, .v-context ul > li > a {
+  display: block;
+  padding: .5rem 1.5rem;
+  font-weight: 400;
+  color: $text;
+  text-decoration: none;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0
+}
+
+.v-context > li > a:focus, .v-context > li > a:hover, .v-context ul > li > a:focus, .v-context ul > li > a:hover {
+  text-decoration: none;
+  background-color: if(lightness($theme-bg) > 40, darken($theme-bg, 5%), lighten($theme-bg, 20%))
+}
+
+.v-context:focus, .v-context > li > a:focus, .v-context ul:focus, .v-context ul > li > a:focus {
+  outline: 0
+}
+
+.v-context__sub > a:after {
+  content: "\203A";
+  float: right;
+  padding-left: 1rem
+}
+
+.v-context__sub > ul {
+  display: none
+}

--- a/src/assets/styles/app/context-menu.scss
+++ b/src/assets/styles/app/context-menu.scss
@@ -50,3 +50,10 @@
 .v-context__sub > ul {
   display: none
 }
+
+.v-context li.separator {
+  height: 0;
+  margin: .5rem 0;
+  overflow: hidden;
+  border-top: 1px solid $text;
+}

--- a/src/components/CoreTabHeader.vue
+++ b/src/components/CoreTabHeader.vue
@@ -1,27 +1,44 @@
 <template>
-  <li class="nav-item" :title="title" >
-    <a
-      class="nav-link"
-      @click.prevent.stop="$emit('click', tab)"
-      @click.middle.prevent.stop="$emit('close', tab)"
-      :class="{ active: selected }"
-    >
-      <i v-if="tab.type === 'table'" :class="iconClass" class="material-icons item-icon table">grid_on</i>
-      <i v-if="tab.type === 'query'" class="material-icons item-icon query">code</i>
-      <i v-if="tab.type === 'settings'" class="material-icons item-icon settings">settings</i>
-      <span class="tab-title truncate">{{title}}</span>
-      <div class="tab-action">
+  <div>
+    <li class="nav-item" :title="title" @contextmenu.prevent="$refs.menu.open">
+      <a
+          class="nav-link"
+          @click.prevent.stop="$emit('click', tab)"
+          @click.middle.prevent.stop="$emit('close', tab)"
+          :class="{ active: selected }"
+      >
+        <i v-if="tab.type === 'table'" :class="iconClass" class="material-icons item-icon table">grid_on</i>
+        <i v-if="tab.type === 'query'" class="material-icons item-icon query">code</i>
+        <i v-if="tab.type === 'settings'" class="material-icons item-icon settings">settings</i>
+        <span class="tab-title truncate">{{title}}</span>
+        <div class="tab-action">
         <span class="tab-close" :class="{unsaved: tab.unsavedChanges}" @click.prevent.stop="$emit('close', tab)">
           <i class="material-icons close">close</i>
           <i class="material-icons unsaved-icon" >fiber_manual_record</i>
         </span>
-      </div>
-    </a>
-  </li>
+        </div>
+      </a>
+    </li>
+
+    <vue-context ref="menu" :close-on-click="true">
+      <li>
+        <a href="#" @click.prevent.stop="$emit('close', tab)">Close</a>
+      </li>
+      <li>
+        <a href="#" @click.prevent.stop="$emit('closeOther', tab)">Close Others</a>
+      </li>
+      <li>
+        <a href="#" @click.prevent.stop="$emit('closeAll')">Close All</a>
+      </li>
+    </vue-context>
+  </div>
 </template>
 <script>
+  import VueContext from 'vue-context';
+
   export default {
     props: ['tab', 'selected'],
+    components: { VueContext },
     data() {
       return {
         unsaved: false,

--- a/src/components/CoreTabHeader.vue
+++ b/src/components/CoreTabHeader.vue
@@ -30,6 +30,10 @@
       <li>
         <a href="#" @click.prevent.stop="$emit('closeAll')">Close All</a>
       </li>
+      <li class="separator"></li>
+      <li>
+        <a href="#" @click.prevent.stop="$emit('duplicate', tab)">Duplicate</a>
+      </li>
     </vue-context>
   </div>
 </template>

--- a/src/components/CoreTabHeader.vue
+++ b/src/components/CoreTabHeader.vue
@@ -22,17 +22,17 @@
 
     <vue-context ref="menu" :close-on-click="true">
       <li>
-        <a href="#" @click.prevent.stop="$emit('close', tab)">Close</a>
+        <a href="#" @click.prevent="$emit('close', tab)">Close</a>
       </li>
       <li v-if="this.tabsCount > 1">
-        <a href="#" @click.prevent.stop="$emit('closeOther', tab)">Close Others</a>
+        <a href="#" @click.prevent="$emit('closeOther', tab)">Close Others</a>
       </li>
       <li v-if="this.tabsCount > 1">
-        <a href="#" @click.prevent.stop="$emit('closeAll')">Close All</a>
+        <a href="#" @click.prevent="$emit('closeAll')">Close All</a>
       </li>
       <li class="separator"></li>
       <li>
-        <a href="#" @click.prevent.stop="$emit('duplicate', tab)">Duplicate</a>
+        <a href="#" @click.prevent="$emit('duplicate', tab)">Duplicate</a>
       </li>
     </vue-context>
   </div>

--- a/src/components/CoreTabHeader.vue
+++ b/src/components/CoreTabHeader.vue
@@ -24,10 +24,10 @@
       <li>
         <a href="#" @click.prevent.stop="$emit('close', tab)">Close</a>
       </li>
-      <li>
+      <li v-if="this.tabsCount > 1">
         <a href="#" @click.prevent.stop="$emit('closeOther', tab)">Close Others</a>
       </li>
-      <li>
+      <li v-if="this.tabsCount > 1">
         <a href="#" @click.prevent.stop="$emit('closeAll')">Close All</a>
       </li>
       <li class="separator"></li>
@@ -41,7 +41,7 @@
   import VueContext from 'vue-context';
 
   export default {
-    props: ['tab', 'selected'],
+    props: ['tab', 'tabsCount', 'selected'],
     components: { VueContext },
     data() {
       return {

--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -6,6 +6,7 @@
           v-for="tab in tabItems"
           :key="tab.id"
           :tab="tab"
+          :tabsCount="tabItems.length"
           :selected="activeTab === tab"
           @click="click"
           @close="close"

--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -178,10 +178,23 @@
         }
       },
       duplicate(tab) {
-        let duplicatedTab = Object.assign( Object.create( Object.getPrototypeOf(tab)), tab)
-        duplicatedTab.id = uuidv4()
-        duplicatedTab.title = "Query #" + this.newTabId
+        let duplicatedTab = {
+            id: uuidv4(),
+            type: tab.type,
+            connection: tab.connection,
+            unsavedChanges: true
+        }
 
+        if(tab.type === 'query') {
+          const query = new FavoriteQuery()
+          query.text = tab.query.text
+
+          duplicatedTab['title'] = "Query #" + this.newTabId
+          duplicatedTab['unsavedChanges'] = true
+          duplicatedTab['query'] = query
+        } else if(tab.type === 'table') {
+          duplicatedTab['table'] = tab.table
+        }
         this.addTab(duplicatedTab)
       }
     },

--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -11,6 +11,7 @@
           @close="close"
           @closeAll="closeAll"
           @closeOther="closeOther"
+          @duplicate="duplicate"
           ></core-tab-header>
       </ul>
       <span class="actions">
@@ -175,6 +176,13 @@
           tab.query.reload()
         }
       },
+      duplicate(tab) {
+        let duplicatedTab = Object.assign( Object.create( Object.getPrototypeOf(tab)), tab)
+        duplicatedTab.id = uuidv4()
+        duplicatedTab.title = "Query #" + this.newTabId
+
+        this.addTab(duplicatedTab)
+      }
     },
     mounted() {
       this.createQuery()

--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -9,6 +9,8 @@
           :selected="activeTab === tab"
           @click="click"
           @close="close"
+          @closeAll="closeAll"
+          @closeOther="closeOther"
           ></core-tab-header>
       </ul>
       <span class="actions">
@@ -39,8 +41,8 @@
   import { uuidv4 } from '@/lib/crypto'
   import TableTable from './tableview/TableTable'
   import AppEvent from '../common/AppEvent'
-import platformInfo from '../common/platform_info'
-import { mapGetters } from 'vuex'
+  import platformInfo from '../common/platform_info'
+  import { mapGetters } from 'vuex'
 
   export default {
     props: [ 'connection' ],
@@ -72,7 +74,7 @@ import { mapGetters } from 'vuex'
           'ctrl+shift+tab': this.previousTab,
         }
 
-        // This is a hack becuase codemirror steals the shortcut
+        // This is a hack because codemirror steals the shortcut
         // when the shortcut is captured on the electron side
         // but not on mac, on mac we don't wanna capture it. Because reasons.
         // 'registerAccelerator' doesn't disable shortcuts on mac.
@@ -80,7 +82,6 @@ import { mapGetters } from 'vuex'
           result[closeTab] = this.closeTab
         }
 
-        
         return result
       }
     },
@@ -128,7 +129,6 @@ import { mapGetters } from 'vuex'
         }
 
         this.addTab(result)
-
       },
       openTable(table) {
         // todo (matthew): trigger this from a vuex event
@@ -152,7 +152,6 @@ import { mapGetters } from 'vuex'
         this.activeTab = tab
       },
       close(tab) {
-
         if (this.activeTab === tab) {
           if(tab === this.lastTab) {
             this.previousTab()
@@ -160,12 +159,22 @@ import { mapGetters } from 'vuex'
             this.nextTab()
           }
         }
+
         this.tabItems = _.without(this.tabItems, tab)
         if (tab.query && tab.query.id) {
           tab.query.reload()
         }
       },
-
+      closeAll() {
+        this.tabItems = []
+      },
+      closeOther(tab) {
+        this.tabItems = [tab]
+        this.activeTab = tab;
+        if (tab.query && tab.query.id) {
+          tab.query.reload()
+        }
+      },
     },
     mounted() {
       this.createQuery()
@@ -178,7 +187,6 @@ import { mapGetters } from 'vuex'
       this.$root.$on('loadTable', this.openTable)
       this.$root.$on('loadSettings', this.openSettings)
       this.$root.$on('favoriteClick', (item) => {
-
         const queriesOnly = this.tabItems.map((item) => {
           return item.query
         })
@@ -196,10 +204,7 @@ import { mapGetters } from 'vuex'
           }
           this.addTab(result)
         }
-
-
       })
-
     }
   }
 </script>

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -30,7 +30,7 @@
 
       <vue-context ref="topPanelMenu" :close-on-click="true">
         <li>
-          <a href="#" @click.prevent.stop="formatSql">Format</a>
+          <a href="#" @click.prevent="formatSql">Format</a>
         </li>
       </vue-context>
     </div>

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="query-editor" v-hotkey="keymap">
-    <div class="top-panel" ref="topPanel">
+    <div class="top-panel" ref="topPanel" @contextmenu.prevent="$refs.topPanelMenu.open">
       <textarea name="editor" class="editor" ref="editor" id="" cols="30" rows="10"></textarea>
       <span class="expand"></span>
       <div class="toolbar text-right">
@@ -27,6 +27,12 @@
           </x-buttons>
         </div>
       </div>
+
+      <vue-context ref="topPanelMenu" :close-on-click="true">
+        <li>
+          <a href="#" @click.prevent.stop="formatSql">Format</a>
+        </li>
+      </vue-context>
     </div>
     <div class="bottom-panel" ref="bottomPanel">
       <progress-bar v-if="running"></progress-bar>
@@ -144,10 +150,12 @@
   import ResultTable from './editor/ResultTable'
   import Statusbar from './common/StatusBar'
   import humanizeDuration from 'humanize-duration'
+  import VueContext from 'vue-context';
+  import sqlFormatter from 'sql-formatter';
 
   export default {
     // this.queryText holds the current editor value, always
-    components: { ResultTable, ProgressBar, Statusbar },
+    components: { ResultTable, ProgressBar, Statusbar, VueContext },
     props: ['tab', 'active'],
     data() {
       return {
@@ -339,7 +347,7 @@
       },
       selectFirstParameter() {
         if (!this.$refs['paramInput'] || this.$refs['paramInput'].length == 0) return
-        this.$refs['paramInput'][0].select()        
+        this.$refs['paramInput'][0].select()
       },
       updateEditorHeight() {
         let height = this.$refs.topPanel.clientHeight
@@ -463,6 +471,9 @@
           }
         }
       },
+      formatSql() {
+        this.editor.setValue(sqlFormatter.format(this.editor.getValue()))
+      }
     },
     mounted() {
       const $editor = this.$refs.editor

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -262,6 +262,7 @@
       keymap() {
         const result = {}
         result[this.ctrlOrCmd('l')] = this.selectEditor
+        result[this.ctrlOrCmd('alt+f')] = this.formatSql
         return result
       },
       connectionType() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7824,7 +7824,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.12:
+lodash@^4.0.0, lodash@^4.16.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.12:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -11219,6 +11219,13 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql-formatter@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-2.3.3.tgz#910ef484fbb988a5e510bea4161157e3b80b2f62"
+  integrity sha512-m6pqVXwsm9GkCHC/+gdPvNowI7PNoVTT6OZMWKwXJoP2MvfntfhcfyliIf4/QX6t+DirSJ6XDSiSS70YvZ87Lw==
+  dependencies:
+    lodash "^4.16.0"
 
 sql-query-identifier@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7851,7 +7851,7 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -12499,6 +12499,20 @@ vue-cli-plugin-electron-builder@^2.0.0-rc.1:
     webpack-chain "^6.0.0"
     webpack-merge "^4.2.2"
     yargs "^14.0.0"
+
+vue-clickaway@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/vue-clickaway/-/vue-clickaway-2.2.2.tgz#cecf6839575e8b2afc5d3edb3efb616d293dbb44"
+  integrity sha512-25SpjXKetL06GLYoLoC8pqAV6Cur9cQ//2g35GRFBV4FgoljbZZjTINR8g2NuVXXDMLSUXaKx5dutgO4PaDE7A==
+  dependencies:
+    loose-envify "^1.2.0"
+
+vue-context@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/vue-context/-/vue-context-6.0.0.tgz#97a1a423fc86fb7a54f46d1567670aba281a5970"
+  integrity sha512-x8gO6xgj0MtTCWcYbDjO/7VJ/gT+nV+unqICvsN0hwqqBzft31eYyExYqrSvfDCRI7ixxObu5tbl7BQAKge7eg==
+  dependencies:
+    vue-clickaway "^2.2.2"
 
 vue-eslint-parser@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR adds a context-menu component and would Fix #270 and would Fix #260.
Already implemented context-menus:
- Tabs
  - close
  - close other
  - close all
  - duplicate a query (tab) 
- Sql editor
  - format sql

The formatting also have a shortkey `meta/strg+alt+f`.

Tabs:
![Peek 2020-08-07 10-36](https://user-images.githubusercontent.com/13292481/89626722-1b220900-d89a-11ea-9bb4-93b605ab8083.gif)

Editor:
![Peek 2020-08-07 10-35](https://user-images.githubusercontent.com/13292481/89626751-25dc9e00-d89a-11ea-85ba-b18c2bd76691.gif)
