### PR TITLE
FEAT: Link to documentation from HELP menu

### DIFF
--- a/apps/studio/src/background/NativeMenuActionHandlers.ts
+++ b/apps/studio/src/background/NativeMenuActionHandlers.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import {AppEvent} from '../common/AppEvent'
 import { buildWindow, getActiveWindows } from './WindowBuilder'
-import { app } from 'electron'
+import { app , shell } from 'electron'
 import platformInfo from '../common/platform_info'
 import path from 'path'
 import { SavedConnection } from '../common/appdb/models/saved_connection'
@@ -80,6 +80,10 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
       iconPath: getIcon()
     })
     app.showAboutPanel()
+  }
+
+  opendocs() {
+    shell.openExternal("http://docs.beekeeperstudio.io/guide/")
   }
 
   devtools(_1: Electron.MenuItem, win: ElectronWindow) {

--- a/apps/studio/src/common/interfaces/IMenuActionHandler.ts
+++ b/apps/studio/src/common/interfaces/IMenuActionHandler.ts
@@ -15,6 +15,7 @@ export interface IMenuActionHandler {
   fullscreen: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   about: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   devtools: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
+  opendocs: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   newWindow: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   newQuery: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   newTab: (menuItem: Electron.MenuItem, win: ElectronWindow) => void

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -73,9 +73,10 @@ export default class extends DefaultMenu {
       {
         label: "Help",
         submenu: [
-          this.menuItems.about,
+          this.menuItems.opendocs,
           this.menuItems.addBeekeeper,
           this.menuItems.devtools,
+          this.menuItems.about,
         ]
       }
     ]

--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -93,6 +93,11 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
       nonNativeMacOSRole: true,
       click: actionHandler.devtools
     },
+    opendocs : {
+      id: 'opendocs',
+      label: 'Beekeper Studio Documentation',
+      click: actionHandler.opendocs
+    },
     reload: {
       id: 'reload-window',
       label: "DEV Force Reload",

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -24,6 +24,7 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   fullscreen = () => send('fullscreen')
   about = () => send('about')
   devtools = () => send('devtools')
+  opendocs = () => send('opendocs')
   newWindow = () => send('newWindow')
   newQuery = () => send('newQuery')
   newTab = () => send('newTab')


### PR DESCRIPTION
- Added new menuitem in HELP menu to open documentation.
- About Beekeper is last item in help menu (like in Firefox, Chrome,
  Word, etc.)

Help menu is now as follows:

- HELP
   - Beekeper Studio Documentation
   - Add Beekeeper's Database
   - Show Developer Tools
   - About Beekeper Studio

Closes #813