### PR TITLE
Broken "sure modal" on close unchange new table tabs

### DIFF
--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -135,12 +135,12 @@
       }
     }
     .item-icon {
+      display: inline-block;
       font-size: 15px;
       padding-left: ($gutter-h * 1.5);
       padding-right: $gutter-h;
       max-width: $gutter-w * 2.8;
       min-width: $gutter-w * 2.6;
-      line-height: $tab-height;
     }
     .tab-action {
       position: absolute;


### PR DESCRIPTION
This PR will fix the broken "sure modal" on close unchange new table tabs.
Before:
![Bildschirmfoto von 2022-04-09 15-05-37](https://user-images.githubusercontent.com/13292481/162575441-63d86817-efa2-458e-840e-541faaad0728.png)
After:
![Bildschirmfoto von 2022-04-09 15-05-44](https://user-images.githubusercontent.com/13292481/162575440-cf20d200-eaec-4dd1-8800-5bdec093a0cd.png)

