### PR TITLE
initial 9.3 support, needs new sql for indexes

### DIFF
--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -45,7 +45,7 @@ export function runCommonTests(getUtil) {
 
 
   describe("Table Structure", () => {
-    test.only("should fetch table properties", async() => {
+    test("should fetch table properties", async() => {
       await getUtil().tablePropertiesTests()
     })
   })

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -5,7 +5,7 @@ export function runCommonTests(getUtil) {
     await getUtil().listTableTests()
   })
 
-  test.only("column tests", async() => {
+  test("column tests", async() => {
     await getUtil().tableColumnsTests()
   })
 
@@ -45,7 +45,7 @@ export function runCommonTests(getUtil) {
 
 
   describe("Table Structure", () => {
-    test("should fetch table properties", async() => {
+    test.only("should fetch table properties", async() => {
       await getUtil().tablePropertiesTests()
     })
   })

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -5,7 +5,6 @@ import { runCommonTests } from './all'
 import { IDbConnectionServerConfig } from '@/lib/db/client'
 
 const TEST_VERSIONS = ['9.3', '9.4', 'latest']
-// const TEST_VERSIONS = ['9.3']
 
 function testWith(dockerTag) {
   describe(`Postgres [${dockerTag}]`, () => {

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -4,7 +4,8 @@ import { Duration, TemporalUnit } from "node-duration"
 import { runCommonTests } from './all'
 import { IDbConnectionServerConfig } from '@/lib/db/client'
 
-const TEST_VERSIONS = ['9.4', 'latest']
+const TEST_VERSIONS = ['9.3', '9.4', 'latest']
+// const TEST_VERSIONS = ['9.3']
 
 function testWith(dockerTag) {
   describe(`Postgres [${dockerTag}]`, () => {


### PR DESCRIPTION
Hoping to get some help from stackoverflow:

https://stackoverflow.com/questions/70397372/how-do-i-make-this-postgres-query-to-find-table-indexes-compatible-with-versions

fix #897

This query needs rewriting without using `WITH ORDINALITY`:

```sql
  SELECT i.indexrelid::regclass AS indexname,
        k.i AS index_order,
        i.indexrelid as id,
        i.indisunique,
        i.indisprimary,
        coalesce(a.attname,
                  (('{' || pg_get_expr(
                              i.indexprs,
                              i.indrelid
                          )
                        || '}')::text[]
                  )[k.i]
                ) AS index_column,
        i.indoption[k.i - 1] = 0 AS ascending
      FROM pg_index i
        CROSS JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, i)
        LEFT JOIN pg_attribute AS a
            ON i.indrelid = a.attrelid AND k.attnum = a.attnum
        JOIN pg_class t on t.oid = i.indrelid
        JOIN pg_namespace c on c.oid = t.relnamespace
      WHERE
       c.nspname = $1 AND
       t.relname = $2

```