### PR TITLE
Connection write mode option

### DIFF
--- a/src/assets/styles/app/connection-interface.scss
+++ b/src/assets/styles/app/connection-interface.scss
@@ -26,7 +26,7 @@
     background: $theme-bg;
     margin: $gutter-w 0;
   }
-  .sqlite-form {
+  .write-mode-form {
     margin-bottom: $gutter-h;
   }
   .text-connect {

--- a/src/common/appdb/models/saved_connection.ts
+++ b/src/common/appdb/models/saved_connection.ts
@@ -211,6 +211,13 @@ export class SavedConnection extends DbConnectionBase {
     }
   }
 
+  @Column({
+    type: 'varchar',
+    nullable: false,
+    default: null
+  })
+  writeMode: string = 'enabled'
+
   get sshMode() {
     return this._sshMode
   }

--- a/src/components/ConnectionInterface.vue
+++ b/src/components/ConnectionInterface.vue
@@ -36,7 +36,15 @@
                 <postgres-form v-if="config.connectionType === 'redshift'" :config="config" :testing="testing"></postgres-form>
                 <sqlite-form v-if="config.connectionType === 'sqlite'" :config="config" :testing="testing"></sqlite-form>
                 <sql-server-form v-if="config.connectionType === 'sqlserver'" :config="config" :testing="testing"></sql-server-form>
-
+                <!-- WRITE MODE -->
+                <div class="form-group write-mode-form">
+                  <label for="writeMode">Write Mode</label>
+                  <select name="writeMode" class="form-control custom-select" v-model="config.writeMode" id="write-mode-select">
+                    <option value="enabled">Enabled</option>
+                    <option value="confirm">Confirm</option>
+                    <option value="readonly">Read Only</option>
+                  </select>
+                </div>
                 <!-- TEST AND CONNECT -->
                 <div class="test-connect row flex-middle">
                   <span class="expand"></span>

--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -536,7 +536,7 @@
         this.editor.execCommand('toggleComment')
       },
       containsWriteVerbs(query) {
-        return _.findIndex(writeVerbs, v => query.indexOf(v + ' ') > -1) > -1
+        return _.findIndex(writeVerbs, v => query.toLowerCase().indexOf(v + ' ') > -1) > -1
       }
     },
     mounted() {

--- a/src/lib/connection-provider.ts
+++ b/src/lib/connection-provider.ts
@@ -32,6 +32,7 @@ export default {
       sslCertFile: config.sslCertFile,
       sslKeyFile: config.sslKeyFile,
       sslRejectUnauthorized: config.sslRejectUnauthorized,
+      writeMode: config.writeMode
     }
   },
 

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -188,6 +188,7 @@ export interface IDbConnectionServerConfig {
   ssl: boolean
   localHost?: string,
   localPort?: number,
+  writeMode: string
 }
 
 export interface IDbSshTunnel {

--- a/src/migration/20210130-add-writemode-column-to-saved-connection-table.js
+++ b/src/migration/20210130-add-writemode-column-to-saved-connection-table.js
@@ -1,0 +1,6 @@
+export default {
+    name: '20210130-add-writemode-column-to-saved-connection-table',
+    async run(runner) {
+      await runner.query('ALTER TABLE saved_connection ADD COLUMN writeMode varchar default "enabled"')
+    }
+  }


### PR DESCRIPTION
This PR adds a new option to connections: **write mode**, It can have one of three values:

- Enabled (default): Current behavior, full write access.
- Confirm: All queries that change data or structure have to be confirmed.
- Read-only: Queries that change data or structure are not allowed.

![connection_writemode](https://user-images.githubusercontent.com/3975210/106370932-4aa06280-635f-11eb-896f-9f8a5f08ae83.gif)
