### PR TITLE
Copy Row as Insert

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -311,6 +311,18 @@ export default Vue.extend({
           },
         },
         {
+          label: '<x-menuitem><x-label>Copy Row (Query)</x-label></x-menuitem>',
+          action: async (_e, cell) => {
+            const tableInsert = {
+              table: this.table.name,
+              schema: this.table.schema,
+              data: [cell.getRow().getData()],
+            }
+            const query = await this.connection.getInsertQuery(tableInsert)
+            this.$native.clipboard.writeText(query)
+          }
+        },
+        {
           label: '<x-menuitem><x-label>Copy Row (JSON)</x-label></x-menuitem>',
           action: (_e, cell) => {
             const data = cell.getRow().getData()

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -3,7 +3,7 @@ import connectTunnel from './tunnel';
 import clients from './clients';
 import createLogger from '../logger';
 import { SSHConnection } from '@/vendor/node-ssh-forward/index';
-import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, SchemaFilterOptions, DatabaseFilterOptions, TableChanges, TableUpdateResult, OrderBy, TableFilter, TableResult, StreamResults, CancelableQuery, ExtendedTableColumn, PrimaryKeyColumn, TableProperties, TableIndex, TableTrigger, } from './models';
+import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, SchemaFilterOptions, DatabaseFilterOptions, TableChanges, TableUpdateResult, OrderBy, TableFilter, TableResult, StreamResults, CancelableQuery, ExtendedTableColumn, PrimaryKeyColumn, TableProperties, TableIndex, TableTrigger, TableInsert } from './models';
 import { AlterTableSpec, IndexAlterations, RelationAlterations } from '@shared/lib/dialects/models';
 
 const logger = createLogger('db');
@@ -35,6 +35,7 @@ export interface DatabaseClient {
   alterRelationSql: (changes: RelationAlterations) => string | null
   alterRelation: (changes: RelationAlterations) => Promise<void>
 
+  getInsertQuery: (tableInsert: TableInsert) => Promise<string>,
   getQuerySelectTop: (table: string, limit: number, schema?: string) => void,
   getTableProperties: (table: string, schema?: string) => Promise<TableProperties | null>,
   getTableCreateScript: (table: string, schema?: string) => Promise<string>,
@@ -149,6 +150,7 @@ export class DBConnection {
   alterRelationSql = bind.bind(null, 'alterRelationSql', this.server, this.database)
   alterRelation = bindAsync.bind(null, 'alterRelation', this.server, this.database)
 
+  getInsertQuery = getInsertQuery.bind(null, this.server, this.database)
   getQuerySelectTop = getQuerySelectTop.bind(null, this.server, this.database)
   getTableCreateScript = getTableCreateScript.bind(null, this.server, this.database)
   getTableSelectScript = getTableSelectScript.bind(null, this.server, this.database)
@@ -376,6 +378,11 @@ function listDatabases(server: IDbConnectionServer, database: IDbConnectionDatab
   return database.connection?.listDatabases(filter);
 }
 
+
+async function getInsertQuery(server: IDbConnectionServer, database: IDbConnectionDatabase, tableInsert: TableInsert) {
+  checkIsConnected(server , database);
+  return database.connection?.getInsertQuery(tableInsert);
+}
 
 async function getQuerySelectTop(server: IDbConnectionServer, database: IDbConnectionDatabase, table: string, schema: string, limit: number) {
   checkIsConnected(server , database);

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -56,6 +56,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters) => selectTop(conn, table, offset, limit, orderBy, filters),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
+    getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
     getViewCreateScript: (view) => getViewCreateScript(conn, view),
@@ -625,6 +626,10 @@ export async function listDatabases(conn, filter) {
     .map((row) => row.Database);
 }
 
+async function getInsertQuery(conn, database, tableInsert) {
+  const columns = await listTableColumns(conn, database, tableInsert.table, tableInsert.schema)
+  return buildInsertQuery(knex, tableInsert, columns)
+}
 
 export function getQuerySelectTop(conn, table, limit) {
   return `SELECT * FROM ${wrapIdentifier(table)} LIMIT ${limit}`;

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -6,7 +6,7 @@ import Database from 'better-sqlite3'
 import { identify } from 'sql-query-identifier';
 import knexlib from 'knex'
 import rawLog from 'electron-log'
-import { buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery } from './utils';
+import { buildInsertQuery, buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery } from './utils';
 import { SqliteCursor } from './sqlite/SqliteCursor';
 import { SqliteChangeBuilder } from '@shared/lib/sql/change_builder/SqliteChangeBuilder';
 import { SqliteData } from '@shared/lib/dialects/sqlite';
@@ -54,6 +54,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters) => selectTop(conn, table, offset, limit, orderBy, filters),
     selectTopStream: (db, table, orderBy, filters, chunkSize) => selectTopStream(conn, db, table, orderBy, filters, chunkSize),
+    getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
     getViewCreateScript: (view) => getViewCreateScript(conn, view),
@@ -96,6 +97,10 @@ function escapeString(value) {
   return value.replace("'", "''")
 }
 
+async function getInsertQuery(conn, database, tableInsert) {
+  const columns = await listTableColumns(conn, database, tableInsert.table, tableInsert.schema)
+  return buildInsertQuery(knex, tableInsert, columns)
+}
 
 export function getQuerySelectTop(client, table, limit) {
   return `SELECT * FROM ${wrapIdentifier(table)} LIMIT ${limit}`;

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -24,6 +24,10 @@ export function runCommonTests(getUtil) {
     await getUtil().queryTests()
   })
 
+  test("get insert query tests", async () => {
+    await getUtil().getInsertQueryTests()
+  })
+
 
   test("table filter tests", async () => {
     await getUtil().filterTests()

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -348,6 +348,22 @@ export class DBTestUtil {
 
   }
 
+  async getInsertQueryTests() {
+    const row = { job_name: "Programmer", hourly_rate: 41 }
+    const tableInsert = { table: 'jobs', schema: this.defaultSchema, data: [row] }
+    const insertQuery = await this.connection.getInsertQuery(tableInsert)
+    const expectedQueries = {
+      postgresql: `insert into "public"."jobs" ("hourly_rate", "job_name") values (41, 'Programmer')`,
+      mysql: "insert into `jobs` (`hourly_rate`, `job_name`) values (41, 'Programmer')",
+      mariadb: "insert into `jobs` (`hourly_rate`, `job_name`) values (41, 'Programmer')",
+      sqlite: "insert into `jobs` (`hourly_rate`, `job_name`) values (41, 'Programmer')",
+      sqlserver: "insert into [dbo].[jobs] ([hourly_rate], [job_name]) values (41, 'Programmer')",
+      cockroachdb: `insert into "public"."jobs" ("hourly_rate", "job_name") values (41, 'Programmer')`
+    }
+
+    expect(insertQuery).toBe(expectedQueries[this.dbType])
+  }
+
   // lets start simple, it should resolve for all connection types
   async tablePropertiesTests() {
     await this.connection.getTableProperties('group', this.defaultSchema)


### PR DESCRIPTION
Allow user to copy a row insert query to clipboard.

![Peek 2022-04-16 15-38](https://user-images.githubusercontent.com/38707148/163668595-18533b06-ff83-48fa-8b32-79a0cbab9dac.gif)

Tasks:
- [x] Add buildInsertQuery method to connection interface
- [x] Update db clients (mysql, postgres, etc) to use [this helper function](https://github.com/beekeeper-studio/beekeeper-studio/blob/50e8ac31e66ff268acd2a701d5750da515e28531/apps/studio/src/lib/db/clients/utils.js#L146)
- [x] Update dropdown item
- [x] Add tests