### PR TITLE
should support clear text plugin out of the box

### DIFF
--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -786,6 +786,13 @@ function configDatabase(server, database) {
     supportBigNumbers: true,
     bigNumberStrings: true,
     connectTimeout  : 60 * 60 * 1000,
+    authPlugins: {
+      mysql_clear_password: pluginOptions => ({ connection, command }) => {
+        const password =
+          command.password || pluginOptions.password || connection.config.password;
+        return Buffer.from(`${password}\0`)
+      }
+    }
   };
 
   if (server.sshTunnel) {


### PR DESCRIPTION
Maybe this should be opt-in?

@MasterOdin what do you think? Should this just be supported out of the box if a Server requests authenticating in this way?

For context:
https://github.com/sidorares/node-mysql2/issues/438

https://github.com/sqlectron/sqlectron-db-core/issues/21