### PR TITLE
Don't eagerly load table sizes on tabletable views

### DIFF
--- a/apps/sqltools/src/assets/styles/app/_layout.scss
+++ b/apps/sqltools/src/assets/styles/app/_layout.scss
@@ -423,7 +423,7 @@ input[type="checkbox"] {
   &:active,
   &:checked,
   &:checked:active {
-    background: $theme-base);
+    background: $theme-base;
     color: $theme-bg;
     box-shadow: none;
   }

--- a/apps/sqltools/src/assets/styles/app/_layout.scss
+++ b/apps/sqltools/src/assets/styles/app/_layout.scss
@@ -603,7 +603,7 @@ input[type=file] {
   }
   &.gutter-horizontal {
     width: 0!important;
-    cursor: e-resize;
+    cursor: ew-resize;
     &:after {
       height: 100%;
       width: 8px;
@@ -611,7 +611,7 @@ input[type=file] {
     }
   }
   &.gutter-vertical {
-    cursor: n-resize;
+    cursor: ns-resize;
     height: 0!important;
     &:after {
       height: 8px;

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -173,6 +173,11 @@ $cell-padding:           $gutter-w;
       pre, input:not([type="checkbox"]) {
         line-height: $row-height;
       }
+      input:not([type="checkbox"]) {
+        &.nullible-input {
+          padding-right: 18px!important;
+        }
+      }
       .tabulator-bks-checkbox {
         padding: 0!important;
       }

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -127,6 +127,18 @@ $cell-padding:           $gutter-w;
       border-color: transparent;
       padding: 4px 6px!important;
       line-height: $row-height - 8px; // row-height - vertical padding
+      z-index: 10;
+      box-shadow: inset 1px solid $theme-base;
+      height: auto!important;
+      &:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        bottom: 0;
+        background: $query-editor-bg;
+      }
     }
     &.active-cell {
       background: $selection;
@@ -149,10 +161,12 @@ $cell-padding:           $gutter-w;
       min-height: $row-height;
       line-height: $row-height + 2px;
       border-radius: $cell-radius;
+      overflow-y: visible;
+      height: auto!important;
       &:focus {
         box-shadow: inset 0 -1px $theme-base!important;
       }
-      pre, input:not([type="checkbox"]), {
+      pre, input:not([type="checkbox"]), textarea {
         padding: 0 $cell-padding!important;
       }
       .tabulator-bks-checkbox {

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -522,9 +522,13 @@ $cell-padding:           $gutter-w;
   input[type="number"] {
     font-weight: bold;
     color: $statusbar-text!important;
+    border-color: rgba($statusbar-text, 0.2);
     padding: 0 ($gutter-h * 1.5);
     width: 60px;
     text-align: center;
+    &:hover, &:focus {
+      border-color: rgba($statusbar-text, 0.25);
+    }
   }
 }
 

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -246,12 +246,9 @@ $cell-padding:           $gutter-w;
 .tabulator-row {
   .tabulator-cell {
     cursor: pointer;
-    &:hover {
+    &:hover, &.editable:hover {
       background: rgba($theme-base,0.08);
     }
-    &.editable:hover {
-      background: rgba($theme-base,0.08);
-    } 
     &.primary-key {
       cursor: default;
       opacity: 0.5;

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -143,7 +143,7 @@ $cell-padding:           $gutter-w;
     }
     &.tabulator-editing {
       box-shadow: inset 0 -1px $theme-base!important;
-      // background: rgba($theme-base, 0.08);
+      background: rgba($theme-base, 0.08);
       padding-left: 0;
       padding-right: 0;
       min-height: $row-height;
@@ -518,6 +518,12 @@ $cell-padding:           $gutter-w;
   a {
     display: inline-flex;
     align-items: center;
+    .material-icons {
+      color: rgba($statusbar-text, 0.68);
+      &:hover {
+        color: $statusbar-text;
+      }
+    }
   }
   input[type="number"] {
     font-weight: bold;

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -42,7 +42,7 @@ $cell-padding:           $gutter-w;
       .tabulator-cell {
         &.primary-key {
           &:hover {
-            background: rgba($theme-base,0.08);
+            background: rgba($theme-base,0.05);
             cursor: pointer;
           }
         }
@@ -63,7 +63,7 @@ $cell-padding:           $gutter-w;
       box-shadow: inset 0 -1px rgba($theme-base, .1);
       .tabulator-cell {
         &:hover {
-          background: rgba($theme-base, 0.08);
+          background: rgba($theme-base, 0.05);
         }
         &.foreign-key-button {
           &:hover {
@@ -159,7 +159,7 @@ $cell-padding:           $gutter-w;
       padding-left: 0;
       padding-right: 0;
       min-height: $row-height;
-      line-height: $row-height + 2px;
+      line-height: $row-height;
       border-radius: $cell-radius;
       overflow-y: visible;
       height: auto!important;
@@ -168,6 +168,10 @@ $cell-padding:           $gutter-w;
       }
       pre, input:not([type="checkbox"]), textarea {
         padding: 0 $cell-padding!important;
+        min-height: $row-height;
+      }
+      pre, input:not([type="checkbox"]) {
+        line-height: $row-height;
       }
       .tabulator-bks-checkbox {
         padding: 0!important;
@@ -247,7 +251,7 @@ $cell-padding:           $gutter-w;
   .tabulator-cell {
     cursor: pointer;
     &:hover, &.editable:hover {
-      background: rgba($theme-base,0.08);
+      background: rgba($theme-base,0.05);
     }
     &.primary-key {
       cursor: default;
@@ -572,5 +576,22 @@ $cell-padding:           $gutter-w;
 
   .tabulator-menu-separator {
     border-top-color: rgba($theme-base, 0.07);
+  }
+}
+
+
+// Tabulator Edit Select
+.tabulator-edit-select-list {
+  &:empty {
+    display: none;
+  }
+  .tabulator-edit-select-list-item {
+    &:hover {
+      background: rgba($theme-base, 0.05);
+    }
+    &.active, &.active:hover {
+      background: $brand-info;
+      color: white;
+    }
   }
 }

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -525,10 +525,6 @@ $cell-padding:           $gutter-w;
     padding: 0 ($gutter-h * 1.5);
     width: 60px;
     text-align: center;
-    &:hover, &:focus {
-      background: rgba(0,0,0,0.1);
-      min-width: auto;
-    }
   }
 }
 

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -408,6 +408,7 @@ $cell-padding:           $gutter-w;
 			&.tabulator-loading{
 				border: 0;
 				color: $text-dark;
+        background-color: black;
 			}
 
 			//error message

--- a/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/sqltools/src/assets/styles/app/vendor/tabulator.scss
@@ -29,7 +29,10 @@ $cell-padding:           $gutter-w;
 
 // Add/Delete/Clone row
 // -------------------------------
+
+
 .tabulator-table {
+
   .tabulator-row {
     &.inserted, 
     &.inserted:hover {
@@ -431,7 +434,7 @@ $cell-padding:           $gutter-w;
 }
 
 .tabulator-footer {
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: flex-end;
   border: 0;
@@ -503,6 +506,28 @@ $cell-padding:           $gutter-w;
     }
     &[data-page="last"]:before {
       content: '\e5dd';
+    }
+  }
+}
+
+// New Pagination
+.tabulator-paginator > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  a {
+    display: inline-flex;
+    align-items: center;
+  }
+  input[type="number"] {
+    font-weight: bold;
+    color: $statusbar-text!important;
+    padding: 0 ($gutter-h * 1.5);
+    width: 60px;
+    text-align: center;
+    &:hover, &:focus {
+      background: rgba(0,0,0,0.1);
+      min-width: auto;
     }
   }
 }

--- a/apps/sqltools/src/assets/styles/themes/light/theme.scss
+++ b/apps/sqltools/src/assets/styles/themes/light/theme.scss
@@ -162,6 +162,20 @@ select {
 
 // Tabulator
 .tabulator-table {
+
+	.tabulator-loader {
+		.tabulator-loader-msg{
+			//loading message
+			&.tabulator-loading{
+        background-color: white;
+			}
+		}
+  }
+
+}
+
+
+
   .tabulator-row {
     &.inserted, 
     &.inserted:hover {

--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -50,13 +50,11 @@ export default {
       this.url = query.url || null
     }
 
-    console.log("received query", query)
 
     this.$nextTick(() => {
       ipcRenderer.send('ready')
     })
     if (this.themeValue) {
-      console.log("setting background to ", this.themeValue)
       document.body.className = `theme-${this.themeValue}`
     }
 
@@ -73,7 +71,7 @@ export default {
   },
   methods: {
     databaseSelected(db) {
-      console.log("Do something here! (Db selected) " + db)
+      // TODO: do something here if needed
     },
   }
 }

--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -605,7 +605,7 @@ input[type=file] {
   }
   &.gutter-horizontal {
     width: 0!important;
-    cursor: e-resize;
+    cursor: ew-resize;
     &:after {
       height: 100%;
       width: 5px;
@@ -613,7 +613,7 @@ input[type=file] {
     }
   }
   &.gutter-vertical {
-    cursor: n-resize;
+    cursor: ns-resize;
     height: 0!important;
     &:after {
       height: 8px;

--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -368,7 +368,17 @@ select {
   background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8' fill='rgba(255,255,255, 0.87)'><polygon points='0,0 8,0 4,4'/></svg>") no-repeat scroll 98% 60% transparent !important;
   padding: 0 0.75rem;
   option {
-    background: lighten($theme-bg, 2%);
+    background: lighten($theme-bg, 3%);
+    color: $text;
+    &:checked, 
+    &:hover {
+      color: white;
+      box-shadow: 0 0 10px 100px $brand-info inset;
+    }
+    &:disabled, &:disabled:hover, &:disabled:focus {
+      background: transparent!important;
+      color: $text-lighter!important;
+    }
   }
 }
 .select-wrap {

--- a/apps/studio/src/assets/styles/app/_variables.scss
+++ b/apps/studio/src/assets/styles/app/_variables.scss
@@ -74,4 +74,4 @@ $tab-height:                2.4rem;
 $tab-padding-w:             1rem;
 
 // Statusbar
-$statusbar-height:          2.8rem;
+$statusbar-height:          2.6rem;

--- a/apps/studio/src/assets/styles/app/connection-labels.scss
+++ b/apps/studio/src/assets/styles/app/connection-labels.scss
@@ -33,13 +33,6 @@ $color-defaults: (
       background-color: rgba(nth($val, 1), 1);
     }
   }
-  &.tabulator-footer {
-    @each $key, $val in $color-defaults {
-      &.#{$key} {
-        background-color: rgba(nth($val, 1), 0.85);
-      }
-    }
-  }
   &.query-meta {
     @each $key, $val in $color-defaults {
       &.#{$key} {
@@ -51,6 +44,15 @@ $color-defaults: (
     @each $key, $val in $color-defaults {
       &.#{$key} {
         background-color: rgba(nth($val, 1), 0.8);
+      }
+    }
+  }
+}
+.core-tabs {
+  .statusbar {
+    @each $key, $val in $color-defaults {
+      &.#{$key} {
+        background-color: rgba(nth($val, 1), 0.85);
       }
     }
   }

--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -220,6 +220,7 @@
     padding: $gutter-h;
     margin-left: -($gutter-h * 0.5);
     margin-right: -($gutter-h * 0.5);
+    flex-wrap: nowrap;
     > * {
       display: inline-flex;
       padding-left: ($gutter-h * 0.5);

--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -1,4 +1,4 @@
-$button-height:     $statusbar-height * 0.65;
+$button-height:     $statusbar-height * 0.75;
 
 .statusbar {
   display: flex;
@@ -103,7 +103,7 @@ $button-height:     $statusbar-height * 0.65;
     height: $button-height;
     line-height: $button-height;
     margin: 0 0.15rem;
-    margin-top: -1px;
+    // margin-top: -1px;
     &:hover[expanded] {
       background: rgba($statusbar-text, 0.15);
     }

--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -3,6 +3,7 @@ $button-height:     $statusbar-height * 0.65;
 .statusbar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   background: $statusbar-bg;
   color: rgba($statusbar-text, 0.87);
   min-height: $statusbar-height;
@@ -73,7 +74,7 @@ $button-height:     $statusbar-height * 0.65;
       color: $statusbar-text;
       height: $button-height;
       line-height: $button-height;
-      min-width: 0;
+      min-width: min-content;
       margin: 0 0.15rem;
       margin-top: -1px;
       padding: 0 0.35rem;
@@ -96,7 +97,7 @@ $button-height:     $statusbar-height * 0.65;
   // ----------------------
   .btn {
     padding: 0 0.6rem;
-    min-width: auto;
+    min-width: min-content;
     background: transparent;
     color: $statusbar-text;
     height: $button-height;

--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -11,6 +11,15 @@ $button-height:     $statusbar-height * 0.65;
   font-size: 0.8rem;
   padding: 0 $gutter-h;
   overflow: hidden;
+
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+      /* display: none; <- Crashes Chrome on hover */
+      -webkit-appearance: none;
+      margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+  }
+
+
   > .col {
     display: flex;
     align-items: center;

--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -103,7 +103,7 @@ $button-height:     $statusbar-height * 0.75;
     height: $button-height;
     line-height: $button-height;
     margin: 0 0.15rem;
-    // margin-top: -1px;
+    margin-top: -1px;
     &:hover[expanded] {
       background: rgba($statusbar-text, 0.15);
     }

--- a/apps/studio/src/assets/styles/app/tabs/table-builder.scss
+++ b/apps/studio/src/assets/styles/app/tabs/table-builder.scss
@@ -95,7 +95,8 @@
         font-size: $cell-font-size;
         pre, input:not([type="checkbox"]) {
           font-size: $cell-font-size;
-          line-height: $row-height + 2px;
+          line-height: $row-height;
+          min-height: $row-height;
         }
         &[type="search"] {
           line-height: $row-height;

--- a/apps/studio/src/assets/styles/app/tabs/table-properties.scss
+++ b/apps/studio/src/assets/styles/app/tabs/table-properties.scss
@@ -272,7 +272,8 @@ $cell-success:           $row-add;
         font-size: $cell-font-size;
         pre, input:not([type="checkbox"]) {
           font-size: $cell-font-size;
-          line-height: $row-height + 2px;
+          line-height: $row-height;
+          min-height: $row-height;
         }
         input {
           border: 0;

--- a/apps/studio/src/assets/styles/app/tabs/table-properties.scss
+++ b/apps/studio/src/assets/styles/app/tabs/table-properties.scss
@@ -401,10 +401,6 @@ $cell-success:           $row-add;
       }
       &.inserted, &.deleted {
         .tabulator-cell {
-          // &.edited {
-          //   background: transparent;
-          //   box-shadow: none;
-          // }
           cursor: pointer;
           &.edited {
             background: rgba($theme-base, 0.05);

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -173,6 +173,11 @@ $cell-padding:           $gutter-w;
       pre, input:not([type="checkbox"]) {
         line-height: $row-height;
       }
+      input:not([type="checkbox"]) {
+        &.nullible-input {
+          padding-right: 18px!important;
+        }
+      }
       .tabulator-bks-checkbox {
         padding: 0!important;
       }

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -29,7 +29,10 @@ $cell-padding:           $gutter-w;
 
 // Add/Delete/Clone row
 // -------------------------------
+
+
 .tabulator-table {
+
   .tabulator-row {
     &.inserted, 
     &.inserted:hover {
@@ -431,7 +434,7 @@ $cell-padding:           $gutter-w;
 }
 
 .tabulator-footer {
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: flex-end;
   border: 0;

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -143,7 +143,7 @@ $cell-padding:           $gutter-w;
     }
     &.tabulator-editing {
       box-shadow: inset 0 -1px $theme-base!important;
-      // background: rgba($theme-base, 0.08);
+      background: rgba($theme-base, 0.08);
       padding-left: 0;
       padding-right: 0;
       min-height: $row-height;

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -518,6 +518,12 @@ $cell-padding:           $gutter-w;
   a {
     display: inline-flex;
     align-items: center;
+    .material-icons {
+      color: rgba($statusbar-text, 0.68);
+      &:hover {
+        color: $statusbar-text;
+      }
+    }
   }
   input[type="number"] {
     font-weight: bold;

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -127,6 +127,18 @@ $cell-padding:           $gutter-w;
       border-color: transparent;
       padding: 4px 6px!important;
       line-height: $row-height - 8px; // row-height - vertical padding
+      z-index: 10;
+      box-shadow: inset 1px solid $theme-base;
+      height: auto!important;
+      &:before {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: 0;
+        left: 0;
+        bottom: 0;
+        background: $query-editor-bg;
+      }
     }
     &.active-cell {
       background: $selection;
@@ -149,10 +161,12 @@ $cell-padding:           $gutter-w;
       min-height: $row-height;
       line-height: $row-height + 2px;
       border-radius: $cell-radius;
+      overflow-y: visible;
+      height: auto!important;
       &:focus {
         box-shadow: inset 0 -1px $theme-base!important;
       }
-      pre, input:not([type="checkbox"]), {
+      pre, input:not([type="checkbox"]), textarea {
         padding: 0 $cell-padding!important;
       }
       .tabulator-bks-checkbox {

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -510,6 +510,28 @@ $cell-padding:           $gutter-w;
   }
 }
 
+// New Pagination
+.tabulator-paginator > div {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  a {
+    display: inline-flex;
+    align-items: center;
+  }
+  input[type="number"] {
+    font-weight: bold;
+    color: $statusbar-text!important;
+    padding: 0 ($gutter-h * 1.5);
+    width: 60px;
+    text-align: center;
+    &:hover, &:focus {
+      background: rgba(0,0,0,0.1);
+      min-width: auto;
+    }
+  }
+}
+
 .tabulator-menu {
   background: lighten($theme-bg, 5%);
   border: none;

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -522,9 +522,13 @@ $cell-padding:           $gutter-w;
   input[type="number"] {
     font-weight: bold;
     color: $statusbar-text!important;
+    border-color: rgba($statusbar-text, 0.2);
     padding: 0 ($gutter-h * 1.5);
     width: 60px;
     text-align: center;
+    &:hover, &:focus {
+      border-color: rgba($statusbar-text, 0.25);
+    }
   }
 }
 

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -42,7 +42,7 @@ $cell-padding:           $gutter-w;
       .tabulator-cell {
         &.primary-key {
           &:hover {
-            background: rgba($theme-base,0.08);
+            background: rgba($theme-base,0.05);
             cursor: pointer;
           }
         }
@@ -63,7 +63,7 @@ $cell-padding:           $gutter-w;
       box-shadow: inset 0 -1px rgba($theme-base, .1);
       .tabulator-cell {
         &:hover {
-          background: rgba($theme-base, 0.08);
+          background: rgba($theme-base, 0.05);
         }
         &.foreign-key-button {
           &:hover {
@@ -159,7 +159,7 @@ $cell-padding:           $gutter-w;
       padding-left: 0;
       padding-right: 0;
       min-height: $row-height;
-      line-height: $row-height + 2px;
+      line-height: $row-height;
       border-radius: $cell-radius;
       overflow-y: visible;
       height: auto!important;
@@ -168,6 +168,10 @@ $cell-padding:           $gutter-w;
       }
       pre, input:not([type="checkbox"]), textarea {
         padding: 0 $cell-padding!important;
+        min-height: $row-height;
+      }
+      pre, input:not([type="checkbox"]) {
+        line-height: $row-height;
       }
       .tabulator-bks-checkbox {
         padding: 0!important;
@@ -246,12 +250,9 @@ $cell-padding:           $gutter-w;
 .tabulator-row {
   .tabulator-cell {
     cursor: pointer;
-    &:hover {
-      background: rgba($theme-base,0.08);
+    &:hover, &.editable:hover {
+      background: rgba($theme-base,0.05);
     }
-    &.editable:hover {
-      background: rgba($theme-base,0.08);
-    } 
     &.primary-key {
       cursor: default;
       opacity: 0.5;
@@ -575,5 +576,22 @@ $cell-padding:           $gutter-w;
 
   .tabulator-menu-separator {
     border-top-color: rgba($theme-base, 0.07);
+  }
+}
+
+
+// Tabulator Edit Select
+.tabulator-edit-select-list {
+  &:empty {
+    display: none;
+  }
+  .tabulator-edit-select-list-item {
+    &:hover {
+      background: rgba($theme-base, 0.05);
+    }
+    &.active, &.active:hover {
+      background: $brand-info;
+      color: white;
+    }
   }
 }

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -525,10 +525,6 @@ $cell-padding:           $gutter-w;
     padding: 0 ($gutter-h * 1.5);
     width: 60px;
     text-align: center;
-    &:hover, &:focus {
-      background: rgba(0,0,0,0.1);
-      min-width: auto;
-    }
   }
 }
 

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -408,6 +408,7 @@ $cell-padding:           $gutter-w;
 			&.tabulator-loading{
 				border: 0;
 				color: $text-dark;
+        background-color: black;
 			}
 
 			//error message

--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -92,7 +92,10 @@
       }
       a {
         .material-icons {
-          color: $statusbar-text-default;
+          color: rgba($statusbar-text-default, 0.68);
+          &:hover {
+            color: $statusbar-text-default;
+          }
         }
       }
     }

--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -80,5 +80,21 @@
         }
       }
     }
+    
+    // New Pagination
+    .tabulator-paginator > div {
+      input[type="number"] {
+        color: $statusbar-text-default!important;
+        border-color: rgba($statusbar-text-default, 0.2);
+        &:hover, &:focus {
+          border-color: rgba($statusbar-text-default, 0.25);
+        }
+      }
+      a {
+        .material-icons {
+          color: $statusbar-text-default;
+        }
+      }
+    }
   }
 }

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -346,10 +346,6 @@ select {
       color: $text-dark;
       &.tabulator-editing {
         box-shadow: inset 0 1px $theme-base;
-        // input:not([type="checkbox"]) {
-        //   background: rgba($theme-base, 0.08);
-        //   box-shadow: inset 0 -1px $theme-base!important;
-        // }
       }
       &.no-edit-highlight {
         &.tabulator-editing {
@@ -438,7 +434,7 @@ select {
     .tabulator-cell {
       &.read-only {
         &:hover {
-          background: rgba($theme-base, 0.08)!important;
+          background: rgba($theme-base, 0.05)!important;
         }
       }
       &.tabulator-editing {

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -259,6 +259,16 @@ select {
   }
 }
 .tabulator {
+
+  .tabulator-loader {
+    .tabulator-loader-msg {
+      &.tabulator-loading {
+        background-color: white;
+      }
+      
+    }
+  }
+
   .tabulator-header {
     .tabulator-col {
       &.foreign-key {

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -346,10 +346,10 @@ select {
       color: $text-dark;
       &.tabulator-editing {
         box-shadow: inset 0 1px $theme-base;
-        input:not([type="checkbox"]) {
-          background: rgba($theme-base, 0.08);
-          box-shadow: inset 0 -1px $theme-base!important;
-        }
+        // input:not([type="checkbox"]) {
+        //   background: rgba($theme-base, 0.08);
+        //   box-shadow: inset 0 -1px $theme-base!important;
+        // }
       }
       &.no-edit-highlight {
         &.tabulator-editing {

--- a/apps/studio/src/background.ts
+++ b/apps/studio/src/background.ts
@@ -109,7 +109,7 @@ app.on('ready', async () => {
   }
   const slice = platformInfo.isDevelopment ? 2 : 1
   const parsedArgs = yargs(process.argv.slice(slice))
-  console.log("Parsing app args", parsedArgs)
+  log.debug("Parsing app args", parsedArgs)
   const options = parsedArgs._.map((url: string) => ({ url }))
   const settings = await initBasics()
   

--- a/apps/studio/src/common/appdb/Connection.ts
+++ b/apps/studio/src/common/appdb/Connection.ts
@@ -1,4 +1,3 @@
-console.log('db-connection')
 import { createConnection, Connection as TypeORMConnection } from "typeorm"
 import { SavedConnection } from "./models/saved_connection"
 import { UsedConnection } from "./models/used_connection"

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -66,7 +66,6 @@
       this.$store.dispatch('pins/unloadPins')
       this.$root.$off(AppEvent.toggleSidebar, this.toggleSidebar)
       if(this.split) {
-        console.log("destroying split")
         this.split.destroy()
       }
     },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -170,9 +170,7 @@
         this.tabItems.filter(t => t.id === id).forEach(t => t.titleScope = value)
       },
       closeTab(id) {
-        console.log("trying to close tab", id)
         const tab = id ? this.tabItems.find((t) => t.id === id) : this.activeTab
-        console.log('close tab', tab)
         this.close(tab)
       },
       handleCreateTab() {
@@ -272,7 +270,6 @@
 
       },
       close(tab) {
-        console.log('closing tab', tab.title)
         if (this.activeTab === tab) {
           if(tab === this.lastTab) {
             this.previousTab()

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -495,7 +495,7 @@
             CodeMirror.commands.autocomplete(editor, null, { completeSingle: false });
 
           } catch (ex) {
-            console.log('no keyup space autocomplete')
+            // do nothing
           }
         }
       },

--- a/apps/studio/src/components/TabTableBuilder.vue
+++ b/apps/studio/src/components/TabTableBuilder.vue
@@ -116,7 +116,6 @@ export default Vue.extend({
   },
   methods: {
     handleChange(columns: SchemaItem[]) {
-      console.log("handling change")
       this.error = undefined
       this.columns = columns
     },

--- a/apps/studio/src/components/TabTableProperties.vue
+++ b/apps/studio/src/components/TabTableProperties.vue
@@ -43,9 +43,10 @@
                 Data <i class="material-icons">north_east</i>
               </x-button>
               <template v-if="properties">
-                <span class="statusbar-item" v-if="properties.length" :title="`${properties.length} Records`">
+                <span class="statusbar-item" :title="totalRecords === null ? 'Loading Total Records...' : `Approximately ${totalRecords} Records`">
                   <i class="material-icons">list_alt</i>
-                  <span>~{{properties.length.toLocaleString()}}</span>
+                  <span v-if="totalRecords === null">Loading...</span>
+                  <span v-else>~{{totalRecords.toLocaleString()}}</span>
                 </span>
                 <span class="statusbar-item" v-if="humanSize !== null" :title="`Table Size ${humanSize}`">
                   <i class="material-icons">aspect_ratio</i>
@@ -108,6 +109,7 @@ export default {
       error: null,
       primaryKeys: [],
       properties: {},
+      totalRecords: null,
       dirtyPills: {},
       rawPills: [
         {
@@ -194,10 +196,19 @@ export default {
       // this is for dev only
       this.error = new Error("Something went wrong")
     },
+    async fetchTotalRecords() {
+      try {
+        this.totalRecords = await this.connection.getTableLength(this.table.name, this.table.schema)
+      } catch (ex) {
+        console.error("unable to fetch total records", ex)
+        this.totalRecords = 0
+      } 
+    },
     async refresh() {
       this.loading = true
       this.error = null
       this.properties = null
+      this.fetchTotalRecords()
       try {
         this.primaryKeys = await this.connection.getPrimaryKeys(this.table.name, this.table.schema)
         if (this.table.entityType === 'table') {

--- a/apps/studio/src/components/export/ExportManager.vue
+++ b/apps/studio/src/components/export/ExportManager.vue
@@ -84,7 +84,6 @@ export default Vue.extend({
         this.addExport(exporter)
         exporter.onProgress(this.notifyProgress.bind(this))
         await exporter.exportToFile()
-        console.log("complete!")
         const n = this.$noty.success(`Export of ${options.table.name} complete`, {
           buttons: [
             Noty.button('Show', "btn btn-primary", () => {

--- a/apps/studio/src/components/sidebar/core/TableList.vue
+++ b/apps/studio/src/components/sidebar/core/TableList.vue
@@ -265,7 +265,6 @@ import { AppEvent } from '@/common/AppEvent'
     beforeDestroy() {
       document.removeEventListener('mousedown', this.maybeUnselect)
       if(this.split) {
-        console.log("destroying split")
         this.split.destroy()
       }
     }

--- a/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
@@ -51,7 +51,7 @@ import { RoutineTypeNames } from '@/lib/db/models'
 
   import { mapGetters } from 'vuex'
 	export default {
-		props: ["connection", "routine", "noSelect", "forceExpand", "forceCollapse"],
+		props: ["connection", "routine", "noSelect", "forceExpand", "forceCollapse", "pinned"],
     mounted() {
     },
     data() {

--- a/apps/studio/src/components/tableinfo/TableInfo.vue
+++ b/apps/studio/src/components/tableinfo/TableInfo.vue
@@ -61,9 +61,7 @@ export default {
       }
     },
     async revertDescription() {
-      console.log("revert", this.oldDescription)
       if (this.oldDescription === undefined) {
-        console.log('not reverting')
         return
       }
       this.properties.description = this.oldDescription
@@ -72,7 +70,6 @@ export default {
     },
     async saveDescription() {
       this.justSaved = true
-      console.log("save")
       this.editingDescription = false
       this.oldDescription = undefined
       const confirmedValue = await this.connection.setTableDescription(this.table.name, this.properties.description, this.table.schema)

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -89,13 +89,10 @@
           Structure <i class="material-icons">north_east</i>
         </x-button>
         <!-- Info -->
-        <span v-if="loadingLength" class="statusbar-item" title="Loading Table Size...">
+        <span class="statusbar-item" :title="loadingLength ? 'Loading Total Records' : `Approximately ${totalRecordsText} Records`">
           <i class="material-icons">list_alt</i>
-          <span>loading...</span>
-        </span>
-        <span v-else class="statusbar-item" :title="`Approximately ${totalRecordsText} Records`">
-          <i class="material-icons">list_alt</i>
-          <span>{{ totalRecordsText }}</span>
+          <span v-if="loadingLength">Loading...</span>
+          <span v-else>{{ totalRecordsText }}</span>
         </span>
         <a @click="refreshTable" tabindex="0" role="button" class="statusbar-item hoverable" v-if="lastUpdatedText && !error" :title="'Updated' + ' ' + lastUpdatedText">
           <i class="material-icons">update</i>
@@ -186,11 +183,6 @@ import {AppEvent} from '../../common/AppEvent';
 import { vueEditor } from '@shared/lib/tabulator/helpers';
 import NullableInputEditorVue from '@shared/components/tabulator/NullableInputEditor.vue';
 
-function sleep(ms) {
-    return new Promise( resolve => setTimeout(resolve, ms) );
-}
-
-
 const CHANGE_TYPE_INSERT = 'insert'
 const CHANGE_TYPE_UPDATE = 'update'
 const CHANGE_TYPE_DELETE = 'delete'
@@ -229,8 +221,7 @@ export default Vue.extend({
 
       // table data
       data: null, // array of data
-      totalRecords: 0,
-      loadingLength: false,
+      totalRecords: null,
       // 
       response: null,
       limit: 100,
@@ -253,6 +244,9 @@ export default Vue.extend({
     };
   },
   computed: {
+    loadingLength() {
+      return this.totalRecords === null
+    },
     page: {
       set(nu) {
         const newPage = Number(nu)
@@ -585,15 +579,11 @@ export default Vue.extend({
   methods: {
     async fetchTableLength() {
       try {
-        this.loadingLength = true
-        await sleep(10000)
         const length = await this.connection.getTableLength(this.table.name, this.table.schema)
         this.totalRecords = length
       } catch(ex) {
         console.error("unable to get table length", ex)
         this.totalRecords = 0
-      } finally {
-        this.loadingLength = false
       }
     },
     openProperties() {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -252,7 +252,6 @@ export default Vue.extend({
     page: {
       set(nu) {
         const newPage = Number(nu)
-        console.log("new page", newPage)
         if (_.isNaN(newPage) || newPage < 1) return
         this.rawPage = newPage
       },

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -635,10 +635,13 @@ export default Vue.extend({
     editorType(dt) {
       const ne = vueEditor(NullableInputEditorVue)
       switch (dt) {
-        case 'text': return 'textarea'
-        case 'json': return 'textarea'
-        case 'jsonb': return 'textarea'
-        case 'bytea': return 'textarea'
+        case 'text':
+        case 'json':
+        case 'jsonb':
+        case 'bytea':
+        case 'tsvector':
+        case '_text':
+          return 'textarea'
         case 'bool': return 'select'
         default: return ne
       }
@@ -1007,6 +1010,7 @@ export default Vue.extend({
     async refreshTable() {
       log.debug('refreshing table')
       const page = this.tabulator.getPage()
+      this.fetchTableLength()
       await this.tabulator.replaceData()
       this.tabulator.setPage(page)
       if (!this.active) this.forceRedraw = true

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -84,7 +84,7 @@
     <statusbar :mode="statusbarMode">
 
       
-      <div class="col truncate expand statusbar-info">
+      <div class="truncate statusbar-info">
         <x-button @click.prevent="openProperties" class="btn btn-flat btn-icon end" title="View Structure">
           Structure <i class="material-icons">north_east</i>
         </x-button>
@@ -105,14 +105,16 @@
       </div>
 
       <!-- Pagination -->
-      <div class="col flex-center expand tabulator-paginator">
-        <a @click="page = page  - 1"><i class="material-icons">navigate_before</i></a>
-        <input type="number" v-model="page" />
-        <a @click="page = page + 1"><i class="material-icons">navigate_next</i></a>
+      <div class="tabulator-paginator">
+        <div class="flex-center flex-middle flex">
+          <a @click="page = page  - 1"><i class="material-icons">navigate_before</i></a>
+          <input type="number" v-model="page" />
+          <a @click="page = page + 1"><i class="material-icons">navigate_next</i></a>
+        </div>
       </div>
 
       <!-- Pending Edits -->
-      <div class="col statusbar-actions flex-right" :class="{'x4': this.totalRecords > this.limit}">
+      <div class="col x4 statusbar-actions flex-right">
         <!-- <div v-if="missingPrimaryKey" class="flex flex-right">
           <span class="statusbar-item">
             <i

--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -41,7 +41,7 @@ export const Mutators = {
    * @returns JsonFriendly
    */
   genericMutator(value: any, preserveComplex: boolean = false): JsonFriendly {
-    const mutate = this.genericMutator
+    const mutate = Mutators.genericMutator
     if (_.isBuffer(value)) return value.toString()
     if (_.isDate(value)) return value.toISOString()
     if (_.isObject(value)) return preserveComplex? _.mapValues(value, (v) => mutate(v, preserveComplex)) : JSON.stringify(value)

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -38,8 +38,11 @@ export interface DatabaseClient {
   listMaterializedViews: (filter?: FilterOptions) => Promise<TableOrView[]>,
   getPrimaryKey: (db: string, table: string, schema?: string) => Promise<string | null>,
   getPrimaryKeys: (db: string, table: string, schema?: string) => Promise<PrimaryKeyColumn[]>,
+  // for tabletable
+  getTableLength(table: string, schema?: string): Promise<number>
   selectTop(table: string, offset: number, limit: number, orderBy: OrderBy[], filters: TableFilter[] | string, schema?: string): Promise<TableResult>,
   selectTopStream(db: string, table: string, orderBy: OrderBy[], filters: TableFilter[] | string, chunkSize: number, schema?: string ): Promise<StreamResults>,
+
   wrapIdentifier: (value: string) => string
   setTableDescription: (table: string, description: string, schema?: string) => Promise<string>
 }
@@ -121,6 +124,9 @@ export class DBConnection {
   query = query.bind(null, this.server, this.database)
   executeQuery = executeQuery.bind(null, this.server, this.database)
   listDatabases = listDatabases.bind(null, this.server, this.database)
+
+  // tabletable
+  getTableLength = bindAsync.bind(null, 'getTableLength', this.server, this.database)
   selectTop = selectTop.bind(null, this.server, this.database)
   selectTopStream = selectTopStream.bind(null, this.server, this.database)
   applyChanges = applyChanges.bind(null, this.server, this.database)

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -457,7 +457,6 @@ function wrap(database: IDbConnectionDatabase, identifier: string | string[]): s
 
 function checkIsConnected(_server: IDbConnectionServer, database: IDbConnectionDatabase) {
   if (database.connecting || !database.connection) {
-    console.log(database)
     throw new Error('There is no connection available.');
   }
 }

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -802,7 +802,6 @@ export async function getPrimaryKeys(conn: HasPool, _database: string, table: st
     AND    i.indisprimary 
     ORDER BY a.attnum
   `
-  console.log("query", psqlQuery)
 
   const redshiftQuery = `
     select tco.constraint_schema,
@@ -1290,7 +1289,6 @@ function driverExecuteQuery(conn: Conn | HasConnection, queryArgs: PostgresQuery
     // node-postgres has support for Promise query
     // but that always returns the "fields" property empty
     return new Promise((resolve, reject) => {
-      console.log(queryArgs.query)
       log.info('RUNNING', queryArgs.query, queryArgs.params)
       connection.query(args, (err: Error, data: QueryResult | QueryResult[]) => {
         if (err) return reject(err);

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -48,6 +48,7 @@ export default async function (server, database) {
     applyChanges: (changes) => applyChanges(conn, changes),
     executeQuery: (queryText) => executeQuery(conn, queryText),
     listDatabases: () => listDatabases(conn),
+    getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters) => selectTop(conn, table, offset, limit, orderBy, filters),
     selectTopStream: (db, table, orderBy, filters, chunkSize) => selectTopStream(conn, db, table, orderBy, filters, chunkSize),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
@@ -87,8 +88,8 @@ export function getQuerySelectTop(client, table, limit) {
   return `SELECT * FROM ${wrapIdentifier(table)} LIMIT ${limit}`;
 }
 
-export async function getTableLength(conn, table, filters) {
-  const { countQuery, params } = buildSelectTopQuery(table, null, null, null, filters)
+export async function getTableLength(conn, table) {
+  const { countQuery, params } = buildSelectTopQuery(table, null, null, null, [])
   const countResults = await driverExecuteQuery(conn, { query: countQuery, params })
   const rowWithTotal = countResults.data.find((row) => { return row.total })
   const totalRecords = rowWithTotal ? rowWithTotal.total : 0

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -558,3 +558,8 @@ async function runWithConnection(conn, run) {
     }
   }
 }
+
+
+export const sqliteTestOnly = {
+  alterTableSql
+}

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -521,7 +521,7 @@ export function driverExecuteQuery(conn, queryArgs) {
       })
 
     } catch (error) {
-      console.log(error)
+      log.error(error)
       reject(error)
     }
   });

--- a/apps/studio/src/lib/db/clients/utils.js
+++ b/apps/studio/src/lib/db/clients/utils.js
@@ -125,11 +125,8 @@ export async function executeSelectTop(queries, conn, executor) {
   const { query, countQuery, params } = queries
   const countResults = await executor(conn, { query: countQuery, params })
   const result = await executor(conn, { query, params })
-  const rowWithTotal = countResults.data.find((row) => { return row.total })
-  const totalRecords = rowWithTotal ? rowWithTotal.total : 0
   return {
     result: result.data,
-    totalRecords: Number(totalRecords),
     fields: Object.keys(result.data[0] || {})
   }  
 }

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -121,7 +121,6 @@ export interface IDbInsert {
 export interface TableResult {
   result: any[];
   fields: string[];
-  totalRecords: Number;
 }
 
 export interface TableChanges {

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -52,7 +52,6 @@ export interface TableProperties {
   description?: string
   size?: number
   indexSize?: number
-  length: number
   indexes: TableIndex[]
   relations: TableKey[]
   triggers: TableTrigger[]

--- a/apps/studio/src/lib/export/export.ts
+++ b/apps/studio/src/lib/export/export.ts
@@ -21,6 +21,8 @@ export abstract class Export {
   error: Error | null = null
   fileSize: number = 0
   lastChunkTime: number = 0
+
+  preserveComplex = true
   // see set status()
   private _status: ExportStatus = ExportStatus.Idle
   timeElapsed: number = 0
@@ -151,7 +153,7 @@ export abstract class Export {
         // log.info(`read ${rows.length} rows`)
         for (let rI = 0; rI < rows.length; rI++) {
           const row = rows[rI];
-          const mutated = Mutators.mutateRow(row, this.columns?.map((c) => c.dataType), true)
+          const mutated = Mutators.mutateRow(row, this.columns?.map((c) => c.dataType), this.preserveComplex)
           const formatted = this.formatRow(mutated)
           this.fileHandle?.write(formatted)
           this.fileHandle?.write(this.rowSeparator)

--- a/apps/studio/src/lib/export/formats/csv.ts
+++ b/apps/studio/src/lib/export/formats/csv.ts
@@ -14,6 +14,8 @@ export class CsvExporter extends Export {
   readonly format: string = 'csv'
   rowSeparator: string = '\n'
 
+  preserveComplex = false
+
   private outputOptions: OutputOptionsCsv
   private headerConfig: Papa.UnparseConfig
   private rowConfig: Papa.UnparseConfig = {

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -392,9 +392,9 @@ const store = new Vuex.Store<State>({
       routines.forEach((r) => r.entityType = 'routine')
       context.commit('routines', routines)
     },
-    async setFilterQuery(context, filterQuery) {
+    setFilterQuery: _.debounce(function (context, filterQuery) {
       context.commit('filterQuery', filterQuery)
-    },
+    }, 500),
     async pinTable(context, table) {
       table.pinned = true
       context.commit('addPinned', table)

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -275,7 +275,6 @@ const store = new Vuex.Store<State>({
     },
 
     async openUrl(context, url: string) {
-      console.log("open url", url)
       const conn = new SavedConnection();
       if (!conn.parse(url)) {
         throw `Unable to parse ${url}`

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -18,7 +18,7 @@ import { CoreTab, EntityFilter } from './models'
 import { entityFilter } from '../lib/db/sql_tools'
 
 import RawLog from 'electron-log'
-import { dialectFor } from '@shared/lib/dialects/models'
+import { Dialect, dialectFor } from '@shared/lib/dialects/models'
 import { PinModule } from './modules/PinModule'
 
 const log = RawLog.scope('store/index')
@@ -81,7 +81,8 @@ const store = new Vuex.Store<State>({
     selectedSidebarItem: null
   },
   getters: {
-    dialect(state: State) {
+    dialect(state: State): Dialect | null {
+      if (!state.usedConfig) return null
       return dialectFor(state.usedConfig.connectionType)
     },
     selectedSidebarItem(state) {

--- a/apps/studio/tests/unit/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/sqlite.spec.js
@@ -1,0 +1,27 @@
+import { sqliteTestOnly } from "../../../../../src/lib/db/clients/sqlite"
+
+
+
+describe("SQLite UNIT test (no connection)", () => {
+  it("Should build alter table statements", async () => {
+    const input = {
+      table: 'foo',
+      alterations: [
+        {
+          columnName: 'a',
+          changeType: 'columnName',
+          newValue: 'b'
+        },
+        {
+          columnName: 'c',
+          changeType: 'columnName',
+          newValue: 'd'
+        }
+      ]
+    }
+
+    const result = await sqliteTestOnly.alterTableSql(null, input)
+    const expected = 'ALTER TABLE "foo" RENAME COLUMN "a" TO "b";ALTER TABLE "foo" RENAME COLUMN "c" TO "d";'
+    expect(result).toBe(expected);
+  })
+})

--- a/shared/src/components/SchemaBuilder.vue
+++ b/shared/src/components/SchemaBuilder.vue
@@ -268,7 +268,7 @@ export default Vue.extend({
       .tabulator-cell {
         min-height: $row-height;
         height: $row-height;
-        line-height: $row-height + 2px;
+        line-height: $row-height;
         padding: 0 $cell-padding;
         min-width: $min-cell-width;
         font-size: $cell-font-size;
@@ -279,11 +279,11 @@ export default Vue.extend({
           padding: 0 $gutter-h!important;
           min-height: $row-height;
           height: $row-height;
-          line-height: $row-height + 2px;
+          line-height: $row-height;
           box-shadow: inset 0 1px $theme-base;
-          input:not([type="checkbox"]) {
-            background: rgba($theme-base, 0.08);
-            box-shadow: inset 0 -1px $theme-base;
+          pre, input:not([type="checkbox"]) {
+            min-height: $row-height;
+            line-height: $row-height;
           }
         }
         &.no-padding {

--- a/shared/src/components/SchemaBuilder.vue
+++ b/shared/src/components/SchemaBuilder.vue
@@ -62,7 +62,6 @@ export default Vue.extend({
       deep: true,
       handler() {
         if (this.builtColumns && this.modified) {
-          console.log("emitting columns")
           this.$emit('columnsChanged', this.builtColumns)
         }
       }

--- a/shared/src/components/SchemaBuilder.vue
+++ b/shared/src/components/SchemaBuilder.vue
@@ -276,7 +276,7 @@ export default Vue.extend({
         flex-grow: 1;
         &.tabulator-editing {
           border: 0;
-          padding: 0 $gutter-h!important;
+          padding: 0 !important;
           min-height: $row-height;
           height: $row-height;
           line-height: $row-height;
@@ -284,6 +284,7 @@ export default Vue.extend({
           pre, input:not([type="checkbox"]) {
             min-height: $row-height;
             line-height: $row-height;
+            padding: $cell-padding!important;
           }
         }
         &.no-padding {

--- a/shared/src/components/tabulator/CheckboxEditor.vue
+++ b/shared/src/components/tabulator/CheckboxEditor.vue
@@ -18,7 +18,6 @@
         if (_e.key === 'Escape') {
           this.$emit('cancel')
         }
-        console.log("keydown", _e.key)
       },
       submit() {
         this.$emit('value', this.checked)

--- a/shared/src/lib/sql/change_builder/ChangeBuilderBase.ts
+++ b/shared/src/lib/sql/change_builder/ChangeBuilderBase.ts
@@ -164,14 +164,6 @@ export abstract class ChangeBuilderBase {
       }).join(';')
     }
 
-    console.log(
-      initial,
-      alterTable,
-      fullRenames,
-      this.alterComments(spec.alterations || []).join(";"),
-      end
-    )
-
     const results = [
       initial,
       alterTable,


### PR DESCRIPTION
Loading table sizes slows down Beekeeper, and is mostly not needed.

This changes a few things
- Table length is loaded, but only for the full table.
- Loading table length does not block the tab from loading
- Table length is not loaded on each page.

Fix #311 