### PR TITLE
Add single and double quote to query parsing regular expression #581

### DIFF
--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -12,7 +12,7 @@ export function splitQueries(queryText: string) {
 }
 
 const badMatch = /(:\w+:)|(:\s*null)/g
-const extractRegex = /(?:[^a-zA-Z0-9_:]|^)(:\w+:?|\$\d+)(?:\W|$)/g
+const extractRegex = /(?:[^'"a-zA-Z0-9_:]|^)(:\w+:?|\$\d+)(?:\W|$)/g
 
 export function extractParams(query: string) {
   if (!query) return []


### PR DESCRIPTION
In response to #581, single and double quotes have been added to the negative match of the regular expression in extractParams(). This change almost feels a little too easy, so please feel free to point out other effects this change might have and I can work on patching those as well.

Sample test string:
INSERT INTO \`table_name\` (\`double_quotes\`, \`no_quotes\`, \`single_quotes\`, \`colon\`, \`colon_single_quotes\`, \`json\`) VALUES ("$1", $2, '$3', :hello, ':world', '{"key":false}')

The extractParams function now only matches the $2 and :hello placeholders in the test string. This also addresses #713, but another issue was brought up in the same thread (parameters being recognized in comments) and this fix does not address that.

Let me know what else is required for this change, if anything.