### PR TITLE
fix error copying data

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -59,7 +59,7 @@ import Papa from 'papaparse'
         return [
           {
             label: '<x-menuitem><x-label>Copy Cell</x-label></x-menuitem>',
-            action: (_e, cell) => this.$native.clipboard.writeText(cell.getValue())
+            action: (_e, cell) => this.$native.clipboard.writeText(String(cell.getValue()))
           },
           {
             label: '<x-menuitem><x-label>Copy Row (JSON)</x-label></x-menuitem>',

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -306,9 +306,7 @@ export default Vue.extend({
         { separator: true },
         {
           label: '<x-menuitem><x-label>Copy Cell</x-label></x-menuitem>',
-          action: (_e, cell) => {
-            this.$native.clipboard.writeText(cell.getValue());
-          },
+          action: (_e, cell) => this.$native.clipboard.writeText(String(cell.getValue()))
         },
         {
           label: '<x-menuitem><x-label>Copy Row (JSON)</x-label></x-menuitem>',


### PR DESCRIPTION
# 🐛 Fix error copying data
Related issue #1174

## Error description
As you can see here, when you try copy an int id value, an error happens. So the value isn't copied.

### Example in a Table
![PR_Bekeeper_Error](https://user-images.githubusercontent.com/79997705/163884948-0f6f9067-0066-49e3-81eb-74b2b5dd8deb.gif)

### Example in a query
![PR_Bekeeper_Error_2](https://user-images.githubusercontent.com/79997705/163884953-aa4d0841-7954-4dc1-b4c3-9f366d06f068.gif)

## Solution preview
On the gif's bellow, you can see that the values are copied correctly, both in the table and in the query.

### Example in a table
![PR_Bekeeper_Ok](https://user-images.githubusercontent.com/79997705/163884962-0a397148-5550-47ca-9f2b-1d65b6f7980d.gif)

### Example in a query
![PR_Bekeeper_Ok_2](https://user-images.githubusercontent.com/79997705/163884964-0435da3f-17bc-418f-a8fc-5c5077f529e8.gif)
