### PR TITLE
Remove duplicate database.connecting check

### DIFF
--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -164,10 +164,6 @@ export function createConnection(server: IDbConnectionServer, database: IDbConne
 async function connect(server: IDbConnectionServer, database: IDbConnectionDatabase) {
   /* eslint no-param-reassign: 0 */
   if (database.connecting) {
-    throw new Error('There is already a connection in progress for this server. Aborting this new request.');
-  }
-
-  if (database.connecting) {
     throw new Error('There is already a connection in progress for this database. Aborting this new request.');
   }
 


### PR DESCRIPTION
Upstream PR: https://github.com/sqlectron/sqlectron-core/pull/115

This removes a duplicate `database.connecting` check. It was probably supposed to be `server.connecting`, except that is not used anywhere else in the codebase. I suspect it might have been planned to be added in the server tunnel connection code, but given that it's not exactly a race condition anyone is struggling with, can probably get away with just getting rid of the check altogether.