### PR TITLE
Filter tables using pipe (|) as an OR clause.

### DIFF
--- a/src/mixins/table_filter.js
+++ b/src/mixins/table_filter.js
@@ -2,10 +2,28 @@ import _ from 'lodash'
 
 export default {
   methods: {
-    filter(tables, filterQuery) {
+    filterSplitOr(tables, filterQuery) {
       if (!filterQuery) {
         return tables
       }
+      const parts = filterQuery.split('|')
+      let tmptables = []
+      parts.forEach(p => {
+        if (p) {
+          tmptables = _.concat(tmptables, this.filter(tables, p))
+        }
+      })
+      return _.uniq(tmptables.sort((a, b) => {
+        if (a.name.toLowerCase() < b.name.toLowerCase()) {
+          return -1
+        } else if (a.name.toLowerCase() < b.name.toLowerCase()) {
+          return 1
+        } else {
+          return 0
+        }
+      }), true)
+    },
+    filter(tables, filterQuery) {
       const startsWithFilter = _(tables)
         .filter((item) => _.startsWith(item.name.toLowerCase(), filterQuery.toLowerCase()))
         .value()
@@ -18,7 +36,7 @@ export default {
   },
   computed: {
     filteredTables() {
-      return this.filter(this.tables, this.filterQuery)
+      return this.filterSplitOr(this.tables, this.filterQuery)
     },
   }
 }


### PR DESCRIPTION
Similar to a feature in HeidiSQL. Adds the ability to use the table filter with an OR type clause using a pipe character as the separator. 

Split terms based on presence of pipe.
Sort results alphabetically, and return unique array.