### PR TITLE
feat: Add copy as markdown feature for result tables

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -43,6 +43,7 @@
     "jquery": "^3.5.0",
     "knex": "^2.0.0",
     "lodash": "^4.17.21",
+    "markdown-table": "^3.0.2",
     "marked": "^4.0.10",
     "material-icons": "^0.7.6",
     "mkdirp": "^1.0.4",

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -5,7 +5,14 @@
       ref="topPanel"
       @contextmenu.prevent.stop="showContextMenu"
     >
-      <merge-manager v-if="query && query.id" :originalText="originalText" :query="query" :unsavedText="unsavedText" @change="onChange" @mergeAccepted="originalText = query.text" />
+      <merge-manager
+        v-if="query && query.id"
+        :originalText="originalText"
+        :query="query"
+        :unsavedText="unsavedText"
+        @change="onChange"
+        @mergeAccepted="originalText = query.text"
+      />
       <div class="no-content" v-if="remoteDeleted">
         <div class="alert alert-danger">
           <i class="material-icons">error_outline</i>
@@ -15,21 +22,36 @@
           <a @click.prevent="close" class="btn btn-flat">Close Tab</a>
         </div>
       </div>
-      <textarea name="editor" class="editor" ref="editor" id="" cols="30" rows="10"></textarea>
+      <textarea
+        name="editor"
+        class="editor"
+        ref="editor"
+        id=""
+        cols="30"
+        rows="10"
+      ></textarea>
       <span class="expand"></span>
       <div class="toolbar text-right">
         <div class="actions btn-group" ref="actions">
-          <x-button @click.prevent="triggerSave" class="btn btn-flat btn-small">Save</x-button>
+          <x-button @click.prevent="triggerSave" class="btn btn-flat btn-small"
+            >Save</x-button
+          >
 
           <x-buttons class="">
-            <x-button class="btn btn-primary btn-small" v-tooltip="'Ctrl+Enter'" @click.prevent="submitTabQuery">
-              <x-label>{{hasSelectedText ? 'Run Selection' : 'Run'}}</x-label>
+            <x-button
+              class="btn btn-primary btn-small"
+              v-tooltip="'Ctrl+Enter'"
+              @click.prevent="submitTabQuery"
+            >
+              <x-label>{{ hasSelectedText ? "Run Selection" : "Run" }}</x-label>
             </x-button>
             <x-button class="btn btn-primary btn-small" menu>
               <i class="material-icons">arrow_drop_down</i>
               <x-menu>
                 <x-menuitem @click.prevent="submitTabQuery">
-                  <x-label>{{hasSelectedText ? 'Run Selection' : 'Run'}}</x-label>
+                  <x-label>{{
+                    hasSelectedText ? "Run Selection" : "Run"
+                  }}</x-label>
                   <x-shortcut value="Control+Enter"></x-shortcut>
                 </x-menuitem>
                 <x-menuitem @click.prevent="submitCurrentQuery">
@@ -41,16 +63,29 @@
           </x-buttons>
         </div>
       </div>
-
-
     </div>
     <div class="bottom-panel" ref="bottomPanel">
-      <progress-bar @cancel="cancelQuery" :message="runningText" v-if="running"></progress-bar>
-      <result-table ref="table" v-else-if="rowCount > 0" :active="active" :tableHeight="tableHeight" :result="result" :query='query'></result-table>
+      <progress-bar
+        @cancel="cancelQuery"
+        :message="runningText"
+        v-if="running"
+      ></progress-bar>
+      <result-table
+        ref="table"
+        v-else-if="rowCount > 0"
+        :active="active"
+        :tableHeight="tableHeight"
+        :result="result"
+        :query="query"
+      ></result-table>
       <div class="message" v-else-if="result">
         <div class="alert alert-info">
           <i class="material-icons-outlined">info</i>
-          <span>Query {{selectedResult + 1}}/{{results.length}}: No Results. {{result.affectedRows || 0}} rows affected. See the select box in the bottom left ↙ for more query results.</span>
+          <span
+            >Query {{ selectedResult + 1 }}/{{ results.length }}: No Results.
+            {{ result.affectedRows || 0 }} rows affected. See the select box in
+            the bottom left ↙ for more query results.</span
+          >
         </div>
       </div>
       <div class="message" v-else-if="errors">
@@ -59,7 +94,7 @@
       <div class="message" v-else-if="info">
         <div class="alert alert-info">
           <i class="material-icon-outlined">info</i>
-          <span>{{info}}</span>
+          <span>{{ info }}</span>
         </div>
       </div>
       <div class="layout-center expand" v-else>
@@ -74,718 +109,846 @@
         @download="download"
         @clipboard="clipboard"
         @clipboardJson="clipboardJson"
+        @clipboardMarkdown="clipboardMarkdown"
         :executeTime="executeTime"
       ></query-editor-status-bar>
     </div>
 
     <!-- Save Modal -->
-    <modal class="vue-dialog beekeeper-modal" name="save-modal" @closed="selectEditor" @opened="selectTitleInput" height="auto" :scrollable="true">
+    <modal
+      class="vue-dialog beekeeper-modal"
+      name="save-modal"
+      @closed="selectEditor"
+      @opened="selectTitleInput"
+      height="auto"
+      :scrollable="true"
+    >
       <form v-if="query" @submit.prevent="saveQuery">
         <div class="dialog-content">
           <div class="dialog-c-title">Saved Query Name</div>
           <div class="modal-form">
-            <div class="alert alert-danger save-errors" v-if="saveError">{{saveError}}</div>
+            <div class="alert alert-danger save-errors" v-if="saveError">
+              {{ saveError }}
+            </div>
             <div class="form-group">
-                <input type="text" ref="titleInput" name="title" class="form-control"  v-model="query.title" autofocus>
+              <input
+                type="text"
+                ref="titleInput"
+                name="title"
+                class="form-control"
+                v-model="query.title"
+                autofocus
+              />
             </div>
           </div>
         </div>
         <div class="vue-dialog-buttons">
-          <button class="btn btn-flat" type="button" @click.prevent="$modal.hide('save-modal')">Cancel</button>
+          <button
+            class="btn btn-flat"
+            type="button"
+            @click.prevent="$modal.hide('save-modal')"
+          >
+            Cancel
+          </button>
           <button class="btn btn-primary" type="submit">Save</button>
         </div>
       </form>
     </modal>
 
     <!-- Parameter modal -->
-    <modal class="vue-dialog beekeeper-modal" name="parameters-modal" @opened="selectFirstParameter" @closed="selectEditor" height="auto" :scrollable="true">
+    <modal
+      class="vue-dialog beekeeper-modal"
+      name="parameters-modal"
+      @opened="selectFirstParameter"
+      @closed="selectEditor"
+      height="auto"
+      :scrollable="true"
+    >
       <form @submit.prevent="submitQuery(queryForExecution, true)">
         <div class="dialog-content">
           <div class="dialog-c-title">Provide parameter values</div>
-          <div class="dialog-c-subtitle">You need to use single quotes around string values. Blank values are invalid</div>
+          <div class="dialog-c-subtitle">
+            You need to use single quotes around string values. Blank values are
+            invalid
+          </div>
           <div class="modal-form">
             <div class="form-group">
-                <div v-for="(param, index) in queryParameterPlaceholders" v-bind:key="index">
-                  <div class="form-group row">
-                    <label>{{param}}</label>
-                    <input type="text" class="form-control" required v-model="queryParameterValues[param]" autofocus ref="paramInput">
-                  </div>
+              <div
+                v-for="(param, index) in queryParameterPlaceholders"
+                v-bind:key="index"
+              >
+                <div class="form-group row">
+                  <label>{{ param }}</label>
+                  <input
+                    type="text"
+                    class="form-control"
+                    required
+                    v-model="queryParameterValues[param]"
+                    autofocus
+                    ref="paramInput"
+                  />
                 </div>
+              </div>
             </div>
           </div>
         </div>
         <div class="vue-dialog-buttons">
-          <button class="btn btn-flat" type="button" @click.prevent="$modal.hide('parameters-modal')">Cancel</button>
+          <button
+            class="btn btn-flat"
+            type="button"
+            @click.prevent="$modal.hide('parameters-modal')"
+          >
+            Cancel
+          </button>
           <button class="btn btn-primary" type="submit">Run</button>
         </div>
       </form>
     </modal>
-
   </div>
 </template>
 
 <script>
+import _ from "lodash";
+import "codemirror/addon/search/searchcursor";
+import CodeMirror from "codemirror";
+import "codemirror/addon/comment/comment";
+import Split from "split.js";
+import { mapGetters, mapState } from "vuex";
+import { identify } from "sql-query-identifier";
+import pluralize from "pluralize";
 
-  import _ from 'lodash'
-  import 'codemirror/addon/search/searchcursor'
-  import CodeMirror from 'codemirror'
-  import 'codemirror/addon/comment/comment'
-  import Split from 'split.js'
-  import { mapGetters, mapState } from 'vuex'
-  import { identify } from 'sql-query-identifier'
-  import pluralize from 'pluralize'
+import { splitQueries, extractParams } from "../lib/db/sql_tools";
+import ProgressBar from "./editor/ProgressBar.vue";
+import ResultTable from "./editor/ResultTable.vue";
+import ShortcutHints from "./editor/ShortcutHints.vue";
 
-  import { splitQueries, extractParams } from '../lib/db/sql_tools'
-  import ProgressBar from './editor/ProgressBar.vue'
-  import ResultTable from './editor/ResultTable.vue'
-  import ShortcutHints from './editor/ShortcutHints.vue'
+import { format } from "sql-formatter";
 
