### PR TITLE
Fix tables not loading on Azure SQL Server

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -77,7 +77,7 @@ async function getVersion(conn) {
   const versionString = result.data.recordset[0].version
   const yearRegex = /SQL Server (\d+)/g
   const yearResults = yearRegex.exec(versionString)
-  const releaseYear = _.toNumber(yearResults[1]) || 2017
+  const releaseYear = (yearResults && _.toNumber(yearResults[1])) || 2017
   return {
     supportOffsetFetch: releaseYear >= 2012,
     releaseYear,


### PR DESCRIPTION
I also encountered the issue in #714, so I took a look and it seems to occur when Beekeeper runs the `SELECT @@VERSION as version` query. Azure runs a specialized version of SQL Server so the output of that command is along the lines of:
```
Microsoft SQL Azure (RTM) - 12.0.2000.8 
	Jul 23 2021 13:14:19 
	Copyright (C) 2019 Microsoft Corporation
```
Which is different from what the version parsing RegEx is expecting (`/SQL Server (\d+)/g`), resulting in a null value since no matches are found.

This PR fixes it by ignoring the version number parse result if it's null and instead falling back to the hardcoded `2017` value in the code. I'm not sure what effect (if any) this will have on features that rely on a specific SQL Server version.