### PR TITLE
tools: fix wrong mssql conversion of bit datatype

### DIFF
--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -32,7 +32,7 @@ export const Mutators = {
       return mutator(item, preserveComplex)
     })
   },
-  
+
   /**
    * Mutate database data to make it json-friendly
    * This is particularly useful for binary-type data
@@ -58,13 +58,16 @@ export const Mutators = {
   bit1Mutator(value: any): JsonFriendly {
     return value[0]
   },
-  
+
   /**
    * Stringify bit data for use in json / UIs
    * @param  {any} value
    * @returns JsonFriendly
    */
   bitMutator(value: any): JsonFriendly {
+    // SQL Server bit data type is an integer data type
+    if (this.connection.connectionType === "sqlserver") return value;
+
     const result = []
     for (let index = 0; index < value.length; index++) {
       result.push(value[index])


### PR DESCRIPTION
SQL Server bit is an integer data type unlike others databases.
I have added an exception for mssql returning original value.

Before:
![before](https://user-images.githubusercontent.com/7884429/127074613-58be45c4-b42e-46ec-9af0-0f58ee9b72a1.png)

After:
![after](https://user-images.githubusercontent.com/7884429/127074657-b33f9c5f-d1cc-4612-bc22-9eb4b896bd9b.png)
