### PR TITLE
Fixed foreign keys for mysql/mariadb & a few optimizations

### DIFF
--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -80,7 +80,7 @@ import { mapGetters } from 'vuex'
           result[closeTab] = this.closeTab
         }
 
-        
+
         return result
       }
     },
@@ -108,7 +108,7 @@ import { mapGetters } from 'vuex'
         }
       },
       setTabTitleScope(id, value) {
-        console.log("setting tab title")
+        console.info("setting tab title")
         this.tabItems.filter(t => t.id === id).forEach(t => t.titleScope = value)
       },
       closeTab() {
@@ -135,7 +135,7 @@ import { mapGetters } from 'vuex'
 
       },
       openTable({ table, filter, tableName }) {
-        
+
         let resolvedTable = null
 
         if (!table && tableName) {

--- a/src/components/editor/ResultTable.vue
+++ b/src/components/editor/ResultTable.vue
@@ -80,10 +80,5 @@
         this.tabulator.download(format, `${title}-${dateString}.${format}`, 'all')
       }
     }
-
-
-
 	}
-
-
 </script>

--- a/src/components/sidebar/core/TableList.vue
+++ b/src/components/sidebar/core/TableList.vue
@@ -75,7 +75,7 @@
         </div>
         <div class="list-body">
           <div class="with-schemas" v-if="tablesHaveSchemas">
-            <TableListSchema 
+            <TableListSchema
               v-for="(blob, index) in schemaTables"
               :title="blob.schema"
               :key="blob.schema"

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -160,6 +160,10 @@ export default {
         const keyData = this.tableKeys[column.columnName]
         const editable = this.editable && column.columnName !== this.primaryKey
 
+        const headerTooltip = (cell) => {
+          return `${cell.getDefinition().title}: ${column.dataType}`
+        }
+
         const result = {
           title: column.columnName,
           field: column.columnName,
@@ -174,7 +178,8 @@ export default {
             //   maxLength: column.columnLength // TODO
             // }
           },
-          cellEdited: this.cellEdited
+          cellEdited: this.cellEdited,
+          headerTooltip
         }
         results.push(result)
         if (keyData) {

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -58,7 +58,7 @@
           >warning</i>
         </span>
       </div>
-      <span ref="paginationArea" class="col x4 flex flex-center tabulator-paginator"></span>
+      <span ref="paginationArea" class="col x4 flex flex-center tabulator-paginator" v-show="this.totalRecords > this.limit"></span>
       <div class="col x4 pending-edits flex flex-right">
         <div v-if="pendingEdits.length > 0">
           <span v-if="editError" class="edit-error">
@@ -124,6 +124,7 @@ export default {
       pendingEdits: [],
       editError: null,
       timeAgo: new TimeAgo('en-US'),
+      totalRecords: null,
       lastUpdated: null,
       lastUpdatedText: null,
       interval: setInterval(this.setlastUpdatedText, 10000)
@@ -412,6 +413,7 @@ export default {
             const data = this.dataToTableData({ rows: r }, this.tableColumns);
             this.data = data
             this.lastUpdated = Date.now()
+            this.totalRecords = totalRecords
             resolve({
               last_page: Math.ceil(totalRecords / limit),
               data

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -29,9 +29,9 @@
                 v-model="filter.value"
                 placeholder="Enter Value"
               />
-              <button 
-                type="button" 
-                class="clear btn-link" 
+              <button
+                type="button"
+                class="clear btn-link"
                 @click.prevent="filter.value = ''"
               >
                 <i class="material-icons">cancel</i>
@@ -48,11 +48,11 @@
     <statusbar :mode="statusbarMode" class="tabulator-footer">
       <div class="col x4">
         <span class="statusbar-item flex flex-middle" v-if="lastUpdatedText" :title="'Updated' + ' ' + lastUpdatedText">
-          <i class="material-icons">update</i> 
+          <i class="material-icons">update</i>
           <span>{{lastUpdatedText}}</span>
         </span>
         <span v-if="missingPrimaryKey" class="col s4pending-edits">
-          <i 
+          <i
           class="material-icons"
           v-tooltip="'No primary key detected, table editing is disabled.'"
           >warning</i>
@@ -175,7 +175,6 @@ export default {
           cellEdited: this.cellEdited
         }
         results.push(result)
-        
 
         if (keyData) {
           const icon = () => "<i class='material-icons fk-link'>launch</i>"
@@ -195,7 +194,7 @@ export default {
           result.cssClass = 'foreign-key'
           results.push(keyResult)
         }
-        
+
       });
       return results
     },
@@ -296,7 +295,6 @@ export default {
         this.$noty.error("Can't edit column -- couldn't figure out primary key")
         // cell.setValue(cell.getOldValue())
         cell.restoreOldValue()
-        console.log(cell)
         return
       }
       const payload = {

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -88,6 +88,7 @@ import Statusbar from '../common/StatusBar'
 import rawLog from 'electron-log'
 import _ from 'lodash'
 import TimeAgo from 'javascript-time-ago'
+import { NULL } from "../../mixins/data_mutators";
 const log = rawLog.scope('TableTable')
 
 export default {
@@ -175,10 +176,19 @@ export default {
           cellEdited: this.cellEdited
         }
         results.push(result)
-
         if (keyData) {
-          const icon = () => "<i class='material-icons fk-link'>launch</i>"
+          const icon = (cell) => {
+            if (cell.getValue() === NULL) {
+              return null
+            }
+
+            return "<i class='material-icons fk-link'>launch</i>"
+          }
           const tooltip = (cell) => {
+            if (cell.getValue() === NULL) {
+              return false
+            }
+
             return `View records in ${keyData.toTable} with ${keyData.toColumn} = ${cell.getValue()}`
           }
           const keyResult = {
@@ -259,6 +269,10 @@ export default {
   },
   methods: {
     fkClick(e, cell) {
+      if (cell.getValue() === NULL) {
+        return false
+      }
+
       log.info('fk-click', cell)
       const value = cell.getValue()
       const fromColumn = cell.getField()

--- a/src/lib/db/clients/mysql.js
+++ b/src/lib/db/clients/mysql.js
@@ -196,7 +196,7 @@ export async function getTableKeys(conn, database, table) {
     FROM information_schema.key_column_usage
     WHERE table_schema = database()
     AND table_name = ?
-    AND ((referenced_table_name IS NOT NULL) OR constraint_name LIKE '%PRIMARY%')
+    AND referenced_table_name IS NOT NULL
   `;
 
   const params = [

--- a/src/mixins/data_mutators.js
+++ b/src/mixins/data_mutators.js
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-const NULL = '(NULL)'
+export const NULL = '(NULL)'
 
 export default {
 


### PR DESCRIPTION
This PR fixed fetching the foreign keys (which mean with mysql you can open the referenced row in a new tab).

It also fixed the issue that the "open referenced row in new tab icom" will be displayed if the cell value is null.
It also will hide the pagination if there are no other pages.