### PR TITLE
Clarified When Results are Truncated

### DIFF
--- a/src/components/TabQueryEditor.vue
+++ b/src/components/TabQueryEditor.vue
@@ -431,7 +431,7 @@
             if (result.rowCount > this.$config.maxResults) {
               result.rows = _.take(result.rows, this.$config.maxResults)
               result.truncated = true
-              result.truncatedRowCount = this.$config.maxResults
+              result.totalRowCount = result.rowCount
             }
           })
           this.results = Object.freeze(results);

--- a/src/components/editor/QueryEditorStatusBar.vue
+++ b/src/components/editor/QueryEditorStatusBar.vue
@@ -8,10 +8,10 @@
         </select>
       </div>
       </span>
-      <div class="statusbar-item row-counts row flex-middle" v-if="rowCount > 0" :title="rowCount + ' ' + 'Total Records'">
+      <div class="statusbar-item row-counts row flex-middle" v-if="rowCount > 0" :title="`${rowCount} Records${result.truncated ? ' (Truncated)' : ''}`">
         <i class="material-icons">list_alt</i>
         <span class="num-rows">{{rowCount}}</span>
-        <span class="truncated-rows" v-if="result && result.truncated">/&nbsp;{{result.truncatedRowCount}}</span>
+        <span class="truncated-rows" v-if="result && result.truncated">/&nbsp;{{result.totalRowCount}}</span>
       </div>
       <div class="statusbar-item affected-rows" v-if="affectedRowsText " :title="affectedRowsText + ' ' + 'Rows Affected'">
         <i class="material-icons">clear_all</i>


### PR DESCRIPTION
Close #693 

When results are truncated, the result count now shows as "${truncated row count} / ${total row count}" and the tooltip message shows that the results were truncated.

When not truncated:
<img width="192" alt="Screen Shot 2021-06-18 at 10 39 47 PM" src="https://user-images.githubusercontent.com/25781337/122629949-1d422000-d086-11eb-9288-4fb77242ae68.png">

When truncated:
<img width="280" alt="Screen Shot 2021-06-18 at 10 31 20 PM" src="https://user-images.githubusercontent.com/25781337/122629932-fbe13400-d085-11eb-9ce9-93b61226cc84.png">