### PR TITLE
Update reference to sqlectron in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,4 @@ Post Release:
 
 ## Big Thanks
 
-Beekeeper Studio wouldn't exist without [Sqlectron-core](https://github.com/sqlectron/sqlectron-core), the core database libraries from the (now unmaintained) Sqlectron project. Beekeeper Studio started as an experimental fork of that repository. A big thanks to @maxcnunes and the rest of the Sqlectron community.
-
-
+Beekeeper Studio wouldn't exist without [Sqlectron-core](https://github.com/sqlectron/sqlectron-core), the core database libraries from the [Sqlectron project](https://github.com/sqlectron/sqlectron-gui). Beekeeper Studio started as an experimental fork of that repository. A big thanks to @maxcnunes and the rest of the Sqlectron community.


### PR DESCRIPTION
Project isn't unmaintained, adds a link to the principal repo.