-  import { format } from 'sql-formatter';
+import QueryEditorStatusBar from "./editor/QueryEditorStatusBar.vue";
+import rawlog from "electron-log";
+import ErrorAlert from "./common/ErrorAlert.vue";
+import { FormatterDialect } from "@shared/lib/dialects/models";
+import MergeManager from "@/components/editor/MergeManager.vue";
+import { AppEvent } from "@/common/AppEvent";
+import { FavoriteQuery } from "@/common/appdb/models/favorite_query";
 
-  import QueryEditorStatusBar from './editor/QueryEditorStatusBar.vue'
-  import rawlog from 'electron-log'
-  import ErrorAlert from './common/ErrorAlert.vue'
-  import {FormatterDialect} from "@shared/lib/dialects/models";
-  import MergeManager from '@/components/editor/MergeManager.vue'
-import { AppEvent } from '@/common/AppEvent'
-import { FavoriteQuery } from '@/common/appdb/models/favorite_query'
+const log = rawlog.scope("query-editor");
+const isEmpty = s => _.isEmpty(_.trim(s));
+const editorDefault = "\n\n\n\n\n\n\n\n\n\n";
 
-  const log = rawlog.scope('query-editor')
-  const isEmpty = (s) => _.isEmpty(_.trim(s))
-  const editorDefault = "\n\n\n\n\n\n\n\n\n\n"
-
-  export default {
-    // this.queryText holds the current editor value, always
-    components: { ResultTable, ProgressBar, ShortcutHints, QueryEditorStatusBar, ErrorAlert, MergeManager},
-    props: ['tab', 'active'],
-    data() {
-      return {
-        results: [],
-        running: false,
-        runningCount: 1,
-        runningType: 'all queries',
-        selectedResult: 0,
-        editor: null,
-        runningQuery: null,
-        error: null,
-        errorMarker: null,
-        saveError: null,
-        info: null,
-        split: null,
-        tableHeight: 0,
-        savePrompt: false,
-        lastWord: null,
-        cursorIndex: null,
-        marker: null,
-        queryParameterValues: {},
-        queryForExecution: null,
-        executeTime: 0,
-        originalText: "",
-        initialized: false,
-        blankQuery: new FavoriteQuery(),
+export default {
+  // this.queryText holds the current editor value, always
+  components: {
+    ResultTable,
+    ProgressBar,
+    ShortcutHints,
+    QueryEditorStatusBar,
+    ErrorAlert,
+    MergeManager
+  },
+  props: ["tab", "active"],
+  data() {
+    return {
+      results: [],
+      running: false,
+      runningCount: 1,
+      runningType: "all queries",
+      selectedResult: 0,
+      editor: null,
+      runningQuery: null,
+      error: null,
+      errorMarker: null,
+      saveError: null,
+      info: null,
+      split: null,
+      tableHeight: 0,
+      savePrompt: false,
+      lastWord: null,
+      cursorIndex: null,
+      marker: null,
+      queryParameterValues: {},
+      queryForExecution: null,
+      executeTime: 0,
+      originalText: "",
+      initialized: false,
+      blankQuery: new FavoriteQuery()
+    };
+  },
+  computed: {
+    ...mapGetters(["dialect"]),
+    ...mapState([
+      "usedConfig",
+      "connection",
+      "database",
+      "tables",
+      "storeInitialized"
+    ]),
+    ...mapState("data/queries", { savedQueries: "items" }),
+    shouldInitialize() {
+      return this.storeInitialized && this.active && !this.initialized;
+    },
+    remoteDeleted() {
+      return this.storeInitialized && this.tab.queryId && !this.query;
+    },
+    query() {
+      return this.tab.findQuery(this.savedQueries || []) || this.blankQuery;
+    },
+    queryTitle() {
+      return this.query?.title;
+    },
+    unsavedText: {
+      get() {
+        return this.tab.unsavedQueryText || "";
+      },
+      set(value) {
+        this.tab.unsavedQueryText = value;
       }
     },
-    computed: {
-      ...mapGetters(['dialect']),
-      ...mapState(['usedConfig', 'connection', 'database', 'tables', 'storeInitialized']),
-      ...mapState('data/queries', {'savedQueries': 'items'}),
-      shouldInitialize() {
-        return this.storeInitialized && this.active && !this.initialized
-      },
-      remoteDeleted() {
-        return this.storeInitialized && this.tab.queryId && !this.query
-      },
-      query() {
-        return this.tab.findQuery(this.savedQueries || []) || this.blankQuery
-      },
-      queryTitle() {
-        return this.query?.title
-      },
-      unsavedText: {
-        get () {
-          return this.tab.unsavedQueryText || ""
-        },
-        set(value) {
-          this.tab.unsavedQueryText = value
-        },
-      },
-      identifyDialect() {
-        // dialect for sql-query-identifier
-        const mappings = {
-          'sqlserver': 'mssql',
-          'sqlite': 'sqlite',
-          'cockroachdb': 'psql',
-          'postgresql': 'psql',
-          'mysql': 'mysql',
-          'mariadb': 'mysql',
-          'redshift': 'psql',
-        }
-        return mappings[this.connectionType] || 'generic'
-      },
-      hasParams() {
-        return !!this.queryParameterPlaceholders?.length
-      },
-      paramsModalRequired() {
-        let result = false
-        this.queryParameterPlaceholders.forEach((param) => {
-          const v = this.queryParameterValues[param]
-          if (!v || _.isEmpty(v.trim())) {
-            result = true
-          }
-        })
-        return result
-      },
-      errors() {
-        const result = [
-          this.error,
-          this.saveError
-        ].filter((e) => e)
-
-        return result.length ? result : null
-      },
-      runningText() {
-        return `Running ${this.runningType} (${pluralize('query', this.runningCount, true)})`
-      },
-      hasSelectedText() {
-        return this.editor ? !!this.editor.getSelection() : false
-      },
-      result() {
-        return this.results[this.selectedResult]
-      },
-      individualQueries() {
-        if (!this.unsavedText) return []
-        return splitQueries(this.unsavedText, this.identifyDialect)
-      },
-      currentlySelectedQueryIndex() {
-        const queries = this.individualQueries
-        for (let i = 0; i < queries.length; i++) {
-          if (this.cursorIndex <= queries[i].end + 1) return i
-        }
-        return null
-      },
-      currentlySelectedQuery() {
-        if (this.currentlySelectedQueryIndex === null) return null
-        return this.individualQueries[this.currentlySelectedQueryIndex]
-      },
-      currentQueryPosition() {
-        if(!this.editor || !this.currentlySelectedQuery || !this.individualQueries) {
-          return null
-        }
-        const qi = this.currentlySelectedQueryIndex
-        const previousQuery = qi === 0 ? null : this.individualQueries[qi - 1]
-        // adding 1 to account for semicolon
-        const start = previousQuery ? previousQuery.end + 1: 0
-        const end = this.currentlySelectedQuery.end
-
-        return {
-          from: start,
-          to: end + 1
-        }
-
-      },
-      rowCount() {
-        return this.result && this.result.rows ? this.result.rows.length : 0
-      },
-      hasText() {
-        return !isEmpty(this.unsavedText)
-      },
-      hasTitle() {
-        return this.query.title && this.query.title.replace(/\s+/, '').length > 0
-      },
-      splitElements() {
-        return [
-          this.$refs.topPanel,
-          this.$refs.bottomPanel,
-        ]
-      },
-      keymap() {
-        if (!this.active) return {}
-        const result = {}
-        result[this.ctrlOrCmd('l')] = this.selectEditor
-        return result
-      },
-      connectionType() {
-        return this.connection.connectionType;
-      },
-      hintOptions() {
-        const result = {}
-        this.tables.forEach(table => {
-          const cleanColumns = table.columns.map(col => {
-            return /\./.test(col.columnName) ? `"${col.columnName}"` : col.columnName
-          })
-
-          // add quoted option for everyone that needs to be quoted
-          if (this.connectionType === 'postgresql' && (/[^a-z0-9_]/.test(table.name) || /^\d/.test(table.name)))
-            result[`"${table.name}"`] = cleanColumns
-
-          // don't add table names that can get in conflict with database schema
-          if (!/\./.test(table.name))
-            result[table.name] = cleanColumns
-        })
-        return { tables: result }
-      },
-      queryParameterPlaceholders() {
-        const params = this.individualQueries.flatMap((qs) => qs.parameters)
-        if (params.length && params[0] === '?') {
-          return []
-        } else {
-          return _.uniq(params)
-        }
-      },
-      deparameterizedQuery() {
-        let query = this.queryForExecution
-        if (_.isEmpty(query)) {
-          return query;
-        }
-        _.each(this.queryParameterPlaceholders, param => {
-          query = query.replace(new RegExp(`(\\W|^)${this.escapeRegExp(param)}(\\W|$)`, 'g'), `$1${this.queryParameterValues[param]}$2`)
-        });
-        return query;
-      },
-      unsavedChanges() {
-        if (_.trim(this.unsavedText) === "" && _.trim(this.originalText) === "") return false
-
-        return !this.query?.id ||
-          _.trim(this.unsavedText) !== _.trim(this.originalText)
-      },
+    identifyDialect() {
+      // dialect for sql-query-identifier
+      const mappings = {
+        sqlserver: "mssql",
+        sqlite: "sqlite",
+        cockroachdb: "psql",
+        postgresql: "psql",
+        mysql: "mysql",
+        mariadb: "mysql",
+        redshift: "psql"
+      };
+      return mappings[this.connectionType] || "generic";
     },
-    watch: {
-      error() {
-        if (this.errorMarker) {
-          this.errorMarker.clear()
+    hasParams() {
+      return !!this.queryParameterPlaceholders?.length;
+    },
+    paramsModalRequired() {
+      let result = false;
+      this.queryParameterPlaceholders.forEach(param => {
+        const v = this.queryParameterValues[param];
+        if (!v || _.isEmpty(v.trim())) {
+          result = true;
         }
-        if (this.dialect === 'postgresql' && this.error && this.error.position) {
-          const [a, b] = this.locationFromPosition(this.queryForExecution, parseInt(this.error.position) - 1, parseInt(this.error.position))
-          this.errorMarker = this.editor.getDoc().markText(a, b, { className: 'error'})
-          this.error.marker = {line: b.line + 1, ch: b.ch}
-        }
-      },
-      queryTitle() {
-        if (this.queryTitle) this.tab.title = this.queryTitle
-      },
-      shouldInitialize() {
-        if (this.shouldInitialize) this.initialize()
-      },
-      unsavedText() {
-        this.saveTab()
-      },
-      remoteDeleted() {
-        // eslint-disable-next-line no-debugger
-        if (this.remoteDeleted) {
-          this.editor?.setOption('readOnly', 'nocursor')
-          this.tab.unsavedChanges = false
-          this.tab.alert = true
-        } else {
-          this.editor?.setOption('readOnly', false)
-        }
-      },
-      unsavedChanges() {
-        this.tab.unsavedChanges = this.unsavedChanges
-      },
-      active() {
-        if(this.active && this.editor) {
-          this.$nextTick(() => {
-            this.editor.refresh()
-            this.editor.focus()
-          })
-        } else {
-          this.$modal.hide('save-modal')
-        }
-      },
-      currentQueryPosition() {
-        if (this.marker){
-          this.marker.clear()
+      });
+      return result;
+    },
+    errors() {
+      const result = [this.error, this.saveError].filter(e => e);
+
+      return result.length ? result : null;
+    },
+    runningText() {
+      return `Running ${this.runningType} (${pluralize(
+        "query",
+        this.runningCount,
+        true
+      )})`;
+    },
+    hasSelectedText() {
+      return this.editor ? !!this.editor.getSelection() : false;
+    },
+    result() {
+      return this.results[this.selectedResult];
+    },
+    individualQueries() {
+      if (!this.unsavedText) return [];
+      return splitQueries(this.unsavedText, this.identifyDialect);
+    },
+    currentlySelectedQueryIndex() {
+      const queries = this.individualQueries;
+      for (let i = 0; i < queries.length; i++) {
+        if (this.cursorIndex <= queries[i].end + 1) return i;
+      }
+      return null;
+    },
+    currentlySelectedQuery() {
+      if (this.currentlySelectedQueryIndex === null) return null;
+      return this.individualQueries[this.currentlySelectedQueryIndex];
+    },
+    currentQueryPosition() {
+      if (
+        !this.editor ||
+        !this.currentlySelectedQuery ||
+        !this.individualQueries
+      ) {
+        return null;
+      }
+      const qi = this.currentlySelectedQueryIndex;
+      const previousQuery = qi === 0 ? null : this.individualQueries[qi - 1];
+      // adding 1 to account for semicolon
+      const start = previousQuery ? previousQuery.end + 1 : 0;
+      const end = this.currentlySelectedQuery.end;
+
+      return {
+        from: start,
+        to: end + 1
+      };
+    },
+    rowCount() {
+      return this.result && this.result.rows ? this.result.rows.length : 0;
+    },
+    hasText() {
+      return !isEmpty(this.unsavedText);
+    },
+    hasTitle() {
+      return this.query.title && this.query.title.replace(/\s+/, "").length > 0;
+    },
+    splitElements() {
+      return [this.$refs.topPanel, this.$refs.bottomPanel];
+    },
+    keymap() {
+      if (!this.active) return {};
+      const result = {};
+      result[this.ctrlOrCmd("l")] = this.selectEditor;
+      return result;
+    },
+    connectionType() {
+      return this.connection.connectionType;
+    },
+    hintOptions() {
+      const result = {};
+      this.tables.forEach(table => {
+        const cleanColumns = table.columns.map(col => {
+          return /\./.test(col.columnName)
+            ? `"${col.columnName}"`
+            : col.columnName;
+        });
+
+        // add quoted option for everyone that needs to be quoted
+        if (
+          this.connectionType === "postgresql" &&
+          (/[^a-z0-9_]/.test(table.name) || /^\d/.test(table.name))
+        )
+          result[`"${table.name}"`] = cleanColumns;
+
+        // don't add table names that can get in conflict with database schema
+        if (!/\./.test(table.name)) result[table.name] = cleanColumns;
+      });
+      return { tables: result };
+    },
+    queryParameterPlaceholders() {
+      const params = this.individualQueries.flatMap(qs => qs.parameters);
+      if (params.length && params[0] === "?") {
+        return [];
+      } else {
+        return _.uniq(params);
+      }
+    },
+    deparameterizedQuery() {
+      let query = this.queryForExecution;
+      if (_.isEmpty(query)) {
+        return query;
+      }
+      _.each(this.queryParameterPlaceholders, param => {
+        query = query.replace(
+          new RegExp(`(\\W|^)${this.escapeRegExp(param)}(\\W|$)`, "g"),
+          `$1${this.queryParameterValues[param]}$2`
+        );
+      });
+      return query;
+    },
+    unsavedChanges() {
+      if (_.trim(this.unsavedText) === "" && _.trim(this.originalText) === "")
+        return false;
+
+      return (
+        !this.query?.id ||
+        _.trim(this.unsavedText) !== _.trim(this.originalText)
+      );
+    }
+  },
+  watch: {
+    error() {
+      if (this.errorMarker) {
+        this.errorMarker.clear();
+      }
+      if (this.dialect === "postgresql" && this.error && this.error.position) {
+        const [a, b] = this.locationFromPosition(
+          this.queryForExecution,
+          parseInt(this.error.position) - 1,
+          parseInt(this.error.position)
+        );
+        this.errorMarker = this.editor
+          .getDoc()
+          .markText(a, b, { className: "error" });
+        this.error.marker = { line: b.line + 1, ch: b.ch };
+      }
+    },
+    queryTitle() {
+      if (this.queryTitle) this.tab.title = this.queryTitle;
+    },
+    shouldInitialize() {
+      if (this.shouldInitialize) this.initialize();
+    },
+    unsavedText() {
+      this.saveTab();
+    },
+    remoteDeleted() {
+      // eslint-disable-next-line no-debugger
+      if (this.remoteDeleted) {
+        this.editor?.setOption("readOnly", "nocursor");
+        this.tab.unsavedChanges = false;
+        this.tab.alert = true;
+      } else {
+        this.editor?.setOption("readOnly", false);
+      }
+    },
+    unsavedChanges() {
+      this.tab.unsavedChanges = this.unsavedChanges;
+    },
+    active() {
+      if (this.active && this.editor) {
+        this.$nextTick(() => {
+          this.editor.refresh();
+          this.editor.focus();
+        });
+      } else {
+        this.$modal.hide("save-modal");
+      }
+    },
+    currentQueryPosition() {
+      if (this.marker) {
+        this.marker.clear();
+      }
+
+      if (!this.individualQueries || this.individualQueries.length < 2) {
+        return;
+      }
+
+      if (!this.currentQueryPosition) {
+        return;
+      }
+      const { from, to } = this.currentQueryPosition;
+
+      const editorText = this.editor.getValue();
+      const lines = editorText.split(/\n/);
+
+      const [markStart, markEnd] = this.locationFromPosition(
+        editorText,
+        from,
+        to
+      );
+      this.marker = this.editor
+        .getDoc()
+        .markText(markStart, markEnd, { className: "highlight" });
+    },
+    hintOptions() {
+      this.editor?.setOption("hintOptions", this.hintOptions);
+    }
+  },
+  methods: {
+    locationFromPosition(queryText, ...rawPositions) {
+      // 1. find the query text inside the editor
+      // 2.
+
+      const editorText = this.editor.getValue();
+
+      const startCharacter = editorText.indexOf(queryText);
+      const lines = editorText.split(/\n/);
+      const positions = rawPositions.map(p => p + startCharacter);
+
+      const finished = positions.map(p => false);
+      const results = positions.map(p => ({ line: null, ch: null }));
+
+      let startOfLine = 0;
+      lines.forEach((line, idx) => {
+        const eol = startOfLine + line.length + 1;
+        positions.forEach((p, pIndex) => {
+          if (startOfLine <= p && p <= eol && !finished[pIndex]) {
+            results[pIndex].line = idx;
+            results[pIndex].ch = p - startOfLine;
+            finished[pIndex] = true;
+          }
+        });
+        startOfLine += line.length + 1;
+      });
+      return results;
+    },
+    initialize() {
+      this.initialized = true;
+      // TODO (matthew): Add hint options for all tables and columns\
+      this.initializeQueries();
+      const startingValue =
+        this.unsavedText || this.query?.text || editorDefault;
+      console.log("starting value", startingValue);
+      this.tab.unsavedChanges = this.unsavedChanges;
+
+      this.$nextTick(() => {
+        this.split = Split(this.splitElements, {
+          elementStyle: (dimension, size) => ({
+            "flex-basis": `calc(${size}%)`
+          }),
+          sizes: [50, 50],
+          gutterSize: 8,
+          direction: "vertical",
+          onDragEnd: () => {
+            this.$nextTick(() => {
+              this.tableHeight = this.$refs.bottomPanel.clientHeight;
+              this.updateEditorHeight();
+            });
+          }
+        });
+
+        const runQueryKeyMap = {
+          "Shift-Ctrl-Enter": this.submitCurrentQuery,
+          "Shift-Cmd-Enter": this.submitCurrentQuery,
+          "Ctrl-Enter": this.submitTabQuery,
+          "Cmd-Enter": this.submitTabQuery,
+          "Ctrl-S": this.triggerSave,
+          "Cmd-S": this.triggerSave,
+          "Shift-Ctrl-F": this.formatSql,
+          "Shift-Cmd-F": this.formatSql,
+          "Ctrl-/": this.toggleComment,
+          "Cmd-/": this.toggleComment,
+          Esc: this.cancelQuery,
+          F5: this.submitTabQuery,
+          "Shift-F5": this.submitCurrentQuery
+        };
+
+        const modes = {
+          mysql: "text/x-mysql",
+          postgresql: "text/x-pgsql",
+          sqlserver: "text/x-mssql"
+        };
+
+        this.editor = CodeMirror.fromTextArea(this.$refs.editor, {
+          lineNumbers: true,
+          mode:
+            this.connection.connectionType in modes
+              ? modes[this.connection.connectionType]
+              : "text/x-sql",
+          theme: "monokai",
+          extraKeys: {
+            "Ctrl-Space": "autocomplete",
+            "Cmd-Space": "autocomplete"
+          },
+          hint: CodeMirror.hint.sql,
+          hintOptions: this.hintOptions
+        });
+        this.editor.setValue(startingValue);
+        this.editor.addKeyMap(runQueryKeyMap);
+        this.editor.on("keydown", (cm, e) => {
+          if (this.$store.state.menuActive) {
+            e.preventDefault();
+          }
+        });
+
+        this.editor.on("change", cm => {
+          // this also updates `this.queryText`
+          // this.tab.query.text = cm.getValue()
+          this.unsavedText = cm.getValue();
+        });
+
+        if (this.connectionType === "postgresql") {
+          this.editor.on("beforeChange", (cm, co) => {
+            const { to, from, origin, text } = co;
+
+            const keywords = CodeMirror.resolveMode(this.editor.options.mode)
+              .keywords;
+
+            // quote names when needed
+            if (
+              origin === "complete" &&
+              keywords[text[0].toLowerCase()] != true
+            ) {
+              const names = text[0]
+                .match(/("[^"]*"|[^.]+)/g)
+                .map(n => (/^\d/.test(n) ? `"${n}"` : n))
+                .map(n => (/[^a-z0-9_]/.test(n) && !/"/.test(n) ? `"${n}"` : n))
+                .join(".");
+
+              co.update(from, to, [names], origin);
+            }
+          });
         }
 
-        if(!this.individualQueries || this.individualQueries.length < 2) {
+        // TODO: make this not suck
+        this.editor.on("keyup", this.maybeAutoComplete);
+        this.editor.on(
+          "cursorActivity",
+          editor =>
+            (this.cursorIndex = editor
+              .getDoc()
+              .indexFromPos(editor.getCursor(true)))
+        );
+        this.editor.focus();
+
+        setTimeout(() => {
+          // this fixes the editor not showing because it doesn't think it's dom element is in view.
+          // its a hit and miss error
+          this.editor.refresh();
+        }, 1);
+
+        // this gives the dom a chance to kick in and render these
+        // before we try to read their heights
+        setTimeout(() => {
+          this.tableHeight = this.$refs.bottomPanel.clientHeight;
+          this.updateEditorHeight();
+        }, 1);
+      });
+    },
+    saveTab: _.debounce(function() {
+      this.$store.dispatch("tabs/save", this.tab);
+    }, 1000),
+    close() {
+      this.$root.$emit(AppEvent.closeTab);
+    },
+    showContextMenu(event) {
+      this.$bks.openMenu({
+        item: this.tab,
+        options: [
+          {
+            name: "Format Query",
+            slug: "format",
+            handler: this.formatSql
+          }
+        ],
+        event
+      });
+    },
+    async cancelQuery() {
+      if (this.running && this.runningQuery) {
+        this.running = false;
+        this.info = "Query Execution Cancelled";
+        await this.runningQuery.cancel();
+        this.runningQuery = null;
+      }
+    },
+    download(format) {
+      this.$refs.table.download(format);
+    },
+    clipboard() {
+      this.$refs.table?.clipboard?.();
+    },
+    clipboardJson() {
+      const data = this.$refs.table?.clipboard?.("json");
+    },
+    clipboardMarkdown() {
+      const data = this.$refs.table?.clipboard?.("markdown");
+    },
+    selectEditor() {
+      this.editor.focus();
+    },
+    selectTitleInput() {
+      this.$refs.titleInput.select();
+    },
+    selectFirstParameter() {
+      if (!this.$refs["paramInput"] || this.$refs["paramInput"].length === 0)
+        return;
+      this.$refs["paramInput"][0].select();
+    },
+    updateEditorHeight() {
+      let height = this.$refs.topPanel.clientHeight;
+      height -= this.$refs.actions.clientHeight;
+      this.editor.setSize(null, height);
+    },
+    triggerSave() {
+      if (this.query?.id) {
+        this.saveQuery();
+      } else {
+        this.$modal.show("save-modal");
+      }
+    },
+    async saveQuery() {
+      if (this.remoteDeleted) return;
+      if (!this.hasTitle || !this.hasText) {
+        this.saveError = new Error(
+          "You need both a title, and some query text."
+        );
+        return;
+      } else {
+        try {
+          const payload = _.clone(this.query);
+          payload.text = this.unsavedText;
+          this.$modal.hide("save-modal");
+          const id = await this.$store.dispatch("data/queries/save", payload);
+          this.tab.queryId = id;
+
+          this.$nextTick(() => {
+            this.unsavedText = this.query.text;
+            this.tab.title = this.query.title;
+            this.originalText = this.query.text;
+          });
+          this.$noty.success("Query Saved");
+        } catch (ex) {
+          this.saveError = ex;
+          this.$noty.error(`Save Error: ${ex.message}`);
+        }
+      }
+    },
+    onChange(text) {
+      this.unsavedText = text;
+      this.editor.setValue(text);
+    },
+    escapeRegExp(string) {
+      return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+    },
+    async submitCurrentQuery() {
+      if (this.currentlySelectedQuery) {
+        this.runningType = "current";
+        this.submitQuery(this.currentlySelectedQuery.text);
+      } else {
+        this.results = [];
+        this.error = "No query to run";
+      }
+    },
+    async submitTabQuery() {
+      const text = this.hasSelectedText
+        ? this.editor.getSelection()
+        : this.editor.getValue();
+      this.runningType = this.hasSelectedText ? "selection" : "everything";
+      if (text.trim()) {
+        this.submitQuery(text);
+      } else {
+        this.error = "No query to run";
+      }
+    },
+    async submitQuery(rawQuery, fromModal = false) {
+      if (this.remoteDeleted) return;
+      this.running = true;
+      this.error = null;
+      this.queryForExecution = rawQuery;
+      this.results = [];
+      this.selectedResult = 0;
+      let identification = [];
+      try {
+        identification = identify(rawQuery, {
+          strict: false,
+          dialect: this.identifyDialect
+        });
+      } catch (ex) {
+        log.error("Unable to identify query", ex);
+      }
+
+      try {
+        if (this.hasParams && (!fromModal || this.paramsModalRequired)) {
+          this.$modal.show("parameters-modal");
           return;
         }
 
-        if (!this.currentQueryPosition) {
-          return
-        }
-        const { from, to } = this.currentQueryPosition
+        const query = this.deparameterizedQuery;
+        this.$modal.hide("parameters-modal");
+        this.runningCount = identification.length || 1;
+        this.runningQuery = this.connection.query(query);
+        const queryStartTime = new Date();
+        const results = await this.runningQuery.execute();
+        const queryEndTime = new Date();
+        this.executeTime = queryEndTime - queryStartTime;
+        let totalRows = 0;
+        results.forEach(result => {
+          result.rowCount = result.rowCount || 0;
 
-        const editorText = this.editor.getValue()
-        const lines = editorText.split(/\n/)
-
-        const [markStart, markEnd] = this.locationFromPosition(editorText, from, to)
-        this.marker = this.editor.getDoc().markText(markStart, markEnd, {className: 'highlight'})
-      },
-      hintOptions() {
-        this.editor?.setOption('hintOptions',this.hintOptions)
-      },
-    },
-    methods: {
-      locationFromPosition(queryText, ...rawPositions) {
-        // 1. find the query text inside the editor
-        // 2.
-
-        const editorText = this.editor.getValue()
-
-        const startCharacter = editorText.indexOf(queryText)
-        const lines = editorText.split(/\n/)
-        const positions = rawPositions.map((p) => p + startCharacter)
-
-        const finished = positions.map((p) => false)
-        const results = positions.map((p) => ({ line: null, ch: null}))
-
-        let startOfLine = 0
-        lines.forEach((line, idx) => {
-          const eol = startOfLine + line.length + 1
-          positions.forEach((p, pIndex) => {
-            if (startOfLine <= p && p <= eol && !finished[pIndex]) {
-              results[pIndex].line = idx
-              results[pIndex].ch = p - startOfLine
-              finished[pIndex] = true
-            }
-          })
-          startOfLine += line.length + 1
-        })
-        return results
-      },
-      initialize() {
-        this.initialized = true
-        // TODO (matthew): Add hint options for all tables and columns\
-        this.initializeQueries()
-        const startingValue = this.unsavedText || this.query?.text || editorDefault
-        console.log("starting value", startingValue)
-        this.tab.unsavedChanges = this.unsavedChanges
-
-        this.$nextTick(() => {
-          this.split = Split(this.splitElements, {
-            elementStyle: (dimension, size) => ({
-                'flex-basis': `calc(${size}%)`,
-            }),
-            sizes: [50,50],
-            gutterSize: 8,
-            direction: 'vertical',
-            onDragEnd: () => {
-              this.$nextTick(() => {
-                this.tableHeight = this.$refs.bottomPanel.clientHeight
-                this.updateEditorHeight()
-              })
-            }
-          })
-
-          const runQueryKeyMap = {
-            "Shift-Ctrl-Enter": this.submitCurrentQuery,
-            "Shift-Cmd-Enter": this.submitCurrentQuery,
-            "Ctrl-Enter": this.submitTabQuery,
-            "Cmd-Enter": this.submitTabQuery,
-            "Ctrl-S": this.triggerSave,
-            "Cmd-S": this.triggerSave,
-            "Shift-Ctrl-F": this.formatSql,
-            "Shift-Cmd-F": this.formatSql,
-            "Ctrl-/": this.toggleComment,
-            "Cmd-/": this.toggleComment,
-            "Esc": this.cancelQuery,
-            "F5": this.submitTabQuery,
-            "Shift-F5": this.submitCurrentQuery
+          // TODO (matthew): remove truncation logic somewhere sensible
+          totalRows += result.rowCount;
+          if (result.rowCount > this.$config.maxResults) {
+            result.rows = _.take(result.rows, this.$config.maxResults);
+            result.truncated = true;
+            result.totalRowCount = result.rowCount;
           }
+        });
+        this.results = Object.freeze(results);
 
-          const modes = {
-            'mysql': 'text/x-mysql',
-            'postgresql': 'text/x-pgsql',
-            'sqlserver': 'text/x-mssql',
-          };
+        const defaultResult = Math.max(results.length - 1, 0);
 
-          this.editor = CodeMirror.fromTextArea(this.$refs.editor, {
-            lineNumbers: true,
-            mode: this.connection.connectionType in modes ? modes[this.connection.connectionType] : "text/x-sql",
-            theme: 'monokai',
-            extraKeys: {"Ctrl-Space": "autocomplete", "Cmd-Space": "autocomplete"},
-            hint: CodeMirror.hint.sql,
-            hintOptions: this.hintOptions
-          })
-          this.editor.setValue(startingValue)
-          this.editor.addKeyMap(runQueryKeyMap)
-          this.editor.on("keydown", (cm, e) => {
-            if (this.$store.state.menuActive) {
-              e.preventDefault()
-            }
-          })
+        const nonEmptyResult = _.chain(results)
+          .findLastIndex(r => !!r.rows?.length)
+          .value();
+        console.log("non empty result", nonEmptyResult);
+        this.selectedResult =
+          nonEmptyResult === -1 ? results.length - 1 : nonEmptyResult;
 
-          this.editor.on("change", (cm) => {
-            // this also updates `this.queryText`
-            // this.tab.query.text = cm.getValue()
-            this.unsavedText = cm.getValue()
-          })
-
-          if (this.connectionType === 'postgresql')  {
-            this.editor.on("beforeChange", (cm, co) => {
-              const { to, from, origin, text } = co;
-
-              const keywords = CodeMirror.resolveMode(this.editor.options.mode).keywords
-
-              // quote names when needed
-              if (origin === 'complete' && keywords[text[0].toLowerCase()] != true) {
-                const names = text[0]
-                  .match(/("[^"]*"|[^.]+)/g)
-                  .map(n => /^\d/.test(n) ? `"${n}"` : n)
-                  .map(n => /[^a-z0-9_]/.test(n) && !/"/.test(n) ? `"${n}"` : n)
-                  .join('.')
-
-                co.update(from, to, [names], origin)
-              }
-            })
-          }
-
-          // TODO: make this not suck
-          this.editor.on('keyup', this.maybeAutoComplete)
-          this.editor.on('cursorActivity', (editor) => this.cursorIndex = editor.getDoc().indexFromPos(editor.getCursor(true)))
-          this.editor.focus()
-
-          setTimeout(() => {
-            // this fixes the editor not showing because it doesn't think it's dom element is in view.
-            // its a hit and miss error
-            this.editor.refresh()
-          }, 1)
-
-          // this gives the dom a chance to kick in and render these
-          // before we try to read their heights
-          setTimeout(() => {
-            this.tableHeight = this.$refs.bottomPanel.clientHeight
-            this.updateEditorHeight()
-          }, 1)
-        })
-      },
-      saveTab: _.debounce(function() {
-        this.$store.dispatch('tabs/save', this.tab)
-      }, 1000),
-      close() {
-        this.$root.$emit(AppEvent.closeTab)
-      },
-      showContextMenu(event) {
-        this.$bks.openMenu({
-          item: this.tab,
-          options: [
-            {
-              name: "Format Query",
-              slug: 'format',
-              handler: this.formatSql
-            }
-          ],
-          event,
-        })
-      },
-      async cancelQuery() {
-        if(this.running && this.runningQuery) {
-          this.running = false
-          this.info = 'Query Execution Cancelled'
-          await this.runningQuery.cancel()
-          this.runningQuery = null
+        this.$store.dispatch("data/usedQueries/save", {
+          text: query,
+          numberOfRecords: totalRows,
+          queryId: this.query?.id,
+          connectionId: this.connection.id
+        });
+        log.debug("identification", identification);
+        const found = identification.find(i => {
+          return (
+            i.type === "CREATE_TABLE" ||
+            i.type === "DROP_TABLE" ||
+            i.type === "ALTER_TABLE"
+          );
+        });
+        if (found) {
+          this.$store.dispatch("updateTables");
         }
-      },
-      download(format) {
-        this.$refs.table.download(format)
-      },
-      clipboard() {
-        this.$refs.table.clipboard()
-      },
-      clipboardJson() {
-        const data = this.$refs.table.clipboard(true)
-      },
-      selectEditor() {
-        this.editor.focus()
-      },
-      selectTitleInput() {
-        this.$refs.titleInput.select()
-      },
-      selectFirstParameter() {
-        if (!this.$refs['paramInput'] || this.$refs['paramInput'].length === 0) return
-        this.$refs['paramInput'][0].select()
-      },
-      updateEditorHeight() {
-        let height = this.$refs.topPanel.clientHeight
-        height -= this.$refs.actions.clientHeight
-        this.editor.setSize(null, height)
-      },
-      triggerSave() {
-        if (this.query?.id) {
-          this.saveQuery()
-        } else {
-          this.$modal.show('save-modal')
+      } catch (ex) {
+        log.error(ex);
+        if (this.running) {
+          this.error = ex;
         }
-      },
-      async saveQuery() {
-        if (this.remoteDeleted) return
-        if (!this.hasTitle || !this.hasText) {
-          this.saveError = new Error("You need both a title, and some query text.")
-          return
-        } else {
-          try {
-            const payload = _.clone(this.query)
-            payload.text = this.unsavedText
-            this.$modal.hide('save-modal')
-            const id = await this.$store.dispatch('data/queries/save', payload)
-            this.tab.queryId = id
-
-            this.$nextTick(() => {
-              this.unsavedText = this.query.text
-              this.tab.title = this.query.title
-              this.originalText = this.query.text
-            })
-            this.$noty.success('Query Saved')
-          } catch (ex) {
-            this.saveError = ex
-            this.$noty.error(`Save Error: ${ex.message}`)
-          }
-        }
-      },
-      onChange(text) {
-        this.unsavedText = text
-        this.editor.setValue(text)
-      },
-      escapeRegExp(string) {
-        return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
-      },
-      async submitCurrentQuery() {
-        if (this.currentlySelectedQuery) {
-          this.runningType = 'current'
-          this.submitQuery(this.currentlySelectedQuery.text)
-        } else {
-          this.results = []
-          this.error = 'No query to run'
-        }
-      },
-      async submitTabQuery() {
-        const text = this.hasSelectedText ? this.editor.getSelection() : this.editor.getValue()
-        this.runningType = this.hasSelectedText ? 'selection' : 'everything'
-        if (text.trim()) {
-          this.submitQuery(text)
-        } else {
-          this.error = 'No query to run'
-        }
-      },
-      async submitQuery(rawQuery, fromModal = false) {
-        if (this.remoteDeleted) return;
-        this.running = true
-        this.error = null
-        this.queryForExecution = rawQuery
-        this.results = []
-        this.selectedResult = 0
-        let identification = []
-        try {
-          identification = identify(rawQuery, { strict: false, dialect: this.identifyDialect })
-        } catch (ex) {
-          log.error("Unable to identify query", ex)
-        }
-
-        try {
-          if (this.hasParams && (!fromModal || this.paramsModalRequired)) {
-            this.$modal.show('parameters-modal')
-            return
-          }
-
-          const query = this.deparameterizedQuery
-          this.$modal.hide('parameters-modal')
-          this.runningCount = identification.length || 1
-          this.runningQuery = this.connection.query(query)
-          const queryStartTime = new Date()
-          const results = await this.runningQuery.execute()
-          const queryEndTime = new Date()
-          this.executeTime = queryEndTime - queryStartTime
-          let totalRows = 0
-          results.forEach(result => {
-            result.rowCount = result.rowCount || 0
-
-            // TODO (matthew): remove truncation logic somewhere sensible
-            totalRows += result.rowCount
-            if (result.rowCount > this.$config.maxResults) {
-              result.rows = _.take(result.rows, this.$config.maxResults)
-              result.truncated = true
-              result.totalRowCount = result.rowCount
-            }
-          })
-          this.results = Object.freeze(results);
-
-          const defaultResult = Math.max(results.length - 1, 0)
-
-          const nonEmptyResult = _.chain(results).findLastIndex((r) => !!r.rows?.length).value()
-          console.log("non empty result", nonEmptyResult)
-          this.selectedResult = nonEmptyResult === -1 ? results.length - 1 : nonEmptyResult
-
-          this.$store.dispatch('data/usedQueries/save', { text: query, numberOfRecords: totalRows, queryId: this.query?.id, connectionId: this.connection.id })
-          log.debug('identification', identification)
-          const found = identification.find(i => {
-            return i.type === 'CREATE_TABLE' || i.type === 'DROP_TABLE' || i.type === 'ALTER_TABLE'
-          })
-          if (found) {
-            this.$store.dispatch('updateTables')
-          }
-        } catch (ex) {
-          log.error(ex)
-          if(this.running) {
-            this.error = ex
-          }
-        } finally {
-          this.running = false
-        }
-      },
-      inQuote() {
-        return false
-      },
-      maybeAutoComplete(editor, e) {
-        // BUGS:
-        // 1. only on periods if not in a quote
-        // 2. post-space trigger after a few SQL keywords
-        //    - from, join
-        const triggerWords = ['from', 'join']
-        const triggers = {
-          '190': 'period'
-        }
-        const space = 32
-        if (editor.state.completionActive) return;
-        if (triggers[e.keyCode] && !this.inQuote(editor, e)) {
-          CodeMirror.commands.autocomplete(editor, null, { completeSingle: false });
-          // return
-        }
-        if (e.keyCode === space) {
-          try {
-            const pos = _.clone(editor.getCursor());
-            if (pos.ch > 0) {
-              pos.ch = pos.ch - 2
-            }
-            const word = editor.findWordAt(pos)
-            const lastWord = editor.getRange(word.anchor, word.head)
-            if (!triggerWords.includes(lastWord.toLowerCase())) return;
-            CodeMirror.commands.autocomplete(editor, null, { completeSingle: false });
-
-          } catch (ex) {
-            // do nothing
-          }
-        }
-      },
-      formatSql() {
-        this.editor.setValue(format(this.editor.getValue(), { language: FormatterDialect(this.dialect) }))
-        this.selectEditor()
-      },
-      toggleComment() {
-        this.editor.execCommand('toggleComment')
-      },
-      initializeQueries() {
-        if (!this.tab.unsavedChanges && this.query?.text) {
-          this.unsavedText = null
-        }
-        if (this.query?.text) {
-          this.originalText = this.query.text
-          if (!this.unsavedText) this.unsavedText = this.query.text
-        }
-      },
-      fakeRemoteChange() {
-        this.query.text = "select * from foo"
+      } finally {
+        this.running = false;
       }
     },
-    mounted() {
-      if (this.shouldInitialize) this.initialize()
-
+    inQuote() {
+      return false;
     },
-    beforeDestroy() {
-      if(this.split) {
-        this.split.destroy()
+    maybeAutoComplete(editor, e) {
+      // BUGS:
+      // 1. only on periods if not in a quote
+      // 2. post-space trigger after a few SQL keywords
+      //    - from, join
+      const triggerWords = ["from", "join"];
+      const triggers = {
+        "190": "period"
+      };
+      const space = 32;
+      if (editor.state.completionActive) return;
+      if (triggers[e.keyCode] && !this.inQuote(editor, e)) {
+        CodeMirror.commands.autocomplete(editor, null, {
+          completeSingle: false
+        });
+        // return
+      }
+      if (e.keyCode === space) {
+        try {
+          const pos = _.clone(editor.getCursor());
+          if (pos.ch > 0) {
+            pos.ch = pos.ch - 2;
+          }
+          const word = editor.findWordAt(pos);
+          const lastWord = editor.getRange(word.anchor, word.head);
+          if (!triggerWords.includes(lastWord.toLowerCase())) return;
+          CodeMirror.commands.autocomplete(editor, null, {
+            completeSingle: false
+          });
+        } catch (ex) {
+          // do nothing
+        }
       }
     },
+    formatSql() {
+      this.editor.setValue(
+        format(this.editor.getValue(), {
+          language: FormatterDialect(this.dialect)
+        })
+      );
+      this.selectEditor();
+    },
+    toggleComment() {
+      this.editor.execCommand("toggleComment");
+    },
+    initializeQueries() {
+      if (!this.tab.unsavedChanges && this.query?.text) {
+        this.unsavedText = null;
+      }
+      if (this.query?.text) {
+        this.originalText = this.query.text;
+        if (!this.unsavedText) this.unsavedText = this.query.text;
+      }
+    },
+    fakeRemoteChange() {
+      this.query.text = "select * from foo";
+    }
+  },
+  mounted() {
+    if (this.shouldInitialize) this.initialize();
+  },
+  beforeDestroy() {
+    if (this.split) {
+      this.split.destroy();
+    }
   }
+};
 </script>
-

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -1,28 +1,68 @@
 <template>
-  <statusbar :class="{'empty': results.length === 0, 'query-meta': true}">
+  <statusbar :class="{ empty: results.length === 0, 'query-meta': true }">
     <template v-if="results.length > 0">
       <div class="truncate statusbar-info">
-        <span v-show="results.length > 1" class="statusbar-item result-selector" :title="'Results'">
-        <div class="select-wrap" v-tooltip="{content: 'More query results in here', placement: 'top', show: showHint, trigger: 'manual', classes: ['tooltip-info']}">
-          <select name="resultSelector" id="resultSelector" @change="updateValue" class="form-control">
-            <option v-for="(result, index) in results" :selected="value == index" :key="index" :value="index">Result {{index + 1}}: {{shortNum(result.rows.length, 0)}} {{pluralize('row', result.rows.length, false)}}</option>
-          </select>
-        </div>
+        <span
+          v-show="results.length > 1"
+          class="statusbar-item result-selector"
+          :title="'Results'"
+        >
+          <div
+            class="select-wrap"
+            v-tooltip="{
+              content: 'More query results in here',
+              placement: 'top',
+              show: showHint,
+              trigger: 'manual',
+              classes: ['tooltip-info']
+            }"
+          >
+            <select
+              name="resultSelector"
+              id="resultSelector"
+              @change="updateValue"
+              class="form-control"
+            >
+              <option
+                v-for="(result, index) in results"
+                :selected="value == index"
+                :key="index"
+                :value="index"
+                >Result {{ index + 1 }}: {{ shortNum(result.rows.length, 0) }}
+                {{ pluralize("row", result.rows.length, false) }}</option
+              >
+            </select>
+          </div>
         </span>
-        <div class="statusbar-item row-counts" v-if="rowCount > 0" :title="`${rowCount} Records${result.truncated ? ' (Truncated)' : ''}`">
+        <div
+          class="statusbar-item row-counts"
+          v-if="rowCount > 0"
+          :title="
+            `${rowCount} Records${result.truncated ? ' (Truncated)' : ''}`
+          "
+        >
           <i class="material-icons">list_alt</i>
-          <span class="num-rows">{{rowCount}}</span>
-          <span class="truncated-rows" v-if="result && result.truncated">/&nbsp;{{result.totalRowCount}}</span>
+          <span class="num-rows">{{ rowCount }}</span>
+          <span class="truncated-rows" v-if="result && result.truncated"
+            >/&nbsp;{{ result.totalRowCount }}</span
+          >
         </div>
-        <div class="statusbar-item affected-rows" v-if="affectedRowsText " :title="affectedRowsText + ' ' + 'Rows Affected'">
+        <div
+          class="statusbar-item affected-rows"
+          v-if="affectedRowsText"
+          :title="affectedRowsText + ' ' + 'Rows Affected'"
+        >
           <i class="material-icons">clear_all</i>
           <span>{{ affectedRowsText }} affected</span>
         </div>
-        <span class="statusbar-item execute-time " v-if="executeTimeText" :title="executionTimeTitle">
+        <span
+          class="statusbar-item execute-time "
+          v-if="executeTimeText"
+          :title="executionTimeTitle"
+        >
           <i class="material-icons">update</i>
-          <span>{{executeTimeText}}</span>
+          <span>{{ executeTimeText }}</span>
         </span>
-
       </div>
     </template>
     <template v-else>
@@ -42,26 +82,38 @@
           <x-menuitem @click.prevent="download('json')">
             <x-label>JSON</x-label>
           </x-menuitem>
-          <hr>
-          <x-menuitem title="Probably don't do this with large results (500+)" @click.prevent="copyToClipboard">
+          <hr />
+          <x-menuitem
+            title="Probably don't do this with large results (500+)"
+            @click.prevent="copyToClipboard"
+          >
             <x-label>Copy to Clipboard (TSV / Excel)</x-label>
           </x-menuitem>
-          <x-menuitem title="Probably don't do this with large results (500+)" @click.prevent="copyToClipboardJson">
+          <x-menuitem
+            title="Probably don't do this with large results (500+)"
+            @click.prevent="copyToClipboardJson"
+          >
             <x-label>Copy to Clipboard (JSON)</x-label>
+          </x-menuitem>
+          <x-menuitem
+            title="Probably don't do this with large results (500+)"
+            @click.prevent="copyToClipboardMarkdown"
+          >
+            <x-label>Copy to Clipboard (Markdown)</x-label>
           </x-menuitem>
         </x-menu>
       </x-button>
-
     </div>
   </statusbar>
 </template>
+
 <script>
 // import Pluralize from 'pluralize'
-import humanizeDuration from 'humanize-duration'
-import Statusbar from '../common/StatusBar'
-import pluralize from 'pluralize'
-import { UserSetting } from '@/common/appdb/models/user_setting';
-import { mapState } from 'vuex';
+import humanizeDuration from "humanize-duration";
+import Statusbar from "../common/StatusBar";
+import pluralize from "pluralize";
+import { UserSetting } from "@/common/appdb/models/user_setting";
+import { mapState } from "vuex";
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
   language: "shortEn",
@@ -74,99 +126,109 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
       h: () => "h",
       m: () => "m",
       s: () => "s",
-      ms: () => "ms",
-    },
-  },
+      ms: () => "ms"
+    }
+  }
 });
 
 export default {
-    props: ['results', 'running', 'value', 'executeTime'],
-    components: { Statusbar },
-    data() {
-      return {
-        showHint: false,
+  props: ["results", "running", "value", "executeTime"],
+  components: { Statusbar },
+  data() {
+    return {
+      showHint: false
+    };
+  },
 
+  watch: {
+    results() {
+      if (this.results && this.results.length > 1 && !this.hasUsedDropdown) {
+        this.showHint = true;
+        setTimeout(() => (this.showHint = false), 2000);
       }
-    },
-
-    watch: {
-      results() {
-        if (this.results && this.results.length > 1 && !this.hasUsedDropdown) {
-          this.showHint = true
-          setTimeout(() => this.showHint = false, 2000)
-        }
-      }
-    },
-    computed: {
-      ...mapState('settings', ['settings']),
-      hasUsedDropdown: {
-        get() {
-          const s = this.settings.hideResultsDropdown
-          return s ? s.value : false
-        },
-        set(value) {
-          this.$store.dispatch('settings/save', { key: 'hideResultsDropdown', value })
-        }
-      },
-      rowCount() {
-        return this.result && this.result.rows ? this.result.rows.length : 0
-      },
-      result() {
-        return this.results[this.value]
-      },
-      affectedRowsText() {
-        if (!this.result) {
-          return null
-        }
-        const rows = this.result.affectedRows || 0
-        return `${rows}`
-      },
-      executeTimeText() {
-        if (!this.executeTime) {
-          return null
-        }
-        const executeTime = this.executeTime || 0
-        return shortEnglishHumanizer(executeTime)
-      },
-      executionTimeTitle() {
-        if (!this.executeTime) {
-          return null;
-        }
-        return `Execution time: ${humanizeDuration(this.executeTime)}`
-      }
-    },
-    mounted() {
-    },
-    methods: {
-      pluralize(word, amount, flag) {
-        return pluralize(word, amount, flag)
-      },
-      // Attribution: https://stackoverflow.com/questions/10599933/convert-long-number-into-abbreviated-string-in-javascript-with-a-special-shortn/10601315
-      shortNum(num, fixed) {
-        if (num === null) { return null; } // terminate early
-        if (num === 0) { return '0'; } // terminate early
-        fixed = (!fixed || fixed < 0) ? 0 : fixed; // number of decimal places to show
-        const b = (num).toPrecision(2).split("e"), // get power
-            k = b.length === 1 ? 0 : Math.floor(Math.min(b[1].slice(1), 14) / 3), // floor at decimals, ceiling at trillions
-            c = k < 1 ? num.toFixed(0 + fixed) : (num / Math.pow(10, k * 3) ).toFixed(1 + fixed), // divide by power
-            d = c < 0 ? c : Math.abs(c), // enforce -0 is 0
-            e = d + ['', 'K', 'M', 'B', 'T'][k]; // append power
-        return e;
-      },
-      updateValue(event) {
-        this.$emit('input', parseInt(event.target.value))
-        this.hasUsedDropdown = true
-      },
-      download(format) {
-        this.$emit('download', format)
-      },
-      copyToClipboard() {
-        this.$emit('clipboard')
-      },
-      copyToClipboardJson() {
-        this.$emit('clipboardJson')
-      }
-
     }
-}
+  },
+  computed: {
+    ...mapState("settings", ["settings"]),
+    hasUsedDropdown: {
+      get() {
+        const s = this.settings.hideResultsDropdown;
+        return s ? s.value : false;
+      },
+      set(value) {
+        this.$store.dispatch("settings/save", {
+          key: "hideResultsDropdown",
+          value
+        });
+      }
+    },
+    rowCount() {
+      return this.result && this.result.rows ? this.result.rows.length : 0;
+    },
+    result() {
+      return this.results[this.value];
+    },
+    affectedRowsText() {
+      if (!this.result) {
+        return null;
+      }
+      const rows = this.result.affectedRows || 0;
+      return `${rows}`;
+    },
+    executeTimeText() {
+      if (!this.executeTime) {
+        return null;
+      }
+      const executeTime = this.executeTime || 0;
+      return shortEnglishHumanizer(executeTime);
+    },
+    executionTimeTitle() {
+      if (!this.executeTime) {
+        return null;
+      }
+      return `Execution time: ${humanizeDuration(this.executeTime)}`;
+    }
+  },
+  mounted() {},
+  methods: {
+    pluralize(word, amount, flag) {
+      return pluralize(word, amount, flag);
+    },
+    // Attribution: https://stackoverflow.com/questions/10599933/convert-long-number-into-abbreviated-string-in-javascript-with-a-special-shortn/10601315
+    shortNum(num, fixed) {
+      if (num === null) {
+        return null;
+      } // terminate early
+      if (num === 0) {
+        return "0";
+      } // terminate early
+      fixed = !fixed || fixed < 0 ? 0 : fixed; // number of decimal places to show
+      const b = num.toPrecision(2).split("e"), // get power
+        k = b.length === 1 ? 0 : Math.floor(Math.min(b[1].slice(1), 14) / 3), // floor at decimals, ceiling at trillions
+        c =
+          k < 1
+            ? num.toFixed(0 + fixed)
+            : (num / Math.pow(10, k * 3)).toFixed(1 + fixed), // divide by power
+        d = c < 0 ? c : Math.abs(c), // enforce -0 is 0
+        e = d + ["", "K", "M", "B", "T"][k]; // append power
+      return e;
+    },
+    updateValue(event) {
+      this.$emit("input", parseInt(event.target.value));
+      this.hasUsedDropdown = true;
+    },
+    download(format) {
+      this.$emit("download", format);
+    },
+    copyToClipboard() {
+      this.$emit("clipboard");
+    },
+    copyToClipboardJson() {
+      this.$emit("clipboardJson");
+    },
+    copyToClipboardMarkdown() {
+      this.$emit("clipboardMarkdown");
+    }
+  }
+};
 </script>

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -5,212 +5,249 @@
 </template>
 
 <script type="text/javascript">
-  import {TabulatorFull} from 'tabulator-tables'
-  import _ from 'lodash'
-  import dateFormat from 'dateformat'
-  import Converter from '../../mixins/data_converter'
-  import Mutators, { escapeHtml } from '../../mixins/data_mutators'
-import globals from '@/common/globals'
-import Papa from 'papaparse'
-import { mapState } from 'vuex'
+import { TabulatorFull } from "tabulator-tables";
+import _ from "lodash";
+import dateFormat from "dateformat";
+import Converter from "../../mixins/data_converter";
+import Mutators, { escapeHtml } from "../../mixins/data_mutators";
+import globals from "@/common/globals";
+import Papa from "papaparse";
+import { mapState } from "vuex";
+import { markdownTable } from "markdown-table";
 
-  export default {
-    mixins: [Converter, Mutators],
-    data() {
-      return {
-        tabulator: null,
-        actualTableHeight: '100%',
-        selectedCell: null
+export default {
+  mixins: [Converter, Mutators],
+  data() {
+    return {
+      tabulator: null,
+      actualTableHeight: "100%",
+      selectedCell: null
+    };
+  },
+  props: ["result", "tableHeight", "query", "active"],
+  watch: {
+    active() {
+      if (!this.tabulator) return;
+      if (this.active) {
+        this.tabulator.restoreRedraw();
+        this.$nextTick(() => {
+          this.tabulator.redraw();
+        });
+      } else {
+        this.tabulator.blockRedraw();
       }
     },
-    props: ['result', 'tableHeight', 'query', 'active'],
-    watch: {
-      active() {
-        if (!this.tabulator) return;
-        if (this.active) {
-          this.tabulator.restoreRedraw()
-          this.$nextTick(() => {
-            this.tabulator.redraw()
-          })
-        } else {
-          this.tabulator.blockRedraw()
-        }
-      },
-      tableData: {
-        handler() {
-          this.tabulator.replaceData(this.tableData)
-        }
-      },
-      tableColumns: {
-        handler() {
-          this.tabulator.setColumns(this.tableColumns)
-        }
-      },
-      tableHeight() {
-        this.tabulator.setHeight(this.actualTableHeight)
+    tableData: {
+      handler() {
+        this.tabulator.replaceData(this.tableData);
       }
     },
-    computed: {
-      ...mapState(['connection']),
-      keymap() {
-        const result = {}
-        result[this.ctrlOrCmd('c')] = this.copyCell
-        return result
-      },
-      tableData() {
-          return this.dataToTableData(this.result, this.tableColumns)
-      },
-      tableTruncated() {
-          return this.result.truncated
-      },
-      cellContextMenu() {
-        return [
-          {
-            label: '<x-menuitem><x-label>Copy Cell</x-label></x-menuitem>',
-            action: (_e, cell) => this.$native.clipboard.writeText(cell.getValue())
-          },
-          {
-            label: '<x-menuitem><x-label>Copy Row (JSON)</x-label></x-menuitem>',
-            action: (_e, cell) => {
-              const data = cell.getRow().getData()
-              const fixed = this.dataToJson(data, true)
-              this.$native.clipboard.writeText(JSON.stringify(fixed))
-            }
-          },
-          {
-            label: '<x-menuitem><x-label>Copy Row (TSV / Excel)</x-label></x-menuitem>',
-            action: (_e, cell) => this.$native.clipboard.writeText(Papa.unparse([this.$bks.cleanData(cell.getRow().getData())], { header: false, quotes: true, delimiter: "\t", escapeFormulae: true }))
-          },
-          {
-            label: '<x-menuitem><x-label>Copy Row (Insert)</x-label></x-menuitem>',
-            action: async (_e, cell) => {
-              const fixed = this.$bks.cleanData(cell.getRow().getData(), this.tableColumns)
-
-              const tableInsert = {
-                table: 'mytable',
-                schema: null,
-                data: [fixed],
-              }
-              const query = await this.connection.getInsertQuery(tableInsert)
-              this.$native.clipboard.writeText(query)
-            }
-          }
-        ]
-      },
-      tableColumns() {
-        const columnWidth = this.result.fields.length > 30 ? globals.bigTableColumnWidth : undefined
-        return this.result.fields.map((column) => {
-          const result = {
-            title: column.name,
-            titleFormatter: 'plaintext',
-            field: column.id,
-            titleDownload: escapeHtml(column.name),
-            dataType: column.dataType,
-            width: columnWidth,
-            mutator: this.resolveTabulatorMutator(column.dataType),
-            formatter: this.cellFormatter,
-            maxInitialWidth: globals.maxColumnWidth,
-            tooltip: true,
-            contextMenu: this.cellContextMenu,
-            cellClick: this.cellClick.bind(this)
-          }
-          return result;
-        })
-      },
-      columnIdTitleMap() {
-        const result = {}
-        this.tableColumns.forEach((column) => {
-          result[column.field] = column.title
-        })
-        return result
+    tableColumns: {
+      handler() {
+        this.tabulator.setColumns(this.tableColumns);
       }
     },
-    beforeDestroy() {
-      if (this.tabulator) {
-        this.tabulator.destroy()
-      }
-      document.removeEventListener('click', this.maybeUnselectCell)
-    },
-    async mounted() {
-      this.tabulator = new TabulatorFull(this.$refs.tabulator, {
-        data: this.tableData, //link data to table
-        reactiveData: true,
-        renderHorizontal: 'virtual',
-        columns: this.tableColumns, //define table columns
-        height: this.actualTableHeight,
-        nestedFieldSeparator: false,
-
-        clipboard: true,
-        keybindings: {
-          copyToClipboard: false
-        },
-        downloadConfig: {
-          columnHeaders: true
-        }
-      });
-      document.addEventListener('click', this.maybeUnselectCell)
-    },
-    methods: {
-      maybeUnselectCell(event) {
-        if (!this.active) return
-        const target = event.target
-        if (this.selectedCell) {
-          const targets = Array.from(this.selectedCell.getElement().getElementsByTagName("*"))
-          if (!targets.includes(target)) {
-            this.selectedCell.getElement().classList.remove('selected')
-            this.selectedCell = null
-          }
-        }
-      },
-      copyCell() {
-        if (!this.active) return;
-        if (!this.selectedCell) return;
-        this.selectedCell.getElement().classList.add('copied')
-        const cell = this.selectedCell
-        setTimeout(() => cell.getElement().classList.remove('copied'), 500)
-        this.$native.clipboard.writeText(this.selectedCell.getValue(), false)
-      },
-      cellClick(e, cell) {
-        if (this.selectedCell) {
-          this.selectedCell.getElement().classList.remove('selected')
-        }
-        this.selectedCell = cell
-        cell.getElement().classList.add('selected')
-      },
-      dataToJson(rawData, firstObjectOnly) {
-        const rows = _.isArray(rawData) ? rawData : [rawData]
-        const result = rows.map((data) => {
-          return this.$bks.cleanData(data, this.tableColumns)
-        })
-        return firstObjectOnly ? result[0] : result
-      },
-      download(format) {
-        const dateString = dateFormat(new Date(), 'yyyy-mm-dd_hMMss')
-        const title = this.query.title ? _.snakeCase(this.query.title) : "query_results"
-        this.tabulator.download(format, `${title}-${dateString}.${format}`, 'all')
-      },
-      clipboard(json) {
-        // this.tabulator.copyToClipboard("all")
-
-        const allRows = this.tabulator.getData()
-        if (allRows.length == 0) {
-          return
-        }
-        const columnTitles = {}
-
-        const result = this.dataToJson(allRows, false)
-
-        if (json) {
-          this.$native.clipboard.writeText(JSON.stringify(result))
-        } else {
-          this.$native.clipboard.writeText(
-            Papa.unparse(
-              result,
-              { header: true, delimiter: "\t", quotes: true, escapeFormulae: true }
-            )
-          )
-        }
-      }
+    tableHeight() {
+      this.tabulator.setHeight(this.actualTableHeight);
     }
-	}
+  },
+  computed: {
+    ...mapState(["connection"]),
+    keymap() {
+      const result = {};
+      result[this.ctrlOrCmd("c")] = this.copyCell;
+      return result;
+    },
+    tableData() {
+      return this.dataToTableData(this.result, this.tableColumns);
+    },
+    tableTruncated() {
+      return this.result.truncated;
+    },
+    cellContextMenu() {
+      return [
+        {
+          label: "<x-menuitem><x-label>Copy Cell</x-label></x-menuitem>",
+          action: (_e, cell) =>
+            this.$native.clipboard.writeText(cell.getValue())
+        },
+        {
+          label: "<x-menuitem><x-label>Copy Row (JSON)</x-label></x-menuitem>",
+          action: (_e, cell) => {
+            const data = cell.getRow().getData();
+            const fixed = this.dataToJson(data, true);
+            this.$native.clipboard.writeText(JSON.stringify(fixed));
+          }
+        },
+        {
+          label:
+            "<x-menuitem><x-label>Copy Row (TSV / Excel)</x-label></x-menuitem>",
+          action: (_e, cell) =>
+            this.$native.clipboard.writeText(
+              Papa.unparse([this.$bks.cleanData(cell.getRow().getData())], {
+                header: false,
+                quotes: true,
+                delimiter: "\t",
+                escapeFormulae: true
+              })
+            )
+        },
+        {
+          label:
+            "<x-menuitem><x-label>Copy Row (Insert)</x-label></x-menuitem>",
+          action: async (_e, cell) => {
+            const fixed = this.$bks.cleanData(
+              cell.getRow().getData(),
+              this.tableColumns
+            );
+
+            const tableInsert = {
+              table: "mytable",
+              schema: null,
+              data: [fixed]
+            };
+            const query = await this.connection.getInsertQuery(tableInsert);
+            this.$native.clipboard.writeText(query);
+          }
+        }
+      ];
+    },
+    tableColumns() {
+      const columnWidth =
+        this.result.fields.length > 30
+          ? globals.bigTableColumnWidth
+          : undefined;
+      return this.result.fields.map(column => {
+        const result = {
+          title: column.name,
+          titleFormatter: "plaintext",
+          field: column.id,
+          titleDownload: escapeHtml(column.name),
+          dataType: column.dataType,
+          width: columnWidth,
+          mutator: this.resolveTabulatorMutator(column.dataType),
+          formatter: this.cellFormatter,
+          maxInitialWidth: globals.maxColumnWidth,
+          tooltip: true,
+          contextMenu: this.cellContextMenu,
+          cellClick: this.cellClick.bind(this)
+        };
+        return result;
+      });
+    },
+    columnIdTitleMap() {
+      const result = {};
+      this.tableColumns.forEach(column => {
+        result[column.field] = column.title;
+      });
+      return result;
+    }
+  },
+  beforeDestroy() {
+    if (this.tabulator) {
+      this.tabulator.destroy();
+    }
+    document.removeEventListener("click", this.maybeUnselectCell);
+  },
+  async mounted() {
+    this.tabulator = new TabulatorFull(this.$refs.tabulator, {
+      data: this.tableData, //link data to table
+      reactiveData: true,
+      renderHorizontal: "virtual",
+      columns: this.tableColumns, //define table columns
+      height: this.actualTableHeight,
+      nestedFieldSeparator: false,
+
+      clipboard: true,
+      keybindings: {
+        copyToClipboard: false
+      },
+      downloadConfig: {
+        columnHeaders: true
+      }
+    });
+    document.addEventListener("click", this.maybeUnselectCell);
+  },
+  methods: {
+    maybeUnselectCell(event) {
+      if (!this.active) return;
+      const target = event.target;
+      if (this.selectedCell) {
+        const targets = Array.from(
+          this.selectedCell.getElement().getElementsByTagName("*")
+        );
+        if (!targets.includes(target)) {
+          this.selectedCell.getElement().classList.remove("selected");
+          this.selectedCell = null;
+        }
+      }
+    },
+    copyCell() {
+      if (!this.active) return;
+      if (!this.selectedCell) return;
+      this.selectedCell.getElement().classList.add("copied");
+      const cell = this.selectedCell;
+      setTimeout(() => cell.getElement().classList.remove("copied"), 500);
+      this.$native.clipboard.writeText(this.selectedCell.getValue(), false);
+    },
+    cellClick(e, cell) {
+      if (this.selectedCell) {
+        this.selectedCell.getElement().classList.remove("selected");
+      }
+      this.selectedCell = cell;
+      cell.getElement().classList.add("selected");
+    },
+    dataToJson(rawData, firstObjectOnly) {
+      const rows = _.isArray(rawData) ? rawData : [rawData];
+      const result = rows.map(data => {
+        return this.$bks.cleanData(data, this.tableColumns);
+      });
+      return firstObjectOnly ? result[0] : result;
+    },
+    download(format) {
+      const dateString = dateFormat(new Date(), "yyyy-mm-dd_hMMss");
+      const title = this.query.title
+        ? _.snakeCase(this.query.title)
+        : "query_results";
+      this.tabulator.download(
+        format,
+        `${title}-${dateString}.${format}`,
+        "all"
+      );
+    },
+    clipboard(format = "excel") {
+      const allRows = this.tabulator.getData();
+      if (allRows.length == 0) return;
+
+      const result = this.dataToJson(allRows, false);
+      let resultText = "";
+
+      // Formatting in JSON format
+      if (format === "json") {
+        resultText = JSON.stringify(result);
+      }
+
+      // Formatting in Mardown table format
+      if (format === "markdown") {
+        const mdHeaders = Object.keys(result[0] ?? {});
+        const mdValues = (result ?? []).slice(1).map(row => Object.values(row));
+
+        resultText = markdownTable([mdHeaders, ...mdValues]);
+      }
+
+      // Formatting in Excel format
+      if (format === "excel") {
+        resultText = Papa.unparse(result, {
+          header: true,
+          delimiter: "\t",
+          quotes: true,
+          escapeFormulae: true
+        });
+      }
+
+      // Copying to clipboard
+      this.$native.clipboard.writeText(resultText);
+    }
+  }
+};
 </script>


### PR DESCRIPTION
## What is done
I have added a copy as markdown (table) feature for the response data table.

## Why
Resolves #1150 

## Changes
- A new package `markdown table` is added to make things easier.
- Minor change made to the clipboard function which was previously accepting just boolean values
  - It now accepts string value, based on which the parsing is done in different formats. With this change, we can easily add new formats in future.