### PR TITLE
Tab reordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "vue-clipboard2": "^0.3.1",
     "vue-js-modal": "^1.3.33",
     "vue-property-decorator": "^8.4.2",
+    "vuedraggable": "^2.24.2",
     "vuejs-noty": "^0.1.3",
     "vuex": "^3.1.1",
     "vuex-persist": "^2.0.1",

--- a/src/assets/styles/app/core-tabs.scss
+++ b/src/assets/styles/app/core-tabs.scss
@@ -58,13 +58,6 @@
       background: lighten($theme-bg, 3%);
       opacity: 0.5;
     }
-    .sortable-drag {
-      border: none !important;
-      transform: translate(0,0);
-      position: relative;
-      margin: -1px;
-      background-clip: content-box;
-    }
     .nav-item {
       max-width: 200px;    
       min-width: 28px;

--- a/src/assets/styles/app/core-tabs.scss
+++ b/src/assets/styles/app/core-tabs.scss
@@ -54,6 +54,17 @@
       min-width: 28px;
       overflow: hidden;
     }
+    .nav-item-wrap-chosen {
+      background: lighten($theme-bg, 3%);
+      opacity: 0.5;
+    }
+    .sortable-drag {
+      border: none !important;
+      transform: translate(0,0);
+      position: relative;
+      margin: -1px;
+      background-clip: content-box;
+    }
     .nav-item {
       max-width: 200px;    
       min-width: 28px;

--- a/src/components/CoreTabs.vue
+++ b/src/components/CoreTabs.vue
@@ -1,7 +1,7 @@
 <template>
   <div  class="core-tabs" v-hotkey="keymap">
     <div class="tabs-header">
-      <ul class="nav-tabs nav">
+      <Draggable v-model="tabItems" tag="ul" class="nav-tabs nav" chosen-class="nav-item-wrap-chosen">
         <core-tab-header
           v-for="tab in tabItems"
           :key="tab.id"
@@ -14,7 +14,7 @@
           @closeOther="closeOther"
           @duplicate="duplicate"
           ></core-tab-header>
-      </ul>
+      </Draggable>
       <span class="actions">
         <a @click.prevent="createQuery(null)" class="btn-fab add-query"><i class=" material-icons">add_circle</i></a>
       </span>
@@ -45,10 +45,11 @@
   import AppEvent from '../common/AppEvent'
   import platformInfo from '../common/platform_info'
   import { mapGetters, mapState } from 'vuex'
+  import Draggable from 'vuedraggable'
 
   export default {
     props: [ 'connection' ],
-    components: { QueryEditor, CoreTabHeader, TableTable },
+    components: { QueryEditor, CoreTabHeader, TableTable, Draggable },
     data() {
       return {
         tabItems: [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -11742,6 +11742,11 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
+sortablejs@^1.10.1:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.12.0.tgz#ee6d7ece3598c2af0feb1559d98595e5ea37cbd6"
+  integrity sha512-bPn57rCjBRlt2sC24RBsu40wZsmLkSo2XeqG8k6DC1zru5eObQUIPPZAQG7W2SJ8FZQYq+BEJmvuw1Zxb3chqg==
+
 source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -13388,6 +13393,13 @@ vue@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+
+vuedraggable@^2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/vuedraggable/-/vuedraggable-2.24.2.tgz#cd98faec99905238469e9b4d235fba5a59fb7da2"
+  integrity sha512-y1NbVhLFOVHHdJl7qsYOtExiTq4zyxF+PxiF9NC8kHEtI6sAFhUHtHYp+ONa8v4S3bAspzGHOHuOq0pNO4fFtA==
+  dependencies:
+    sortablejs "^1.10.1"
 
 vuejs-noty@^0.1.3:
   version "0.1.3"


### PR DESCRIPTION
This PR adds the ability to reorder tabs by dragging and dropping them, as mentioned in #352, by using the package vue-draggable.

Testing this on Windows 10 using WSL2 and VcXsrv, I noticed a white border around the dragged element, which I found to be impossible to remove. This border exists on all dragged elements, even if using native drag and drop (which vue-draggable relies on anyways), so I'm unsure what the cause or solution to this would be.

Edit: It turned out to be an issue with VcXsrv. There's no border when running it on Windows or Linux natively.
![tab_sort](https://user-images.githubusercontent.com/3975210/97792024-2fe01580-1bd9-11eb-848c-ffaeb23e4497.gif)
