### PR TITLE
Partitions fix 96

### DIFF
--- a/apps/studio/src/components/TabTableProperties.vue
+++ b/apps/studio/src/components/TabTableProperties.vue
@@ -194,6 +194,8 @@ export default {
       const isTable = this.table.entityType === 'table'
       // TODO (day): when we support more dbs, this will need to be an array of all the possible types.
       // Postgres table type for a partitioned table.
+      const partitionTableType = 'p';
+      const supportedFeatures = this.connection.supportedFeatures();
       return this.rawPills.filter((p) => {
 
         if (!this.properties) {
@@ -202,11 +204,13 @@ export default {
           }
         }
 
-        if (p.needsProperties && !this.connection.supportedFeatures().properties) {
+        if (p.needsProperties && !supportedFeatures.properties) {
           return false
         }
 
-        if (p.needsPartitions && (!this.connection.supportedFeatures().partitions && !this.properties.partitions?.length)) {
+        if (p.needsPartitions && (!supportedFeatures.partitions ||
+          ((!supportedFeatures.editPartitions && !this.properties.partitions?.length) ||
+          (supportedFeatures.editPartitions && this.table.tabletype != partitionTableType)))) {
           return false
         }
         if(p.tableOnly) {

--- a/apps/studio/src/components/TabTableProperties.vue
+++ b/apps/studio/src/components/TabTableProperties.vue
@@ -194,7 +194,6 @@ export default {
       const isTable = this.table.entityType === 'table'
       // TODO (day): when we support more dbs, this will need to be an array of all the possible types.
       // Postgres table type for a partitioned table.
-      const partitionTableType = 'p';
       return this.rawPills.filter((p) => {
 
         if (!this.properties) {
@@ -207,7 +206,7 @@ export default {
           return false
         }
 
-        if (p.needsPartitions && (!this.connection.supportedFeatures().partitions || this.table.tabletype !== partitionTableType)) {
+        if (p.needsPartitions && (!this.connection.supportedFeatures().partitions && !this.properties.partitions?.length)) {
           return false
         }
         if(p.tableOnly) {

--- a/apps/studio/src/components/tableinfo/TablePartitions.vue
+++ b/apps/studio/src/components/tableinfo/TablePartitions.vue
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <div class="expand" /> 
+    <div class="expand" />
     <status-bar class="tablulator-footer">
       <div class="flex flex-middle statusbar-actions">
         <slot name="footer" />
@@ -54,7 +54,7 @@
 import Vue from 'vue';
 import DataMutators from '../../mixins/data_mutators'
 import { TabulatorFull, Tabulator } from 'tabulator-tables'
-type RowComponent = Tabulator.RowComponent; 
+type RowComponent = Tabulator.RowComponent;
 type CellComponent = Tabulator.CellComponent;
 import _ from 'lodash';
 import { TabulatorStateWatchers, vueEditor, trashButton } from '@shared/lib/tabulator/helpers'
@@ -265,7 +265,7 @@ export default Vue.extend({
     },
     // Load a template for partition expressions based on previous partitions.
     loadExpressionTemplate(partition: any | null) {
-      if (partition == null) {
+      if (!partition || !partition.expression) {
         this.expressionTemplate = '';
         return
       }

--- a/apps/studio/src/lib/db/client.ts
+++ b/apps/studio/src/lib/db/client.ts
@@ -37,7 +37,7 @@ export interface DatabaseClient {
   listTableTriggers: (table: string, schema?: string) => Promise<TableTrigger[]>,
   listTableIndexes: (db: string, table: string, schema?: string) => Promise<TableIndex[]>,
   listSchemas: (db: string, filter?: SchemaFilterOptions) => Promise<string[]>,
-  listTablePartitions: (table: string) => Promise<TablePartition[]>
+  listTablePartitions: (table: string, schema?: string) => Promise<TablePartition[]>
   getTableReferences: (table: string, schema?: string) => void,
   getTableKeys: (db: string, table: string, schema?: string) => void,
   query: (queryText: string) => CancelableQuery,
@@ -504,7 +504,7 @@ function getViewCreateScript(server: IDbConnectionServer, database: IDbConnectio
 
 function getMaterializedViewCreateScript(server: IDbConnectionServer, database: IDbConnectionDatabase, view: string /* , schema */) {
   checkIsConnected(server , database);
-  
+
   if(typeof database.connection?.getMaterializedViewCreateScript !== 'function') {
     return null;
   } else {

--- a/apps/studio/src/lib/db/clients/mysql.js
+++ b/apps/studio/src/lib/db/clients/mysql.js
@@ -35,7 +35,7 @@ export default async function (server, database) {
   const versionInfo = await getVersion(conn)
 
   return {
-    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true, partitions: false }),
+    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true, partitions: false, editPartitions: false }),
     versionString: () => getVersionString(versionInfo),
     wrapIdentifier,
     defaultSchema: () => null,

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -159,7 +159,9 @@ export default async function (server: any, database: any): Promise<DatabaseClie
 
   const version = await getVersion(conn)
 
-  const features = version.isRedshift ? { customRoutines: true, comments: false, properties: false, partitions: false } : { customRoutines: true, comments: true, properties: true, partitions: version.hasPartitions}
+  const features = version.isRedshift ? 
+    { customRoutines: true, comments: false, properties: false, partitions: false, editPartitions: false } :
+    { customRoutines: true, comments: true, properties: true, partitions: version.hasPartitions, editPartitions: version.number >= 100000}
 
 
   return {

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -46,7 +46,7 @@ export default async function (server, database) {
   const version = await driverExecuteQuery(conn, { query: 'SELECT sqlite_version()' });
 
   return {
-    supportedFeatures: () => ({ customRoutines: false, comments: false, properties: true, partitions: false }),
+    supportedFeatures: () => ({ customRoutines: false, comments: false, properties: true, partitions: false, editPartitions: false }),
     versionString: () => getVersionString(version),
     wrapIdentifier,
     defaultSchema: () => null,

--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -49,7 +49,7 @@ export default async function (server, database) {
   const version = await getVersion(conn);
 
   return {
-    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true, partitions: false}),
+    supportedFeatures: () => ({ customRoutines: true, comments: true, properties: true, partitions: false, editPartitions: false }),
     versionString: () => getVersionString(version),
     wrapIdentifier,
     defaultSchema: () => 'dbo',

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -198,11 +198,13 @@ export interface Routine extends DatabaseEntity {
   type: RoutineType;
 }
 
+// NOTE (day): note sure if this is really where we want to put edit partitions?
 export interface SupportedFeatures {
   customRoutines: boolean;
   comments: boolean;
   properties: boolean;
   partitions: boolean;
+  editPartitions: boolean;
 }
 
 export interface FieldDescriptor {


### PR DESCRIPTION
Removed the ability to edit partitions on v < 10
![Peek 2023-03-30 01-39](https://user-images.githubusercontent.com/58712803/228765121-bfa8578b-23eb-4671-be66-638e3a8a5062.gif)
(Apologies for my background bleeding through on click, not sure why that's happening, screencaps hate me)

I'm not really sure if having it as a supported feature is really what we want to do? I think it's between that and having it as a disabled feature on the dialect?

Also, should I just hide the partition expression column for now?
