### PR TITLE
Feat: duplicate table

### DIFF
--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -25,6 +25,7 @@ export enum AppEvent {
   hideSchema = 'hideSchema',
   deleteDatabaseElement = 'deleteDatabaseElement',
   dropDatabaseElement = 'dropDatabaseElement',
+  duplicateDatabaseTable = 'duplicateDatabaseTable',
 }
 
 export interface RootBinding {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -89,7 +89,7 @@
           <span class="expand"></span>
           <button ref="no" @click.prevent="$modal.hide(duplicateTableModal)" class="btn btn-sm btn-flat">Cancel</button>
           <!-- <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateTableAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button> -->
-          <pending-changes :submit-apply="duplicateTable" :submit-sql="duplicateTableSql" />
+          <pending-changes-button :submit-apply="duplicateTable" :submit-sql="duplicateTableSql" />
         </div>
       </modal>
     </portal>
@@ -116,7 +116,7 @@
   import TabWithTable from './common/TabWithTable.vue';
   import TabIcon from './tab/TabIcon.vue'
   import { DatabaseEntity } from "@/lib/db/models"
-  import PendingChanges from '../components/common/PendingChanges.vue'
+  import PendingChangesButton from './common/PendingChangesButton.vue'
 
   export default Vue.extend({
     props: [ 'connection' ],
@@ -131,7 +131,7 @@
       TableBuilder,
       TabWithTable,
       TabIcon,
-      PendingChanges
+      PendingChangesButton
     },
     data() {
       return {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -78,11 +78,12 @@
 
       <modal :name="duplicateTableModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
         <div class="dialog-content">
-          <div class="dialog-c-title">{{this.dbAction | titleCase}} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
+          <div class="dialog-c-title">{{this.dbAction | titleCase }} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
           <div class="form-group">
-            <label for="duplicatedTableName">New name</label>
+            <label for="duplicatedTableName">New table name</label>
             <input type="text" name="duplicatedTableName" class="form-control" required v-model="duplicatedTableName" autofocus>
           </div>
+          <small>* Indexes, relations or triggers will not be duplicated</small>
         </div>
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
@@ -263,6 +264,12 @@
         })
       },
       completeDuplicateAction(){
+        const { tableName, newTableName, schema, entityType } = this.dbDuplicateTableParams
+
+        if (entityType !== 'table' && this.dbAction == 'duplicate') {
+          this.$noty.warning("Sorry, you can only duplicate tables.")
+          return;
+        }
 
         if(this.dbElement === this.dublicatedTableName){
           this.$noty.warning("Sorry, you can't duplicate to the same name.")
@@ -274,7 +281,7 @@
           return;
         }
 
-        const { tableName, newTableName, schema } = this.dbDuplicateTableParams
+
         this.$modal.hide(this.duplicateTableModal)
 
         this.$nextTick(async() => {
@@ -298,6 +305,8 @@
             this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
           }
         })
+
+
       },
       beforeOpened() {
         this.lastFocused = document.activeElement

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -73,6 +73,23 @@
           <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDeleteAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
         </div>
       </modal>
+
+      <!-- Duplicate Modal -->
+
+      <modal :name="duplicateModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
+        <div class="dialog-content">
+          <div class="dialog-c-title">{{this.dbAction | titleCase}} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
+          <div class="form-group">
+            <label for="duplicatedTableName">New name</label>
+            <input type="text" name="duplicatedTableName" class="form-control" required v-model="duplicatedTableName" autofocus>
+          </div>
+        </div>
+        <div class="vue-dialog-buttons">
+          <span class="expand"></span>
+          <button ref="no" @click.prevent="$modal.hide(duplicateModal)" class="btn btn-sm btn-flat">Cancel</button>
+          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
+        </div>
+      </modal>
     </portal>
   </div>
 </template>
@@ -125,7 +142,10 @@
         dbAction: null,
         dbElement: null,
         dbEntityType: null,
-        dbDeleteElementParams: null
+        dbDeleteElementParams: null,
+        // below are connected to the modal for duplicate
+        dbDuplicateTableParams: null,
+        duplicatedTableName: null,
       }
     },
     watch: {
@@ -153,6 +173,9 @@
       modalName() {
         return "dropTruncateModal"
       },
+      duplicateModal() {
+        return "duplicateModal"
+      },
       tabItems: {
         get() {
           return this.$store.getters['tabs/sortedTabs']
@@ -178,6 +201,7 @@
           { event: AppEvent.hideSchema, handler: this.hideSchema },
           { event: AppEvent.deleteDatabaseElement, handler: this.deleteDatabaseElement },
           { event: AppEvent.dropDatabaseElement, handler: this.dropDatabaseElement },
+          { event: AppEvent.duplicateDatabaseTable, handler: this.duplicateDatabaseTable },
         ]
       },
       contextOptions() {
@@ -230,6 +254,43 @@
             if (this.dbAction.toLowerCase() === 'truncate') {
               await this.connection.truncateElement(dbName, entityType?.toUpperCase(), schema)
             }
+
+            this.$noty.success(`${this.dbAction} completed successfully`)
+
+          } catch (ex) {
+            this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
+          }
+        })
+      },
+      completeDuplicateAction(){
+
+        if(this.dbElement === this.dublicatedTableName){
+          this.$noty.warning("Sorry, you can't duplicate to the same name.")
+          return;
+        }
+
+        if (this.duplicatedTableName === null || this.duplicatedTableName === '' || this.duplicatedTableName === undefined) {
+          this.$noty.warning("Please enter a name for the new table.")
+          return;
+        }
+
+        const { tableName, newTableName, schema } = this.dbDuplicateTableParams
+        this.$modal.hide(this.duplicateModal)
+
+        this.$nextTick(async() => {
+          try {
+            if (this.dbAction.toLowerCase() !== 'duplicate') {
+              return
+            }
+
+            await this.connection.duplicateTable(tableName, newTableName, schema)
+
+            // timeout is more about aesthetics so it doesn't refresh the table right away.
+            setTimeout(() => {
+              this.$store.dispatch('updateTables')
+              this.$store.dispatch('updateRoutines')
+              }, 500)
+
 
             this.$noty.success(`${this.dbAction} completed successfully`)
 
@@ -331,6 +392,24 @@
         this.dbDeleteElementParams = dbActionParams
 
         this.$modal.show(this.modalName)
+      },
+      duplicateDatabaseTable({item: dbActionParams, action: dbAction}){
+        console.log('*******', {dbActionParams, dbAction})
+
+        this.dbElement = dbActionParams.name
+        this.dbAction = dbAction
+        this.dbEntityType = dbActionParams.entityType
+
+
+        this.duplicatedTableName = `${dbActionParams.name}_copy`
+
+        this.dbDuplicateTableParams = {
+          tableName: dbActionParams.name,
+          newTableName: this.duplicatedTableName,
+          schema: dbActionParams.schema
+        }
+
+        this.$modal.show(this.duplicateModal)
       },
       async loadRoutineCreate(routine) {
         const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema)

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -88,7 +88,7 @@
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
           <button ref="no" @click.prevent="$modal.hide(duplicateTableModal)" class="btn btn-sm btn-flat">Cancel</button>
-          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
+          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateTableAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
         </div>
       </modal>
     </portal>
@@ -263,16 +263,16 @@
           }
         })
       },
-      completeDuplicateAction(){
-        const { tableName, newTableName, schema, entityType } = this.dbDuplicateTableParams
+      completeDuplicateTableAction(){
+        const { tableName, schema,  entityType } = this.dbDuplicateTableParams
 
         if (entityType !== 'table' && this.dbAction == 'duplicate') {
           this.$noty.warning("Sorry, you can only duplicate tables.")
           return;
         }
 
-        if(this.dbElement === this.dublicatedTableName){
-          this.$noty.warning("Sorry, you can't duplicate to the same name.")
+        if(tableName === this.duplicatedTableName){
+          this.$noty.warning("Sorry, you can't duplicate with the same name.")
           return;
         }
 
@@ -280,7 +280,6 @@
           this.$noty.warning("Please enter a name for the new table.")
           return;
         }
-
 
         this.$modal.hide(this.duplicateTableModal)
 
@@ -290,7 +289,7 @@
               return
             }
 
-            await this.connection.duplicateTable(tableName, newTableName, schema)
+            await this.connection.duplicateTable(tableName, this.duplicatedTableName, schema)
 
             // timeout is more about aesthetics so it doesn't refresh the table right away.
             setTimeout(() => {
@@ -305,8 +304,6 @@
             this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
           }
         })
-
-
       },
       beforeOpened() {
         this.lastFocused = document.activeElement
@@ -403,19 +400,16 @@
         this.$modal.show(this.modalName)
       },
       duplicateDatabaseTable({item: dbActionParams, action: dbAction}){
-        console.log('*******', {dbActionParams, dbAction})
-
         this.dbElement = dbActionParams.name
         this.dbAction = dbAction
         this.dbEntityType = dbActionParams.entityType
-
 
         this.duplicatedTableName = `${dbActionParams.name}_copy`
 
         this.dbDuplicateTableParams = {
           tableName: dbActionParams.name,
-          newTableName: this.duplicatedTableName,
-          schema: dbActionParams.schema
+          schema: dbActionParams.schema,
+          entityType: dbActionParams.entityType
         }
 
         this.$modal.show(this.duplicateTableModal)

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -354,6 +354,9 @@ export default Vue.extend({
 
         } catch (ex) {
           this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
+        } finally {
+          this.duplicateTableName = null
+          this.dbDuplicateTableParams = null
         }
       })
     },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -76,7 +76,7 @@
 
       <!-- Duplicate Modal -->
 
-      <modal :name="duplicateModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
+      <modal :name="duplicateTableModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
         <div class="dialog-content">
           <div class="dialog-c-title">{{this.dbAction | titleCase}} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
           <div class="form-group">
@@ -86,7 +86,7 @@
         </div>
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
-          <button ref="no" @click.prevent="$modal.hide(duplicateModal)" class="btn btn-sm btn-flat">Cancel</button>
+          <button ref="no" @click.prevent="$modal.hide(duplicateTableModal)" class="btn btn-sm btn-flat">Cancel</button>
           <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
         </div>
       </modal>
@@ -173,8 +173,8 @@
       modalName() {
         return "dropTruncateModal"
       },
