### PR TITLE
Added canel button and show the row count of a table

### DIFF
--- a/src/assets/styles/app/statusbar.scss
+++ b/src/assets/styles/app/statusbar.scss
@@ -67,7 +67,7 @@
 
   // Connection Status
   // ---------------------------
-  .connection-button, 
+  .connection-button,
   .connection-button > .btn {
     height: $statusbar-height;
     line-height: $statusbar-height;
@@ -140,7 +140,7 @@
   // Query Status
   // ----------------------------
   .statusbar-item {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     padding: 0 $gutter-h;
     .material-icons {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -379,6 +379,19 @@
           results.forEach(result => {
             result.rowCount = result.rowCount || 0
 
+            let rows = []
+            result.rows.forEach(row => {
+              const tmpRow = {}
+              for (let [key, value] of Object.entries(row)) {
+                if(value instanceof Buffer) {
+                  value = value.toString()
+                }
+                tmpRow[key] = value
+              }
+              rows.push(tmpRow)
+            })
+            result.rows = rows
+
             // TODO (matthew): remove truncation logic somewhere sensible
             totalRows += result.rowCount
             if (result.rowCount > this.$config.maxResults) {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -379,19 +379,6 @@
           results.forEach(result => {
             result.rowCount = result.rowCount || 0
 
-            let rows = []
-            result.rows.forEach(row => {
-              const tmpRow = {}
-              for (let [key, value] of Object.entries(row)) {
-                if(value instanceof Buffer) {
-                  value = value.toString()
-                }
-                tmpRow[key] = value
-              }
-              rows.push(tmpRow)
-            })
-            result.rows = rows
-
             // TODO (matthew): remove truncation logic somewhere sensible
             totalRows += result.rowCount
             if (result.rowCount > this.$config.maxResults) {

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -41,6 +41,7 @@
       <result-table ref="table" v-else-if="rowCount > 0" :tableHeight="tableHeight" :result="result" :query='query'></result-table>
       <div class="message" v-else-if="result"><div class="alert alert-info"><i class="material-icons">info</i><span>Query Executed Successfully. No Results</span></div></div>
       <div class="message" v-else-if="error"><div class="alert alert-danger"><i class="material-icons">warning</i><span>{{error}}</span></div></div>
+      <div class="message" v-else-if="info"><div class="alert alert-info"><i class="material-icons">warning</i><span>{{info}}</span></div></div>
       <div v-else><!-- No Data --></div>
       <span class="expand" v-if="!result"></span>
       <!-- STATUS BAR -->
@@ -132,6 +133,7 @@
         editor: null,
         runningQuery: null,
         error: null,
+        info: null,
         split: null,
         tableHeight: 0,
         savePrompt: false,
@@ -289,6 +291,7 @@
     methods: {
       cancelQuery() {
         this.running = false
+        this.info = 'Query Execution Cancelled'
         this.runningQuery.cancel()
         this.runningQuery = null
       },

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -290,10 +290,12 @@
     },
     methods: {
       cancelQuery() {
-        this.running = false
-        this.info = 'Query Execution Cancelled'
-        this.runningQuery.cancel()
-        this.runningQuery = null
+        if(this.running && this.runningQuery) {
+          this.running = false
+          this.info = 'Query Execution Cancelled'
+          this.runningQuery.cancel()
+          this.runningQuery = null
+        }
       },
       download(format) {
         this.$refs.table.download(format)
@@ -491,6 +493,8 @@
           "Shift-Cmd-F": this.formatSql,
           "Ctrl-/": this.toggleComment,
           "Cmd-/": this.toggleComment,
+          "Ctrl-C": this.cancelQuery,
+          "Cmd-C": this.cancelQuery
         }
 
         const modes = {

--- a/src/components/editor/QueryEditorStatusBar.vue
+++ b/src/components/editor/QueryEditorStatusBar.vue
@@ -20,6 +20,12 @@
       </span>
       <span class="expand"></span>
     </template>
+    <template v-else-if="running">
+      <span class="expand"></span>
+      <x-buttons class="download-results">
+        <x-button class="btn btn-link btn-small" @click.stop.prevent="cancelQuery">Cancel Query</x-button>
+      </x-buttons>
+    </template>
     <template v-else>
       <span class="expand"></span>
       <span class="empty">No Data</span>
@@ -55,7 +61,7 @@ import humanizeDuration from 'humanize-duration'
 import Statusbar from '../common/StatusBar'
 
 export default {
-    props: ['results', 'value', 'executeTime'],
+    props: ['results', 'running', 'value', 'executeTime'],
     components: { Statusbar },
 
     computed: {
@@ -83,6 +89,9 @@ export default {
     mounted() {
     },
     methods: {
+      cancelQuery() {
+        this.$emit('cancelQuery')
+      },
       updateValue(event) {
         this.$emit('input', event.target.value)
       },

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -286,7 +286,11 @@ export default {
       lastUpdated: null,
       // callbacks
       ajaxRequestFunc: this.dataFetch,
-      index: this.primaryKey
+      index: this.primaryKey,
+      keybindings: {
+        "scrollToEnd": false,
+        "scrollToStart": false,
+      }
     });
 
   },

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -47,13 +47,13 @@
     <div ref="table"></div>
     <statusbar :mode="statusbarMode" class="tabulator-footer">
       <div class="col x4">
-        <span class="statusbar-item flex flex-middle" v-if="lastUpdatedText && !editError" :title="'Updated' + ' ' + lastUpdatedText">
-          <i class="material-icons">update</i>
-          <span>{{lastUpdatedText}}</span>
-        </span>
         <span class="statusbar-item flex flex-middle" v-if="lastUpdatedText && !editError" :title="'Total records: ' + totalRecords">
           <i class="material-icons">list</i>
           <span>{{ totalRecords }} records</span>
+        </span>
+        <span class="statusbar-item flex flex-middle" v-if="lastUpdatedText && !editError" :title="'Updated' + ' ' + lastUpdatedText">
+          <i class="material-icons">update</i>
+          <span>{{lastUpdatedText}}</span>
         </span>
         <span v-if="editError" class="statusbar-item error" :title="editError">
           <i class="material-icons">error</i>

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -51,6 +51,10 @@
           <i class="material-icons">update</i>
           <span>{{lastUpdatedText}}</span>
         </span>
+        <span class="statusbar-item flex flex-middle" v-if="lastUpdatedText && !editError" :title="'Total records: ' + totalRecords">
+          <i class="material-icons">list</i>
+          <span>{{ totalRecords }} records</span>
+        </span>
         <span v-if="editError" class="statusbar-item error" :title="editError">
           <i class="material-icons">error</i>
           <span class="">Error Saving Changes</span>
@@ -202,7 +206,7 @@ export default {
           cellEdited: this.cellEdited
         }
         results.push(result)
-        
+
 
         if (keyData) {
           const icon = () => "<i class='material-icons fk-link'>launch</i>"
@@ -222,7 +226,7 @@ export default {
           result.cssClass = 'foreign-key'
           results.push(keyResult)
         }
-        
+
       });
       return results
     },
@@ -263,7 +267,7 @@ export default {
     if (this.initialFilter) {
       this.filter = _.clone(this.initialFilter)
     }
-    
+
     this.rawTableKeys = await this.connection.getTableKeys(this.table.name, this.table.schema)
     // TODO (matthew): re-enable after implementing for all DBs
     this.primaryKey = await this.connection.getPrimaryKey(this.table.name, this.table.schema)

--- a/src/mixins/data_mutators.js
+++ b/src/mixins/data_mutators.js
@@ -11,6 +11,7 @@ export default {
 
     genericMutator(value) {
       // if (_.isNil(value)) return NULL
+      if(value instanceof Buffer) return value.toString()
       if (_.isDate(value)) return value.toISOString()
       if (_.isObject(value)) return JSON.stringify(value)
       if (_.isArray(value)) return JSON.stringify(value)


### PR DESCRIPTION
This PR:

-  Adds a button to cancel queries (Fix #185 and Fix #128)
-  Adds the row count of tables (Fix #151)
-  Fix hex values (Fix #54)
-  Allow to use `END` and `POS1` to jump within editing input (Fix #295)

![Peek 2020-08-19 16-17](https://user-images.githubusercontent.com/13292481/90646447-81624080-e237-11ea-8c50-255b92202757.gif)

![Bildschirmfoto von 2020-08-18 18-48-47](https://user-images.githubusercontent.com/13292481/90542065-da709c80-e183-11ea-984c-9fbdb69ae82a.png)

![Peek 2020-08-18 18-52](https://user-images.githubusercontent.com/13292481/90542183-02600000-e184-11ea-8ac9-08e9333ab186.gif)
