### PR TITLE
fix: MySql CREATE Routine statement

### DIFF
--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -322,7 +322,7 @@
         this.$nextTick(() => this.$modal.show(this.modalName))
       },
       async loadRoutineCreate(routine) {
-        const result = await this.connection.getRoutineCreateScript(routine.name, routine.schema)
+        const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema)
         const stringResult = format(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
         this.createQuery(stringResult)
       },

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -684,10 +684,12 @@ export async function getViewCreateScript(conn, view) {
 
 export async function getRoutineCreateScript(conn, routine, type) {
   const sql = `SHOW CREATE ${type.toUpperCase()} ${routine}`;
-
   const { data } = await driverExecuteQuery(conn, { query: sql });
-
-  return data.map((row) => row[`Create ${type}`]);
+  const result =  data.map((row) => {
+    const upperCaseIndexedRow = Object.keys(row).reduce((prev, current) => ({...prev, [current.toUpperCase()]: row[current]}), {});
+    return upperCaseIndexedRow[`CREATE ${type.toUpperCase()}`];
+  });
+  return result;
 }
 
 export function wrapIdentifier(value) {


### PR DESCRIPTION
I realised that pressing SQL: Create button of Stored Procedure for MySql host does not work. While I debugging the code, I realised that some parameters of getRoutineCreateScript function did not be passed correctly and I fixed that issue. 

Moreover the column names of result of  "SHOW CREATE" may differ MySql versions. For example sql version I am using shows column name of CREATE statement as "Create Procedure". The other versions may show the column name as "Create procedure". The difference were causing error before I fixed it.