### PR TITLE
PG -  numeric precision and scale + date

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -555,9 +555,11 @@ export async function listTableColumns(
       column_default,
       ${column_comment_clause}
       CASE
-        WHEN character_maximum_length is not null  and udt_name != 'text'
+        WHEN character_maximum_length is not null  and udt_name != 'text' 
           THEN CONCAT(udt_name, concat('(', concat(character_maximum_length::varchar(255), ')')))
-        WHEN datetime_precision is not null THEN
+        WHEN numeric_precision is not null 
+        	THEN CONCAT(udt_name, concat('(', concat(numeric_precision::varchar(255),',',numeric_scale, ')')))
+        WHEN datetime_precision is not null AND udt_name != 'date' THEN
           CONCAT(udt_name, concat('(', concat(datetime_precision::varchar(255), ')')))
         ELSE udt_name
       END as data_type

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -558,7 +558,7 @@ export async function listTableColumns(
         WHEN character_maximum_length is not null  and udt_name != 'text' 
           THEN CONCAT(udt_name, concat('(', concat(character_maximum_length::varchar(255), ')')))
         WHEN numeric_precision is not null 
-        	THEN CONCAT(udt_name, concat('(', concat(numeric_precision::varchar(255),',',numeric_scale, ')')))
+        	THEN CONCAT(udt_name, concat('(', concat(numeric_precision::varchar(255),',',numeric_scale::varchar(255), ')')))
         WHEN datetime_precision is not null AND udt_name != 'date' THEN
           CONCAT(udt_name, concat('(', concat(datetime_precision::varchar(255), ')')))
         ELSE udt_name


### PR DESCRIPTION
I fixed the numeric scale and precision, but I'm not sure about the date. What types of dates do you need to see date_precision for? In my opinion, I should comment out this function and leave only the name of the type or make exceptions for certain types.
<img width="642" alt="Screenshot 2023-03-18 at 10 30 28" src="https://user-images.githubusercontent.com/103044576/226097394-9ee44cdb-3a71-40c8-bbc9-fc166c189cf3.png">


https://github.com/beekeeper-studio/beekeeper-studio/issues/1072