### PR TITLE
fix: link to pricing page broken

### DIFF
--- a/apps/studio/docs/team_workspaces/README.md
+++ b/apps/studio/docs/team_workspaces/README.md
@@ -54,7 +54,7 @@ After connecting to a workspace, Beekeeper works just the same as it does usuall
 
 ## Workspace Billing
 
-- [View Pricing](https://app.beekeeperstudio.io/pricing)
+- [View Pricing](https://beekeeperstudio.io/pricing)
 
 ### When you get charged
 


### PR DESCRIPTION
Link to pricing page is https://app.beekeeperstudio.io/pricing. It's supposed to be https://beekeeperstudio.io/pricing