### PR TITLE
fix: sort connections by selected option

### DIFF
--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -249,6 +249,7 @@ const log = rawLog.scope('connection-sidebar');
         return `label-${color}`
       },
       sortConnections(by) {
+        this.connectionConfigs.sort((a, b) => a[by].toString().localeCompare(b[by].toString()))
         this.settings.sortOrder.userValue = by
         this.settings.sortOrder.save()
       }


### PR DESCRIPTION
fix: Changing saved connections sorting doesn't actually change the order. https://github.com/beekeeper-studio/beekeeper-studio/issues/1032#issue-1137072495