### PR TITLE
Fixing async loading with pinned tabs

### DIFF
--- a/apps/studio/src/components/sidebar/core/PinnedTableList.vue
+++ b/apps/studio/src/components/sidebar/core/PinnedTableList.vue
@@ -5,16 +5,18 @@
         <div>Pinned <span class="badge">{{orderedPins.length}}</span></div>
       </div>
     </div>
-    <Draggable :options="{handle: '.pin-wrapper'}" v-model="orderedPins" tag="div" ref="pinContainer" class="list-body">
+    <Draggable :options="{handle: '.drag-handle'}" v-model="orderedPins" tag="div" ref="pinContainer" class="list-body">
       <div class="pin-wrapper" v-for="p in orderedPins" :key="p.id || p.entity.name">
         <table-list-item
           v-if="p.entityType !== 'routine'"
           :table="p.entity"
           :pinned="true"
           :connection="connection"
+          :draggable="true"
           :container="$refs.pinContainer"
           :forceExpand="allExpanded"
           :forceCollapse="allCollapsed"
+          @selected="refreshColumns"
           :noSelect="true"
           @contextmenu.prevent.stop="$bks.openMenu({item: p.entity, event: $event, options: tableMenuOptions})"
 
@@ -22,11 +24,12 @@
         <routine-list-item
           v-else
           :container="$refs.pinContainer"
+          :draggable="true"
           :routine="p.entity"
           :connection="connection"
           :pinned="true"
-          :forceExpand="forceExpand"
-          :forceCollapse="forceCollapse"
+          :forceExpand="allExpanded"
+          :forceCollapse="allCollapsed"
           @contextmenu.prevent.stop="$bks.openMenu({item: p.entity, event: $event, options: routineMenuOptions})"
 
         />
@@ -59,6 +62,11 @@ export default Vue.extend({
         this.$store.dispatch('pins/reorder', pins)
       }
     }
+  },
+  methods: {
+    refreshColumns(table) {
+      this.$store.dispatch('updateTableColumns', table)
+    },
   }
 
 })

--- a/apps/studio/src/components/sidebar/core/TableList.vue
+++ b/apps/studio/src/components/sidebar/core/TableList.vue
@@ -37,7 +37,6 @@
         :allExpanded="allExpanded"
         :allCollapsed="allCollapsed"
         :connection="connection"
-        @selected="tableSelected"
         @unselected="tableUnselected"
       />
     </div>
@@ -58,7 +57,7 @@
                 <span>{{totalHiddenEntities > 99 ? '99+' : totalHiddenEntities}}</span>
               </span>
               <div class="hi-tooltip">
-                <span>You can unhide entities to add it here. </span>
+                <span>Right click an entity to hide it. </span>
                 <a @click="$modal.show('hidden-entities')">View hidden</a><span>.</span>
               </div>
             </span>
@@ -289,26 +288,30 @@
         }
         }
       },
+      refreshExpandedColumns() {
+        this.expandedTables.forEach((k) => {
+          const t = this.tableFromKey(k)
+          if (t) {
+            this.$store.dispatch('updateTableColumns', t)
+          }
+        })
+      },
+      refreshPinnedColumns() {
+        this.orderedPins.forEach((p) => {
+          const t = this.tables.find((table) => p.matches(table))
+          if (t) {
+            this.$store.dispatch('updateTableColumns', t)
+          }
+        })
+      },
       refreshTables() {
         this.$store.dispatch('updateRoutines')
         this.$store.dispatch('updateTables').then(() => {
           // When we refresh sidebar tables we need to also refresh:
           // 1. Any open tables
           // 2. Any pinned tables
-
-          this.expandedTables.forEach((k) => {
-            const t = this.tableFromKey(k)
-            if (t) {
-              this.$store.dispatch('updateTableColumns', t)
-            }
-          })
-
-          this.orderedPins.forEach((p) => {
-            const t = this.tables.find((table) => p.matches(table))
-            if (t) {
-              this.$store.dispatch('updateTableColumns', t)
-            }
-          })
+          this.refreshExpandedColumns()
+          this.refreshPinnedColumns()
         })
       },
       newTable() {

--- a/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
@@ -3,9 +3,13 @@
     <a class="list-item-btn" role="button" v-bind:class="{'active': selected,'open': showArgs }">
       <span class="btn-fab open-close" @mousedown.prevent="toggleArgs" @contextmenu.stop.prevent="" >
         <i v-if="displayParams.length > 0" class="dropdown-icon material-icons">keyboard_arrow_right</i>
-      </span>      
+      </span>
       <span class="item-wrapper flex flex-middle expand">
-        <i :title="title" :class="iconClass" class="item-icon material-icons">functions</i>
+        <div :title="draggable ? 'drag me!' : ''" class="table-item-wrapper drag-handle" :class="{ 'draggable': draggable }">
+          <i :title="title" :class="iconClass" class="item-icon entity-icon material-icons">functions</i>
+          <i class="material-icons item-icon dh" v-if="draggable">menu</i>
+        </div>
+
         <span class="table-name truncate" :title="routine.name">{{routine.name}}</span>
       </span>
       <span class="actions" v-bind:class="{'pinned': pinned}">
@@ -33,6 +37,19 @@
       cursor: pointer;
     }
   }
