### PR TITLE
Add support for multiple foreign keys on a column in table view.

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -401,7 +401,8 @@ export default Vue.extend({
     tableKeys() {
       const result = {}
       this.rawTableKeys.forEach((item) => {
-        result[item.fromColumn] = item
+        if (!result[item.fromColumn]) result[item.fromColumn] = [];
+        result[item.fromColumn].push(item);
       })
       return result
     },
@@ -414,7 +415,7 @@ export default Vue.extend({
       // to the FK table.
       this.table.columns.forEach(column => {
 
-        const keyData = this.tableKeys[column.columnName]
+        const keyDatas: any[] = this.tableKeys[column.columnName]
 
         // this needs fixing
         // currently it doesn't fetch the right result if you update the PK
@@ -432,8 +433,11 @@ export default Vue.extend({
         }
 
         let headerTooltip = `${column.columnName} ${column.dataType}`
-        if (keyData) {
-          headerTooltip += ` -> ${keyData.toTable}(${keyData.toColumn})`
+        if (keyDatas && keyDatas.length > 0) {
+          if (keyDatas.length === 1)
+            headerTooltip += ` -> ${keyDatas[0].toTable}(${keyDatas[0].toColumn})`
+          else
+            headerTooltip += ` -> ${keyDatas.map(item => `${item.toTable}(${item.toColumn})`).join(', ').replace(/, (?![\s\S]*, )/, ', or ')}`
         } else if (isPK) {
           headerTooltip += ' [Primary Key]'
         }
@@ -470,12 +474,27 @@ export default Vue.extend({
         }
         results.push(result)
 
-
-        if (keyData) {
+        if (keyDatas && keyDatas.length > 0) {
           const icon = () => "<i class='material-icons fk-link'>launch</i>"
           const tooltip = () => {
-            return `View record in ${keyData.toTable}`
+            if (keyDatas.length == 1)
+              return `View record in ${keyDatas[0].toTable}`
+            else 
+              return `View records in ${(keyDatas.map(item => item.toTable).join(', ') as string).replace(/, (?![\s\S]*, )/, ', or ')}`
           }
+          let clickMenu = null;
+          if (keyDatas.length > 1) {
+            clickMenu = [];
+            keyDatas.forEach(x => {
+              clickMenu.push({
+                label: `<x-menuitem><x-label>${x.toTable}(${x.toColumn})</x-label></x-menuitem>`,
+                action: (_e, cell) => {
+                  this.fkClick(_e, cell, x.toTable, x.toColumn);
+                }
+              })
+            })
+          }
+
           const keyResult = {
             headerSort: false,
             download: false,
@@ -484,8 +503,9 @@ export default Vue.extend({
             field: column.columnName + '-link--bks',
             title: "",
             cssClass: "foreign-key-button",
-            cellClick: this.fkClick,
+            cellClick: clickMenu == null ? this.fkClick : null,
             formatter: icon,
+            clickMenu,
             tooltip
           }
           result.cssClass = 'foreign-key'
@@ -747,18 +767,20 @@ export default Vue.extend({
         default: return ne
       }
     },
-    fkClick(_e, cell) {
+    fkClick(_e, cell, toTable = null, toColumn = null) {
       const fromColumn = cell.getField().replace(/-link--bks$/g, "")
       const valueCell = this.valueCellFor(cell)
       const value = valueCell.getValue()
 
-      const keyData = this.tableKeys[fromColumn]
-      if (!keyData) {
+      const keyDatas = this.tableKeys[fromColumn]
+      if (!keyDatas || keyDatas.length === 0) {
         log.error("fk-click, couldn't find key data. Please open an issue. fromColumn:", fromColumn)
         this.$noty.error("Unable to open foreign key. See dev console")
       }
-      const tableName = keyData.toTable
-      const schemaName = keyData.toSchema
+      const keyData = toColumn == null || toTable == null ? keyDatas[0] : keyDatas.find(x => x.toTable === toTable && x.toColumn === toColumn);
+
+      const tableName = keyData.toTable;
+      const schemaName = keyData.toSchema;
       const table = this.$store.state.tables.find(t => {
         return (!schemaName || schemaName === t.schema) && t.name === tableName
       })


### PR DESCRIPTION
I made these changes with respect to #1246.

In my day to day use of beekeeper, I have run into this a couple times: I have multiple foreign keys on a column, but beekeeper can only navigate to one of them. I elected to just add a menu to navigate to any of the foreign keys on that column, as evaluating the keys on a row by row basis would probably be super expensive (the example table I have below has two columns with 4 FKs each, and we have thousands of records in production right now).

These are the tooltips that have changed:
![tooltips](https://user-images.githubusercontent.com/58712803/174860218-8093dc2f-90f7-4557-97dd-581d09459e6e.gif)

And here is the clickMenu for columns with multiple FKs.
![navigation](https://user-images.githubusercontent.com/58712803/174860697-264fbe0c-7478-4173-b509-37eac561dacc.gif)

The default behaviour for this has not changed. If there is 1 FK, simply clicking the FK button will navigate. But if there are multiple FKs, then you get this click menu and you have to choose which table you'd like to navigate to.

Hopefully this PR is clear enough, but if you have any questions/comments, let me know. I also completely understand if this isn't an ideal solution for you, but I'd be happy to work on it further if required. Thanks for reading!
