### PR TITLE
FIX bad version interpretation on Windows

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -100,7 +100,7 @@ async function getVersion(conn: HasPool): Promise<VersionInfo> {
     isCockroach,
     isRedshift,
     number: parseInt(
-      version.split(" ")[isPostgres ? 1 : 2].replace(/^v/i, '').split(".").map((s: string) => s.padStart(2, "0")).join("").padEnd(6, "0"),
+      version.split(" ")[isPostgres ? 1 : 2].replace(/(^v)|(,$)/ig, '').split(".").map((s: string) => s.padStart(2, "0")).join("").padEnd(6, "0"),
       10
     )
   }


### PR DESCRIPTION
Due to a comma in version output causing this issue https://github.com/beekeeper-studio/beekeeper-studio/issues/1524

I just update the replace regex to remove comma if present.

It would be better to refacto the whole function based on regex but need to etablish a test set first.