### PR TITLE
FIX: Copied cell values have a new line separator

### DIFF
--- a/src/components/editor/ResultTable.vue
+++ b/src/components/editor/ResultTable.vue
@@ -101,7 +101,7 @@
     },
     methods: {
       cellClick(e, cell) {
-        this.selectChildren(cell.getElement())
+        this.selectChildren(cell.getElement().querySelector('pre'))
       },
       download(format) {
         const dateString = dateFormat(new Date(), 'yyyy-mm-dd_hMMss')


### PR DESCRIPTION
When copying a value of the column from the results table it adds a new line separator to the data and it's very annoying when you need to copy the column value and paste it to the string constant for example.

Here is a live example:
![before](https://user-images.githubusercontent.com/6809545/111855338-04ae5680-892d-11eb-9750-21354ab1d91f.gif)

After reviewing I found that it passes table cell which contains ```pre``` tag with basically column data and also ```div``` elements related to column resizer. And in a result Selection class selects all those unneeded elements.

Here is how it works now for result-table cells:
![after](https://user-images.githubusercontent.com/6809545/111855458-c9f8ee00-892d-11eb-99e3-0c30650bbd0d.gif)

