### PR TITLE
Allow unpin table from "yellow pin" icon

### DIFF
--- a/apps/studio/src/components/sidebar/core/table_list/TableListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/TableListItem.vue
@@ -11,7 +11,7 @@
       <span class="actions" v-bind:class="{'pinned': pinned}">
         <span v-if="!pinned" @mousedown.prevent.stop="pin" class="btn-fab pin" :title="'Pin'"><i class="bk-pin"></i></span>
         <span v-if="pinned" @mousedown.prevent.stop="unpin" class="btn-fab unpin" :title="'Unpin'"><i class="material-icons">clear</i></span>
-        <span v-if="pinned" class="btn-fab pinned"><i class="bk-pin" :title="'Unpin'"></i></span>
+        <span v-if="pinned" @mousedown.prevent.stop="unpin" class="btn-fab pinned"><i class="bk-pin" :title="'Unpin'"></i></span>
       </span>
     </a>
     <div v-if="showColumns" class="sub-items">


### PR DESCRIPTION
Hi, first of all awesome App!

I Just installed is a few minutes ago and I have a little suggestion. I was using the "pin" in some tables and I was expecting to **unpin a table clicking the "yellow pin"**, but nothing happens.
I think it will be nice to have this feature to allow users to **"pin / unpin" faster**, rather than moving to the upper tab to unpin them from the "X" button.