### PR TITLE
Fixed contextmenu binding

### DIFF
--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="nav-item-wrap" v-hotkey="keymap" @contextmenu="$emit('contextmenu', $event)">
-    <li class="nav-item" :title="title + scope">
+  <div class="nav-item-wrap" v-hotkey="keymap">
+    <li class="nav-item" :title="title + scope" @contextmenu="$emit('contextmenu', $event)">
       <a
         class="nav-link"
         @mousedown="mousedown"


### PR DESCRIPTION
Currently the contextmenu binding of the tabs is wrong, its also listening for right clicks on the modal.

https://user-images.githubusercontent.com/13292481/162575832-bf82a37a-c711-4250-8d97-ab19e0406b63.mp4

  