### PR TITLE
#1583 - Fix partitions so they don't hide inherited tables

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -291,7 +291,7 @@ export async function listTablePartitions(conn: HasPool, tableName: string, sche
       JOIN pg_class pt                ON pt.oid = i.inhrelid
       JOIN pg_stat_all_tables ps      ON ps.relid = i.inhrelid
       JOIN pg_namespace nmsp_parent   ON nmsp_parent.oid = base_tb.relnamespace 
-    WHERE nmsp_parent.nspname = ? AND base_tb.relname = ?;
+    WHERE nmsp_parent.nspname = ? AND base_tb.relname = ? AND base_tb.relkind = 'p';
   `, [schemaName, tableName]).toQuery();
 
   const data = await driverExecuteSingle(conn, { query: sql });

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -250,18 +250,21 @@ export async function listTables(conn: HasPool, filter: FilterOptions = { schema
       `quote_ident(t.table_schema) = pc.relnamespace::regnamespace::text` :
       't.table_schema = (SELECT nspname FROM pg_namespace as pn WHERE pn.oid = pc.relnamespace)';
     sql += `
-        pc.relkind as tabletype
+        pc.relkind as tabletype,
+        parent_pc.relkind as parenttype
       FROM information_schema.tables AS t
       JOIN pg_class AS pc
         ON t.table_name = pc.relname AND ${schemaStatement}
       LEFT OUTER JOIN pg_inherits AS i
         ON pc.oid = i.inhrelid
+      LEFT OUTER JOIN pg_class AS parent_pc
+        ON parent_pc.oid = i.inhparent
       WHERE t.table_type NOT LIKE '%VIEW%'
-      AND i.inhrelid::regclass IS NULL
     `;
   } else {
     sql += `
-        'r' as tabletype
+        'r' as tabletype,
+        'r' as parenttype
       FROM information_schema.tables AS t
       WHERE t.table_type NOT LIKE '%VIEW%'
     `;

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -28,6 +28,7 @@ export interface TableOrView extends DatabaseEntity {
   columns?: TableColumn[];
   partitions?: TablePartition[];
   tabletype?: string | null
+  parenttype?: string | null
 }
 
 export interface IndexedColumn {

--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -13,7 +13,8 @@ export function splitQueries(queryText: string, dialect) {
 
 export function entityFilter(rawTables: any[], allFilters: EntityFilter) {
   const tables = rawTables.filter((table) => {
-    return (table.entityType === 'table' && allFilters.showTables) ||
+    return (table.entityType === 'table' && allFilters.showTables && 
+      ((table.parenttype != 'p' && !allFilters.showPartitions) || allFilters.showPartitions)) ||
       (table.entityType === 'view' && allFilters.showViews) ||
       (table.entityType === 'materialized-view' && allFilters.showViews) ||
       (Object.keys(RoutineTypeNames).includes(table.type) && allFilters.showRoutines)

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -84,7 +84,8 @@ const store = new Vuex.Store<State>({
       filterQuery: undefined,
       showTables: true,
       showRoutines: true,
-      showViews: true
+      showViews: true,
+      showPartitions: false
     },
     tablesLoading: "Loading tables...",
     columnsLoading: 'Loading columns...',
@@ -134,7 +135,7 @@ const store = new Vuex.Store<State>({
       return _.sortBy(state.usedConfigs, 'updatedAt').reverse()
     },
     filteredTables(state) {
-      return entityFilter(state.tables, state.entityFilter)
+      return entityFilter(state.tables, state.entityFilter);
     },
     filteredRoutines(state) {
       return entityFilter(state.routines, state.entityFilter)
@@ -204,6 +205,9 @@ const store = new Vuex.Store<State>({
     showRoutines(state) {
       state.entityFilter.showRoutines = !state.entityFilter.showRoutines
     },
+    showPartitions(state) {
+      state.entityFilter.showPartitions = !state.entityFilter.showPartitions
+    },
     tabActive(state, tab: CoreTab) {
       state.activeTab = tab
     },
@@ -230,7 +234,8 @@ const store = new Vuex.Store<State>({
         filterQuery: undefined,
         showTables: true,
         showViews: true,
-        showRoutines: true
+        showRoutines: true,
+        showPartitions: false
       }
     },
     updateConnection(state, {connection, database}) {
@@ -435,8 +440,10 @@ const store = new Vuex.Store<State>({
           onlyTables.forEach((t) => {
             t.entityType = 'table'
             t.columns = []
-            if (!context.state.connection.supportedFeatures().partitions) 
-              t.tabletype = null;
+            // if (!context.state.connection.supportedFeatures().partitions) {
+            //   t.tabletype = null;
+            //   t.parenttype = null;
+            // } 
           })
           const views = await context.state.connection.listViews({ schema })
           views.forEach((v) => {

--- a/apps/studio/src/store/models.ts
+++ b/apps/studio/src/store/models.ts
@@ -5,7 +5,8 @@ export interface EntityFilter {
   filterQuery?: string
   showTables: boolean
   showViews: boolean
-  showRoutines: boolean
+  showRoutines: boolean,
+  showPartitions: boolean
 }
 
 export enum TabType {

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -261,10 +261,13 @@ function testWith(dockerTag, socket = false) {
     it("Partitions should have parenttype 'p'", async () => {
       if (dockerTag == 'latest') {
         const tables = await util.connection.listTables({ schema: 'public', tables: ['partition_1', 'another_partition', 'party']});
+        const partition1 = tables.find((value) => value.name == 'partition_1');
+        const another = tables.find((value) => value.name == 'another_partition');
+        const party = tables.find((value) => value.name == 'party');
 
-        expect(tables[0].parenttype).toBe('p');
-        expect(tables[1].parenttype).toBe('p');
-        expect(tables[2].parenttype).toBe('p');
+        expect(partition1.parenttype).toBe('p');
+        expect(another.parenttype).toBe('p');
+        expect(party.parenttype).toBe('p');
       }
     })
     // END regression tests for Bug #1583

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -81,7 +81,7 @@ function testWith(dockerTag, socket = false) {
           CREATE TABLE party PARTITION OF partitionedtable
           FOR VALUES FROM (21) TO (30);
 
-          CREATE TABLE parenttable (
+          CREATE TABLE parent (
             id INTEGER PRIMARY KEY
           );
           CREATE TABLE child (


### PR DESCRIPTION
Fix #1583 

Partitions filtering was also filtering out inherited tables that aren't partitions.

This PR changes how we filter partitions, as we were filtering them in the query itself before. Now we are just grabbing the parent table's relkind and using that to determine if it's a partition or not client side.

TODO:
- [x] Integration test
- [x] Disable pg < 10