### PR TITLE
Fix swapped tooltips in global sidebar

### DIFF
--- a/src/components/sidebar/GlobalSidebar.vue
+++ b/src/components/sidebar/GlobalSidebar.vue
@@ -14,7 +14,7 @@
         @click.prevent="click('queries')"
         class="nav-item"
         :class="{ active: activeItem === 'queries'}"
-        title="Run History"
+        title="Saved Queries"
       >
         <span class="material-icons">star</span>
       </a>
@@ -23,7 +23,7 @@
         @click.prevent="click('history')"
         class="nav-item"
         :class="{ active: activeItem === 'history'}"
-        title="Saved Queries"
+        title="Run History"
       >
         <span class="material-icons">history</span>
       </a>


### PR DESCRIPTION
"Saved Queries" and "Run History" are the wrong way around.

<img width="236" alt="Screen Shot 2021-06-17 at 11 04 32 PM" src="https://user-images.githubusercontent.com/4956308/122514568-fd94f400-cfc0-11eb-9091-5959f1d2e5f1.png">