-      duplicateModal() {
-        return "duplicateModal"
+      duplicateTableModal() {
+        return "duplicateTableModal"
       },
       tabItems: {
         get() {
@@ -275,7 +275,7 @@
         }
 
         const { tableName, newTableName, schema } = this.dbDuplicateTableParams
-        this.$modal.hide(this.duplicateModal)
+        this.$modal.hide(this.duplicateTableModal)
 
         this.$nextTick(async() => {
           try {
@@ -409,7 +409,7 @@
           schema: dbActionParams.schema
         }
 
-        this.$modal.show(this.duplicateModal)
+        this.$modal.show(this.duplicateTableModal)
       },
       async loadRoutineCreate(routine) {
         const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema)

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -83,7 +83,7 @@
             <label for="duplicatedTableName">New table name</label>
             <input type="text" name="duplicatedTableName" class="form-control" required v-model="duplicatedTableName" autofocus>
           </div>
-          <small>* Indexes, relations or triggers will not be duplicated</small>
+          <small>This will create a new table and copy all existing data into it. Keep in mind that any indexes, relations, or triggers associated with the original table will not be duplicated in the new table</small>
         </div>
         <div class="vue-dialog-buttons">
           <span class="expand"></span>

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -88,7 +88,8 @@
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
           <button ref="no" @click.prevent="$modal.hide(duplicateTableModal)" class="btn btn-sm btn-flat">Cancel</button>
-          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateTableAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
+          <!-- <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateTableAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button> -->
+          <pending-changes :submit-apply="duplicateTable" :submit-sql="duplicateTableSql" />
         </div>
       </modal>
     </portal>
@@ -115,6 +116,7 @@
   import TabWithTable from './common/TabWithTable.vue';
   import TabIcon from './tab/TabIcon.vue'
   import { DatabaseEntity } from "@/lib/db/models"
+  import PendingChanges from '../components/common/PendingChanges.vue'
 
   export default Vue.extend({
     props: [ 'connection' ],
@@ -129,6 +131,7 @@
       TableBuilder,
       TabWithTable,
       TabIcon,
+      PendingChanges
     },
     data() {
       return {
@@ -262,6 +265,12 @@
             this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
           }
         })
+      },
+      duplicateTable(){
+        console.log("duplicateTable")
+      },
+      duplicateTableSql(){
+        console.log("duplicateTableSql")
       },
       completeDuplicateTableAction(){
         const { tableName, schema,  entityType } = this.dbDuplicateTableParams

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -269,50 +269,23 @@ export default Vue.extend({
       }
 
       try {
-        this.error = null
         const sql = await this.connection.duplicateTableSql(tableName, this.duplicateTableName, schema)
         const formatted = format(sql, { language: FormatterDialect(this.dialect) })
 
-        this.$modal.hide(this.duplicateTableModal)
+        const tab = new OpenTab('query')
+        tab.unsavedQueryText = formatted
+        tab.title = `Duplicating table: ${tableName}`
+        tab.active = true
+        tab.unsavedChanges = false
+        tab.alert = false
+        tab.position = 99
 
-        /** im here */
+        await this.addTab(tab)
 
-        this.$nextTick(() => {
-          this.$store.dispatch('tabs/add', {
-            title: `Duplicate Table`,
-            type: 'query',
-            content: formatted,
-            icon: 'mdi-table',
-            active: true,
-            closable: true,
-            dirty: true,
-            schema: this.dbDuplicateTableParams.schema,
-            database: this.dbDuplicateTableParams.database,
-            entityType: this.dbDuplicateTableParams.entityType,
-            name: this.dbDuplicateTableParams.tableName,
-            query: formatted,
-            queryType: 'alter',
-            queryName: 'duplicateTable',
-            queryAction: 'duplicate',
-            queryTarget: this.dbDuplicateTableParams.tableName,
-            queryTargetSchema: this.dbDuplicateTableParams.schema,
-            queryTargetDatabase: this.dbDuplicateTableParams.database,
-            queryTargetEntityType: this.dbDuplicateTableParams.entityType,
-            queryTargetType: 'table',
-            queryTargetAction: 'duplicate',
-            queryTargetActionType: 'alter',
-            queryTargetActionName: 'duplicateTable',
-            queryTargetActionParams: {
-              tableName: this.dbDuplicateTableParams.tableName,
-              schema: this.dbDuplicateTableParams.schema,
-              database: this.dbDuplicateTableParams.database,
-              entityType: this.dbDuplicateTableParams.entityType,
-              duplicateTableName: this.duplicateTableName,
-            },
-          })
-        })
       } catch (ex) {
-        this.error = ex
+        this.$noty.error(`Error printing ${this.dbAction} query: ${ex.message}`)
+      } finally {
+        this.$modal.hide(this.duplicateTableModal)
       }
     },
     async duplicateTable() {
@@ -394,6 +367,7 @@ export default Vue.extend({
       await this.$store.dispatch('tabs/setActive', tab)
     },
     async addTab(item: OpenTab) {
+
       await this.$store.dispatch('tabs/add', item)
       await this.setActiveTab(item)
     },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -1,21 +1,12 @@
 <template>
-  <div  class="core-tabs" v-hotkey="keymap">
+  <div class="core-tabs" v-hotkey="keymap">
     <div class="tabs-header">
       <!-- <div class="nav-tabs nav"> -->
-      <Draggable :options="dragOptions" v-model="tabItems" tag="ul" class="nav-tabs nav" chosen-class="nav-item-wrap-chosen">
-        <core-tab-header
-          v-for="tab in tabItems"
-          :key="tab.id"
-          :tab="tab"
-          :tabsCount="tabItems.length"
-          :selected="activeTab === tab"
-          @click="click"
-          @close="close"
-          @closeAll="closeAll"
-          @closeOther="closeOther"
-          @closeToRight="closeToRight"
-          @duplicate="duplicate"
-          ></core-tab-header>
+      <Draggable :options="dragOptions" v-model="tabItems" tag="ul" class="nav-tabs nav"
+        chosen-class="nav-item-wrap-chosen">
+        <core-tab-header v-for="tab in tabItems" :key="tab.id" :tab="tab" :tabsCount="tabItems.length"
+          :selected="activeTab === tab" @click="click" @close="close" @closeAll="closeAll" @closeOther="closeOther"
+          @closeToRight="closeToRight" @duplicate="duplicate"></core-tab-header>
       </Draggable>
       <!-- </div> -->
       <span class="actions">
@@ -27,68 +18,61 @@
         <div class="expand layout-center"><shortcut-hints></shortcut-hints></div>
         <statusbar class="tabulator-footer"></statusbar>
       </div>
-      <div
-        v-for="(tab, idx) in tabItems"
-        class="tab-pane"
-        :id="'tab-' + idx"
-        :key="tab.id"
-        :class="{active: (activeTab === tab)}"
-        v-show="activeTab === tab"
-      >
-        <QueryEditor v-if="tab.type === 'query'" :active="activeTab === tab" :tab="tab" :tabId="tab.id" :connection="connection"></QueryEditor>
+      <div v-for="(tab, idx) in tabItems" class="tab-pane" :id="'tab-' + idx" :key="tab.id"
+        :class="{ active: (activeTab === tab) }" v-show="activeTab === tab">
+        <QueryEditor v-if="tab.type === 'query'" :active="activeTab === tab" :tab="tab" :tabId="tab.id"
+          :connection="connection"></QueryEditor>
         <tab-with-table v-if="tab.type === 'table'" :tab="tab" @close="close">
           <template v-slot:default="slotProps">
-            <TableTable
-              :tab="tab"
-              :active="activeTab === tab"
-              :connection="connection"
-              :initialFilter="tab.filter"
-              :table="slotProps.table"
-            ></TableTable>
+            <TableTable :tab="tab" :active="activeTab === tab" :connection="connection" :initialFilter="tab.filter"
+              :table="slotProps.table"></TableTable>
           </template>
         </tab-with-table>
         <tab-with-table v-if="tab.type === 'table-properties'" :tab="tab" @close="close">
           <template v-slot:default="slotProps">
-            <TableProperties
-              :active="activeTab === tab"
-              :tab="tab" :tabId="tab.id"
-              :connection="connection"
-              :table="slotProps.table"
-            ></TableProperties>
+            <TableProperties :active="activeTab === tab" :tab="tab" :tabId="tab.id" :connection="connection"
+              :table="slotProps.table"></TableProperties>
           </template>
         </tab-with-table>
-        <TableBuilder v-if="tab.type === 'table-builder'" :active="activeTab === tab" :tab="tab" :tabId="tab.id" :connection="connection"></TableBuilder>
+        <TableBuilder v-if="tab.type === 'table-builder'" :active="activeTab === tab" :tab="tab" :tabId="tab.id"
+          :connection="connection"></TableBuilder>
 
       </div>
     </div>
     <portal to="modals">
-      <modal :name="modalName" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
+      <modal :name="modalName" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened"
+        @closed="sureClosed" @before-open="beforeOpened">
         <div class="dialog-content">
-          <div class="dialog-c-title">Really {{this.dbAction | titleCase}} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
+          <div class="dialog-c-title">Really {{ this.dbAction | titleCase }} <span class="tab-like"><tab-icon
+                :tab="tabIcon" /> {{ this.dbElement }}</span>?</div>
           <p>This change cannot be undone</p>
         </div>
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
           <button ref="no" @click.prevent="$modal.hide(modalName)" class="btn btn-sm btn-flat">Cancel</button>
-          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDeleteAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button>
+          <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDeleteAction"
+            class="btn btn-sm btn-primary">{{ this.titleCaseAction }} {{ this.dbElement }}</button>
         </div>
       </modal>
 
       <!-- Duplicate Modal -->
 
-      <modal :name="duplicateTableModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened" @closed="sureClosed" @before-open="beforeOpened">
+      <modal :name="duplicateTableModal" class="beekeeper-modal vue-dialog sure header-sure" @opened="sureOpened"
+        @closed="sureClosed" @before-open="beforeOpened">
         <div class="dialog-content">
-          <div class="dialog-c-title">{{this.dbAction | titleCase }} <span class="tab-like"><tab-icon :tab="tabIcon" /> {{this.dbElement}}</span>?</div>
+          <div class="dialog-c-title">{{ this.dbAction | titleCase }} <span class="tab-like"><tab-icon :tab="tabIcon" />
+              {{ this.dbElement }}</span>?</div>
           <div class="form-group">
-            <label for="duplicatedTableName">New table name</label>
-            <input type="text" name="duplicatedTableName" class="form-control" required v-model="duplicatedTableName" autofocus>
+            <label for="duplicateTableName">New table name</label>
+            <input type="text" name="duplicateTableName" class="form-control" required v-model="duplicateTableName"
+              autofocus>
           </div>
-          <small>This will create a new table and copy all existing data into it. Keep in mind that any indexes, relations, or triggers associated with the original table will not be duplicated in the new table</small>
+          <small>This will create a new table and copy all existing data into it. Keep in mind that any indexes,
+            relations, or triggers associated with the original table will not be duplicated in the new table</small>
         </div>
         <div class="vue-dialog-buttons">
           <span class="expand"></span>
           <button ref="no" @click.prevent="$modal.hide(duplicateTableModal)" class="btn btn-sm btn-flat">Cancel</button>
-          <!-- <button @focusout="sureOpen && $refs.no && $refs.no.focus()" @click.prevent="completeDuplicateTableAction" class="btn btn-sm btn-primary">{{this.titleCaseAction}} {{this.dbElement}}</button> -->
           <pending-changes-button :submit-apply="duplicateTable" :submit-sql="duplicateTableSql" />
         </div>
       </modal>
@@ -98,452 +82,511 @@
 
 <script lang="ts">
 
-  import _ from 'lodash'
-  import { format } from 'sql-formatter';
-  import QueryEditor from './TabQueryEditor.vue'
-  import Statusbar from './common/StatusBar.vue'
-  import CoreTabHeader from './CoreTabHeader.vue'
-  import TableTable from './tableview/TableTable.vue'
-  import TableProperties from './TabTableProperties.vue'
-  import TableBuilder from './TabTableBuilder.vue'
-  import {AppEvent} from '../common/AppEvent'
-  import { mapGetters, mapState } from 'vuex'
-  import Draggable from 'vuedraggable'
-  import ShortcutHints from './editor/ShortcutHints.vue'
-  import { FormatterDialect } from '@shared/lib/dialects/models';
-  import Vue from 'vue';
-  import { OpenTab } from '@/common/appdb/models/OpenTab';
-  import TabWithTable from './common/TabWithTable.vue';
-  import TabIcon from './tab/TabIcon.vue'
-  import { DatabaseEntity } from "@/lib/db/models"
-  import PendingChangesButton from './common/PendingChangesButton.vue'
+import _ from 'lodash'
+import { format } from 'sql-formatter';
+import QueryEditor from './TabQueryEditor.vue'
+import Statusbar from './common/StatusBar.vue'
+import CoreTabHeader from './CoreTabHeader.vue'
+import TableTable from './tableview/TableTable.vue'
+import TableProperties from './TabTableProperties.vue'
+import TableBuilder from './TabTableBuilder.vue'
+import { AppEvent } from '../common/AppEvent'
+import { mapGetters, mapState } from 'vuex'
+import Draggable from 'vuedraggable'
+import ShortcutHints from './editor/ShortcutHints.vue'
+import { FormatterDialect } from '@shared/lib/dialects/models';
+import Vue from 'vue';
+import { OpenTab } from '@/common/appdb/models/OpenTab';
+import TabWithTable from './common/TabWithTable.vue';
+import TabIcon from './tab/TabIcon.vue'
+import { DatabaseEntity } from "@/lib/db/models"
+import PendingChangesButton from './common/PendingChangesButton.vue'
 
-  export default Vue.extend({
-    props: [ 'connection' ],
-    components: {
-      Statusbar,
-      QueryEditor,
-      CoreTabHeader,
-      TableTable,
-      TableProperties,
-      Draggable,
-      ShortcutHints,
-      TableBuilder,
-      TabWithTable,
-      TabIcon,
-      PendingChangesButton
-    },
-    data() {
+export default Vue.extend({
+  props: ['connection'],
+  components: {
+    Statusbar,
+    QueryEditor,
+    CoreTabHeader,
+    TableTable,
+    TableProperties,
+    Draggable,
+    ShortcutHints,
+    TableBuilder,
+    TabWithTable,
+    TabIcon,
+    PendingChangesButton
+  },
+  data() {
+    return {
+      showExportModal: false,
+      tableExportOptions: null,
+      dragOptions: {
+        handle: '.nav-item'
+      },
+      // below are connected to the modal for delete/truncate
+      sureOpen: false,
+      lastFocused: null,
+      dbAction: null,
+      dbElement: null,
+      dbEntityType: null,
+      dbDeleteElementParams: null,
+      // below are connected to the modal for duplicate
+      dbDuplicateTableParams: null,
+      duplicateTableName: null,
+    }
+  },
+  watch: {
+
+  },
+  filters: {
+    titleCase: function (value) {
+      if (!value) return ''
+      value = value.toString()
+      return value.charAt(0).toUpperCase() + value.slice(1)
+    }
+  },
+  computed: {
+    ...mapState('tabs', { 'activeTab': 'active' }),
+    ...mapGetters({ 'menuStyle': 'settings/menuStyle', 'dialect': 'dialect' }),
+    tabIcon() {
       return {
-        showExportModal: false,
-        tableExportOptions: null,
-        dragOptions: {
-          handle: '.nav-item'
-        },
-        // below are connected to the modal for delete/truncate
-        sureOpen: false,
-        lastFocused: null,
-        dbAction: null,
-        dbElement: null,
-        dbEntityType: null,
-        dbDeleteElementParams: null,
-        // below are connected to the modal for duplicate
-        dbDuplicateTableParams: null,
-        duplicatedTableName: null,
+        type: this.dbEntityType,
+        entityType: this.dbEntityType
       }
     },
-    watch: {
-
+    titleCaseAction() {
+      return _.capitalize(this.dbAction)
     },
-    filters: {
-      titleCase: function (value) {
-        if (!value) return ''
-        value = value.toString()
-        return value.charAt(0).toUpperCase() + value.slice(1)
+    modalName() {
+      return "dropTruncateModal"
+    },
+    duplicateTableModal() {
+      return "duplicateTableModal"
+    },
+    tabItems: {
+      get() {
+        return this.$store.getters['tabs/sortedTabs']
+      },
+      set(newTabs: OpenTab[]) {
+        this.$store.dispatch('tabs/reorder', newTabs)
       }
     },
-    computed: {
-      ...mapState('tabs', { 'activeTab': 'active'}),
-      ...mapGetters({ 'menuStyle': 'settings/menuStyle', 'dialect': 'dialect'}),
-      tabIcon() {
-        return {
-          type: this.dbEntityType,
-          entityType: this.dbEntityType
-        }
-      },
-      titleCaseAction() {
-        return _.capitalize(this.dbAction)
-      },
-      modalName() {
-        return "dropTruncateModal"
-      },
-      duplicateTableModal() {
-        return "duplicateTableModal"
-      },
-      tabItems: {
-        get() {
-          return this.$store.getters['tabs/sortedTabs']
-        },
-        set(newTabs: OpenTab[]) {
-          this.$store.dispatch('tabs/reorder', newTabs)
-        }
-      },
-      rootBindings() {
-        return [
-          { event: AppEvent.closeTab, handler: this.closeCurrentTab },
-          { event: AppEvent.newTab, handler: this.createQuery},
-          { event: AppEvent.createTable, handler: this.openTableBuilder},
-          { event: 'historyClick', handler: this.createQueryFromItem},
-          { event: AppEvent.loadTable, handler: this.openTable },
-          { event: AppEvent.openTableProperties, handler: this.openTableProperties},
-          { event: 'loadSettings', handler: this.openSettings },
-          { event: 'loadTableCreate', handler: this.loadTableCreate },
-          { event: 'loadRoutineCreate', handler: this.loadRoutineCreate },
-          { event: 'favoriteClick', handler: this.favoriteClick },
-          { event: 'exportTable', handler: this.openExportModal },
-          { event: AppEvent.hideEntity, handler: this.hideEntity },
-          { event: AppEvent.hideSchema, handler: this.hideSchema },
-          { event: AppEvent.deleteDatabaseElement, handler: this.deleteDatabaseElement },
-          { event: AppEvent.dropDatabaseElement, handler: this.dropDatabaseElement },
-          { event: AppEvent.duplicateDatabaseTable, handler: this.duplicateDatabaseTable },
-        ]
-      },
-      contextOptions() {
-        return [
-          { name: "Close", slug: 'close', handler: ({item}) => this.close(item)},
-          { name: "Close Others", slug: 'close-others', handler: ({item}) => this.closeOther(item)},
-          { name: 'Close All', slug: 'close-all', handler: this.closeAll},
-          { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({item}) => this.closeToRight(item)},
-          { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.duplicate(item)}
-        ]
-      },
-      lastTab() {
-        return this.tabItems[this.tabItems.length - 1];
-      },
-      firstTab() {
-        return this.tabItems[0]
-      },
-      activeIdx() {
-        return _.indexOf(this.tabItems, this.activeTab)
-      },
-      keymap() {
-        const result = {
-          'ctrl+tab': this.nextTab,
-          'ctrl+shift+tab': this.previousTab,
-        }
-
-        return result
-      },
+    rootBindings() {
+      return [
+        { event: AppEvent.closeTab, handler: this.closeCurrentTab },
+        { event: AppEvent.newTab, handler: this.createQuery },
+        { event: AppEvent.createTable, handler: this.openTableBuilder },
+        { event: 'historyClick', handler: this.createQueryFromItem },
+        { event: AppEvent.loadTable, handler: this.openTable },
+        { event: AppEvent.openTableProperties, handler: this.openTableProperties },
+        { event: 'loadSettings', handler: this.openSettings },
+        { event: 'loadTableCreate', handler: this.loadTableCreate },
+        { event: 'loadRoutineCreate', handler: this.loadRoutineCreate },
+        { event: 'favoriteClick', handler: this.favoriteClick },
+        { event: 'exportTable', handler: this.openExportModal },
+        { event: AppEvent.hideEntity, handler: this.hideEntity },
+        { event: AppEvent.hideSchema, handler: this.hideSchema },
+        { event: AppEvent.deleteDatabaseElement, handler: this.deleteDatabaseElement },
+        { event: AppEvent.dropDatabaseElement, handler: this.dropDatabaseElement },
+        { event: AppEvent.duplicateDatabaseTable, handler: this.duplicateDatabaseTable },
+      ]
     },
-    methods: {
-      completeDeleteAction() {
-        const { schema, name: dbName, entityType } = this.dbDeleteElementParams
-        if (entityType !== 'table' && this.dbAction == 'truncate') {
-          this.$noty.warning("Sorry, you can only truncate tables.")
-          return;
-        }
-        this.$modal.hide(this.modalName)
-        this.$nextTick(async() => {
-          try {
-            if (this.dbAction.toLowerCase() === 'drop') {
-              await this.connection.dropElement(dbName, entityType?.toUpperCase(), schema)
-              // timeout is more about aesthetics so it doesn't refresh the table right away.
+    contextOptions() {
+      return [
+        { name: "Close", slug: 'close', handler: ({ item }) => this.close(item) },
+        { name: "Close Others", slug: 'close-others', handler: ({ item }) => this.closeOther(item) },
+        { name: 'Close All', slug: 'close-all', handler: this.closeAll },
+        { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({ item }) => this.closeToRight(item) },
+        { name: "Duplicate", slug: 'duplicate', handler: ({ item }) => this.duplicate(item) }
+      ]
+    },
+    lastTab() {
+      return this.tabItems[this.tabItems.length - 1];
+    },
+    firstTab() {
+      return this.tabItems[0]
+    },
+    activeIdx() {
+      return _.indexOf(this.tabItems, this.activeTab)
+    },
+    keymap() {
+      const result = {
+        'ctrl+tab': this.nextTab,
+        'ctrl+shift+tab': this.previousTab,
+      }
 
-              setTimeout(() => {
-                this.$store.dispatch('updateTables')
-                this.$store.dispatch('updateRoutines')
-              }, 500)
-            }
-
-            if (this.dbAction.toLowerCase() === 'truncate') {
-              await this.connection.truncateElement(dbName, entityType?.toUpperCase(), schema)
-            }
-
-            this.$noty.success(`${this.dbAction} completed successfully`)
-
-          } catch (ex) {
-            this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
-          }
-        })
-      },
-      duplicateTable(){
-        console.log("duplicateTable")
-      },
-      duplicateTableSql(){
-        console.log("duplicateTableSql")
-      },
-      completeDuplicateTableAction(){
-        const { tableName, schema,  entityType } = this.dbDuplicateTableParams
-
-        if (entityType !== 'table' && this.dbAction == 'duplicate') {
-          this.$noty.warning("Sorry, you can only duplicate tables.")
-          return;
-        }
-
-        if(tableName === this.duplicatedTableName){
-          this.$noty.warning("Sorry, you can't duplicate with the same name.")
-          return;
-        }
-
-        if (this.duplicatedTableName === null || this.duplicatedTableName === '' || this.duplicatedTableName === undefined) {
-          this.$noty.warning("Please enter a name for the new table.")
-          return;
-        }
-
-        this.$modal.hide(this.duplicateTableModal)
-
-        this.$nextTick(async() => {
-          try {
-            if (this.dbAction.toLowerCase() !== 'duplicate') {
-              return
-            }
-
-            await this.connection.duplicateTable(tableName, this.duplicatedTableName, schema)
-
+      return result
+    },
+  },
+  methods: {
+    completeDeleteAction() {
+      const { schema, name: dbName, entityType } = this.dbDeleteElementParams
+      if (entityType !== 'table' && this.dbAction == 'truncate') {
+        this.$noty.warning("Sorry, you can only truncate tables.")
+        return;
+      }
+      this.$modal.hide(this.modalName)
+      this.$nextTick(async () => {
+        try {
+          if (this.dbAction.toLowerCase() === 'drop') {
+            await this.connection.dropElement(dbName, entityType?.toUpperCase(), schema)
             // timeout is more about aesthetics so it doesn't refresh the table right away.
+
             setTimeout(() => {
               this.$store.dispatch('updateTables')
               this.$store.dispatch('updateRoutines')
-              }, 500)
-
-
-            this.$noty.success(`${this.dbAction} completed successfully`)
-
-          } catch (ex) {
-            this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
+            }, 500)
           }
+
+          if (this.dbAction.toLowerCase() === 'truncate') {
+            await this.connection.truncateElement(dbName, entityType?.toUpperCase(), schema)
+          }
+
+          this.$noty.success(`${this.dbAction} completed successfully`)
+
+        } catch (ex) {
+          this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
+        }
+      })
+    },
+    async duplicateTableSql() {
+      const { tableName, schema, entityType } = this.dbDuplicateTableParams
+
+      if (entityType !== 'table' && this.dbAction == 'duplicate') {
+        this.$noty.warning("Sorry, you can only duplicate tables.")
+        return;
+      }
+
+      if (tableName === this.duplicateTableName) {
+        this.$noty.warning("Sorry, you can't duplicate with the same name.")
+        return;
+      }
+
+      if (this.duplicateTableName === null || this.duplicateTableName === '' || this.duplicateTableName === undefined) {
+        this.$noty.warning("Please enter a name for the new table.")
+        return;
+      }
+
+      try {
+        this.error = null
+        const sql = await this.connection.duplicateTableSql(tableName, this.duplicateTableName, schema)
+        const formatted = format(sql, { language: FormatterDialect(this.dialect) })
+
+        this.$modal.hide(this.duplicateTableModal)
+
+        /** im here */
+
+        this.$nextTick(() => {
+          this.$store.dispatch('tabs/add', {
+            title: `Duplicate Table`,
+            type: 'query',
+            content: formatted,
+            icon: 'mdi-table',
+            active: true,
+            closable: true,
+            dirty: true,
+            schema: this.dbDuplicateTableParams.schema,
+            database: this.dbDuplicateTableParams.database,
+            entityType: this.dbDuplicateTableParams.entityType,
+            name: this.dbDuplicateTableParams.tableName,
+            query: formatted,
+            queryType: 'alter',
+            queryName: 'duplicateTable',
+            queryAction: 'duplicate',
+            queryTarget: this.dbDuplicateTableParams.tableName,
+            queryTargetSchema: this.dbDuplicateTableParams.schema,
+            queryTargetDatabase: this.dbDuplicateTableParams.database,
+            queryTargetEntityType: this.dbDuplicateTableParams.entityType,
+            queryTargetType: 'table',
+            queryTargetAction: 'duplicate',
+            queryTargetActionType: 'alter',
+            queryTargetActionName: 'duplicateTable',
+            queryTargetActionParams: {
+              tableName: this.dbDuplicateTableParams.tableName,
+              schema: this.dbDuplicateTableParams.schema,
+              database: this.dbDuplicateTableParams.database,
+              entityType: this.dbDuplicateTableParams.entityType,
+              duplicateTableName: this.duplicateTableName,
+            },
+          })
         })
-      },
-      beforeOpened() {
-        this.lastFocused = document.activeElement
-      },
-      sureOpened() {
-        this.sureOpen = true
-        this.$refs.no.focus()
-      },
-      sureClosed() {
-        this.sureOpen = false
-        if (this.lastFocused) {
-          this.lastFocused.focus()
-        }
-      },
-      openContextMenu(event, item) {
-        this.contextEvent = { event, item }
-      },
-      contextClick({ option, item }) {
-        switch (option.slug) {
-          case 'close':
-            return this.close(item)
-          case 'close-others':
-            return this.closeOther(item)
-          case 'close-all':
-            return this.closeAll();
-          case 'close-to-right':
-            return this.closeToRight(item);
-          case 'duplicate':
-            return this.duplicate(item);
-        }
-      },
-      async setActiveTab(tab) {
-        await this.$store.dispatch('tabs/setActive', tab)
-      },
-      async addTab(item: OpenTab) {
-        await this.$store.dispatch('tabs/add', item)
-        await this.setActiveTab(item)
-      },
-      nextTab() {
-        if(this.activeTab == this.lastTab) {
-          this.setActiveTab(this.firstTab)
-        } else {
-          this.setActiveTab(this.tabItems[this.activeIdx + 1])
-        }
-      },
+      } catch (ex) {
+        this.error = ex
+      }
+    },
+    async duplicateTable() {
+      const { tableName, schema, entityType } = this.dbDuplicateTableParams
 
-      previousTab() {
-        if(this.activeTab == this.firstTab) {
-          this.setActiveTab(this.lastTab)
-        } else {
-          this.setActiveTab(this.tabItems[this.activeIdx - 1])
-        }
-      },
-      closeCurrentTab() {
-        if (this.activeTab) this.close(this.activeTab)
-      },
-      handleCreateTab() {
-        this.createQuery()
-      },
-      createQuery(optionalText) {
-        // const text = optionalText ? optionalText : ""
-        let qNum = 0
-        let tabName = "New Query"
-        do {
-          qNum = qNum + 1
-          tabName = `Query #${qNum}`
-        } while (this.tabItems.filter((t) => t.title === tabName).length > 0);
+      if (entityType !== 'table' && this.dbAction == 'duplicate') {
+        this.$noty.warning("Sorry, you can only duplicate tables.")
+        return;
+      }
 
-        const result = new OpenTab('query')
-        result.title = tabName,
-        result.unsavedChanges = false
-        result.unsavedQueryText = optionalText
-        this.addTab(result)
-      },
-      async loadTableCreate(table) {
-        let method = null
-        if (table.entityType === 'table') method = this.connection.getTableCreateScript
-        else if (table.entityType === 'view') method = this.connection.getViewCreateScript
-        else if (table.entityType === 'materialized-view') method = this.connection.getMaterializedViewCreateScript
-        if (!method) {
-          this.$noty.error(`Can't find script for ${table.name} (${table.entityType})`)
-          return
-        }
-        const result = await method(table.name, table.schema)
-        const stringResult = format(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
-        this.createQuery(stringResult)
-      },
-      dropDatabaseElement({ item: dbActionParams, action: dbAction }) {
-        this.dbElement = dbActionParams.name
-        this.dbAction = dbAction
-        this.dbEntityType = dbActionParams.entityType
-        this.dbDeleteElementParams = dbActionParams
+      if (tableName === this.duplicateTableName) {
+        this.$noty.warning("Sorry, you can't duplicate with the same name.")
+        return;
+      }
 
-        this.$modal.show(this.modalName)
-      },
-      duplicateDatabaseTable({item: dbActionParams, action: dbAction}){
-        this.dbElement = dbActionParams.name
-        this.dbAction = dbAction
-        this.dbEntityType = dbActionParams.entityType
+      if (this.duplicateTableName === null || this.duplicateTableName === '' || this.duplicateTableName === undefined) {
+        this.$noty.warning("Please enter a name for the new table.")
+        return;
+      }
 
-        this.duplicatedTableName = `${dbActionParams.name}_copy`
+      this.$modal.hide(this.duplicateTableModal)
 
-        this.dbDuplicateTableParams = {
-          tableName: dbActionParams.name,
-          schema: dbActionParams.schema,
-          entityType: dbActionParams.entityType
-        }
-
-        this.$modal.show(this.duplicateTableModal)
-      },
-      async loadRoutineCreate(routine) {
-        const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema)
-        const stringResult = format(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
-        this.createQuery(stringResult)
-      },
-      openTableBuilder() {
-        const tab = new OpenTab('table-builder')
-        tab.title = "New Table"
-        tab.unsavedChanges = true
-        this.addTab(tab)
-      },
-      openTableProperties({ table }) {
-        const t = new OpenTab('table-properties')
-        t.tableName = table.name
-        t.schemaName = table.schema
-        t.title = table.name
-        const existing = this.tabItems.find((tab) => tab.matches(t))
-        if (existing) return this.$store.dispatch('tabs/setActive', existing)
-        this.addTab(t)
-      },
-      openTable({ table, filter}) {
-        const tab = new OpenTab('table')
-        tab.title = table.name
-        tab.tableName = table.name
-        tab.schemaName = table.schema
-        tab.entityType = table.entityType
-        tab.filter = filter
-        tab.titleScope = "all"
-        const existing = this.tabItems.find((t) => t.matches(tab))
-        if (existing) return this.$store.dispatch('tabs/setActive', existing)
-        this.addTab(tab)
-      },
-      openExportModal(options) {
-        this.tableExportOptions = options
-        this.showExportModal = true
-      },
-      hideEntity(entity: DatabaseEntity) {
-        this.$store.dispatch('hideEntities/addEntity', entity)
-      },
-      hideSchema(schema: string) {
-        this.$store.dispatch('hideEntities/addSchema', schema)
-      },
-      openSettings() {
-        const tab = new OpenTab('settings')
-        tab.title = "Settings"
-        this.addTab(tab)
-      },
-      async click(tab) {
-        await this.setActiveTab(tab)
-
-      },
-      async close(tab) {
-        if (this.activeTab === tab) {
-          if(tab === this.lastTab) {
-            this.previousTab()
-          } else {
-            this.nextTab()
+      this.$nextTick(async () => {
+        try {
+          if (this.dbAction.toLowerCase() !== 'duplicate') {
+            return
           }
+
+          await this.connection.duplicateTable(tableName, this.duplicateTableName, schema)
+
+          // timeout is more about aesthetics so it doesn't refresh the table right away.
+          setTimeout(() => {
+            this.$store.dispatch('updateTables')
+            this.$store.dispatch('updateRoutines')
+          }, 500)
+
+
+          this.$noty.success(`${this.dbAction} completed successfully`)
+
+        } catch (ex) {
+          this.$noty.error(`Error performing ${this.dbAction}: ${ex.message}`)
         }
-        await this.$store.dispatch("tabs/remove", tab)
-        if (tab.queryId) {
-          await this.$store.dispatch('data/queries/reload', tab.queryId)
+      })
+    },
+    beforeOpened() {
+      this.lastFocused = document.activeElement
+    },
+    sureOpened() {
+      this.sureOpen = true
+      this.$refs.no.focus()
+    },
+    sureClosed() {
+      this.sureOpen = false
+      if (this.lastFocused) {
+        this.lastFocused.focus()
+      }
+    },
+    openContextMenu(event, item) {
+      this.contextEvent = { event, item }
+    },
+    contextClick({ option, item }) {
+      switch (option.slug) {
+        case 'close':
+          return this.close(item)
+        case 'close-others':
+          return this.closeOther(item)
+        case 'close-all':
+          return this.closeAll();
+        case 'close-to-right':
+          return this.closeToRight(item);
+        case 'duplicate':
+          return this.duplicate(item);
+      }
+    },
+    async setActiveTab(tab) {
+      await this.$store.dispatch('tabs/setActive', tab)
+    },
+    async addTab(item: OpenTab) {
+      await this.$store.dispatch('tabs/add', item)
+      await this.setActiveTab(item)
+    },
+    nextTab() {
+      if (this.activeTab == this.lastTab) {
+        this.setActiveTab(this.firstTab)
+      } else {
+        this.setActiveTab(this.tabItems[this.activeIdx + 1])
+      }
+    },
+
+    previousTab() {
+      if (this.activeTab == this.firstTab) {
+        this.setActiveTab(this.lastTab)
+      } else {
+        this.setActiveTab(this.tabItems[this.activeIdx - 1])
+      }
+    },
+    closeCurrentTab() {
+      if (this.activeTab) this.close(this.activeTab)
+    },
+    handleCreateTab() {
+      this.createQuery()
+    },
+    createQuery(optionalText) {
+      // const text = optionalText ? optionalText : ""
+      let qNum = 0
+      let tabName = "New Query"
+      do {
+        qNum = qNum + 1
+        tabName = `Query #${qNum}`
+      } while (this.tabItems.filter((t) => t.title === tabName).length > 0);
+
+      const result = new OpenTab('query')
+      result.title = tabName,
+        result.unsavedChanges = false
+      result.unsavedQueryText = optionalText
+      this.addTab(result)
+    },
+    async loadTableCreate(table) {
+      let method = null
+      if (table.entityType === 'table') method = this.connection.getTableCreateScript
+      else if (table.entityType === 'view') method = this.connection.getViewCreateScript
+      else if (table.entityType === 'materialized-view') method = this.connection.getMaterializedViewCreateScript
+      if (!method) {
+        this.$noty.error(`Can't find script for ${table.name} (${table.entityType})`)
+        return
+      }
+      const result = await method(table.name, table.schema)
+      const stringResult = format(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
+      this.createQuery(stringResult)
+    },
+    dropDatabaseElement({ item: dbActionParams, action: dbAction }) {
+      this.dbElement = dbActionParams.name
+      this.dbAction = dbAction
+      this.dbEntityType = dbActionParams.entityType
+      this.dbDeleteElementParams = dbActionParams
+
+      this.$modal.show(this.modalName)
+    },
+    duplicateDatabaseTable({ item: dbActionParams, action: dbAction }) {
+      this.dbElement = dbActionParams.name
+      this.dbAction = dbAction
+      this.dbEntityType = dbActionParams.entityType
+
+      this.duplicateTableName = `${dbActionParams.name}_copy`
+
+      this.dbDuplicateTableParams = {
+        tableName: dbActionParams.name,
+        schema: dbActionParams.schema,
+        entityType: dbActionParams.entityType
+      }
+
+      this.$modal.show(this.duplicateTableModal)
+    },
+    async loadRoutineCreate(routine) {
+      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema)
+      const stringResult = format(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
+      this.createQuery(stringResult)
+    },
+    openTableBuilder() {
+      const tab = new OpenTab('table-builder')
+      tab.title = "New Table"
+      tab.unsavedChanges = true
+      this.addTab(tab)
+    },
+    openTableProperties({ table }) {
+      const t = new OpenTab('table-properties')
+      t.tableName = table.name
+      t.schemaName = table.schema
+      t.title = table.name
+      const existing = this.tabItems.find((tab) => tab.matches(t))
+      if (existing) return this.$store.dispatch('tabs/setActive', existing)
+      this.addTab(t)
+    },
+    openTable({ table, filter }) {
+      const tab = new OpenTab('table')
+      tab.title = table.name
+      tab.tableName = table.name
+      tab.schemaName = table.schema
+      tab.entityType = table.entityType
+      tab.filter = filter
+      tab.titleScope = "all"
+      const existing = this.tabItems.find((t) => t.matches(tab))
+      if (existing) return this.$store.dispatch('tabs/setActive', existing)
+      this.addTab(tab)
+    },
+    openExportModal(options) {
+      this.tableExportOptions = options
+      this.showExportModal = true
+    },
+    hideEntity(entity: DatabaseEntity) {
+      this.$store.dispatch('hideEntities/addEntity', entity)
+    },
+    hideSchema(schema: string) {
+      this.$store.dispatch('hideEntities/addSchema', schema)
+    },
+    openSettings() {
+      const tab = new OpenTab('settings')
+      tab.title = "Settings"
+      this.addTab(tab)
+    },
+    async click(tab) {
+      await this.setActiveTab(tab)
+
+    },
+    async close(tab) {
+      if (this.activeTab === tab) {
+        if (tab === this.lastTab) {
+          this.previousTab()
+        } else {
+          this.nextTab()
         }
-      },
-      closeAll() {
-        this.$store.dispatch('tabs/unload')
-      },
-      closeOther(tab) {
-        const others = _.without(this.tabItems, tab)
-        this.$store.dispatch('tabs/remove', others)
+      }
+      await this.$store.dispatch("tabs/remove", tab)
+      if (tab.queryId) {
+        await this.$store.dispatch('data/queries/reload', tab.queryId)
+      }
+    },
+    closeAll() {
+      this.$store.dispatch('tabs/unload')
+    },
+    closeOther(tab) {
+      const others = _.without(this.tabItems, tab)
+      this.$store.dispatch('tabs/remove', others)
+      this.setActiveTab(tab)
+      if (tab.queryId) {
+        this.$store.dispatch('data/queries/reload', tab.queryId)
+      }
+    },
+    closeToRight(tab) {
+      const tabIndex = _.indexOf(this.tabItems, tab)
+      const activeTabIndex = _.indexOf(this.tabItems, this.activeTab)
+
+      const tabsToRight = this.tabItems.slice(tabIndex + 1)
+
+      if (this.activeTab && activeTabIndex > tabIndex) {
         this.setActiveTab(tab)
-        if (tab.queryId) {
-          this.$store.dispatch('data/queries/reload', tab.queryId)
-        }
-      },
-      closeToRight(tab) {
-        const tabIndex = _.indexOf(this.tabItems, tab)
-        const activeTabIndex = _.indexOf(this.tabItems, this.activeTab)
-
-        const tabsToRight = this.tabItems.slice(tabIndex + 1)
-
-        if (this.activeTab && activeTabIndex > tabIndex) {
-          this.setActiveTab(tab)
-        }
-
-        this.$store.dispatch('tabs/remove', tabsToRight)
-      },
-      duplicate(other: OpenTab) {
-        const tab = other.duplicate()
-
-        if(tab.type === 'query') {
-          tab.title = "Query #" + (this.tabItems.length + 1)
-          tab.unsavedChanges = true
-        }
-        this.addTab(tab)
-      },
-      favoriteClick(item) {
-        const tab = new OpenTab('query')
-        tab.title = item.title
-        tab.queryId = item.id
-        tab.unsavedChanges = false
-
-        const existing = this.tabItems.find((t) => t.matches(tab))
-        if (existing) return this.$store.dispatch('tabs/setActive', existing)
-
-        this.addTab(tab)
-
-      },
-      createQueryFromItem(item) {
-        this.createQuery(item.text)
       }
+
+      this.$store.dispatch('tabs/remove', tabsToRight)
     },
-    beforeDestroy() {
-      this.unregisterHandlers(this.rootBindings)
-    },
-    async mounted() {
-      await this.$store.dispatch('tabs/load')
-      if (!this.tabItems?.length) {
-        this.createQuery()
+    duplicate(other: OpenTab) {
+      const tab = other.duplicate()
+
+      if (tab.type === 'query') {
+        tab.title = "Query #" + (this.tabItems.length + 1)
+        tab.unsavedChanges = true
       }
-      this.registerHandlers(this.rootBindings)
+      this.addTab(tab)
+    },
+    favoriteClick(item) {
+      const tab = new OpenTab('query')
+      tab.title = item.title
+      tab.queryId = item.id
+      tab.unsavedChanges = false
+
+      const existing = this.tabItems.find((t) => t.matches(tab))
+      if (existing) return this.$store.dispatch('tabs/setActive', existing)
+
+      this.addTab(tab)
+
+    },
+    createQueryFromItem(item) {
+      this.createQuery(item.text)
     }
-  })
+  },
+  beforeDestroy() {
+    this.unregisterHandlers(this.rootBindings)
+  },
+  async mounted() {
+    await this.$store.dispatch('tabs/load')
+    if (!this.tabItems?.length) {
+      this.createQuery()
+    }
+    this.registerHandlers(this.rootBindings)
+  }
+})
 </script>

--- a/apps/studio/src/components/common/PendingChanges.vue
+++ b/apps/studio/src/components/common/PendingChanges.vue
@@ -1,0 +1,48 @@
+<template>
+    <x-buttons class="pending-changes">
+        <x-button class="btn btn-primary" @click.prevent="submitApply">
+            <span>{{ labelApply || 'Apply' }}</span>
+        </x-button>
+        <x-button class="btn btn-primary" menu>
+            <i class="material-icons">arrow_drop_down</i>
+            <x-menu>
+                <x-menuitem @click.prevent="submitApply">
+                    <x-label>
+                        {{ labelApply || 'Apply' }}
+                    </x-label>
+                    <x-shortcut value="Control+S"></x-shortcut>
+                </x-menuitem>
+                <x-menuitem @click.prevent="submitSql">
+                    <x-label>
+                        {{ labelSql || 'Copy to SQL' }}
+                    </x-label>
+                    <x-shortcut value="Control+Shift+S"></x-shortcut>
+                </x-menuitem>
+            </x-menu>
+        </x-button>
+    </x-buttons>
+</template>
+
+<script>
+export default {
+    name: 'PendingChanges',
+    props: {
+        submitApply: Function,
+        submitSql: Function,
+        labelApply: String,
+        labelSql: String,
+    },
+    hotkeys() {
+        const result = {}
+        result[this.ctrlOrCmd('s')] = this.submitApply.bind(this)
+        result[this.ctrlOrCmd('shift+s')] = this.submitSql.bind(this)
+        return result
+    },
+}
+</script>
+
+<style module>
+x-buttons.pending-changes .btn {
+    margin: 0;
+}
+</style>

--- a/apps/studio/src/components/common/PendingChangesButton.vue
+++ b/apps/studio/src/components/common/PendingChangesButton.vue
@@ -1,5 +1,5 @@
 <template>
-    <x-buttons class="pending-changes-button">
+    <x-buttons class="pending-changes-button" v-hotkey="hotkeys">
         <x-button class="btn btn-primary" @click.prevent="submitApply" style="margin:0">
             <span>{{ labelApply || 'Apply' }}</span>
         </x-button>
@@ -32,12 +32,14 @@ export default {
         labelApply: String,
         labelSql: String,
     },
-    hotkeys() {
-        const result = {}
-        result[this.ctrlOrCmd('s')] = this.submitApply.bind(this)
-        result[this.ctrlOrCmd('shift+s')] = this.submitSql.bind(this)
-        return result
-    },
+    computed: {
+        hotkeys() {
+            const result = {}
+            result[this.ctrlOrCmd('s')] = this.submitApply.bind(this)
+            result[this.ctrlOrCmd('shift+s')] = this.submitSql.bind(this)
+            return result
+        }
+    }
 }
 </script>
 

--- a/apps/studio/src/components/common/PendingChangesButton.vue
+++ b/apps/studio/src/components/common/PendingChangesButton.vue
@@ -1,9 +1,9 @@
 <template>
-    <x-buttons class="pending-changes">
-        <x-button class="btn btn-primary" @click.prevent="submitApply">
+    <x-buttons class="pending-changes-button">
+        <x-button class="btn btn-primary" @click.prevent="submitApply" style="margin:0">
             <span>{{ labelApply || 'Apply' }}</span>
         </x-button>
-        <x-button class="btn btn-primary" menu>
+        <x-button class="btn btn-primary" menu style="margin:0">
             <i class="material-icons">arrow_drop_down</i>
             <x-menu>
                 <x-menuitem @click.prevent="submitApply">
@@ -25,7 +25,7 @@
 
 <script>
 export default {
-    name: 'PendingChanges',
+    name: 'PendingChangesButton',
     props: {
         submitApply: Function,
         submitSql: Function,
@@ -41,8 +41,3 @@ export default {
 }
 </script>
 
-<style module>
-x-buttons.pending-changes .btn {
-    margin: 0;
-}
-</style>

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -82,6 +82,9 @@ export interface DatabaseClient {
   // delete stuff
   dropElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => Promise<void>
   truncateElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => Promise<void>
+
+  // duplicate table
+  duplicateTable: (tableName: string, newTableName: string, schema?: string) => Promise<void>
 }
 
 export type IDbClients = keyof typeof clients
@@ -489,7 +492,7 @@ function getViewCreateScript(server: IDbConnectionServer, database: IDbConnectio
 
 function getMaterializedViewCreateScript(server: IDbConnectionServer, database: IDbConnectionDatabase, view: string /* , schema */) {
   checkIsConnected(server , database);
-  
+
   if(typeof database.connection?.getMaterializedViewCreateScript !== 'function') {
     return null;
   } else {

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -212,6 +212,9 @@ export class DBConnection {
   dropElement = bindAsync.bind(null, 'dropElement', this.server, this.database)
   truncateElement = bindAsync.bind(null, 'truncateElement', this.server, this.database)
 
+  // duplicateTAble
+  duplicateTable = bindAsync.bind(null, 'duplicateTable', this.server, this.database)
+
   async currentDatabase() {
     return this.database.database
   }

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -215,6 +215,7 @@ export class DBConnection {
 
   // duplicateTAble
   duplicateTable = bindAsync.bind(null, 'duplicateTable', this.server, this.database)
+  duplicateTableSql = bind.bind(null, 'duplicateTableSql', this.server, this.database)
 
   async currentDatabase() {
     return this.database.database

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -84,7 +84,8 @@ export interface DatabaseClient {
   truncateElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => Promise<void>
 
   // duplicate table
-  duplicateTable: (tableName: string, newTableName: string, schema?: string) => Promise<void>
+  duplicateTable: (tableName: string, duplicateTableName: string, schema?: string) => Promise<void>
+  duplicateTableSql: (tableName: string, duplicateTableName: string, schema?: string) => string
 }
 
 export type IDbClients = keyof typeof clients

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -760,7 +760,8 @@ export async function truncateElement (conn, elementName, typeOfElement) {
 }
 
 export async function duplicateTable(conn, tableName, newTable) {
-  const sql = `CREATE TABLE ${wrapIdentifier(newTable)} LIKE ${wrapIdentifier(tableName)}`;
+  let sql = `CREATE TABLE ${wrapIdentifier(newTable)} LIKE ${wrapIdentifier(tableName)};`;
+  sql += `INSERT INTO ${wrapIdentifier(newTable)} SELECT * FROM ${wrapIdentifier(tableName)};`;
 
   await driverExecuteQuery(conn, { query: sql });
 }

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -13,7 +13,7 @@ import { MysqlCursor } from './mysql/MySqlCursor';
 import { buildDeleteQueries, buildInsertQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral } from './utils';
 import { MysqlData } from '@shared/lib/dialects/mysql'
 import { ClientError } from '../client';
-import { duplicateTable } from './postgresql';
+
 
 const log = rawLog.scope('mysql')
 const logger = () => log

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -13,6 +13,7 @@ import { MysqlCursor } from './mysql/MySqlCursor';
 import { buildDeleteQueries, buildInsertQueries, buildInsertQuery, buildSelectTopQuery, escapeString, joinQueries, escapeLiteral } from './utils';
 import { MysqlData } from '@shared/lib/dialects/mysql'
 import { ClientError } from '../client';
+import { duplicateTable } from './postgresql';
 
 const log = rawLog.scope('mysql')
 const logger = () => log
@@ -91,7 +92,10 @@ export default async function (server, database) {
 
     // remove things
     dropElement: (elementName, typeOfElement) => dropElement(conn, elementName, typeOfElement),
-    truncateElement: (elementName, typeOfElement) => truncateElement(conn, elementName, typeOfElement)
+    truncateElement: (elementName, typeOfElement) => truncateElement(conn, elementName, typeOfElement),
+
+    // duplicate table
+    duplicateTable: (tableName, newTableName) => duplicateTable(conn, tableName, newTableName)
   };
 }
 
@@ -754,6 +758,13 @@ export async function truncateElement (conn, elementName, typeOfElement) {
     await driverExecuteQuery(connClient, { query: sql })
   });
 }
+
+export async function duplicateTable(conn, tableName, newTable) {
+  const sql = `CREATE TABLE ${wrapIdentifier(newTable)} LIKE ${wrapIdentifier(tableName)}`;
+
+  await driverExecuteQuery(conn, { query: sql });
+}
+
 
 export async function getTableProperties(conn, table) {
   const propsSql = `

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -219,7 +219,8 @@ export default async function (server: any, database: any): Promise<DatabaseClie
     truncateElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => truncateElement(conn, elementName, typeOfElement, schema),
 
     // duplicate table
-    duplicateTable: (tableName: string, newTableName: string, schema?: string) => duplicateTable(conn, tableName, newTableName, schema),
+    duplicateTable: (tableName: string, duplicateTableName: string, schema?: string) => duplicateTable(conn, tableName, duplicateTableName, schema),
+    duplicateTableSql: (tableName: string, duplicateTableName: string, schema?: string) => duplicateTableSql(tableName, duplicateTableName, schema),
   };
 }
 
@@ -1417,13 +1418,20 @@ export async function truncateElement (conn: Conn, elementName: string, typeOfEl
   });
 }
 
-export async function duplicateTable(conn: Conn, tableName: string,  newTableName: string, schema: string) {
+export async function duplicateTable(conn: Conn, tableName: string,  duplicateTableName: string, schema: string) {
+  const sql = duplicateTableSql(tableName, duplicateTableName, schema);
+
+  await driverExecuteQuery(conn, { query: sql });
+}
+
+export function duplicateTableSql(tableName: string,  duplicateTableName: string, schema: string) {
   const sql = `
-    CREATE TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(newTableName)} AS
+    CREATE TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(duplicateTableName)} AS
     SELECT * FROM ${wrapIdentifier(schema)}.${wrapIdentifier(tableName)}
   `;
 
-  await driverExecuteQuery(conn, { query: sql });
+  return sql;
+
 }
 
 async function configDatabase(server: { sshTunnel: boolean, config: IDbConnectionServerConfig}, database: { database: string}) {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -216,7 +216,10 @@ export default async function (server: any, database: any): Promise<DatabaseClie
 
     setTableDescription: (table: string, description: string, schema = defaultSchema) => setTableDescription(conn, table, description, schema),
     dropElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string|null) => dropElement(conn, elementName, typeOfElement, schema),
-    truncateElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => truncateElement(conn, elementName, typeOfElement, schema)
+    truncateElement: (elementName: string, typeOfElement: DatabaseElement, schema?: string) => truncateElement(conn, elementName, typeOfElement, schema),
+
+    // duplicate table
+    duplicateTable: (tableName: string, newTableName: string, schema?: string) => duplicateTable(conn, tableName, newTableName, schema),
   };
 }
 
@@ -1412,6 +1415,15 @@ export async function truncateElement (conn: Conn, elementName: string, typeOfEl
 
     await driverExecuteSingle(connClient, { query: sql })
   });
+}
+
+export async function duplicateTable(conn: Conn, tableName: string,  newTableName: string, schema: string) {
+  const sql = `
+    CREATE TABLE ${wrapIdentifier(schema)}.${wrapIdentifier(newTableName)} AS
+    SELECT * FROM ${wrapIdentifier(schema)}.${wrapIdentifier(tableName)}
+  `;
+
+  await driverExecuteQuery(conn, { query: sql });
 }
 
 async function configDatabase(server: { sshTunnel: boolean, config: IDbConnectionServerConfig}, database: { database: string}) {

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -88,7 +88,10 @@ export default async function (server, database) {
 
     // delete stuff
     dropElement: (elementName, typeOfElement) => dropElement(conn, elementName, typeOfElement),
-    truncateElement: (elementName) => truncateElement(conn, elementName)
+    truncateElement: (elementName) => truncateElement(conn, elementName),
+
+    // duplicate table
+    duplicateTable: (tableName, newTableName) => duplicateTable(conn, tableName, newTableName)
   };
 }
 
@@ -509,6 +512,15 @@ export async function truncateElement (conn, elementName) {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `Delete from ${PD.wrapIdentifier(elementName)}; vacuum;`
+
+    await driverExecuteQuery(connClient, { query: sql })
+  });
+}
+
+export async function duplicateTable (conn, tableName, newTable) {
+  await runWithConnection(conn, async (connection) => {
+    const connClient = { connection };
+    const sql = `CREATE TABLE ${PD.wrapIdentifier(newTable)} AS SELECT * FROM ${PD.wrapIdentifier(tableName)};`
 
     await driverExecuteQuery(connClient, { query: sql })
   });

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -14,7 +14,8 @@ import { ClientError } from '../client';
 const log = rawLog.scope('sqlite')
 const logger = () => log
 
-const knex = knexlib({ client: 'better-sqlite3',
+const knex = knexlib({
+  client: 'better-sqlite3',
   // silence the "sqlite does not support inserting default values" warnings on every insert
   useNullAsDefault: true,
 })
@@ -63,7 +64,7 @@ export default async function (server, database) {
     getQuerySelectTop: (table, limit) => getQuerySelectTop(conn, table, limit),
     getTableCreateScript: (table) => getTableCreateScript(conn, table),
     getViewCreateScript: (view) => getViewCreateScript(conn, view),
-    getMaterializedViewCreateScript:  () => Promise.resolve([]),
+    getMaterializedViewCreateScript: () => Promise.resolve([]),
     getRoutineCreateScript: (routine) => getRoutineCreateScript(conn, routine),
     truncateAllTables: () => truncateAllTables(conn),
     getTableProperties: (table) => getTableProperties(conn, table),
@@ -91,7 +92,8 @@ export default async function (server, database) {
     truncateElement: (elementName) => truncateElement(conn, elementName),
 
     // duplicate table
-    duplicateTable: (tableName, newTableName) => duplicateTable(conn, tableName, newTableName)
+    duplicateTableSql: (tableName, dublicateTableName) => duplicateTableSql(tableName, dublicateTableName),
+    duplicateTable: (tableName, dublicateTableName) => duplicateTable(conn, tableName, dublicateTableName)
   };
 }
 
@@ -189,11 +191,11 @@ export function query(conn, queryText) {
 
 export async function insertRows(cli, inserts) {
 
-    for (const command of buildInsertQueries(knex, inserts)) {
-      await driverExecuteQuery(cli, { query: command })
-    }
+  for (const command of buildInsertQueries(knex, inserts)) {
+    await driverExecuteQuery(cli, { query: command })
+  }
 
-    return true
+  return true
 }
 
 export async function applyChanges(conn, changes) {
@@ -201,7 +203,7 @@ export async function applyChanges(conn, changes) {
 
   await runWithConnection(conn, async (connection) => {
     const cli = { connection }
-    await driverExecuteQuery(cli, { query: 'BEGIN'})
+    await driverExecuteQuery(cli, { query: 'BEGIN' })
 
     try {
       if (changes.inserts) {
@@ -216,7 +218,7 @@ export async function applyChanges(conn, changes) {
         await deleteRows(cli, changes.deletes)
       }
 
-      await driverExecuteQuery(cli, { query: 'COMMIT'})
+      await driverExecuteQuery(cli, { query: 'COMMIT' })
     } catch (ex) {
       log.error("query exception: ", ex)
       await driverExecuteQuery(cli, { query: 'ROLLBACK' })
@@ -390,10 +392,10 @@ export async function listTableIndexes(conn, database, table) {
   const { data } = await driverExecuteQuery(conn, { query: sql });
 
   const allSQL = data.map((row) => `PRAGMA INDEX_XINFO('${escapeString(row.name)}')`).join(";")
-  const infos = await driverExecuteQuery(conn, { query: allSQL, multiple: true})
+  const infos = await driverExecuteQuery(conn, { query: allSQL, multiple: true })
 
   const indexColumns = infos.map((result) => {
-    return result.data.filter((r) => !!r.name).map((r) => ({name: r.name, order: r.desc ? 'DESC' : 'ASC'}))
+    return result.data.filter((r) => !!r.name).map((r) => ({ name: r.name, order: r.desc ? 'DESC' : 'ASC' }))
   })
 
   return data.map((row, idx) => ({
@@ -422,7 +424,7 @@ export function getTableReferences() {
 
 export async function getPrimaryKeys(conn, database, table) {
   const sql = `pragma table_info('${escapeString(table)}')`
-  const { data } = await driverExecuteQuery(conn, { query: sql})
+  const { data } = await driverExecuteQuery(conn, { query: sql })
   const found = data.filter(r => r.pk > 0)
   if (!found || found.length === 0) return []
   return found.map((r) => ({
@@ -499,7 +501,7 @@ export async function truncateAllTables(conn) {
   });
 }
 
-export async function dropElement (conn, elementName, typeOfElement) {
+export async function dropElement(conn, elementName, typeOfElement) {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `DROP ${PD.wrapLiteral(typeOfElement)} ${wrapIdentifier(elementName)}`
@@ -508,7 +510,7 @@ export async function dropElement (conn, elementName, typeOfElement) {
   });
 }
 
-export async function truncateElement (conn, elementName) {
+export async function truncateElement(conn, elementName) {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `Delete from ${PD.wrapIdentifier(elementName)}; vacuum;`
@@ -517,13 +519,17 @@ export async function truncateElement (conn, elementName) {
   });
 }
 
-export async function duplicateTable (conn, tableName, newTable) {
+export async function duplicateTable(conn, tableName, dublicateTableName) {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
-    const sql = `CREATE TABLE ${PD.wrapIdentifier(newTable)} AS SELECT * FROM ${PD.wrapIdentifier(tableName)};`
+    const sql = duplicateTableSql(tableName, dublicateTableName)
 
     await driverExecuteQuery(connClient, { query: sql })
   });
+}
+
+export function duplicateTableSql(tableName, dublicateTableName) {
+  return `CREATE TABLE ${PD.wrapIdentifier(dublicateTableName)} AS SELECT * FROM ${PD.wrapIdentifier(tableName)};`
 }
 
 export async function getTableProperties(conn, table) {
@@ -641,7 +647,7 @@ export function driverExecuteQuery(conn, queryArgs) {
     for (let index = 0; index < statements.length; index++) {
       const statement = statements[index];
       const r = await runQuery(connection, statement)
-      results.push({...r, statement})
+      results.push({ ...r, statement })
     }
 
     return queryArgs.multiple ? results : results[0];

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -7,7 +7,8 @@ import { identify } from 'sql-query-identifier';
 import knexlib from 'knex'
 import _, { defaults } from 'lodash';
 
-import { buildDatabseFilter,
+import {
+  buildDatabseFilter,
   buildDeleteQueries,
   buildInsertQuery,
   buildInsertQueries,
@@ -48,7 +49,7 @@ export default async function (server, database) {
   const version = await getVersion(conn);
 
   return {
-    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true}),
+    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true }),
     versionString: () => getVersionString(version),
     wrapIdentifier,
     defaultSchema: () => 'dbo',
@@ -114,12 +115,14 @@ export default async function (server, database) {
     truncateElement: (elementName, typeOfElement, schema) => truncateElement(conn, elementName, typeOfElement, schema),
 
     // duplicate
-    duplicateTable: (table, newTableName, schema) => duplicateTable(conn, table, newTableName, schema),
+    duplicateTableSql: (table, duplicateTableName, schema) => duplicateTableSql(conn, table, duplicateTableName, schema),
+    duplicateTable: (table, duplicateTableName, schema) => duplicateTable(conn, table, duplicateTableName, schema),
+
   };
 }
 
 async function getVersion(conn) {
-  const result = await driverExecuteQuery(conn, { query: "SELECT @@VERSION as version"})
+  const result = await driverExecuteQuery(conn, { query: "SELECT @@VERSION as version" })
   const versionString = result.data.recordset[0].version
   const yearRegex = /SQL Server (\d+)/g
   const yearResults = yearRegex.exec(versionString)
@@ -233,12 +236,12 @@ function genSelectNew(table, offset, limit, orderBy, filters, schema, selects) {
     ${orderByString}
     ${offsetString}
     `
-    return query
+  return query
 }
 
 async function getTableLength(conn, table, schema) {
   const countQuery = genCountQuery(table, [], schema)
-  const countResults = await driverExecuteQuery(conn, { query: countQuery})
+  const countResults = await driverExecuteQuery(conn, { query: countQuery })
   const rowWithTotal = countResults.data.recordset.find((row) => { return row.total })
   const totalRecords = rowWithTotal ? rowWithTotal.total : 0
   return totalRecords
@@ -516,7 +519,7 @@ export async function listTableTriggers(conn, table, schema) {
 
   return data.recordset.map((row) => {
     const update = row.isupdate === 1 ? 'UPDATE' : null
-    const del = row.isdelete === 1 ? 'DELETE': null
+    const del = row.isdelete === 1 ? 'DELETE' : null
     const insert = row.isinsert === 1 ? 'INSERT' : null
     const instead = row.isinsteadof === 1 ? 'INSEAD_OF' : null
 
@@ -696,7 +699,7 @@ export async function getPrimaryKeys(conn, database, table, schema) {
   WHERE OBJECTPROPERTY(OBJECT_ID(CONSTRAINT_SCHEMA + '.' + QUOTENAME(CONSTRAINT_NAME)), 'IsPrimaryKey') = 1
   AND TABLE_NAME = ${wrapValue(table)} AND TABLE_SCHEMA = ${wrapValue(schema)}
   `
-  const { data } = await driverExecuteQuery(conn, { query: sql})
+  const { data } = await driverExecuteQuery(conn, { query: sql })
   if (!data.recordset || data.recordset.length === 0) return []
 
   return data.recordset.map((r) => ({
@@ -732,7 +735,7 @@ export async function applyChanges(conn, changes) {
 
       sql.push('COMMIT')
 
-      await driverExecuteQuery(cli, { query: sql.join(';')})
+      await driverExecuteQuery(cli, { query: sql.join(';') })
 
       if (changes.updates) {
         const selectQueries = buildSelectQueriesFromUpdates(knex, changes.updates)
@@ -865,7 +868,7 @@ export async function truncateAllTables(conn) {
   });
 }
 
-export async function dropElement (conn, elementName, typeOfElement, schema = 'dbo') {
+export async function dropElement(conn, elementName, typeOfElement, schema = 'dbo') {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `DROP ${D.wrapLiteral(typeOfElement)} ${wrapIdentifier(schema)}.${wrapIdentifier(elementName)}`
@@ -874,7 +877,7 @@ export async function dropElement (conn, elementName, typeOfElement, schema = 'd
   });
 }
 
-export async function truncateElement (conn, elementName, typeOfElement, schema = 'dbo') {
+export async function truncateElement(conn, elementName, typeOfElement, schema = 'dbo') {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `TRUNCATE ${D.wrapLiteral(typeOfElement)} ${wrapIdentifier(schema)}.${wrapIdentifier(elementName)}`
@@ -883,14 +886,19 @@ export async function truncateElement (conn, elementName, typeOfElement, schema 
   });
 }
 
-export async function duplicateTable(conn, tableName, newTableName, schema = 'dbo') {
+export async function duplicateTable(conn, tableName, duplicateTableName, schema = 'dbo') {
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
-    const sql = `SELECT * INTO ${wrapIdentifier(schema)}.${wrapIdentifier(newTableName)} FROM ${wrapIdentifier(schema)}.${wrapIdentifier(tableName)}`
+    const sql = duplicateTableSql(tableName, duplicateTableName, schema)
 
     await driverExecuteQuery(connClient, { query: sql })
   });
 }
+
+export function duplicateTableSql(tableName, duplicateTableName, schema) {
+  return `SELECT * INTO ${wrapIdentifier(schema)}.${wrapIdentifier(duplicateTableName)} FROM ${wrapIdentifier(schema)}.${wrapIdentifier(tableName)}`
+}
+
 
 async function getTableDescription(conn, table, schema = defaultSchema) {
   const query = `SELECT *
@@ -917,7 +925,7 @@ export async function getTableProperties(conn, table, schema = defaultSchema) {
 
   const description = await getTableDescription(conn, table, schema)
   const sizeQuery = `EXEC sp_spaceused N'${escapeString(schema)}.${escapeString(table)}'; `
-  const { data }  = await driverExecuteQuery(conn, { query: sizeQuery })
+  const { data } = await driverExecuteQuery(conn, { query: sizeQuery })
   const row = data.recordset ? data.recordset[0] || {} : {}
   const relations = await getTableKeys(conn, null, table, schema)
   return {
@@ -971,7 +979,7 @@ WHERE
     AND tables.name = ${D.escapeString(table, true)}
 
   `
-  const { data } = await driverExecuteQuery(conn, { query: sql})
+  const { data } = await driverExecuteQuery(conn, { query: sql })
   return data.recordset.map((d) => {
     return {
       column: d.columnName,

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -93,7 +93,7 @@ export default async function (server, database) {
     listCharsets: () => [],
     getDefaultCharset: () => null,
     /*
-      From https://docs.microsoft.com/en-us/sql/t-sql/statements/create-database-transact-sql?view=sql-server-ver16&tabs=sqlpool: 
+      From https://docs.microsoft.com/en-us/sql/t-sql/statements/create-database-transact-sql?view=sql-server-ver16&tabs=sqlpool:
       Collation name can be either a Windows collation name or a SQL collation name. If not specified, the database is assigned the default collation of the instance of SQL Server
 
       Having this, going to keep collations at the default because there are literally thousands of options
@@ -111,7 +111,10 @@ export default async function (server, database) {
 
     // remove things
     dropElement: (elementName, typeOfElement, schema) => dropElement(conn, elementName, typeOfElement, schema),
-    truncateElement: (elementName, typeOfElement, schema) => truncateElement(conn, elementName, typeOfElement, schema)
+    truncateElement: (elementName, typeOfElement, schema) => truncateElement(conn, elementName, typeOfElement, schema),
+
+    // duplicate
+    duplicateTable: (table, newTableName, schema) => duplicateTable(conn, table, newTableName, schema),
   };
 }
 
@@ -875,6 +878,15 @@ export async function truncateElement (conn, elementName, typeOfElement, schema 
   await runWithConnection(conn, async (connection) => {
     const connClient = { connection };
     const sql = `TRUNCATE ${D.wrapLiteral(typeOfElement)} ${wrapIdentifier(schema)}.${wrapIdentifier(elementName)}`
+
+    await driverExecuteQuery(connClient, { query: sql })
+  });
+}
+
+export async function duplicateTable(conn, tableName, newTableName, schema = 'dbo') {
+  await runWithConnection(conn, async (connection) => {
+    const connClient = { connection };
+    const sql = `SELECT * INTO ${wrapIdentifier(schema)}.${wrapIdentifier(newTableName)} FROM ${wrapIdentifier(schema)}.${wrapIdentifier(tableName)}`
 
     await driverExecuteQuery(connClient, { query: sql })
   });

--- a/apps/studio/src/mixins/TableListContextMenus.ts
+++ b/apps/studio/src/mixins/TableListContextMenus.ts
@@ -97,6 +97,13 @@ export default {
             this.$root.$emit(AppEvent.dropDatabaseElement, { item, action: 'truncate' })
           }
         },
+        {
+          name: "Duplicate",
+          slug: 'sql-duplicate',
+          handler: ({ item }) => {
+            this.$root.$emit(AppEvent.duplicateDatabaseTable, { item, action: 'duplicate' })
+          }
+        },
       ]
     },
     schemaMenuOptions() {

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -79,7 +79,7 @@ export function runCommonTests(getUtil) {
     test("Invalid database name", async () => {
       await getUtil().badCreateDatabaseTests()
     })
-    
+
     test("Should create database", async () => {
       await getUtil().createDatabaseTests()
     })
@@ -96,6 +96,20 @@ export function runCommonTests(getUtil) {
 
     test("Bad input shouldn't allow table truncate", async () => {
       await getUtil().badTruncateTableTests()
+    })
+  })
+
+  describe("Duplicate Table Tests", () => {
+    beforeEach(async() => {
+      await prepareTestTable(getUtil())
+    })
+
+    test("Should duplicate table", async () => {
+      await getUtil().duplicateTableTests()
+    })
+
+    test("Bad input shouldn't allow table duplication", async () => {
+      await getUtil().badDuplicateTableTests()
     })
   })
 

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -111,6 +111,10 @@ export function runCommonTests(getUtil) {
     test("Bad input shouldn't allow table duplication", async () => {
       await getUtil().badDuplicateTableTests()
     })
+
+    test("Should print the duplicate table query", async () => {
+      await getUtil().duplicateTableSqlTests()
+    })
   })
 
   describe("Table Structure", () => {

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -237,9 +237,6 @@ export class DBTestUtil {
     }
   }
 
-
-
-
   async listTableTests() {
     const tables = await this.connection.listTables({ schema: this.defaultSchema })
     expect(tables.length).toBeGreaterThanOrEqual(this.expectedTables)

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -199,7 +199,7 @@ export class DBTestUtil {
       cockroachdb: 'group"drop table test_inserts"'
     }
     try {
-      // TODO: this is not the right method to call here
+      // TODO: this should not the right method to call here
       await this.connection.dropElement(expectedQueries[this.dbType], 'TABLE', this.defaultSchema)
       const newRowCount = await this.knex.select().from('group')
       expect(newRowCount.length).toEqual(initialRowCount.length)

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -209,6 +209,16 @@ export class DBTestUtil {
     }
   }
 
+  async duplicateTableSqlTests() {
+    const sql = await this.connection.duplicateTableSql('group', 'group_copy', this.defaultSchema)
+
+    expect(sql).not.toBeUndefined()
+    expect(sql).not.toBeNull()
+    expect(sql).not.toEqual('')
+
+  }
+
+
   async duplicateTableTests() {
     const tables = await this.connection.listTables({ schema: this.defaultSchema })
 


### PR DESCRIPTION
The new feature adds an item to the contextual menu that appears when the user right-clicks on a table. This item allows the user to duplicate the table, copying both the structure and the data (except indexes, triggers, constraints) (it works doing a "select * into <new_table> from <table_name>).

The video that has been provided demonstrates how the feature works in action, allowing users to see exactly how the new functionality will benefit them. Overall, this feature should make it much easier and more efficient for users to duplicate tables, saving them time and effort in their database editing work.

Link to the video: https://youtu.be/cn0dG4YSIZk

Furthermore, it is worth mentioning that in the future, there is also a possibility to add a flag that allows the user to choose how much data to copy when duplicating a table. Specifically, the flag could enable the user to copy all data, only a certain number of records (X records), or no data at all. This added functionality would provide even more flexibility and control to users when using the duplicate table feature.

Tested with MYSQL, POSTGRES, MSSQL.

Thanks