### PR TITLE
fix getPrimaryKey for mysql not quoting table name

### DIFF
--- a/src/lib/db/clients/mysql.js
+++ b/src/lib/db/clients/mysql.js
@@ -182,8 +182,11 @@ export async function getTableReferences(conn, table) {
 
 export async function getPrimaryKey(conn, database, table) {
   logger().debug('finding foreign key for', database, table)
-  const sql = `SHOW KEYS FROM ${table} WHERE Key_name = 'PRIMARY'`
-  const { data } = await driverExecuteQuery(conn, { query: sql })
+  const sql = `SHOW KEYS FROM ?? WHERE Key_name = 'PRIMARY'`
+  const params = [
+    table,
+  ];
+  const { data } = await driverExecuteQuery(conn, { query: sql, params })
   return data[0] ? data[0].Column_name : null
 }
 


### PR DESCRIPTION
Fixes the issue in #136 (not auto-linking it in case you want to leave it open till test suite is in place)

This adjusts the query so that the table name is properly escaped, and so that it will not throw an error when the table name is a mysql keyword.