### PR TITLE
Copy to sql

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -146,7 +146,6 @@
           </span>
         </div> -->
 
-        <!-- TODO (day): Copy to SQL button here?-->
         <template v-if="pendingChangesCount > 0">
           <x-button class="btn btn-flat" @click.prevent="discardChanges">Reset</x-button>
           <x-buttons class="pending-changes">
@@ -344,6 +343,7 @@ export default Vue.extend({
       result[this.ctrlOrCmd('r')] = this.refreshTable.bind(this)
       result[this.ctrlOrCmd('n')] = this.cellAddRow.bind(this)
       result[this.ctrlOrCmd('s')] = this.saveChanges.bind(this)
+      result[this.ctrlOrCmd('shift+s')] = this.copyToSql.bind(this)
       result[this.ctrlOrCmd('f')] = () => this.$refs.valueInput.focus()
       result[this.ctrlOrCmd('c')] = this.copyCell
       return result
@@ -1211,8 +1211,6 @@ export default Vue.extend({
         const sql = await this.connection.getChangesSql(changes)
         const formatted = format(sql, { language: FormatterDialect(this.dialect) })
         this.$root.$emit(AppEvent.newTab, formatted)
-          
-        this.resetPendingChanges()
       } catch(ex) {
         console.error(ex);
         this.pendingChanges.updates.forEach(edit => {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1208,7 +1208,7 @@ export default Vue.extend({
           updates: this.pendingChanges.updates,
           deletes: this.pendingChanges.deletes
         }
-        const sql = await this.connection.applyChangesSql(changes)
+        const sql = this.connection.applyChangesSql(changes)
         const formatted = format(sql, { language: FormatterDialect(this.dialect) })
         this.$root.$emit(AppEvent.newTab, formatted)
       } catch(ex) {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1208,7 +1208,7 @@ export default Vue.extend({
           updates: this.pendingChanges.updates,
           deletes: this.pendingChanges.deletes
         }
-        const sql = await this.connection.getChangesSql(changes)
+        const sql = await this.connection.applyChangesSql(changes)
         const formatted = format(sql, { language: FormatterDialect(this.dialect) })
         this.$root.$emit(AppEvent.newTab, formatted)
       } catch(ex) {

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -59,6 +59,7 @@ export interface DatabaseClient {
   alterRelationSql: (changes: RelationAlterations) => string | null
   alterRelation: (changes: RelationAlterations) => Promise<void>
 
+  getChangesSql: (changes: TableChanges) => Promise<string>,
   getInsertQuery: (tableInsert: TableInsert) => Promise<string>,
   getQuerySelectTop: (table: string, limit: number, schema?: string) => void,
   getTableProperties: (table: string, schema?: string) => Promise<TableProperties | null>,
@@ -178,6 +179,7 @@ export class DBConnection {
   selectTop = selectTop.bind(null, this.server, this.database)
   selectTopStream = selectTopStream.bind(null, this.server, this.database)
   applyChanges = applyChanges.bind(null, this.server, this.database)
+  getChangesSql = getChangesSql.bind(null, this.server, this.database)
 
   // alter table
   alterTableSql = bind.bind(null, 'alterTableSql', this.server, this.database)
@@ -401,6 +403,11 @@ function query(server: IDbConnectionServer, database: IDbConnectionDatabase, que
 function applyChanges(server: IDbConnectionServer, database: IDbConnectionDatabase, changes: TableChanges) {
   checkIsConnected(server, database)
   return database.connection?.applyChanges(changes)
+}
+
+function getChangesSql(server: IDbConnectionServer, database: IDbConnectionDatabase, changes: TableChanges) {
+  checkIsConnected(server, database)
+  return database.connection?.getChangesSql(changes);
 }
 
 function bind(functionName: string, server: IDbConnectionServer, database: IDbConnectionDatabase, ...args) {

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -59,7 +59,7 @@ export interface DatabaseClient {
   alterRelationSql: (changes: RelationAlterations) => string | null
   alterRelation: (changes: RelationAlterations) => Promise<void>
 
-  applyChangesSql: (changes: TableChanges) => Promise<string>,
+  applyChangesSql: (changes: TableChanges) => string,
   getInsertQuery: (tableInsert: TableInsert) => Promise<string>,
   getQuerySelectTop: (table: string, limit: number, schema?: string) => void,
   getTableProperties: (table: string, schema?: string) => Promise<TableProperties | null>,

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -59,7 +59,7 @@ export interface DatabaseClient {
   alterRelationSql: (changes: RelationAlterations) => string | null
   alterRelation: (changes: RelationAlterations) => Promise<void>
 
-  getChangesSql: (changes: TableChanges) => Promise<string>,
+  applyChangesSql: (changes: TableChanges) => Promise<string>,
   getInsertQuery: (tableInsert: TableInsert) => Promise<string>,
   getQuerySelectTop: (table: string, limit: number, schema?: string) => void,
   getTableProperties: (table: string, schema?: string) => Promise<TableProperties | null>,
@@ -179,7 +179,7 @@ export class DBConnection {
   selectTop = selectTop.bind(null, this.server, this.database)
   selectTopStream = selectTopStream.bind(null, this.server, this.database)
   applyChanges = applyChanges.bind(null, this.server, this.database)
-  getChangesSql = getChangesSql.bind(null, this.server, this.database)
+  applyChangesSql = applyChangesSql.bind(null, this.server, this.database)
 
   // alter table
   alterTableSql = bind.bind(null, 'alterTableSql', this.server, this.database)
@@ -405,9 +405,9 @@ function applyChanges(server: IDbConnectionServer, database: IDbConnectionDataba
   return database.connection?.applyChanges(changes)
 }
 
-function getChangesSql(server: IDbConnectionServer, database: IDbConnectionDatabase, changes: TableChanges) {
+function applyChangesSql(server: IDbConnectionServer, database: IDbConnectionDatabase, changes: TableChanges) {
   checkIsConnected(server, database)
-  return database.connection?.getChangesSql(changes);
+  return database.connection?.applyChangesSql(changes);
 }
 
 function bind(functionName: string, server: IDbConnectionServer, database: IDbConnectionDatabase, ...args) {

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -10,7 +10,7 @@ import globals from '../../../common/globals';
 import { createCancelablePromise } from '../../../common/utils';
 import { errors } from '../../errors';
 import { MysqlCursor } from './mysql/MySqlCursor';
-import { buildDeleteQueries, buildInsertQueries, buildUpdateQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral, getChangesSql } from './utils';
+import { buildDeleteQueries, buildInsertQueries, buildUpdateQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral, applyChangesSql } from './utils';
 import { MysqlData } from '@shared/lib/dialects/mysql'
 import { ClientError } from '../client';
 
@@ -67,7 +67,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes) => getChangesSql(changes, knex),
+    applyChangesSql: (changes) => applyChangesSql(changes, knex),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -10,7 +10,7 @@ import globals from '../../../common/globals';
 import { createCancelablePromise } from '../../../common/utils';
 import { errors } from '../../errors';
 import { MysqlCursor } from './mysql/MySqlCursor';
-import { buildDeleteQueries, buildInsertQueries, buildUpdateQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral } from './utils';
+import { buildDeleteQueries, buildInsertQueries, buildUpdateQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral, getChangesSql } from './utils';
 import { MysqlData } from '@shared/lib/dialects/mysql'
 import { ClientError } from '../client';
 
@@ -67,7 +67,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes) => getChangesSql(changes),
+    getChangesSql: (changes) => getChangesSql(changes, knex),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
@@ -664,17 +664,6 @@ export async function listDatabases(conn, filter) {
   return data
     .filter((item) => filterDatabase(item, filter, 'Database'))
     .map((row) => row.Database);
-}
-
-async function getChangesSql(changes) {
-  const queries = [
-    ...buildInsertQueries(knex, changes.inserts || []),
-    ...buildUpdateQueries(knex, changes.updates || []),
-    ...buildDeleteQueries(knex, changes.deletes || [])
-  ].filter((i) => !!i && _.isString(i)).join(';')
-
-  if (queries.length) 
-    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 async function getInsertQuery(conn, database, tableInsert) {

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -10,7 +10,7 @@ import globals from '../../../common/globals';
 import { createCancelablePromise } from '../../../common/utils';
 import { errors } from '../../errors';
 import { MysqlCursor } from './mysql/MySqlCursor';
-import { buildDeleteQueries, buildInsertQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral } from './utils';
+import { buildDeleteQueries, buildInsertQueries, buildUpdateQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral } from './utils';
 import { MysqlData } from '@shared/lib/dialects/mysql'
 import { ClientError } from '../client';
 
@@ -67,6 +67,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
+    getChangesSql: (changes) => getChangesSql(changes),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
@@ -663,6 +664,17 @@ export async function listDatabases(conn, filter) {
   return data
     .filter((item) => filterDatabase(item, filter, 'Database'))
     .map((row) => row.Database);
+}
+
+async function getChangesSql(changes) {
+  const queries = [
+    ...buildInsertQueries(knex, changes.inserts || []),
+    ...buildUpdateQueries(knex, changes.updates || []),
+    ...buildDeleteQueries(knex, changes.deletes || [])
+  ].filter((i) => !!i && _.isString(i)).join(';')
+
+  if (queries.length) 
+    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 async function getInsertQuery(conn, database, tableInsert) {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -12,7 +12,7 @@ import logRaw from 'electron-log'
 import { DatabaseClient, IDbConnectionServerConfig, DatabaseElement } from '../client'
 import { AWSCredentials, ClusterCredentialConfiguration, RedshiftCredentialResolver } from '../authentication/amazon-redshift';
 import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, IndexedColumn, } from "../models";
-import { buildDatabseFilter, buildDeleteQueries, buildInsertQuery, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, joinQueries } from './utils';
+import { buildDatabseFilter, buildDeleteQueries, buildInsertQuery, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, joinQueries, getChangesSql } from './utils';
 import { createCancelablePromise } from '../../../common/utils';
 import { errors } from '../../errors';
 import globals from '../../../common/globals';
@@ -187,7 +187,7 @@ export default async function (server: any, database: any): Promise<DatabaseClie
     getTableLength: (table: string, schema: string) => getTableLength(conn, table, schema),
     selectTop: (table: string, offset: number, limit: number, orderBy: OrderBy[], filters: TableFilter[] | string, schema: string = defaultSchema, selects: string[] = ['*']) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (database: string, table: string, orderBy: OrderBy[], filters: TableFilter[] | string, chunkSize: number, schema: string = defaultSchema) => selectTopStream(conn, database, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes: TableChanges): Promise<string> => getChangesSql(changes),
+    getChangesSql: (changes: TableChanges): Promise<string> => getChangesSql(changes, knex),
     getInsertQuery: (tableInsert: TableInsert): Promise<string> => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit, schema = defaultSchema) => getQuerySelectTop(conn, table, limit, schema),
     getTableCreateScript: (table, schema = defaultSchema) => getTableCreateScript(conn, table, schema),
@@ -1205,17 +1205,6 @@ export async function listDatabases(conn: Conn, filter?: DatabaseFilterOptions) 
   const data = await driverExecuteSingle(conn, { query: sql, params });
 
   return data.rows.map((row) => row.datname);
-}
-
-async function getChangesSql(changes: TableChanges): Promise<string> {
-  const queries = [
-    ...buildInsertQueries(knex, changes.inserts || []),
-    ...buildUpdateQueries(knex, changes.updates || []),
-    ...buildDeleteQueries(knex, changes.deletes || [])
-  ].filter((i) => !!i && _.isString(i)).join(';')
-
-  if (queries.length) 
-    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 export async function getInsertQuery(conn: HasPool, database: string, tableInsert: TableInsert): Promise<string> {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -187,7 +187,7 @@ export default async function (server: any, database: any): Promise<DatabaseClie
     getTableLength: (table: string, schema: string) => getTableLength(conn, table, schema),
     selectTop: (table: string, offset: number, limit: number, orderBy: OrderBy[], filters: TableFilter[] | string, schema: string = defaultSchema, selects: string[] = ['*']) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (database: string, table: string, orderBy: OrderBy[], filters: TableFilter[] | string, chunkSize: number, schema: string = defaultSchema) => selectTopStream(conn, database, table, orderBy, filters, chunkSize, schema),
-    applyChangesSql: (changes: TableChanges): Promise<string> => applyChangesSql(changes, knex),
+    applyChangesSql: (changes: TableChanges): string => applyChangesSql(changes, knex),
     getInsertQuery: (tableInsert: TableInsert): Promise<string> => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit, schema = defaultSchema) => getQuerySelectTop(conn, table, limit, schema),
     getTableCreateScript: (table, schema = defaultSchema) => getTableCreateScript(conn, table, schema),

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -12,7 +12,7 @@ import logRaw from 'electron-log'
 import { DatabaseClient, IDbConnectionServerConfig, DatabaseElement } from '../client'
 import { AWSCredentials, ClusterCredentialConfiguration, RedshiftCredentialResolver } from '../authentication/amazon-redshift';
 import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, IndexedColumn, } from "../models";
-import { buildDatabseFilter, buildDeleteQueries, buildInsertQuery, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, joinQueries, getChangesSql } from './utils';
+import { buildDatabseFilter, buildDeleteQueries, buildInsertQuery, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, joinQueries, applyChangesSql } from './utils';
 import { createCancelablePromise } from '../../../common/utils';
 import { errors } from '../../errors';
 import globals from '../../../common/globals';
@@ -187,7 +187,7 @@ export default async function (server: any, database: any): Promise<DatabaseClie
     getTableLength: (table: string, schema: string) => getTableLength(conn, table, schema),
     selectTop: (table: string, offset: number, limit: number, orderBy: OrderBy[], filters: TableFilter[] | string, schema: string = defaultSchema, selects: string[] = ['*']) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (database: string, table: string, orderBy: OrderBy[], filters: TableFilter[] | string, chunkSize: number, schema: string = defaultSchema) => selectTopStream(conn, database, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes: TableChanges): Promise<string> => getChangesSql(changes, knex),
+    applyChangesSql: (changes: TableChanges): Promise<string> => applyChangesSql(changes, knex),
     getInsertQuery: (tableInsert: TableInsert): Promise<string> => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit, schema = defaultSchema) => getQuerySelectTop(conn, table, limit, schema),
     getTableCreateScript: (table, schema = defaultSchema) => getTableCreateScript(conn, table, schema),

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -5,8 +5,9 @@ import _ from 'lodash'
 import Database from 'better-sqlite3'
 import { identify } from 'sql-query-identifier';
 import knexlib from 'knex'
+import { makeEscape } from 'knex/lib/util/string'
 import rawLog from 'electron-log'
-import { buildInsertQuery, buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery, escapeLiteral } from './utils';
+import { buildInsertQuery, buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery, escapeLiteral, buildUpdateQueries } from './utils';
 import { SqliteCursor } from './sqlite/SqliteCursor';
 import { SqliteChangeBuilder } from '@shared/lib/sql/change_builder/SqliteChangeBuilder';
 import { SqliteData } from '@shared/lib/dialects/sqlite';
@@ -17,6 +18,16 @@ const logger = () => log
 const knex = knexlib({ client: 'better-sqlite3',
   // silence the "sqlite does not support inserting default values" warnings on every insert
   useNullAsDefault: true,
+})
+
+// HACK (day): this is to prevent the 'str.replace is not a function' error that seems to happen with all changes.
+knex.client = Object.assign(knex.client, {
+  _escapeBinding: makeEscape({
+    escapeString(str) {
+      str = _.toString(str)
+      return str ? `'${str.replace(/'/g, "''")}'` : ''
+    }
+  })
 })
 
 const sqliteErrors = {
@@ -59,6 +70,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize) => selectTopStream(conn, db, table, orderBy, filters, chunkSize),
+    getChangesSql: (changes) => getChangesSql(changes),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
@@ -87,7 +99,7 @@ export default async function (server, database) {
 
     // delete stuff
     dropElement: (elementName, typeOfElement) => dropElement(conn, elementName, typeOfElement),
-    truncateElement: (elementName) => truncateElement(conn, elementName)
+    truncateElement: (elementName) => truncateElement(conn, elementName),
   };
 }
 
@@ -110,6 +122,17 @@ export function wrapIdentifier(value) {
 
 function escapeString(value) {
   return value.replace("'", "''")
+}
+
+async function getChangesSql(changes) {
+  let queries = [
+    ...buildInsertQueries(knex, changes.inserts || []),
+    ...buildUpdateQueries(knex, changes.updates || []),
+    ...buildDeleteQueries(knex, changes.deletes || [])
+  ].filter((i) => !!i && _.isString(i)).join(';')
+
+  if (queries.length) 
+    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 async function getInsertQuery(conn, database, tableInsert) {
@@ -222,6 +245,7 @@ export async function applyChanges(conn, changes) {
 
   return results
 }
+
 
 export async function updateValues(cli, updates) {
   const commands = updates.map(update => {

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -7,7 +7,7 @@ import { identify } from 'sql-query-identifier';
 import knexlib from 'knex'
 import { makeEscape } from 'knex/lib/util/string'
 import rawLog from 'electron-log'
-import { buildInsertQuery, buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery, escapeLiteral, buildUpdateQueries, getChangesSql } from './utils';
+import { buildInsertQuery, buildInsertQueries, buildDeleteQueries, genericSelectTop, buildSelectTopQuery, escapeLiteral, buildUpdateQueries, applyChangesSql } from './utils';
 import { SqliteCursor } from './sqlite/SqliteCursor';
 import { SqliteChangeBuilder } from '@shared/lib/sql/change_builder/SqliteChangeBuilder';
 import { SqliteData } from '@shared/lib/dialects/sqlite';
@@ -70,7 +70,7 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(conn, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize) => selectTopStream(conn, db, table, orderBy, filters, chunkSize),
-    getChangesSql: (changes) => getChangesSql(changes, knex),
+    applyChangesSql: (changes) => applyChangesSql(changes, knex),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -16,7 +16,8 @@ import { buildDatabseFilter,
   buildUpdateQueries,
   escapeString,
   joinQueries,
-  escapeLiteral
+  escapeLiteral,
+  getChangesSql
 } from './utils';
 import logRaw from 'electron-log'
 import { SqlServerCursor } from './sqlserver/SqlServerCursor';
@@ -72,7 +73,7 @@ export default async function (server, database) {
     getTableLength: (table, schema) => getTableLength(conn, table, schema),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes) => getChangesSql(changes),
+    getChangesSql: (changes) => getChangesSql(changes, knex),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
@@ -281,17 +282,6 @@ export function wrapIdentifier(value) {
 
 export function wrapValue(value) {
   return `'${value.replaceAll(/'/g, "''")}'`
-}
-
-async function getChangesSql(changes) {
-  const queries = [
-    ...buildInsertQueries(knex, changes.inserts || []),
-    ...buildUpdateQueries(knex, changes.updates || []),
-    ...buildDeleteQueries(knex, changes.deletes || [])
-  ].filter((i) => !!i && _.isString(i)).join(';')
-
-  if (queries.length) 
-    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 async function getInsertQuery(conn, database, tableInsert) {

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -72,6 +72,7 @@ export default async function (server, database) {
     getTableLength: (table, schema) => getTableLength(conn, table, schema),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
+    getChangesSql: (changes) => getChangesSql(changes),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
@@ -280,6 +281,17 @@ export function wrapIdentifier(value) {
 
 export function wrapValue(value) {
   return `'${value.replaceAll(/'/g, "''")}'`
+}
+
+async function getChangesSql(changes) {
+  const queries = [
+    ...buildInsertQueries(knex, changes.inserts || []),
+    ...buildUpdateQueries(knex, changes.updates || []),
+    ...buildDeleteQueries(knex, changes.deletes || [])
+  ].filter((i) => !!i && _.isString(i)).join(';')
+
+  if (queries.length) 
+    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 async function getInsertQuery(conn, database, tableInsert) {

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -17,7 +17,7 @@ import { buildDatabseFilter,
   escapeString,
   joinQueries,
   escapeLiteral,
-  getChangesSql
+  applyChangesSql
 } from './utils';
 import logRaw from 'electron-log'
 import { SqlServerCursor } from './sqlserver/SqlServerCursor';
@@ -66,6 +66,7 @@ export default async function (server, database) {
     getTableKeys: (db, table, schema) => getTableKeys(conn, db, table, schema),
     getPrimaryKey: (db, table, schema) => getPrimaryKey(conn, db, table, schema),
     getPrimaryKeys: (db, table, schema) => getPrimaryKeys(conn, db, table, schema),
+    applyChangesSql: (changes) => applyChangesSql(changes, knex),
     applyChanges: (changes) => applyChanges(conn, changes),
     query: (queryText) => query(conn, queryText),
     executeQuery: (queryText) => executeQuery(conn, queryText),
@@ -73,7 +74,6 @@ export default async function (server, database) {
     getTableLength: (table, schema) => getTableLength(conn, table, schema),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(conn, table, offset, limit, orderBy, filters, schema, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(conn, db, table, orderBy, filters, chunkSize, schema),
-    getChangesSql: (changes) => getChangesSql(changes, knex),
     getInsertQuery: (tableInsert) => getInsertQuery(conn, database.database, tableInsert),
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),

--- a/apps/studio/src/lib/db/clients/utils.ts
+++ b/apps/studio/src/lib/db/clients/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015 The SQLECTRON Team
 import _ from 'lodash'
 import logRaw from 'electron-log'
-import { TableDelete, TableInsert, TableUpdate } from '../models'
+import { TableChanges, TableDelete, TableInsert, TableUpdate } from '../models'
 
 const log = logRaw.scope('db/util')
 
@@ -100,6 +100,17 @@ export function buildFilterString(filters, columns = []) {
   return {
     filterString, filterParams
   }
+}
+
+export async function getChangesSql(changes: TableChanges, knex: any): Promise<string> {
+  const queries = [
+    ...buildInsertQueries(knex, changes.inserts || []),
+    ...buildUpdateQueries(knex, changes.updates || []),
+    ...buildDeleteQueries(knex, changes.deletes || [])
+  ].filter((i) => !!i && _.isString(i)).join(';')
+
+  if (queries.length) 
+    return queries.endsWith(';') ? queries : `${queries};`
 }
 
 export function buildSelectTopQuery(table, offset, limit, orderBy, filters, countTitle = 'total', columns = [], selects = ['*']) {

--- a/apps/studio/src/lib/db/clients/utils.ts
+++ b/apps/studio/src/lib/db/clients/utils.ts
@@ -102,7 +102,7 @@ export function buildFilterString(filters, columns = []) {
   }
 }
 
-export async function applyChangesSql(changes: TableChanges, knex: any): Promise<string> {
+export function applyChangesSql(changes: TableChanges, knex: any): string {
   const queries = [
     ...buildInsertQueries(knex, changes.inserts || []),
     ...buildUpdateQueries(knex, changes.updates || []),

--- a/apps/studio/src/lib/db/clients/utils.ts
+++ b/apps/studio/src/lib/db/clients/utils.ts
@@ -102,7 +102,7 @@ export function buildFilterString(filters, columns = []) {
   }
 }
 
-export async function getChangesSql(changes: TableChanges, knex: any): Promise<string> {
+export async function applyChangesSql(changes: TableChanges, knex: any): Promise<string> {
   const queries = [
     ...buildInsertQueries(knex, changes.inserts || []),
     ...buildUpdateQueries(knex, changes.updates || []),

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -149,6 +149,16 @@ export function runCommonTests(getUtil) {
     })
   })
 
+  describe("Get data modification SQL", () => {
+    beforeEach(async () => {
+      await prepareTestTable(getUtil())
+    })
+
+    test("Should generate scripts for all types of changes", () => {
+      itShouldGenerateSQLForAllChanges(getUtil())
+    })
+  })
+
 }
 
 // test functions below
@@ -619,4 +629,61 @@ export const itShouldNotCommitOnChangeErrorCompositePK = async function(util) {
     lastName: 'Tester'
   })
 
+}
+
+export const itShouldGenerateSQLForAllChanges = function(util) {
+  const changes = {
+    inserts: [
+      {
+        table: 'test_inserts',
+        schema: util.options.defaultSchema,
+        data: [{
+          id: 1,
+          firstName: 'Tom',
+          lastName: 'Tester'
+        }]
+      },
+      {
+        table: 'test_inserts',
+        schema: util.options.defaultSchema,
+        data: [{
+          id: 2,
+          firstName: 'Jane',
+          lastName: 'Doe'
+        }]
+      }
+    ],
+    updates: [
+      {
+        table: 'test_inserts',
+        schema: util.options.defaultSchema,
+        primaryKeys: [
+          {
+            column: 'id',
+            value: 1
+          }
+        ],
+        column: 'firstName',
+        value: 'Testy'
+      }
+    ],
+    deletes: [
+      {
+        table: 'test_inserts',
+        schema: util.options.defaultSchema,
+        primaryKeys: [{
+          column: 'id', value: 2
+        }],
+      }
+    ]
+  };
+
+  const sql = util.connection.applyChangesSql(changes).toLowerCase();
+
+  expect(sql.includes('insert'));
+  expect(sql.includes('update'));
+  expect(sql.includes('delete'));
+  expect(sql.includes('test_inserts'));
+  expect(sql.includes('jane'));
+  expect(sql.includes('testy'));
 }


### PR DESCRIPTION
Close #1534 

Copy to SQL for data view.
I mainly went off of the implementation for this feature in the tableSchema view.

Adds a dropdown to the apply button in data view:
![image](https://user-images.githubusercontent.com/58712803/224196219-f3ea2273-8692-4642-a972-29bda11e5221.png)

When clicked, changes that are pending are converted to sql and opened in a new tab:
![image](https://user-images.githubusercontent.com/58712803/224196303-b77d0407-8498-45b3-b6c1-d313f07c7e1f.png)
![image](https://user-images.githubusercontent.com/58712803/224196345-2da718d3-6fab-485c-9b85-bda88f9f4d46.png)

Note: I ran into an issue with updating data in sqlite tables. It was an issue with the knex client, which I did fix, but the solution seems kinda hacky to me.

This has been tested on Sqlite3, Sql Server, Postgres, and MySql
