### PR TITLE
Add select to bool type at edit mode

### DIFF
--- a/src/assets/styles/app/vendor/tabulator.scss
+++ b/src/assets/styles/app/vendor/tabulator.scss
@@ -198,9 +198,21 @@ $foreign-key-width:      24px;
 			}
 		}
   }
-  
+
 }
 
+.tabulator-edit-select-list {
+  background: $theme-bg;
+  color: white;
+  border-width: 1;
+  border-color: rgba($theme-base, 0.06);
+  border-radius: 2px;
+  margin-top: $gutter-h;
+
+	.tabulator-edit-select-list-item{
+    color: $text-dark;
+	}
+}
 
 .tabulator-footer {
   display: flex;

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -184,9 +184,10 @@ export default {
         // currently it doesn't fetch the right result if you update the PK
         // because it uses the PK to fetch the result.
         const editable = this.editable && column.columnName !== this.primaryKey
-        const useTextarea = column.dataType === 'text'
-        const editorType = useTextarea ? 'textarea' : 'input'
         const slimDataType = this.slimDataType(column.dataType)
+        const editorType = this.editorType(column.dataType)
+        const useVerticalNavigation = editorType === 'textarea'
+
         const formatter = () => {
           return `<span class="tabletable-title">${column.columnName} <span class="badge">${slimDataType}</span></span>`
         }
@@ -210,8 +211,12 @@ export default {
           cellEditCancelled: cell => cell.getRow().normalizeHeight(),
           formatter: (cell) => _.isNil(cell.getValue()) ? '(NULL)' : cell.getValue(),
           editorParams: {
-            verticalNavigation: useTextarea ? 'editor' : undefined,
+            verticalNavigation: useVerticalNavigation ? 'editor' : undefined,
             search: true,
+            ...(column.dataType === 'bool'
+              ? { values: ['true', 'false'] }
+              : {}
+            )
             // elementAttributes: {
             //   maxLength: column.columnLength // TODO
             // }
@@ -317,6 +322,13 @@ export default {
         return dt.split("(")[0]
       }
       return null
+    },
+    editorType(dt) {
+      switch (dt) {
+        case 'text': return 'textarea'
+        case 'bool': return 'select'
+        default: return 'input'
+      }
     },
     fkClick(e, cell) {
       log.info('fk-click', cell)


### PR DESCRIPTION
Before this PR columns with type bool in edit mode used a textfield that was allowing to any value be placed.

With this PR columns with type bool in edit mode will use a select with only `true` and `false` options.

![Peek 19-08-2020 22-14](https://user-images.githubusercontent.com/4943174/90705479-66a8bf80-e269-11ea-961c-7b0a308848cf.gif)
