### PR TITLE
Turn off built-in support for speckcheck #926

### DIFF
--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -39,7 +39,8 @@ class BeekeeperWindow {
       webPreferences: {
         enableRemoteModule: true,
         nodeIntegration: Boolean(process.env.ELECTRON_NODE_INTEGRATION),
-        contextIsolation: false
+        contextIsolation: false,
+        spellcheck: false
       },
       icon: getIcon()
     })


### PR DESCRIPTION
Hi, I think the spellcheck is really annoying.  
Also, I saw someone reported it in the issues. https://github.com/beekeeper-studio/beekeeper-studio/issues/926
Following the docs from electron, I disabled the spellcheck when the window is created. 
https://www.electronjs.org/docs/latest/tutorial/spellchecker