### PR TITLE
Update Electron to latest 13.x release

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -122,7 +122,7 @@
     "@vue/test-utils": "^1.0.3",
     "aws-sdk": "^2.645.0",
     "babel-eslint": "^10.0.1",
-    "electron": "12.1.0",
+    "electron": "13.6.9",
     "electron-builder-notarize": "beekeeper-studio/electron-builder-notarize#master",
     "electron-devtools-installer": "^3.1.1",
     "electron-updater": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5508,10 +5508,10 @@ electron-util@^0.14.1:
     electron-is-dev "^1.1.0"
     new-github-issue-url "^0.2.1"
 
-electron@12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-12.1.0.tgz#615a7f9dbb2fc79cc72361fba9f39d005c697bca"
-  integrity sha512-joQlYI/nTIrTUldO3GENZ2j225eKar9nTQBSEwSUSWN4h65QGDmXNQ7dbWPmLlkUQWtHhz8lXhFk30OLG9ZjLw==
+electron@13.6.9:
+  version "13.6.9"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.6.9.tgz#7bd83cc1662ceaaa09dcd132a7b507cec888b028"
+  integrity sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"


### PR DESCRIPTION
Fixes https://github.com/beekeeper-studio/beekeeper-studio/issues/1034

Electron 13 breaking changes are minimal, from their release notes:

- Fixed so window.open() parameter frameName is no longer set as window title. #27481
- Changed session.setPermissionCheckHandler(handler) to allow for handler's first parameter, webContents to be null. #19903

See: https://www.electronjs.org/releases/stable?version=13&page=6#13.0.0

No usages of those APIs appear to be in this project.

EDIT: I see there were more extensive breaking changes planned: https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-130

---

Hi! I ran into the same error referenced in #1034 and did a little research for similar issues in other Electron apps.

There was a thread in Ubunbtu's tracker about a similar issue, that appears to be an upstream Chromium problem that was patched.

Seems like the Electron team backported the fix for the issue, but not into the 12.x tree.

See https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1944468.

(EDIT: Not actually sure _which_ change it was that was needed, the errors in that thread are a bit different)

Because I'm not very familiar with the project, I'm not sure if there's anything else that needs updated along side the Electron library.

The only change from the app I can see is that the dev tools are now open by default when launching the `electron:serve` command.

I've not given the app a very thorough test as yet, so let me know what I can do to help get this released :)

P.S. on Fedora I'm using an X11 session, not Wayland, so not 100% sure it's identical to the other issue, however I do have the same Nvidia driver installed, and the `--in-process-gpu` did resolve for me before updating Electron.
