### PR TITLE
Feature #1257 - Add "Close Tabs to Right" option to tab right-click menu

### DIFF
--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -93,6 +93,7 @@ import TabIcon from './tab/TabIcon.vue'
           { name: "Close", slug: 'close', handler: ({event}) => this.maybeClose(event)},
           { name: "Close Others", slug: 'close-others', handler: ({item}) => this.$emit('closeOther', item)},
           { name: 'Close All', slug: 'close-all', handler: ({item}) => this.$emit('closeAll', item)},
+          { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({item}) => this.$emit('closeToRight', item)},
           { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.$emit('duplicate', item) }
         ]
       },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -413,7 +413,7 @@
         const tabsToRight = this.tabItems.slice(tabIndex + 1)
 
         if (this.activeTab && activeTabIndex > tabIndex) {
-         this.setActiveTab(tab)
+          this.setActiveTab(tab)
         }
 
         this.$store.dispatch('tabs/remove', tabsToRight)

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -407,14 +407,14 @@
         }
       },
       closeToRight(tab) {
-        const sliceIndex = _.indexOf(this.tabItems, tab);
+        const tabIndex = _.indexOf(this.tabItems, tab);
         const activeTabIndex = _.indexOf(this.tabItems, this.activeTab);
 
-        const others = this.tabItems.slice(sliceIndex + 1);
+        const others = this.tabItems.slice(tabIndex + 1);
 
         this.$store.dispatch('tabs/remove', others)
 
-        if (this.activeTab && activeTabIndex > sliceIndex) {
+        if (this.activeTab && activeTabIndex > tabIndex) {
          this.setActiveTab(tab)
         }
       },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -13,6 +13,7 @@
           @close="close"
           @closeAll="closeAll"
           @closeOther="closeOther"
+          @closeToRight="closeToRight"
           @duplicate="duplicate"
           ></core-tab-header>
       </Draggable>
@@ -184,6 +185,7 @@
           { name: "Close", slug: 'close', handler: ({item}) => this.close(item)},
           { name: "Close Others", slug: 'close-others', handler: ({item}) => this.closeOther(item)},
           { name: 'Close All', slug: 'close-all', handler: this.closeAll},
+          { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({item}) => this.closeToRight(item)},
           { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.duplicate(item)}
         ]
       },
@@ -260,6 +262,8 @@
             return this.closeOther(item)
           case 'close-all':
             return this.closeAll();
+          case 'close-to-right':
+            return this.closeToRight(item);
           case 'duplicate':
             return this.duplicate(item);
         }
@@ -400,6 +404,18 @@
         this.setActiveTab(tab)
         if (tab.queryId) {
           this.$store.dispatch('data/queries/reload', tab.queryId)
+        }
+      },
+      closeToRight(tab) {
+        const sliceIndex = _.indexOf(this.tabItems, tab);
+        const activeTabIndex = _.indexOf(this.tabItems, this.activeTab);
+
+        const others = this.tabItems.slice(sliceIndex + 1);
+
+        this.$store.dispatch('tabs/remove', others)
+
+        if (this.activeTab && activeTabIndex > sliceIndex) {
+         this.setActiveTab(tab)
         }
       },
       duplicate(other: OpenTab) {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -410,9 +410,9 @@
         const tabIndex = _.indexOf(this.tabItems, tab);
         const activeTabIndex = _.indexOf(this.tabItems, this.activeTab);
 
-        const others = this.tabItems.slice(tabIndex + 1);
+        const tabsToRight = this.tabItems.slice(tabIndex + 1);
 
-        this.$store.dispatch('tabs/remove', others)
+        this.$store.dispatch('tabs/remove', tabsToRight)
 
         if (this.activeTab && activeTabIndex > tabIndex) {
          this.setActiveTab(tab)

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -407,16 +407,16 @@
         }
       },
       closeToRight(tab) {
-        const tabIndex = _.indexOf(this.tabItems, tab);
-        const activeTabIndex = _.indexOf(this.tabItems, this.activeTab);
+        const tabIndex = _.indexOf(this.tabItems, tab)
+        const activeTabIndex = _.indexOf(this.tabItems, this.activeTab)
 
-        const tabsToRight = this.tabItems.slice(tabIndex + 1);
-
-        this.$store.dispatch('tabs/remove', tabsToRight)
+        const tabsToRight = this.tabItems.slice(tabIndex + 1)
 
         if (this.activeTab && activeTabIndex > tabIndex) {
          this.setActiveTab(tab)
         }
+
+        this.$store.dispatch('tabs/remove', tabsToRight)
       },
       duplicate(other: OpenTab) {
         const tab = other.duplicate()


### PR DESCRIPTION
Hi, it's my first open-source PR and I've never worked with Vue before so please take it easy on me :) I'm a big fan of Beekeeper.

Resolves #1257

Introduced in this PR:

- A new right-click menu option that closes all tabs to the right of the selected tab

- When the current active tab is to the right of the clicked option, the active tab switches to the clicked tab (which is now the `lastTab`).

https://user-images.githubusercontent.com/12005272/212591541-19289567-58b5-450a-9933-7a9904589e64.mov 

https://user-images.githubusercontent.com/12005272/212591548-776417d5-f937-445f-9db3-bc50c68d8d92.mov

