### PR TITLE
PR to Fix Issue 1399 (sqlite int64s)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,10 @@
 module.exports = {
   "root": true,
   "env": {
-    "node": true
+    "node": true,
+    // activate “es2020” globals to fix 'BigInt' is not defined
+    // https://futurestud.io/tutorials/eslint-how-to-fix-bigint-is-not-defined
+    "es2020": true,
   },
   "ignorePatterns": ["node_modules", "dist", "apps/**/tsconfig.json"],
   "extends": [

--- a/apps/studio/src/common/initializers/big_int_initializer.ts
+++ b/apps/studio/src/common/initializers/big_int_initializer.ts
@@ -1,0 +1,18 @@
+
+// Fix (part 1 of 3) Issue #1399 - int64s not displaying properly
+// (part 2 is in apps/studio/src/lib/db/clients/sqlite.js
+// and part 3 is in shared/src/lib/dialects/index.ts)
+// This part fixes "TypeError: Do not know how to serialize a BigInt"
+// by adding a toJSON() method to BigInts (like Numbers have)
+
+// for ts
+// from: https://github.com/GoogleChromeLabs/jsbi/issues/30#issuecomment-1006088574
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+interface BigInt {
+  /** Convert to BigInt to string form in JSON.stringify */
+  toJSON: () => string;
+}
+
+// for js
+BigInt.prototype.toJSON = function() { return this.toString() }
+

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -149,7 +149,9 @@ export default {
       },
       // Attribution: https://stackoverflow.com/questions/10599933/convert-long-number-into-abbreviated-string-in-javascript-with-a-special-shortn/10601315
       shortNum(num, fixed) {
-        if (num === null) { return null; } // terminate early
+        // fix "TypeError: Cannot read property 'toPrecision' of undefined" (after INSERT and CREATE TABLE commands)
+        if (num === null || typeof num === 'undefined') { return null; } // terminate early
+
         if (num === 0) { return '0'; } // terminate early
         fixed = (!fixed || fixed < 0) ? 0 : fixed; // number of decimal places to show
         const b = (num).toPrecision(2).split("e"), // get power

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -25,10 +25,6 @@ const sqliteErrors = {
 
 const PD = SqliteData
 
-// Fix (part 1 of 3) Issue #1399 - int64s not displaying properly
-// Fixes "TypeError: Do not know how to serialize a BigInt"
-BigInt.prototype.toJSON = function() { return this.toString() }
-
 export default async function (server, database) {
   const dbConfig = configDatabase(server, database);
   logger().debug('create driver client for sqlite3 with config %j', dbConfig);

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -643,10 +643,10 @@ async function runWithConnection(conn, run) {
   try {
     db = new Database(conn.dbConfig.database)
 
-    // Fix (part 2 of 3) Issue #1399 - int64s not displaying properly
+    // Fix (part 1 of 2) Issue #1399 - int64s not displaying properly
     // Binds ALL better-sqlite3 integer columns as BigInts by default
     // https://github.com/WiseLibs/better-sqlite3/blob/master/docs/integer.md#getting-bigints-from-the-database
-    // (Part 3 of 3 is in shared/src/lib/dialects/index.ts)
+    // (Part 2 of 2 is in apps/studio/src/common/initializers/big_int_initializer.ts)
     db.defaultSafeIntegers(true);
 
     const results = await run(db)

--- a/apps/studio/src/main.ts
+++ b/apps/studio/src/main.ts
@@ -40,6 +40,7 @@ import BeekeeperPlugin from './plugins/BeekeeperPlugin'
 import 'codemirror/addon/merge/merge'
 import _ from 'lodash'
 import NotyPlugin from '@/plugins/NotyPlugin'
+import './common/initializers/big_int_initializer.ts'
 
 (async () => {
   try {

--- a/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
@@ -47,4 +47,69 @@ describe("Sqlite Tests", () => {
     }).not.toThrowError()
   })
 
+  describe("Issue-1399 Regresstion Tests", () => {
+    let row
+    beforeAll( async() => {
+      row = await prepareBug1399TestData(util)
+    }, 3267)
+
+    // All SQLite integer-type columns store & return BigInts not Numbers
+    // so test an 18-digit BigInt stored in EACH type of integer column
+    // doesn't get rounded down to a (15-significant-digit) Number on retrieval
+    test("value inserted into INT column should ==== the value selected back out", async () => {
+      await Bug1399TestInt(row)
+    })
+    test("value inserted into BIGINT column should ==== the value selected back out", async () => {
+      await Bug1399TestBigInt(row)
+    })
+    test("value inserted into UNSIGNED BIGINT column should ==== the value selected back out", async () => {
+      await Bug1399TestUnsignedBigInt(row)
+    })
+  })
+
+  const Bug1399TestInt = (resultRow) => {
+    expect( resultRow.test_int.toString()     ).toBe( BigInt( '326335020369620480' ).toString() )
+  }
+  const Bug1399TestBigInt = async (resultRow) => {
+    expect( resultRow.test_bigint.toString()  ).toBe( BigInt( '326335020369620480' ).toString() )
+  }
+  const Bug1399TestUnsignedBigInt = async (resultRow) => {
+    expect( resultRow.test_ubigint.toString() ).toBe( BigInt( '326335020369620480' ).toString() )
+  }
+
+  const prepareBug1399TestData = async function(util) {
+    const drop = await util.connection.query('DROP TABLE IF EXISTS test_bug1399')
+    await drop.execute()
+
+    // create a test table that has various integer-type columns to detect the bug
+    const create_sql = `
+      CREATE TABLE test_bug1399 (
+        id integer not null primary key autoincrement,
+        test_int INT,
+        test_bigint BIGINT,
+        test_ubigint UNSIGNED BIG INT
+      );
+    `
+    const create_query = await util.connection.query(create_sql)
+    await create_query.execute()
+
+    // and insert integers (with more than 15 significant digits) into them
+    const insert_bigints_sql = `
+      INSERT INTO test_bug1399 VALUES (
+        null,
+        326335020369620480,
+        326335020369620480,
+        326335020369620480
+      );
+    `
+    const insert_bigints_query = await util.connection.query(insert_bigints_sql)
+    await insert_bigints_query.execute()
+
+    // then select those same big integers back out, and return the row
+    const r = await util.connection.selectTop('test_bug1399')
+    const result = r.result
+
+    expect(result.length).toBe(1)
+    return { ...result[0] }
+  }
 })

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -10,6 +10,7 @@ import { getDialectData } from '../../../../shared/src/lib/dialects/'
 import _ from 'lodash'
 import { TableIndex } from '../../src/lib/db/models'
 export const dbtimeout = 120000
+import '../../src/common/initializers/big_int_initializer.ts'
 
 
 const KnexTypes: any = {

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -424,21 +424,22 @@ export class DBTestUtil {
   async columnFilterTests() {
     let r = await this.connection.selectTop("people_jobs", 0, 10, [], [], this.defaultSchema)
     expect(r.result).toEqual([{
-      person_id: this.personId,
-      job_id: this.jobId,
+      // integer equality tests need additional logic for sqlite's BigInts (Issue #1399)
+      person_id: this.dbType === 'sqlite' ? BigInt(this.personId) : this.personId,
+      job_id: this.dbType === 'sqlite' ? BigInt(this.jobId) : this.jobId,
       created_at: null,
       updated_at: null,
     }])
 
     r = await this.connection.selectTop("people_jobs", 0, 10, [], [], this.defaultSchema, ['person_id'])
     expect(r.result).toEqual([{
-      person_id: this.personId,
+      person_id: this.dbType === 'sqlite' ? BigInt(this.personId) : this.personId,
     }])
 
     r = await this.connection.selectTop("people_jobs", 0, 10, [], [], this.defaultSchema, ['person_id', 'job_id'])
     expect(r.result).toEqual([{
-      person_id: this.personId,
-      job_id: this.jobId,
+      person_id: this.dbType === 'sqlite' ? BigInt(this.personId) : this.personId,
+      job_id: this.dbType === 'sqlite' ? BigInt(this.jobId) : this.jobId,
     }])
   }
 

--- a/shared/src/lib/dialects/index.ts
+++ b/shared/src/lib/dialects/index.ts
@@ -5,14 +5,6 @@ import { PostgresData } from "./postgresql";
 import { SqliteData } from "./sqlite";
 import { SqlServerData } from "./sqlserver";
 
-// Fix (part 3 of 3) Issue #1399 - int64s not displaying properly
-// Fixes error 'BigInt' is not defined in lib/db/clients/sqlite.js
-declare global {
-  interface BigIntConstructor {
-    toJSON:()=>BigInt;
-  }
-}
-
 export function getDialectData(dialect: Dialect): DialectData  {
   switch (dialect) {
     case "postgresql":

--- a/shared/src/lib/dialects/index.ts
+++ b/shared/src/lib/dialects/index.ts
@@ -5,6 +5,14 @@ import { PostgresData } from "./postgresql";
 import { SqliteData } from "./sqlite";
 import { SqlServerData } from "./sqlserver";
 
+// Fix (part 3 of 3) Issue #1399 - int64s not displaying properly
+// Fixes error 'BigInt' is not defined in lib/db/clients/sqlite.js
+declare global {
+  interface BigIntConstructor {
+    toJSON:()=>BigInt;
+  }
+}
+
 export function getDialectData(dialect: Dialect): DialectData  {
   switch (dialect) {
     case "postgresql":


### PR DESCRIPTION
- Add new sqlite regression test that proves the error
- Fix bug by calling db.defaultSafeIntegers(true) on new connections
- Configue eslint-loader to target es2020 and recognize BigInt's as a type to fix startup error
- Update columnFilterTests in integration/lib/db/clients/all.js to handle sqlite BigInts
- Added useNullAsDefault option to knex connection to silence (some of) the "sqlite does not support inserting default values" warnings
- Fix (unrelated) error in QueryEditorStatusBar.vue's shortNum() function (when creating tables)
