### PR TITLE
Can't edit text inputs after window.confirm - dialog called from the main process

### DIFF
--- a/apps/studio/src/background.ts
+++ b/apps/studio/src/background.ts
@@ -67,11 +67,25 @@ async function initBasics() {
   log.info("Building the window")
   log.info("managing updates")
   manageUpdates()
+  
   ipcMain.on(AppEvent.openExternally, (_e: electron.IpcMainEvent, args: any[]) => {
     const url = args[0]
     if (!url) return
     electron.shell.openExternal(url)
   })
+
+  ipcMain.on('openDialog',(event)=> {
+    require('electron').dialog.showMessageBox(this, {
+      type: 'question',
+      buttons: ['Yes', 'No'],
+      title: 'beekeeper-studio',
+      message: 'Are you sure? You will lose unsaved changes.'
+    }).then(function (result) {
+      if(result.response === 0)
+        event.sender.send('closeDialog',result);
+      });
+  })
+
   return settings
 }
 

--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -26,6 +26,7 @@
 </template>
 <script>
   import TableIcon from '@/components/common/TableIcon.vue'
+  import { ipcRenderer } from 'electron'
 
   export default {
     props: ['tab', 'tabsCount', 'selected'],
@@ -41,11 +42,10 @@
         event.stopPropagation()
         event.preventDefault()
         if (this.tab.unsavedChanges) {
-          if (window.confirm("Are you sure? You will lose unsaved changes.")) {
-            this.$emit('close', this.tab)
-          }
+          ipcRenderer.on('closeDialog',(event,data) => this.$emit('close', this.tab));
+          ipcRenderer.send('openDialog');
         } else {
-          this.$emit('close', this.tab)
+          this.$emit('close', this.tab);
         }
       },
       doNothing() {


### PR DESCRIPTION
Found a problem with window.confirm:

![beekeeper](https://user-images.githubusercontent.com/34251622/152873523-4478ca61-ea3d-43e5-a0af-6149a6fb7692.gif)

Since this is the function that blocks the execution thread of the script - I modified the solution to use the electron dialog.