### PR TITLE
Set the default port after the database type has been changed

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -44,6 +44,7 @@ export class DbConnectionBase extends ApplicationEntity {
   @Column({ type: 'varchar', name: 'connectionType'})
   public set connectionType(value: Nullable<IDbClients>) {
     this._connectionType = parseConnectionType(value)
+    this._port = this.defaultPort
   }
 
   public get connectionType() {
@@ -61,7 +62,7 @@ export class DbConnectionBase extends ApplicationEntity {
   }
 
   public get port() : Nullable<number> {
-    return this._port || this.defaultPort
+    return this._port
   }
 
 


### PR DESCRIPTION
This PR fixes #1086.
The current version set the default port every time the input is empty.
With this PR the default port will be set once while changing the database type.