### PR TITLE
Show database version in footer

### DIFF
--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -3,7 +3,7 @@
   <x-button class="btn btn-link btn-icon" menu>
     <i class="material-icons">link</i>
     <span class="connection-name truncate expand">{{connectionName}}</span>
-    <span class="connection-type badge truncate">{{connectionType}}</span>
+    <span class="connection-type badge truncate" v-tooltip="databaseVersion">{{connectionType}}</span>
     <x-menu>
       <x-menuitem @click.prevent="disconnect(false)" class="red">
         <x-label><i class="material-icons">power_settings_new</i>Disconnect</x-label>
@@ -30,7 +30,7 @@
     </div>
   </modal>
   <modal class="vue-dialog beekeeper-modal" name="running-exports-modal" height="auto" :scrollable="true">
-    <form @submit.prevent="disconnect(true)">      
+    <form @submit.prevent="disconnect(true)">
       <div class="dialog-content">
         <div class="dialog-c-title">Confirm Disconnect</div>
         There are active exports running. Are you sure you want to disconnect?
@@ -58,7 +58,7 @@ export default {
   },
   computed: {
       ...mapState({'config': 'usedConfig'}),
-      ...mapGetters({'hasRunningExports': 'exports/hasRunningExports', 'workspace': 'workspace'}),
+      ...mapGetters({'hasRunningExports': 'exports/hasRunningExports', 'workspace': 'workspace', 'versionString': 'versionString'}),
       connectionName() {
         const config = this.config
         if (!config) return 'Connection'
@@ -67,6 +67,9 @@ export default {
       },
       connectionType() {
         return `${this.config.connectionType}`
+      },
+      databaseVersion() {
+        return this.versionString
       }
   },
   methods: {

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -9,7 +9,8 @@ import { AlterTableSpec, IndexAlterations, RelationAlterations } from '@shared/l
 const logger = createLogger('db');
 
 export interface DatabaseClient {
-  supportedFeatures: () => SupportedFeatures
+  supportedFeatures: () => SupportedFeatures,
+  versionString: () => string,
   disconnect: () => void,
   listTables: (db: string, filter?: FilterOptions) => Promise<TableOrView[]>,
   listViews: (filter?: FilterOptions) => Promise<TableOrView[]>,
@@ -166,6 +167,7 @@ export class DBConnection {
   async currentDatabase() {
     return this.database.database
   }
+  versionString = versionString.bind(null, this.server, this.database)
 }
 
 export function createConnection(server: IDbConnectionServer, database: IDbConnectionDatabase ) {
@@ -481,4 +483,8 @@ function checkIsConnected(_server: IDbConnectionServer, database: IDbConnectionD
   if (database.connecting || !database.connection) {
     throw new Error('There is no connection available.');
   }
+}
+
+function versionString(_server: IDbConnectionServer, database: IDbConnectionDatabase): string {
+  return database.connection?.versionString();
 }

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -34,6 +34,7 @@ export default async function (server, database) {
 
   return {
     supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true }),
+    versionString: () => getVersionString(versionInfo),
     wrapIdentifier,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
@@ -106,6 +107,10 @@ async function getVersion(conn) {
     version: Number(stuff[0] || 0)
   }
 
+}
+
+function getVersionString(versionInfo) {
+  return versionInfo.versionString
 }
 
 

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -155,6 +155,7 @@ export default async function (server: any, database: any): Promise<DatabaseClie
   return {
     /* eslint max-len:0 */
     supportedFeatures: () => features,
+    versionString: () => getVersionString(version),
     wrapIdentifier,
     disconnect: () => disconnect(conn),
     listTables: (_db: string, filter: FilterOptions | undefined) => listTables(conn, filter),
@@ -1500,6 +1501,10 @@ async function runWithConnection<T>(x: Conn, run: (p: PoolClient) => Promise<T>)
   } finally {
     connection.release();
   }
+}
+
+function getVersionString(version: VersionInfo): string {
+  return version.version.split(" on ")[0];
 }
 
 

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -29,10 +29,11 @@ export default async function (server, database) {
   const conn = { dbConfig };
 
   // light solution to test connection with with the server
-  await driverExecuteQuery(conn, { query: 'SELECT sqlite_version()' });
+  const version = await driverExecuteQuery(conn, { query: 'SELECT sqlite_version()' });
 
   return {
     supportedFeatures: () => ({ customRoutines: false, comments: false, properties: true }),
+    versionString: () => getVersionString(version),
     wrapIdentifier,
     disconnect: () => disconnect(conn),
     listTables: () => listTables(conn),
@@ -210,7 +211,7 @@ export async function updateValues(cli, updates) {
       whereList.push(`${wrapIdentifier(column)} = ?`);
       params.push(value);
     })
-    
+
     const where = whereList.join(" AND ");
 
     return {
@@ -627,6 +628,10 @@ export async function executeWithTransaction(conn, queryArgs) {
       throw ex
     }
   })
+}
+
+function getVersionString(version) {
+  return version.data[0]["sqlite_version()"];
 }
 
 

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -37,8 +37,11 @@ export default async function (server, database) {
   // light solution to test connection with with the server
   await driverExecuteQuery(conn, { query: 'SELECT 1' });
 
+  const version = await getVersion(conn);
+
   return {
     supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true}),
+    versionString: () => getVersionString(version),
     wrapIdentifier,
     disconnect: () => disconnect(conn),
     listTables: (db, filter) => listTables(conn, filter),
@@ -96,6 +99,10 @@ async function getVersion(conn) {
     releaseYear,
     versionString
   }
+}
+
+function getVersionString(version) {
+  return version.versionString.split(" \n\t")[0];
 }
 
 export async function disconnect(conn) {

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -34,9 +34,7 @@ export default async function (server, database) {
 
   const conn = { dbConfig };
 
-  // light solution to test connection with with the server
-  await driverExecuteQuery(conn, { query: 'SELECT 1' });
-
+  // get version and test connection
   const version = await getVersion(conn);
 
   return {

--- a/apps/studio/src/lib/db/server.ts
+++ b/apps/studio/src/lib/db/server.ts
@@ -7,6 +7,7 @@ export interface IDbConnectionPublicServer {
   disconnect: () => void
   end: () => void
   createConnection: (dbName?: string, cryptoSecret?: string) => DBConnection
+  versionString: () => string
 }
 
 export function createServer(config: IDbConnectionServerConfig): IDbConnectionPublicServer {
@@ -78,5 +79,10 @@ export function createServer(config: IDbConnectionServerConfig): IDbConnectionPu
       // @ts-ignore
       return server.db[dbName];
     },
+
+    versionString() {
+      // get version string from the first db, since all db's on the server have the same version
+      return server.db[Object.keys(server.db)[0]].versionString();
+    }
   } as IDbConnectionPublicServer;
 }

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -160,7 +160,9 @@ const store = new Vuex.Store<State>({
       }
       return []
     },
-
+    versionString(state) {
+      return state.server.versionString();
+    }
   },
   mutations: {
     storeInitialized(state, b: boolean) {

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -1,6 +1,10 @@
 
 export function runCommonTests(getUtil) {
 
+  test("get database version should work", async() => {
+    await getUtil().databaseVersionTest()
+  })
+
   test("list tables should work", async() => {
     await getUtil().listTableTests()
   })

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -515,4 +515,9 @@ export class DBTestUtil {
       table.integer("one").unsigned().notNullable().primary()
     })
   }
+
+  async databaseVersionTest() {
+    const version = this.connection.versionString();
+    expect(version).toBeDefined()
+  }
 }


### PR DESCRIPTION
I added a way to display the database version.
There is not much space in the footer, so I added a tooltip for the connection type where the version is displayed.

Maybe someone has a better idea?

### Demo
![postgres](https://user-images.githubusercontent.com/32418474/176132521-bbd7335e-5b89-497d-a059-d3a7c52cdab2.gif)

![mariadb](https://user-images.githubusercontent.com/32418474/176132534-8778b6b3-2570-4cda-9b09-bbb3e4e3568c.gif)

![sqlserver](https://user-images.githubusercontent.com/32418474/176132543-fbb3d5c1-a361-45b9-9a07-5887b1ebda64.gif)

![sqlite](https://user-images.githubusercontent.com/32418474/176132888-8810c226-a1aa-4db7-bcf8-b19421e24df2.gif)


Fixes #1156