### PR TITLE
Fix broken table list

### DIFF
--- a/apps/studio/src/components/tableview/ColumnFilterModal.vue
+++ b/apps/studio/src/components/tableview/ColumnFilterModal.vue
@@ -76,7 +76,7 @@
   </modal>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
   .modal-form {
     margin-top: 0.25rem;
   }


### PR DESCRIPTION
I'm sorry, I just realized I've made a mistake to not add the scoped attribute. The table list was broken because the style is overridden by this component.