### PR TITLE
Changes to fix sql query formatting

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -123,6 +123,7 @@
   import QueryEditorStatusBar from './editor/QueryEditorStatusBar.vue'
   import rawlog from 'electron-log'
   import ErrorAlert from './common/ErrorAlert.vue'
+  import {FormatterDialect} from "@shared/lib/dialects/models";
   const log = rawlog.scope('query-editor')
 
   export default {
@@ -517,7 +518,7 @@
         }
       },
       formatSql() {
-        this.editor.setValue(format(this.editor.getValue()))
+        this.editor.setValue(format(this.editor.getValue(), { language: FormatterDialect(this.dialect) }))
         this.selectEditor()
       },
       toggleComment() {

--- a/shared/src/lib/dialects/models.ts
+++ b/shared/src/lib/dialects/models.ts
@@ -38,9 +38,9 @@ export function KnexDialect(d: Dialect): KnexDialect {
 
 export type FormatterDialect = 'postgresql' | 'mysql' | 'mariadb' | 'sql' | 'tsql' | 'redshift'
 export function FormatterDialect(d: Dialect): FormatterDialect {
-  if (!d) return 'sql'
+  if (!d) return 'mysql'
   if (d === 'sqlserver') return 'tsql'
-  if (d === 'sqlite') return 'sql'
+  if (d === 'sqlite') return 'mysql'
   return d
 }
 
@@ -58,7 +58,7 @@ export class ColumnType {
   get pretty() {
     if (this.supportsLength) {
       return `${this.name.toUpperCase()}(${this.defaultLength})`
-    } 
+    }
     return this.name.toUpperCase()
   }
 }


### PR DESCRIPTION
Related to [BUG: mysql-formatter adds spaces when using backticks #814](https://github.com/beekeeper-studio/beekeeper-studio/issues/814)

A change to `apps/studio/src/components/TabQueryEditor.vue` to feed the dialect into the query formatting in keeping with the implementation in other areas.

A change to `shared/src/lib/dialects/models.ts` to use 'mysql' as the default dialect. This is in contrast to using 'sql' which is affected by a bug in the underlying library, [mysql-formatter](https://github.com/zeroturnaround/sql-formatter/issues/139)

Please let me know what you think of these changes and if you have any suggestions.

-James