### PR TITLE
Add double click action to list-item-btn at TableListItem

### DIFF
--- a/src/components/sidebar/core/table_list/TableListItem.vue
+++ b/src/components/sidebar/core/table_list/TableListItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="list-item">
-    <a class="list-item-btn" role="button" v-bind:class="{'active': selected,'open': showColumns }" @mousedown.prevent="toggleColumns">
+    <a class="list-item-btn" role="button" @dblclick="openTable()" v-bind:class="{'active': selected,'open': showColumns }" @mousedown.prevent="toggleColumns">
       <span class="btn-fab open-close" >
         <i class="dropdown-icon material-icons">keyboard_arrow_right</i>
       </span>


### PR DESCRIPTION
As we open a database with double click, I think open a table should be the same.