### PR TITLE
#1564 - Fix table list dups

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -249,10 +249,10 @@ export async function listTables(conn: HasPool, filter: FilterOptions = { schema
     sql += `
         pc.relkind as tabletype
       FROM information_schema.tables AS t
+      JOIN pg_class AS pc
+      ON t.table_name = pc.relname AND t.table_schema = pc.relnamespace::regnamespace::text
       LEFT OUTER JOIN pg_inherits AS i
-      ON t.table_name::text = i.inhrelid::regclass::text
-      LEFT OUTER JOIN pg_class AS pc
-      ON t.table_name = pc.relname
+      ON pc.oid = i.inhrelid
       WHERE t.table_type NOT LIKE '%VIEW%'
       AND i.inhrelid::regclass IS NULL
     `;


### PR DESCRIPTION
Fix #1564 
![image](https://user-images.githubusercontent.com/58712803/230669502-9aa52185-55f5-4d2c-ae46-66d1f6e615fd.png)

This issue was caused by the new partitions script, which was just going off of table name in one of the joins :facepalm:.

Now joining on tablename and schema name, as well as oid in a different join.