### PR TITLE
Copy Row As Insert Statement

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -752,9 +752,7 @@ export default Vue.extend({
     },
     cellCopyRowAsInsert(e, cell) {
       const row = cell.getRow()
-      console.log(row)
       const data = { ...row.getData() }
-      console.log(data)
       const payload = {
         table: this.table.name,
         schema: this.table.schema,

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -752,7 +752,9 @@ export default Vue.extend({
     },
     cellCopyRowAsInsert(e, cell) {
       const row = cell.getRow()
+      console.log(row)
       const data = { ...row.getData() }
+      console.log(data)
       const payload = {
         table: this.table.name,
         schema: this.table.schema,
@@ -762,19 +764,19 @@ export default Vue.extend({
       this.$native.clipboard.writeText(insertQuery);
     },
     createInsertStatement(payload) {
-      let query = `INSERT INTO ${payload.schema}.${payload.table} (`
+      const allColumns = Object.keys(payload.data)
+        .filter(key => payload.data[key] !== undefined)
 
-      query += Object.keys(payload.data)
+      let query = `INSERT INTO ${payload.schema}.${payload.table} (`
+      query += allColumns
         .map(columnName => `${columnName}`)
         .join(", ")
-
       query += ") VALUES ("
-
-      query += Object.keys(payload.data)
+      query += allColumns
         .map(columnName => `${payload.data[columnName] ? `'${payload.data[columnName]}'` : 'null'}`)
         .join(", ")
-
       query += ");";
+
       return query
     },
     cellCloneRow(e, cell) {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -279,6 +279,12 @@ export default Vue.extend({
         },
         { separator: true },
         {
+          label: '<x-menuitem><x-label>Copy as insert</x-label></x-menuitem>',
+          action: this.cellCopyRowAsInsert.bind(this),
+          disabled: !this.editable
+        },
+        { separator: true },
+        {
           label: '<x-menuitem><x-label>Copy</x-label></x-menuitem>',
           action: (e, cell) => {
             this.$native.clipboard.writeText(cell.getValue());
@@ -743,6 +749,33 @@ export default Vue.extend({
       let pendingUpdates = _.reject(this.pendingChanges.updates, { 'key': payload.key })
       pendingUpdates.push(payload)
       this.$set(this.pendingChanges, 'updates', pendingUpdates)
+    },
+    cellCopyRowAsInsert(e, cell) {
+      const row = cell.getRow()
+      const data = { ...row.getData() }
+      const payload = {
+        table: this.table.name,
+        schema: this.table.schema,
+        data
+      }
+      const insertQuery = this.createInsertStatement(payload);
+      this.$native.clipboard.writeText(insertQuery);
+    },
+    createInsertStatement(payload) {
+      let query = `INSERT INTO ${payload.schema}.${payload.table} (`
+
+      query += Object.keys(payload.data)
+        .map(columnName => `${columnName}`)
+        .join(", ")
+
+      query += ") VALUES ("
+
+      query += Object.keys(payload.data)
+        .map(columnName => `${payload.data[columnName] ? `'${payload.data[columnName]}'` : 'null'}`)
+        .join(", ")
+
+      query += ");";
+      return query
     },
     cellCloneRow(e, cell) {
       const row = cell.getRow()


### PR DESCRIPTION
Added a feature to copy a row as insert statement.

UI Changes:
1. Added a button on right click menu on table page and with label `Copy as insert`.

Creates insert statement and registers it to clipboard of the system.