### PR TITLE
Psql mixed case

### DIFF
--- a/src/lib/db/clients/postgresql.js
+++ b/src/lib/db/clients/postgresql.js
@@ -451,7 +451,7 @@ export async function getTableKeys(conn, database, table, schema) {
 
 export async function getPrimaryKey(conn, database, table, schema) {
   
-  const tablename = escapeString(schema ? `${schema}.${table}` : table)
+  const tablename = escapeString(schema ? `${wrapIdentifier(schema)}.${wrapIdentifier(table)}` : wrapIdentifier(table))
   const query = `
     SELECT a.attname as column_name, format_type(a.atttypid, a.atttypmod) AS data_type
     FROM   pg_index i

--- a/src/lib/db/clients/sqlserver.js
+++ b/src/lib/db/clients/sqlserver.js
@@ -63,7 +63,7 @@ export async function disconnect(conn) {
 }
 
 export async function selectTop(conn, table, offset, limit, orderBy, filters, schema) {
-  let orderByString = ""
+  let orderByString = "ORDER BY (SELECT NULL)"
   let filterString = ""
   if (orderBy && orderBy.length > 0) {
     orderByString = "order by " + (orderBy.map((item) => {

--- a/tests/integration/lib/db/clients/postgres.spec.js
+++ b/tests/integration/lib/db/clients/postgres.spec.js
@@ -7,28 +7,32 @@ describe("Postgres Tests", () => {
   let util
 
   beforeAll(async () => {
-    const timeoutDefault = 5000
-    jest.setTimeout(dbtimeout)
-    // environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up();
-    // container = environment.getContainer("psql_1")
-
-    container = await new GenericContainer("postgres")
-      .withEnv("POSTGRES_PASSWORD", "example")
-      .withEnv("POSTGRES_DB", "banana")
-      .withExposedPorts(5432)
-      .withStartupTimeout(new Duration(dbtimeout, TemporalUnit.MILLISECONDS))
-      .start()
-    jest.setTimeout(timeoutDefault)
-    const config = {
-      client: 'postgresql',
-      host: container.getContainerIpAddress(),
-      port: container.getMappedPort(5432),
-      user: 'postgres',
-      password: 'example'
+    try {
+      const timeoutDefault = 5000
+      jest.setTimeout(dbtimeout)
+      // environment = await new DockerComposeEnvironment(composeFilePath, composeFile).up();
+      // container = environment.getContainer("psql_1")
+  
+      container = await new GenericContainer("postgres")
+        .withEnv("POSTGRES_PASSWORD", "example")
+        .withEnv("POSTGRES_DB", "banana")
+        .withExposedPorts(5432)
+        .withStartupTimeout(new Duration(dbtimeout, TemporalUnit.MILLISECONDS))
+        .start()
+      jest.setTimeout(timeoutDefault)
+      const config = {
+        client: 'postgresql',
+        host: container.getContainerIpAddress(),
+        port: container.getMappedPort(5432),
+        user: 'postgres',
+        password: 'example'
+      }
+      util = new DBTestUtil(config, "banana")
+      await util.setupdb()
+    } catch (ex) {
+      console.log("ERROR")
+      console.log(ex)
     }
-    util = new DBTestUtil(config, "banana")
-    await util.setupdb()
-
   })
 
   afterAll(async() => {

--- a/tests/lib/db.ts
+++ b/tests/lib/db.ts
@@ -95,6 +95,9 @@ export class DBTestUtil {
     expect(await this.connection.getPrimaryKey("group", this.defaultSchema))
       .toBe("id");
     
+    expect(await this.connection.getPrimaryKey("MixedCase", this.defaultSchema))
+      .toBe("id");
+    
     const stR = await this.connection.selectTop("group", 0, 10, ["select"], null, this.defaultSchema)
     expect(stR)
       .toMatchObject({ result: [], totalRecords: 0 })
@@ -119,7 +122,7 @@ export class DBTestUtil {
 
     r = await this.connection.selectTop("MixedCase", 0, 1, [], null, this.defaultSchema)
     result = r.result.map((r: any) => r.bananas)
-    expect(result).toBe(["pears"])
+    expect(result).toMatchObject(["pears"])
 
     console.log("pk tests")
     // primary key tests
@@ -149,6 +152,7 @@ export class DBTestUtil {
       table.string("country").notNullable()
     })
 
+    // create with mixed case
     await this.knex.raw('create table "MixedCase"(id SERIAL primary key, bananas varchar(255))')
 
     await this.knex.schema.createTable('group', (table) => {

--- a/tests/lib/db.ts
+++ b/tests/lib/db.ts
@@ -152,8 +152,10 @@ export class DBTestUtil {
       table.string("country").notNullable()
     })
 
-    // create with mixed case
-    await this.knex.raw('create table "MixedCase"(id SERIAL primary key, bananas varchar(255))')
+    await this.knex.schema.createTable('MixedCase', (table) => {
+      table.increments().primary()
+      table.string("bananas")
+    })
 
     await this.knex.schema.createTable('group', (table) => {
       table.increments().primary()


### PR DESCRIPTION
Fixes #452 

I changed how I fetch primary keys and that caused a problem in that a string of an identifier still needs internal quoting.