### PR TITLE
Table view column visibility toggle

### DIFF
--- a/src/assets/styles/app/vendor/xel.scss
+++ b/src/assets/styles/app/vendor/xel.scss
@@ -860,7 +860,8 @@ x-menubar {
  */
 
 x-popover {
-  color: var(--text-color);
+  color: $theme-base !important;
+  background: $theme-bg;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 2px;
   box-shadow: var(--elevation-5);

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -355,7 +355,7 @@ export default {
       height: this.actualTableHeight,
       columns: this.tableColumns,
       nestedFieldSeparator: false,
-      virtualDomHoz: true,
+      virtualDom: true,
       ajaxURL: "http://fake",
       ajaxSorting: true,
       ajaxFiltering: true,

--- a/src/components/tableview/TableTable.vue
+++ b/src/components/tableview/TableTable.vue
@@ -355,7 +355,7 @@ export default {
       height: this.actualTableHeight,
       columns: this.tableColumns,
       nestedFieldSeparator: false,
-      virtualDom: true,
+      virtualDomHoz: true,
       ajaxURL: "http://fake",
       ajaxSorting: true,
       ajaxFiltering: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12354,9 +12354,9 @@ table@^5.2.3:
     string-width "^3.0.0"
 
 tabulator-tables@^4.8.0:
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/tabulator-tables/-/tabulator-tables-4.8.2.tgz#c1246652955ba1e98336e35d83343f7102aa6443"
-  integrity sha512-yTK2gl2dUlJhuIMzBP1tAjF5nmc9KMWSDw6wmMmMHT/ucoHWmIuRYXqqm6wAAq0bC0B1/QDyITEJv4tJ673pMg==
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/tabulator-tables/-/tabulator-tables-4.8.4.tgz#aa3f50001aae3aec86619db8b49ec35a4e5cfb5a"
+  integrity sha512-sSs3GoWPF3/l/8m+WGUbmsLASkLVB3bB7RnW/4/g/zwOQoxM9pWdaeZE+Nk7UJjjb6K9fW3dfIQnozIfNpFATw==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
This PR adds the ability to toggle column visibility on the table view via a popover, implementing the feature requested in #358.

When hiding one or more columns, the button triggering the popover changes its color to `info` in order to signify that not all available columns are being displayed.

FYI: While implementing this, I experienced a weird glitch that resulted in the column data not being reintroduced to the table when re-selecting a hidden column if the table data was re-rendered while that column was hidden, shifting the data and mismatching it to the headers. This issue seems to originate in tabulators virtual dom, since switching the `virtualDomHoz` option to the default `virtualDom` option fixed it. Is there any reason why `virtualDomHoz` was preferred to the default virtual dom method?

![column_toggle](https://user-images.githubusercontent.com/3975210/96386166-30b88680-1199-11eb-8c75-3285d737d32b.gif)