### PR TITLE
Use the default postgres database if no default database is given

### DIFF
--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -406,22 +406,22 @@ export async function getTableReferences(conn, table, schema) {
 export async function getTableKeys(conn, database, table, schema) {
   const sql = `
     SELECT
-        tc.table_schema as from_schema, 
-        tc.table_name as from_table, 
-        kcu.column_name as from_column, 
+        tc.table_schema as from_schema,
+        tc.table_name as from_table,
+        kcu.column_name as from_column,
         ccu.table_schema AS to_schema,
         ccu.table_name AS to_table,
         ccu.column_name AS to_column,
         tc.constraint_name
-    FROM 
-        information_schema.table_constraints AS tc 
+    FROM
+        information_schema.table_constraints AS tc
         JOIN information_schema.key_column_usage AS kcu
           ON tc.constraint_name = kcu.constraint_name
           AND tc.table_schema = kcu.table_schema
         JOIN information_schema.constraint_column_usage AS ccu
           ON ccu.constraint_name = tc.constraint_name
           AND ccu.table_schema = tc.table_schema
-    WHERE tc.constraint_type = 'FOREIGN KEY' 
+    WHERE tc.constraint_type = 'FOREIGN KEY'
     AND tc.table_name=$1 and tc.table_schema = $2;
   `;
 
@@ -451,7 +451,7 @@ export async function getPrimaryKey(conn, database, table, schema) {
     FROM information_schema.key_column_usage AS c
     LEFT JOIN information_schema.table_constraints AS t
     ON t.constraint_name = c.constraint_name
-    WHERE t.table_name = $1 and t.table_schema = $2 
+    WHERE t.table_name = $1 and t.table_schema = $2
     AND t.constraint_type = 'PRIMARY KEY'
   `
   const params = [table, schema]

--- a/src/lib/db/server.js
+++ b/src/lib/db/server.js
@@ -51,7 +51,7 @@ export function createServer(serverConfig) {
         return server.db[dbName];
       }
 
-      if(dbName === null && server.config.client === 'postgresql') {
+      if(dbName === null && serverConfig.client === 'postgresql') {
         dbName = 'postgres'
       }
 

--- a/src/lib/db/server.js
+++ b/src/lib/db/server.js
@@ -51,6 +51,10 @@ export function createServer(serverConfig) {
         return server.db[dbName];
       }
 
+      if(dbName === null) {
+        dbName = 'postgres'
+      }
+
       const database = {
         database: dbName,
         connection: null,

--- a/src/lib/db/server.js
+++ b/src/lib/db/server.js
@@ -51,7 +51,7 @@ export function createServer(serverConfig) {
         return server.db[dbName];
       }
 
-      if(dbName === null) {
+      if(dbName === null && server.config.client === 'postgresql') {
         dbName = 'postgres'
       }
 


### PR DESCRIPTION
Currently the underlaying library for postrgres tries to connect with the database username if no default database is given.
It makes more sense to connect to the default `postgres` database if no default database is given.

FIx #292 