### PR TITLE
Allow Manual update prompt for windows portable

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 import { app, protocol } from 'electron'
 import log from 'electron-log'
 import * as electron from 'electron'
+import { ipcMain } from 'electron'
 import {
   installVueDevtools
 } from 'vue-cli-plugin-electron-builder/lib'
@@ -61,6 +62,11 @@ async function createFirstWindow () {
   buildWindow(settings)
   log.info("managing updates")
   manageUpdates()
+  ipcMain.on('open-externally', (e: electron.IpcMainEvent, args: any[]) => {
+    const url = args[0]
+    if (!url) return
+    electron.shell.openExternal(url)
+  })
 }
 
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,8 @@ import { UserSetting } from './common/appdb/models/user_setting'
 import Connection from './common/appdb/Connection'
 import Migration from './migration/index'
 import { buildWindow } from './background/WindowBuilder'
+
+import AppEvent from './common/AppEvent'
 function initUserDirectory(d: string) {
   if (!fs.existsSync(d)) {
     fs.mkdirSync(d, { recursive: true })
@@ -62,7 +64,7 @@ async function createFirstWindow () {
   buildWindow(settings)
   log.info("managing updates")
   manageUpdates()
-  ipcMain.on('open-externally', (e: electron.IpcMainEvent, args: any[]) => {
+  ipcMain.on(AppEvent.openExternally, (e: electron.IpcMainEvent, args: any[]) => {
     const url = args[0]
     if (!url) return
     electron.shell.openExternal(url)

--- a/src/background/NativeMenuActionHandlers.ts
+++ b/src/background/NativeMenuActionHandlers.ts
@@ -7,7 +7,7 @@ import path from 'path'
 import { SavedConnection } from '../common/appdb/models/saved_connection'
 import { IGroupedUserSettings } from '../common/appdb/models/user_setting'
 import { IMenuActionHandler } from 'common/interfaces/IMenuActionHandler'
-
+import { shell } from 'electron'
 
 type ElectronWindow = Electron.BrowserWindow | undefined
 
@@ -27,7 +27,6 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
     if (win) {
       win.webContents.undo()
     }
-    
   }
   redo(_1: Electron.MenuItem, win: ElectronWindow) {
     if (win) win.webContents.redo()

--- a/src/background/WindowBuilder.ts
+++ b/src/background/WindowBuilder.ts
@@ -5,6 +5,7 @@ import { createProtocol } from "vue-cli-plugin-electron-builder/lib"
 import platformInfo from '../common/platform_info'
 import NativeMenuActionHandlers from './NativeMenuActionHandlers'
 import { IGroupedUserSettings } from '../common/appdb/models/user_setting'
+import AppEvent from 'common/AppEvent'
 
 
 const windows: BeekeeperWindow[] = []

--- a/src/background/update_manager.ts
+++ b/src/background/update_manager.ts
@@ -54,7 +54,8 @@ export function manageUpdates(debug?: boolean) {
   })
 
   autoUpdater.on('update-available', () => {
-    getActiveWindows().forEach(beeWin => beeWin.send('update-available'))
+    const message = platformInfo.isPortable ? 'manual-update' : 'update-available'
+    getActiveWindows().forEach(beeWin => beeWin.send(message))
   })
 
   ipcMain.on('download-update', () => {

--- a/src/common/AppEvent.ts
+++ b/src/common/AppEvent.ts
@@ -5,5 +5,6 @@ export default {
   newTab: 'nt',
   closeTab: 'ct',
   disconnect: 'dc',
-  beekeeperAdded: 'bkadd'
+  beekeeperAdded: 'bkadd',
+  openExternally: 'oe'
 }

--- a/src/common/platform_info.ts
+++ b/src/common/platform_info.ts
@@ -23,6 +23,7 @@ const platformInfo = {
   isWindows, isMac,
   isLinux: !isWindows && !isMac,
   isSnap: p.env.ELECTRON_SNAP,
+  isPortable: isWindows && p.env.PORTABLE_EXECUTABLE_DIR,
   isDevelopment: isDevEnv,
   isAppImage: p.env.DESKTOPINTEGRATION === 'AppImageLauncher',
   sshAuthSock: p.env.SSH_AUTH_SOCK,

--- a/src/components/AutoUpdater.vue
+++ b/src/components/AutoUpdater.vue
@@ -6,6 +6,8 @@
 import { ipcRenderer } from 'electron'
 import Noty from 'noty'
 
+import AppEvent from '../common/AppEvent'
+
 export default {
   data() {
     return {
@@ -64,7 +66,7 @@ export default {
       this.manualNotification.show()
     },
     linkToDownload() {
-      ipcRenderer.send('open-externally', ["https://beekeeperstudio.io/get"])
+      ipcRenderer.send(AppEvent.openExternally, ["https://beekeeperstudio.io/get"])
     },
     triggerInstall() {
       ipcRenderer.send('install-update')

--- a/src/components/AutoUpdater.vue
+++ b/src/components/AutoUpdater.vue
@@ -9,6 +9,18 @@ import Noty from 'noty'
 export default {
   data() {
     return {
+      manualNotification: new Noty({
+        text: "A new version is available. Download from our website now.",
+        layout: 'bottomRight',
+        timeout: false,
+        closeWith: 'button',
+        buttons: [ 
+          Noty.button('Not now', 'btn btn-flat', () => {
+            this.manualNotification.close();
+          }),
+          Noty.button('Download', 'btn btn-primary', this.linkToDownload)
+        ]
+      }),
       downloadNotification: new Noty({
         text: 'A new version is availble. Download now?',
         layout: 'bottomRight',
@@ -38,6 +50,7 @@ export default {
   },
   mounted() {
     ipcRenderer.on('update-available', this.notifyUpdate)
+    ipcRenderer.on('manual-update', this.notifyManual)
     ipcRenderer.on('update-downloaded', this.notifyDownloaded)
     ipcRenderer.send('updater-ready')
   },
@@ -46,6 +59,12 @@ export default {
       ipcRenderer.send('download-update')
       this.downloadNotification.close()
       this.$noty.info("Hold tight! Downloading update...")
+    },
+    notifyManual() {
+      this.manualNotification.show()
+    },
+    linkToDownload() {
+      ipcRenderer.send('open-externally', ["https://beekeeperstudio.io/get"])
     },
     triggerInstall() {
       ipcRenderer.send('install-update')


### PR DESCRIPTION
Currently the windows portable runner auto-updates then installs itself, that's silly.