+  .drag-handle.draggable {
+    .dh {
+      display: none;
+    }
+    &:hover {
+      .dh {
+        display: inline-block;
+      }
+      .entity-icon {
+        display: none;
+      }
+    }
+  }
 </style>
 
 <script type="text/javascript">
@@ -40,7 +57,7 @@ import { RoutineTypeNames } from '@/lib/db/models'
 
   import { mapGetters } from 'vuex'
 	export default {
-		props: ["connection", "routine", "noSelect", "forceExpand", "forceCollapse", "pinned"],
+		props: ["connection", "routine", "noSelect", "forceExpand", "forceCollapse", "pinned", 'draggable'],
     mounted() {
     },
     data() {

--- a/apps/studio/src/components/sidebar/core/table_list/TableListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/TableListItem.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="list-item" @contextmenu="$emit('contextmenu', $event)">
     <a class="list-item-btn" role="button" v-bind:class="{'active': active, 'selected': selected,'open': showColumns }">
-      <span @contextmenu.prevent.stop="" class="btn-fab open-close" @mousedown.prevent="toggleColumns" >
+      <span @contextmenu.prevent.stop="" class="btn-fab open-close" @mousedown.prevent="toggleColumns">
         <i class="dropdown-icon material-icons">keyboard_arrow_right</i>
       </span>
       <span class="item-wrapper flex flex-middle expand" @dblclick.prevent="openTable" @mousedown="selectItem">
-        <table-icon :table="table" />
+        <div :title="draggable ? 'drag me!' : ''" class="table-item-wrapper drag-handle" :class="{ 'draggable': draggable }">
+          <table-icon :table="table" class="table-icon" />
+          <i class="material-icons item-icon dh" v-if="draggable">menu</i>
+        </div>
         <span class="table-name truncate" :title="table.name">{{table.name}}</span>
       </span>
       <span class="actions" v-bind:class="{'pinned': pinned}">
@@ -29,13 +32,27 @@
   </div>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped="true">
   .sub-item {
     .title {
       user-select: text;
       cursor: pointer;
     }
   }
+  .drag-handle.draggable {
+    .dh {
+      display: none;
+    }
+    &:hover {
+      .dh {
+        display: inline-block;
+      }
+      .table-icon {
+        display: none;
+      }
+    }
+  }
+
 </style>
 
 <script type="text/javascript">
@@ -46,7 +63,7 @@ import { AppEvent } from '../../../../common/AppEvent'
 import { uuidv4 } from '../../../../lib/uuid'
 import TableIcon from '@/components/common/TableIcon.vue'
 	export default {
-		props: ["connection", "table", "noSelect", "forceExpand", "forceCollapse", "container", "pinned"],
+		props: ["connection", "table", "noSelect", "forceExpand", "forceCollapse", "container", "pinned", "draggable"],
     components: { TableIcon },
     mounted() {
       this.showColumns = !!this.table.showColumns

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -409,7 +409,6 @@ const store = new Vuex.Store<State>({
           await connection?.listMaterializedViewColumns(table.name, table.schema) :
           await connection?.listTableColumns(table.name, table.schema)) || []
 
-        // TODO (don't update columns if nothing has changed (use duck typing))
         const updated = _.xorWith(table.columns, columns, _.isEqual)
         log.debug('Should I update table columns?', updated)
         if (updated?.length) {

--- a/apps/studio/src/store/modules/PinModule.ts
+++ b/apps/studio/src/store/modules/PinModule.ts
@@ -93,5 +93,5 @@ export const PinModule: Module<State, RootState> = {
       }
     }
   }
-  
+
 }


### PR DESCRIPTION
- If you connect to a DB with saved pins, they will now load in columns properly
- Fixed an unrelated bug that removed focus from the editor when expanding pins
  - This was due to 'draggable'. Moved dragging to the table icon only.