### PR TITLE
Fixup: log variable not required

### DIFF
--- a/src/components/sidebar/core/table_list/TableListItem.vue
+++ b/src/components/sidebar/core/table_list/TableListItem.vue
@@ -54,9 +54,7 @@
 
   import { mapGetters, mapState } from 'vuex'
   import _ from 'lodash'
-  import rawLog from 'electron-log'
 
-  const log = rawLog.scope('TableListItem')
 	export default {
 		props: ["connection", "table", "noSelect", "forceExpand", "forceCollapse", "container"],
     mounted() {


### PR DESCRIPTION
The use of this variable was resulting in an error message at build-time:

```
 ERROR  Failed to compile with 1 error                                                                                                                                     14:44:51

 error  in ./src/components/sidebar/core/table_list/TableListItem.vue

Module Error (from ./node_modules/eslint-loader/index.js):
error: 'log' is assigned a value but never used (no-unused-vars) at src/components/sidebar/core/table_list/TableListItem.vue:59:9:
```