### PR TITLE
Added ability to select all (Cmd/Ctl+A) in the background process

### DIFF
--- a/src/background/NativeMenuActionHandlers.ts
+++ b/src/background/NativeMenuActionHandlers.ts
@@ -37,6 +37,9 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
   paste(_1: Electron.MenuItem, win: Electron.BrowserWindow) {
     win.webContents.paste()
   }
+  selectAll(_1: Electron.MenuItem, win: Electron.BrowserWindow) {
+    win.webContents.selectAll()
+  }
 
   setZoom = async (level: number) => {
     getActiveWindows().forEach(window => {

--- a/src/common/menus/MenuBuilder.ts
+++ b/src/common/menus/MenuBuilder.ts
@@ -64,7 +64,6 @@ export default class extends DefaultMenu {
           this.menuItems.cut,
           this.menuItems.copy,
           this.menuItems.paste,
-          { type: 'separator' },
           this.menuItems.selectAll,
         ]
       },

--- a/src/common/menus/MenuBuilder.ts
+++ b/src/common/menus/MenuBuilder.ts
@@ -64,6 +64,8 @@ export default class extends DefaultMenu {
           this.menuItems.cut,
           this.menuItems.copy,
           this.menuItems.paste,
+          { type: 'separator' },
+          this.menuItems.selectAll,
         ]
       },
       this.viewMenu(),


### PR DESCRIPTION
Thanks so much for making such a beautiful app! I've been using it for the past week and absolutely love it!

One point of friction for me is the inability to select all text from inputs when creating/updating connections. For a bit of context, one of the apps I work in has a local database port that changes from time to time. I'd love to simply paste in the new one without having to backspace every character beforehand.

I noticed that Electron already had `Select All` partially setup. So I simply added in the final steps and updated the native menu to include it under the "Edit" section. Here's a preview of the new functionality:
![select-all-command](https://user-images.githubusercontent.com/3155373/94559978-a29b5100-0227-11eb-97e1-5ff61badcf6a.gif)

If there was a reason for not including it, or if I am not including it incorrectly, please feel free to let me know. I'll be super happy to adjust as needed. Thanks for your time!