### PR TITLE
Use the x-mssql mode for mssql

### DIFF
--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -469,9 +469,14 @@
           "Cmd+Shift+F": this.formatSql
         }
 
+        const modes = {
+          'mysql': 'text/x-mysql',
+          'postgresql': 'text/x-pgsql',
+          'sqlserver': 'text/x-mssql',
+        };
         this.editor = CodeMirror.fromTextArea($editor, {
           lineNumbers: true,
-          mode: this.connection.connectionType === 'sqlserver' ? 'text/x-mssql' : "text/x-sql",
+          mode: this.connection.connectionType in modes ? modes[this.connection.connectionType] : "text/x-sql",
           theme: 'monokai',
           extraKeys: {"Ctrl-Space": "autocomplete", "Cmd-Space": "autocomplete"},
           hint: CodeMirror.hint.sql,

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -471,7 +471,7 @@
 
         this.editor = CodeMirror.fromTextArea($editor, {
           lineNumbers: true,
-          mode: "text/x-sql",
+          mode: this.connection.connectionType === 'sqlserver' ? 'text/x-mssql' : "text/x-sql",
           theme: 'monokai',
           extraKeys: {"Ctrl-Space": "autocomplete", "Cmd-Space": "autocomplete"},
           hint: CodeMirror.hint.sql,


### PR DESCRIPTION
This PR will change the mode of the codemirror editor.
Codemirror has internal a variable called `backslashStringEscapes` which will decide if a backslash will escape or not.

For the current used mode `x-sql` the  `backslashStringEscapes` is not set which means its true.

Fix #199
![Bildschirmfoto von 2020-08-14 22-34-51](https://user-images.githubusercontent.com/13292481/90290562-6336c200-de7e-11ea-9a4f-b274d0c9bc1e.png)


Update: This PR will now use also the correct type for `mysql` and `postgresql`.
Because of the correct mode the following two Issues are fixed:

Fix #209 
![Bildschirmfoto von 2020-08-14 22-31-05](https://user-images.githubusercontent.com/13292481/90290399-1a7f0900-de7e-11ea-8299-9cccdc0e2c55.png)

Fix #208
![Bildschirmfoto von 2020-08-14 22-30-25](https://user-images.githubusercontent.com/13292481/90290430-28348e80-de7e-11ea-8461-ea8ccb026511.png)
 