### PR TITLE
feat: support schema autocomplete

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -168,7 +168,7 @@
   import MergeManager from '@/components/editor/MergeManager.vue'
   import { AppEvent } from '@/common/AppEvent'
   import { FavoriteQuery } from '@/common/appdb/models/favorite_query'
-  import { makeDBHint, queryTable } from '@/lib/editor'
+  import { makeDBHint, findTableOrViewByWord } from '@/lib/editor'
 
   const log = rawlog.scope('query-editor')
   const isEmpty = (s) => _.isEmpty(_.trim(s))
@@ -915,8 +915,8 @@
       fakeRemoteChange() {
         this.query.text = "select * from foo"
       },
-      async getColumnsForAutocomplete(table) {
-        const tableToFind = this.tables.find(({name, schema}) => table.name === name && table.schema === schema)
+      async getColumnsForAutocomplete(tableWord) {
+        const tableToFind = findTableOrViewByWord(this.tables, tableWord)
         if (!tableToFind) return null
         // Only refresh columns if we don't have them cached.
         if (!tableToFind.columns?.length) {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -206,7 +206,7 @@
       }
     },
     computed: {
-      ...mapGetters(['dialect', 'defaultSchema']),
+      ...mapGetters(['dialect', 'dialectData', 'defaultSchema']),
       ...mapState(['usedConfig', 'connection', 'database', 'tables', 'storeInitialized']),
       ...mapState('data/queries', {'savedQueries': 'items'}),
       ...mapState('settings', ['settings']),
@@ -342,7 +342,7 @@
         return this.connection.connectionType;
       },
       hintOptions() {
-        const dbHint = makeDBHint(this.tables, this.connectionType)
+        const dbHint = makeDBHint(this.tables, this.dialectData)
         return { tables: dbHint.tables, schemas: dbHint.schemas }
       },
       queryParameterPlaceholders() {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -168,6 +168,7 @@
   import MergeManager from '@/components/editor/MergeManager.vue'
   import { AppEvent } from '@/common/AppEvent'
   import { FavoriteQuery } from '@/common/appdb/models/favorite_query'
+  import { makeDBHint, queryTable } from '@/lib/editor'
 
   const log = rawlog.scope('query-editor')
   const isEmpty = (s) => _.isEmpty(_.trim(s))

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -915,8 +915,8 @@
       fakeRemoteChange() {
         this.query.text = "select * from foo"
       },
-      async getColumnsForAutocomplete(tableName) {
-        const tableToFind = queryTable(this.hintOptions.dbHint, tableName)
+      async getColumnsForAutocomplete(table) {
+        const tableToFind = this.tables.find(({name, schema}) => table.name === name && table.schema === schema)
         if (!tableToFind) return null
         // Only refresh columns if we don't have them cached.
         if (!tableToFind.columns?.length) {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -342,8 +342,8 @@
         return this.connection.connectionType;
       },
       hintOptions() {
-        const dbHint = makeDBHint(this.tables, this.dialectData)
-        return { tables: dbHint.tables, schemas: dbHint.schemas }
+        const dbHint = makeDBHint(this.tables, this.dialectData, this.defaultSchema)
+        return { dbHint }
       },
       queryParameterPlaceholders() {
         let params = this.individualQueries.flatMap((qs) => qs.parameters)
@@ -916,7 +916,7 @@
         this.query.text = "select * from foo"
       },
       async getColumnsForAutocomplete(tableName) {
-        const tableToFind = queryTable(tableName, this.tables)
+        const tableToFind = queryTable(this.hintOptions.dbHint, tableName)
         if (!tableToFind) return null
         // Only refresh columns if we don't have them cached.
         if (!tableToFind.columns?.length) {

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -89,12 +89,7 @@ export function makeDBHint(
   };
 }
 
-const SCHEMA_TABLE = new RegExp(
-  "(?:(?<schema>[quote]?.+?[quote]?)\\.(?<table1>[quote]?.+[quote]?)|(?<table2>[quote]?.+[quote]?))".replaceAll(
-    "quote",
-    "'\"`"
-  )
-);
+const SCHEMA_TABLE = /(?:(?<schema>(['"`]?).+?\2?)\.(?<table1>(['"`]?).+\4?)|(?<table2>(['"`]?).+\6?))/
 
 export function queryTable(dbHint: DBHint, query: string) {
   const schemaTable = SCHEMA_TABLE.exec(query);
@@ -162,5 +157,5 @@ export function isQuote(str: string) {
 const WORD_SPLITTER = /`[^`]*`[^\s]*|'[^']*'[^\s]*|"[^"]*"[^\s]*|[^\s]+/g;
 
 export function splitWords(text: string) {
-  return text.match(WORD_SPLITTER);
+  return text.match(WORD_SPLITTER) || [];
 }

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -1,4 +1,5 @@
 import type { TableOrView } from "@/lib/db/models";
+import { DialectData } from "@shared/lib/dialects/models";
 
 interface DBHintTable {
   name: string;
@@ -22,16 +23,13 @@ interface DBHint {
 
 export function makeDBHint(
   tables: TableOrView[],
-  connectionType: string
+  dialectData: DialectData,
 ): DBHint {
   const schemaSet: Set<string> = new Set();
   const hintTables: DBHintTable[] = [];
   tables.forEach((table) => {
     hintTables.push({
-      name:
-        connectionType === "postgresql"
-          ? sanitizeTableName(table.name)
-          : table.name,
+      name: dialectData.maybeWrapIdentifier(table.name),
       schema: table.schema,
     });
     if (table.schema) schemaSet.add(table.schema);
@@ -95,10 +93,4 @@ export function pushTablesToResult(
       };
     })
   );
-}
-
-const tableNameValidationRegex = /(?:[^a-z0-9_]|^\d)/;
-
-export function sanitizeTableName(name: string): string {
-  return tableNameValidationRegex.test(name) ? `"${name}"` : name;
 }

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -94,6 +94,13 @@ export function findTablesBySchema(dbHint: DBHint, schema: string) {
   return dbHint.tableWords.filter((table) => table.schema === schema);
 }
 
+export function findTableOrViewByWord(tableOrViews: TableOrView[], word: Word) {
+  return tableOrViews.find(
+    (tableOrView) =>
+      tableOrView.name === word.name && tableOrView.schema === word.schema
+  );
+}
+
 export function splitSchemaTable(str: string) {
   const [schema, ...table] = str.split(".");
   return [schema, table.join(".")];

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -9,9 +9,7 @@ interface Word {
 }
 
 /**
- * A list of all words in key-value form, where the key is the word in uppercase.
- * It's best to use the `findWord` function to find a word, as it will handle
- * uppercase and lowercase words.
+ * A list of all words in key-value form, where the key is the word that's case sensitive.
  */
 type WordList = Record<string, Word>;
 
@@ -27,11 +25,8 @@ export interface DBHint {
   schemaWordList: WordList;
 }
 
-/**
- * Use this instead of accessing the wordList directly
- */
 export function findWord(wordList: WordList, word: string) {
-  return wordList[word.toUpperCase()];
+  return wordList[word];
 }
 
 export function makeDBHint(
@@ -56,16 +51,17 @@ export function makeDBHint(
 
     tableWords.push(word);
 
-    return {
-      ...acc,
-      [table.name.toUpperCase()]: word,
-    };
+    const key = table.name;
+    const registeredWord = acc[key];
+    if (registeredWord && registeredWord.schema === defaultSchema) return acc;
+
+    return { ...acc, [key]: word };
   }, {});
 
   const schemaWordList = Array.from(schemaSet).reduce(
     (acc, name) => ({
       ...acc,
-      [name.toUpperCase()]: {
+      [name]: {
         name,
         text: name,
         type: "schema",
@@ -95,4 +91,9 @@ export function queryTable(dbHint: DBHint, query: string) {
 
 export function findTablesBySchema(dbHint: DBHint, schema: string) {
   return dbHint.tableWords.filter((table) => table.schema === schema);
+}
+
+export function splitSchemaTable(str: string) {
+  const [schema, ...table] = str.split(".");
+  return [schema, table.join(".")];
 }

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -32,10 +32,11 @@ export function findWord(wordList: WordList, word: string) {
 export function makeDBHint(
   tables: TableOrView[],
   dialectData: DialectData,
-  defaultSchema?: string
+  defaultSchema?: string | null
 ): DBHint {
   const schemaSet = new Set<string>();
   if (defaultSchema) schemaSet.add(defaultSchema);
+  if(defaultSchema === null) defaultSchema = undefined;
 
   const tableWords: Word[] = [];
 

--- a/apps/studio/src/lib/editor.ts
+++ b/apps/studio/src/lib/editor.ts
@@ -1,0 +1,104 @@
+import type { TableOrView } from "@/lib/db/models";
+
+interface DBHintTable {
+  name: string;
+  schema?: string;
+}
+
+type DBHintSchema = string;
+
+interface Word {
+  text: string;
+  type: "table" | "schema";
+  schema?: string;
+}
+
+type WordList = Record<string, Word>;
+
+interface DBHint {
+  tables: DBHintTable[];
+  schemas: DBHintSchema[];
+}
+
+export function makeDBHint(
+  tables: TableOrView[],
+  connectionType: string
+): DBHint {
+  const schemaSet: Set<string> = new Set();
+  const hintTables: DBHintTable[] = [];
+  tables.forEach((table) => {
+    hintTables.push({
+      name:
+        connectionType === "postgresql"
+          ? sanitizeTableName(table.name)
+          : table.name,
+      schema: table.schema,
+    });
+    if (table.schema) schemaSet.add(table.schema);
+  });
+  return {
+    tables: hintTables,
+    schemas: Array.from(schemaSet),
+  };
+}
+
+export function parseDBHintTables(tables: DBHintTable[]): WordList {
+  return tables.reduce(
+    (acc, table) => ({
+      ...acc,
+      [table.name.toUpperCase()]: {
+        text: table.name,
+        type: "table" as const,
+        schema: table.schema,
+      },
+    }),
+    {}
+  );
+}
+
+export function parseDBHintTable(table: DBHintTable): Word {
+  return {
+    text: table.name,
+    type: "table" as const,
+    schema: table.schema,
+  };
+}
+
+const captureTableNameRegex = /"(.*)"/;
+
+export function queryTable(
+  query: string,
+  tables: DBHintTable[] | TableOrView[]
+) {
+  const tableNameQuery = captureTableNameRegex.exec(query)?.[1] || query;
+  return tables.find(
+    (table) =>
+      `${table.schema}.${table.name}` === query || table.name === tableNameQuery
+  );
+}
+
+export function findTablesBySchema(schema: string, tables: DBHintTable[]) {
+  return tables.filter((table) => table.schema === schema);
+}
+
+export function pushTablesToResult(
+  tables: DBHintTable[],
+  result: any[],
+  textModifier?: (text: string) => string
+) {
+  result.push(
+    ...tables.map((table) => {
+      const tableName = textModifier ? textModifier(table.name) : table.name;
+      return {
+        text: table.schema ? `${table.schema}.${tableName}` : tableName,
+        displayText: table.name,
+      };
+    })
+  );
+}
+
+const tableNameValidationRegex = /(?:[^a-z0-9_]|^\d)/;
+
+export function sanitizeTableName(name: string): string {
+  return tableNameValidationRegex.test(name) ? `"${name}"` : name;
+}

--- a/apps/studio/src/vendor/sql-hint/index.js
+++ b/apps/studio/src/vendor/sql-hint/index.js
@@ -147,7 +147,7 @@ const { parseDBHintTables, findTablesBySchema, pushTablesToResult, queryTable, p
     }
 
     const maybeSchema = nameParts[0];
-    if (schemaList.includes(maybeSchema)) {
+    if (nameParts.length <= 2 && schemaList.includes(maybeSchema)) {
       const tables = findTablesBySchema(maybeSchema, hintTables);
       pushTablesToResult(tables, result, (tableName) =>
         useIdentifierQuotes ? insertIdentifierQuotes(tableName) : tableName

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -132,3 +132,32 @@ export const dbHint: DBHint = {
     },
   },
 };
+
+export const tableOrViewsWithoutSchema: TableOrView[] = [
+  {
+    name: "my_table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+];
+
+export const dbHintWithoutSchema: DBHint = {
+  tableWordList: {
+    my_table: {
+      name: "my_table",
+      text: "my_table",
+      type: "table",
+    },
+  },
+  tableWords: [
+    {
+      name: "my_table",
+      text: "my_table",
+      type: "table",
+    },
+  ],
+  schemaWordList: {},
+};
+

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -19,6 +19,30 @@ export const tableOrViews: TableOrView[] = [
     columns: [],
   },
   {
+    schema: "public",
+    name: "CASE_SENSITIVE_table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+  {
+    schema: "public",
+    name: "CASE_sensitive_table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+  {
+    schema: "_timescaledb_cache",
+    name: "my_table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+  {
     schema: "_timescaledb_cache",
     name: "cache_inval_bgw_job",
     tabletype: "r",
@@ -30,23 +54,35 @@ export const tableOrViews: TableOrView[] = [
 
 export const dbHint: DBHint = {
   tableWordList: {
-    MY_TABLE: {
+    my_table: {
       name: "my_table",
       text: "my_table",
       type: "table",
       schema: "public",
     },
-    "SPECIAL+TABLE": {
+    "special+table": {
       name: "special+table",
       text: '"special+table"',
       type: "table",
       schema: "public",
     },
-    CACHE_INVAL_BGW_JOB: {
+    cache_inval_bgw_job: {
       name: "cache_inval_bgw_job",
       text: "cache_inval_bgw_job",
       type: "table",
       schema: "_timescaledb_cache",
+    },
+    CASE_SENSITIVE_table: {
+      name: "CASE_SENSITIVE_table",
+      text: '"CASE_SENSITIVE_table"',
+      type: "table",
+      schema: "public",
+    },
+    CASE_sensitive_table: {
+      name: "CASE_sensitive_table",
+      text: '"CASE_sensitive_table"',
+      type: "table",
+      schema: "public",
     },
   },
   tableWords: [
@@ -63,6 +99,24 @@ export const dbHint: DBHint = {
       schema: "public",
     },
     {
+      name: "CASE_SENSITIVE_table",
+      text: '"CASE_SENSITIVE_table"',
+      type: "table",
+      schema: "public",
+    },
+    {
+      name: "CASE_sensitive_table",
+      text: '"CASE_sensitive_table"',
+      type: "table",
+      schema: "public",
+    },
+    {
+      name: "my_table",
+      text: "my_table",
+      type: "table",
+      schema: "_timescaledb_cache",
+    },
+    {
       name: "cache_inval_bgw_job",
       text: "cache_inval_bgw_job",
       type: "table",
@@ -70,12 +124,11 @@ export const dbHint: DBHint = {
     },
   ],
   schemaWordList: {
-    PUBLIC: { name: "public", text: "public", type: "schema" },
-    _TIMESCALEDB_CACHE:
-    {
+    public: { name: "public", text: "public", type: "schema" },
+    _timescaledb_cache: {
       name: "_timescaledb_cache",
       text: "_timescaledb_cache",
       type: "schema",
     },
-  }
+  },
 };

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -1,3 +1,5 @@
+import { PostgresData } from "../../../../shared/src/lib/dialects/postgresql";
+import { SqliteData } from "../../../../shared/src/lib/dialects/sqlite";
 import { TableOrView } from "../../src/lib/db/models";
 import { DBHint } from "../../src/lib/editor";
 
@@ -53,7 +55,8 @@ export const tableOrViews: TableOrView[] = [
 ];
 
 export const dbHint: DBHint = {
-  tableWordList: {
+  defaultSchema: "public",
+  defaultTableWordList: {
     my_table: {
       name: "my_table",
       text: "my_table",
@@ -65,12 +68,6 @@ export const dbHint: DBHint = {
       text: '"special+table"',
       type: "table",
       schema: "public",
-    },
-    cache_inval_bgw_job: {
-      name: "cache_inval_bgw_job",
-      text: "cache_inval_bgw_job",
-      type: "table",
-      schema: "_timescaledb_cache",
     },
     CASE_SENSITIVE_table: {
       name: "CASE_SENSITIVE_table",
@@ -131,6 +128,7 @@ export const dbHint: DBHint = {
       type: "schema",
     },
   },
+  dialect: PostgresData,
 };
 
 export const tableOrViewsWithoutSchema: TableOrView[] = [
@@ -144,7 +142,7 @@ export const tableOrViewsWithoutSchema: TableOrView[] = [
 ];
 
 export const dbHintWithoutSchema: DBHint = {
-  tableWordList: {
+  defaultTableWordList: {
     my_table: {
       name: "my_table",
       text: "my_table",
@@ -159,5 +157,5 @@ export const dbHintWithoutSchema: DBHint = {
     },
   ],
   schemaWordList: {},
+  dialect: SqliteData,
 };
-

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -1,4 +1,5 @@
 import { TableOrView } from "../../src/lib/db/models";
+import { DBHint } from "../../src/lib/editor";
 
 export const tableOrViews: TableOrView[] = [
   {
@@ -26,3 +27,55 @@ export const tableOrViews: TableOrView[] = [
     columns: [],
   },
 ];
+
+export const dbHint: DBHint = {
+  tableWordList: {
+    MY_TABLE: {
+      name: "my_table",
+      text: "my_table",
+      type: "table",
+      schema: "public",
+    },
+    "SPECIAL+TABLE": {
+      name: "special+table",
+      text: '"special+table"',
+      type: "table",
+      schema: "public",
+    },
+    CACHE_INVAL_BGW_JOB: {
+      name: "cache_inval_bgw_job",
+      text: "cache_inval_bgw_job",
+      type: "table",
+      schema: "_timescaledb_cache",
+    },
+  },
+  tableWords: [
+    {
+      name: "my_table",
+      text: "my_table",
+      type: "table",
+      schema: "public",
+    },
+    {
+      name: "special+table",
+      text: '"special+table"',
+      type: "table",
+      schema: "public",
+    },
+    {
+      name: "cache_inval_bgw_job",
+      text: "cache_inval_bgw_job",
+      type: "table",
+      schema: "_timescaledb_cache",
+    },
+  ],
+  schemaWordList: {
+    PUBLIC: { name: "public", text: "public", type: "schema" },
+    _TIMESCALEDB_CACHE:
+    {
+      name: "_timescaledb_cache",
+      text: "_timescaledb_cache",
+      type: "schema",
+    },
+  }
+};

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -52,6 +52,14 @@ export const tableOrViews: TableOrView[] = [
     entityType: "table",
     columns: [],
   },
+  {
+    schema: "schema with spaces",
+    name: "testtable",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
 ];
 
 export const dbHint: DBHint = {
@@ -119,12 +127,23 @@ export const dbHint: DBHint = {
       type: "table",
       schema: "_timescaledb_cache",
     },
+    {
+      name: "testtable",
+      text: "testtable",
+      type: "table",
+      schema: "schema with spaces",
+    },
   ],
   schemaWordList: {
     public: { name: "public", text: "public", type: "schema" },
     _timescaledb_cache: {
       name: "_timescaledb_cache",
       text: "_timescaledb_cache",
+      type: "schema",
+    },
+    "schema with spaces": {
+      name: "schema with spaces",
+      text: '"schema with spaces"',
       type: "schema",
     },
   },

--- a/apps/studio/tests/fixtures/tables.ts
+++ b/apps/studio/tests/fixtures/tables.ts
@@ -1,0 +1,28 @@
+import { TableOrView } from "../../src/lib/db/models";
+
+export const tableOrViews: TableOrView[] = [
+  {
+    schema: "public",
+    name: "my_table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+  {
+    schema: "public",
+    name: "special+table",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+  {
+    schema: "_timescaledb_cache",
+    name: "cache_inval_bgw_job",
+    tabletype: "r",
+    parenttype: null,
+    entityType: "table",
+    columns: [],
+  },
+];

--- a/apps/studio/tests/unit/lib/editor.spec.js
+++ b/apps/studio/tests/unit/lib/editor.spec.js
@@ -4,8 +4,14 @@ import {
   findTablesBySchema,
   findWord,
   splitSchemaTable,
+  findTableOrViewByWord,
 } from "../../../src/lib/editor";
-import { dbHint, tableOrViews } from "../../fixtures/tables";
+import {
+  dbHint,
+  dbHintWithoutSchema,
+  tableOrViews,
+  tableOrViewsWithoutSchema,
+} from "../../fixtures/tables";
 import { PostgresData } from "../../../../../shared/src/lib/dialects/postgresql";
 import { SqliteData } from "../../../../../shared/src/lib/dialects/sqlite";
 import { SqlServerData } from "../../../../../shared/src/lib/dialects/sqlserver";
@@ -77,6 +83,12 @@ describe("lib/editor", () => {
     const dialectData = SqliteData;
     const defaultSchema = null;
 
+    it("should make arrays of tables and schemas", () => {
+      expect(
+        makeDBHint(tableOrViewsWithoutSchema, dialectData, defaultSchema)
+      ).toEqual(dbHintWithoutSchema);
+    });
+
     it("should return empty array of tables and schemas", () => {
       expect(makeDBHint([], dialectData, defaultSchema)).toEqual({
         tableWordList: {},
@@ -108,6 +120,24 @@ describe("lib/editor", () => {
           schema: "_timescaledb_cache",
         },
       ]);
+    });
+  });
+
+  describe("findTableOrViewByWord", () => {
+    it("should find a tableOrView by word (with schema)", () => {
+      const tableWord = queryTable(dbHint, "my_table");
+      expect(findTableOrViewByWord(tableOrViews, tableWord)).toMatchObject({
+        name: "my_table",
+      });
+    });
+
+    it("should find a tableOrView by word (without schema)", () => {
+      const tableWord = queryTable(dbHintWithoutSchema, "my_table");
+      expect(
+        findTableOrViewByWord(tableOrViewsWithoutSchema, tableWord)
+      ).toMatchObject({
+        name: "my_table",
+      });
     });
   });
 

--- a/apps/studio/tests/unit/lib/editor.spec.js
+++ b/apps/studio/tests/unit/lib/editor.spec.js
@@ -1,0 +1,130 @@
+import {
+  makeDBHint,
+  parseDBHintTable,
+  parseDBHintTables,
+  queryTable,
+  findTablesBySchema,
+  pushTablesToResult,
+  sanitizeTableName,
+} from "../../../src/lib/editor";
+import { tableOrViews } from "../../fixtures/tables";
+
+describe("lib/editor", () => {
+  let dbHint;
+
+  beforeAll(() => {
+    dbHint = makeDBHint(tableOrViews, "postgresql");
+  });
+
+  describe("makeDBHint", () => {
+    it("should make arrays of tables and schemas", () => {
+      expect(makeDBHint(tableOrViews, "postgresql")).toEqual({
+        tables: [
+          { name: "my_table", schema: "public" },
+          { name: '"special+table"', schema: "public" },
+          { name: "cache_inval_bgw_job", schema: "_timescaledb_cache" },
+        ],
+        schemas: ["public", "_timescaledb_cache"],
+      });
+    });
+
+    it("should return empty array when there is no table or schema", () => {
+      expect(makeDBHint([])).toEqual({ tables: [], schemas: [] });
+      expect(makeDBHint([{ name: "my_table" }])).toEqual({
+        tables: [{ name: "my_table" }],
+        schemas: [],
+      });
+    });
+  });
+
+  describe("parseDBHintTables", () => {
+    it("should parse tables for addMatches() wordList", () => {
+      const wordList = parseDBHintTables(dbHint.tables);
+      expect(wordList).toEqual({
+        MY_TABLE: { text: "my_table", type: "table", schema: "public" },
+        '"SPECIAL+TABLE"': {
+          text: '"special+table"',
+          type: "table",
+          schema: "public",
+        },
+        CACHE_INVAL_BGW_JOB: {
+          text: "cache_inval_bgw_job",
+          type: "table",
+          schema: "_timescaledb_cache",
+        },
+      });
+    });
+  });
+
+  describe("parseDBHintTable", () => {
+    it("should parse one table", () => {
+      expect(parseDBHintTable(dbHint.tables[0])).toEqual({
+        text: "my_table",
+        type: "table",
+        schema: "public",
+      });
+    });
+  });
+
+  describe("findTablesBySchema", () => {
+    it("should find tables by schema", () => {
+      const tables = findTablesBySchema("_timescaledb_cache", dbHint.tables);
+      expect(tables).toEqual([
+        {
+          name: "cache_inval_bgw_job",
+          schema: "_timescaledb_cache",
+        },
+      ]);
+    });
+  });
+
+  describe("pushTablesToResult", () => {
+    it("should mutably push tables to result (like addMatches)", () => {
+      const tables = [
+        {
+          name: "my_table",
+          schema: "public",
+        },
+      ];
+      const result = [];
+      pushTablesToResult(tables, result);
+      expect(result).toEqual([
+        {
+          text: "public.my_table",
+          displayText: "my_table",
+        },
+      ]);
+    });
+  });
+
+  describe("queryTable", () => {
+    it("should query a table", () => {
+      expect(queryTable("my_table", dbHint.tables)).toEqual({
+        name: "my_table",
+        schema: "public",
+      });
+      expect(queryTable("public.my_table", dbHint.tables)).toEqual({
+        name: "my_table",
+        schema: "public",
+      });
+    });
+
+    it("should query a table inside quotes", () => {
+      expect(queryTable('"special+table"', tableOrViews)).toMatchObject({
+        name: 'special+table',
+        schema: "public",
+      });
+      expect(queryTable('public."special+table"', tableOrViews)).toMatchObject({
+        name: 'special+table',
+        schema: "public",
+      });
+    });
+  });
+
+  describe("sanitizeTableName", () => {
+    it("should sanitize table names", () => {
+      expect(sanitizeTableName("my+table")).toEqual('"my+table"');
+      expect(sanitizeTableName("1my_table")).toEqual('"1my_table"');
+    });
+  });
+});

--- a/apps/studio/tests/unit/lib/editor.spec.js
+++ b/apps/studio/tests/unit/lib/editor.spec.js
@@ -5,20 +5,22 @@ import {
   queryTable,
   findTablesBySchema,
   pushTablesToResult,
-  sanitizeTableName,
 } from "../../../src/lib/editor";
 import { tableOrViews } from "../../fixtures/tables";
+import { PostgresData } from "../../../../../shared/src/lib/dialects/postgresql";
+
+const dialectData = PostgresData;
 
 describe("lib/editor", () => {
   let dbHint;
 
   beforeAll(() => {
-    dbHint = makeDBHint(tableOrViews, "postgresql");
+    dbHint = makeDBHint(tableOrViews, dialectData);
   });
 
   describe("makeDBHint", () => {
     it("should make arrays of tables and schemas", () => {
-      expect(makeDBHint(tableOrViews, "postgresql")).toEqual({
+      expect(makeDBHint(tableOrViews, dialectData)).toEqual({
         tables: [
           { name: "my_table", schema: "public" },
           { name: '"special+table"', schema: "public" },
@@ -29,8 +31,8 @@ describe("lib/editor", () => {
     });
 
     it("should return empty array when there is no table or schema", () => {
-      expect(makeDBHint([])).toEqual({ tables: [], schemas: [] });
-      expect(makeDBHint([{ name: "my_table" }])).toEqual({
+      expect(makeDBHint([], dialectData)).toEqual({ tables: [], schemas: [] });
+      expect(makeDBHint([{ name: "my_table" }], dialectData)).toEqual({
         tables: [{ name: "my_table" }],
         schemas: [],
       });
@@ -118,13 +120,6 @@ describe("lib/editor", () => {
         name: 'special+table',
         schema: "public",
       });
-    });
-  });
-
-  describe("sanitizeTableName", () => {
-    it("should sanitize table names", () => {
-      expect(sanitizeTableName("my+table")).toEqual('"my+table"');
-      expect(sanitizeTableName("1my_table")).toEqual('"1my_table"');
     });
   });
 });

--- a/apps/studio/tests/unit/lib/editor.spec.js
+++ b/apps/studio/tests/unit/lib/editor.spec.js
@@ -265,10 +265,7 @@ describe("lib/editor", () => {
 
   describe("separateWords", () => {
     it("should separate a text into words", () => {
-      expect(splitWords("FROM public.table")).toEqual([
-        "FROM",
-        "public.table",
-      ]);
+      expect(splitWords("FROM public.table")).toEqual(["FROM", "public.table"]);
       expect(splitWords("FROM `my table` AS t")).toEqual([
         "FROM",
         "`my table`",

--- a/apps/studio/tests/unit/lib/editor.spec.js
+++ b/apps/studio/tests/unit/lib/editor.spec.js
@@ -75,7 +75,7 @@ describe("lib/editor", () => {
 
   describe("makeDBHint (DB without schemas)", () => {
     const dialectData = SqliteData;
-    const defaultSchema = undefined;
+    const defaultSchema = null;
 
     it("should return empty array of tables and schemas", () => {
       expect(makeDBHint([], dialectData, defaultSchema)).toEqual({
@@ -87,9 +87,9 @@ describe("lib/editor", () => {
         makeDBHint([{ name: "my_table" }], dialectData, defaultSchema)
       ).toMatchObject({
         tableWordList: {
-          my_table: { name: "my_table" },
+          my_table: { name: "my_table", schema: undefined },
         },
-        tableWords: [{ name: "my_table" }],
+        tableWords: [{ name: "my_table", schema: undefined }],
         schemaWordList: {},
       });
     });

--- a/shared/src/lib/dialects/models.ts
+++ b/shared/src/lib/dialects/models.ts
@@ -80,6 +80,7 @@ export interface DialectData {
   columnTypes: ColumnType[],
   constraintActions: string[]
   wrapIdentifier: (s: string) => string
+  maybeWrapIdentifier: (s: string) => string
   escapeString: (s: string, quote?: boolean) => string
   wrapLiteral: (s: string) => string
   disabledFeatures?: {
@@ -138,6 +139,12 @@ export function defaultWrapLiteral(str: string): string {
 
 export function defaultWrapIdentifier(value: string): string {
   return value ? `"${value.replaceAll(/"/g, '""')}"` : ''
+}
+
+const mayebWrapIdentifierRegex = /(?:[^a-z0-9_]|^\d)/;
+
+export function defaultMaybeWrapIdentifier(value: string): string {
+  return mayebWrapIdentifierRegex.test(value) ? `"${value}"` : value;
 }
 
 export interface SchemaConfig {

--- a/shared/src/lib/dialects/models.ts
+++ b/shared/src/lib/dialects/models.ts
@@ -80,9 +80,10 @@ export interface DialectData {
   columnTypes: ColumnType[],
   constraintActions: string[]
   wrapIdentifier: (s: string) => string
-  maybeWrapIdentifier: (s: string) => string
+  friendlyNormalizedIdentifier: (s: string) => string
   escapeString: (s: string, quote?: boolean) => string
   wrapLiteral: (s: string) => string
+  unwrapIdentifier: (s: string) => string
   disabledFeatures?: {
     informationSchema?: {
       extra?: boolean
@@ -143,8 +144,8 @@ export function defaultWrapIdentifier(value: string): string {
 
 const mayebWrapIdentifierRegex = /(?:[^a-z0-9_]|^\d)/;
 
-export function defaultMaybeWrapIdentifier(value: string): string {
-  return mayebWrapIdentifierRegex.test(value) ? `"${value}"` : value;
+export function friendlyNormalizedIdentifier(value: string, quote: '`' | "'" | '"' = '"'): string {
+  return mayebWrapIdentifierRegex.test(value) ? `${quote}${value}${quote}` : value;
 }
 
 export interface SchemaConfig {

--- a/shared/src/lib/dialects/mysql.ts
+++ b/shared/src/lib/dialects/mysql.ts
@@ -3,7 +3,7 @@ import {
   ColumnType,
   defaultConstraintActions,
   defaultEscapeString,
-  defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier,
   DialectData,
   SpecialTypes,
 } from "./models";
@@ -21,16 +21,22 @@ const supportsLength = [
 
 const defaultLength = (t: string) => t.startsWith('var') ? 255 : 8
 
+const UNWRAPPER = /^`(.*)`$/
+
 export const MysqlData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [...defaultConstraintActions, 'RESTRICT'],
   wrapIdentifier(value: string) {
     return (value !== '*' ? `\`${value.replaceAll(/`/g, '``')}\`` : '*');
   },
-  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier: (s) => friendlyNormalizedIdentifier(s, '`'),
   escapeString: defaultEscapeString,
   wrapLiteral(value: string) {
     return value.replaceAll(';', '')
+  },
+  unwrapIdentifier(value: string) {
+    const matched = value.match(UNWRAPPER);
+    return matched ? matched[1] : value;
   },
   disabledFeatures: {
     alter: {

--- a/shared/src/lib/dialects/mysql.ts
+++ b/shared/src/lib/dialects/mysql.ts
@@ -1,5 +1,13 @@
-import _ from "lodash"
-import { ColumnType, defaultConstraintActions, defaultEscapeString, DialectData, SpecialTypes } from "./models"
+import _ from "lodash";
+import {
+  ColumnType,
+  defaultConstraintActions,
+  defaultEscapeString,
+  defaultMaybeWrapIdentifier,
+  DialectData,
+  SpecialTypes,
+} from "./models";
+
 
 
 const types = [
@@ -19,6 +27,7 @@ export const MysqlData: DialectData = {
   wrapIdentifier(value: string) {
     return (value !== '*' ? `\`${value.replaceAll(/`/g, '``')}\`` : '*');
   },
+  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
   escapeString: defaultEscapeString,
   wrapLiteral(value: string) {
     return value.replaceAll(';', '')

--- a/shared/src/lib/dialects/postgresql.ts
+++ b/shared/src/lib/dialects/postgresql.ts
@@ -1,6 +1,12 @@
-import { ColumnType, defaultConstraintActions, defaultEscapeString, defaultWrapLiteral, DialectData, SpecialTypes } from "./models";
-
-
+import {
+  ColumnType,
+  defaultConstraintActions,
+  defaultEscapeString,
+  defaultMaybeWrapIdentifier,
+  defaultWrapLiteral,
+  DialectData,
+  SpecialTypes,
+} from "./models";
 
 const types = [
   ...SpecialTypes,
@@ -25,6 +31,7 @@ export const PostgresData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [...defaultConstraintActions, 'RESTRICT'],
   wrapIdentifier: (id: string) => id ? `"${id.replaceAll(/"/g, '""')}"` : null,
+  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
   disabledFeatures: {

--- a/shared/src/lib/dialects/postgresql.ts
+++ b/shared/src/lib/dialects/postgresql.ts
@@ -2,7 +2,7 @@ import {
   ColumnType,
   defaultConstraintActions,
   defaultEscapeString,
-  defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier,
   defaultWrapLiteral,
   DialectData,
   SpecialTypes,
@@ -27,13 +27,19 @@ const charsets = [
   'BIG5', 'EUC_CN', 'EUC_JP', 'EUC_JIS_2004', 'EUC_KR', 'EUC_TW', 'GB18030', 'GBK', 'ISO_8859_5', 'ISO_8859_6', 'ISO_8859_7', 'ISO_8859_8', 'JOHAB', 'KOI8R', 'KOI8U', 'LATIN1', 'LATIN2', 'LATIN3', 'LATIN4', 'LATIN5', 'LATIN6', 'LATIN7', 'LATIN8', 'LATIN9', 'LATIN10', 'MULE_INTERNAL', 'SJIS', 'SHIFT_JIS_2004', 'SQL_ASCII', 'UHC', 'UTF8', 'WIN866', 'WIN874', 'WIN1250', 'WIN1251', 'WIN1252', 'WIN1253', 'WIN1254', 'WIN1255', 'WIN1256', 'WIN1257', 'WIN1258'
 ]
 
+const UNWRAPPER = /^"(.*)"$/
+
 export const PostgresData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [...defaultConstraintActions, 'RESTRICT'],
   wrapIdentifier: (id: string) => id ? `"${id.replaceAll(/"/g, '""')}"` : null,
-  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier: (s) => friendlyNormalizedIdentifier(s, '"'),
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
+  unwrapIdentifier(value: string) {
+    const matched = value.match(UNWRAPPER);
+    return matched ? matched[1] : value;
+  },
   disabledFeatures: {
     informationSchema: {
       extra: true

--- a/shared/src/lib/dialects/redshift.ts
+++ b/shared/src/lib/dialects/redshift.ts
@@ -1,4 +1,11 @@
-import { ColumnType, defaultEscapeString, defaultWrapLiteral, DialectData, SpecialTypes } from "./models";
+import {
+  ColumnType,
+  defaultEscapeString,
+  defaultMaybeWrapIdentifier,
+  defaultWrapLiteral,
+  DialectData,
+  SpecialTypes,
+} from "./models";
 
 const types = [
   ...SpecialTypes,
@@ -18,6 +25,7 @@ export const RedshiftData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [],
   wrapIdentifier: (id: string) => `"${id.replaceAll(/"/g, '""')}"`,
+  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
   disabledFeatures: {

--- a/shared/src/lib/dialects/redshift.ts
+++ b/shared/src/lib/dialects/redshift.ts
@@ -1,7 +1,7 @@
 import {
   ColumnType,
   defaultEscapeString,
-  defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier,
   defaultWrapLiteral,
   DialectData,
   SpecialTypes,
@@ -25,9 +25,10 @@ export const RedshiftData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [],
   wrapIdentifier: (id: string) => `"${id.replaceAll(/"/g, '""')}"`,
-  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier: friendlyNormalizedIdentifier,
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
+  unwrapIdentifier: (s) => s,
   disabledFeatures: {
     alter: {
       multiStatement: true

--- a/shared/src/lib/dialects/sqlite.ts
+++ b/shared/src/lib/dialects/sqlite.ts
@@ -2,7 +2,7 @@ import {
   ColumnType,
   defaultConstraintActions,
   defaultEscapeString,
-  defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier,
   defaultWrapIdentifier,
   defaultWrapLiteral,
   DialectData,
@@ -20,6 +20,7 @@ const supportsLength = [
 
 const defaultLength = (t: string) => t.startsWith('var') ? 255 : 8
 
+const UNWRAPPER = /^(?:`(.*)`|'(.*)'|"(.*)")$/
 
 export const SqliteData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
@@ -27,7 +28,12 @@ export const SqliteData: DialectData = {
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
   wrapIdentifier: defaultWrapIdentifier,
-  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier: friendlyNormalizedIdentifier,
+  unwrapIdentifier(value: string) {
+    const matched = value.match(UNWRAPPER);
+    if (matched) return matched[1] || matched[2] || matched[3];
+    return value;
+  },
   disabledFeatures: {
     comments: true,
     alter: {

--- a/shared/src/lib/dialects/sqlite.ts
+++ b/shared/src/lib/dialects/sqlite.ts
@@ -1,5 +1,13 @@
-import { ColumnType, defaultConstraintActions, defaultEscapeString, defaultWrapIdentifier, defaultWrapLiteral, DialectData, SpecialTypes } from "./models"
-
+import {
+  ColumnType,
+  defaultConstraintActions,
+  defaultEscapeString,
+  defaultMaybeWrapIdentifier,
+  defaultWrapIdentifier,
+  defaultWrapLiteral,
+  DialectData,
+  SpecialTypes,
+} from "./models";
 
 const types = [
   ...SpecialTypes,
@@ -19,6 +27,7 @@ export const SqliteData: DialectData = {
   escapeString: defaultEscapeString,
   wrapLiteral: defaultWrapLiteral,
   wrapIdentifier: defaultWrapIdentifier,
+  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
   disabledFeatures: {
     comments: true,
     alter: {

--- a/shared/src/lib/dialects/sqlserver.ts
+++ b/shared/src/lib/dialects/sqlserver.ts
@@ -3,7 +3,7 @@ import {
   ColumnType,
   defaultConstraintActions,
   defaultEscapeString,
-  defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier,
   defaultWrapLiteral,
   DialectData,
   SpecialTypes,
@@ -27,13 +27,19 @@ export interface DefaultConstraint {
   table: string
 }
 
+const UNWRAPPER = /^"(.*)"$/
+
 export const SqlServerData: DialectData = {
   columnTypes: types.map((t) => new ColumnType(t, supportsLength.includes(t), defaultLength(t))),
   constraintActions: [...defaultConstraintActions],
   wrapIdentifier: (value) =>   _.isString(value) ?
     (value !== '*' ? `[${value.replace(/\[/g, '[')}]` : '*') : value,
-  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
+  friendlyNormalizedIdentifier: (s) => friendlyNormalizedIdentifier(s, '"'),
   wrapLiteral: defaultWrapLiteral,
+  unwrapIdentifier(value: string) {
+    const matched = value.match(UNWRAPPER);
+    return matched ? matched[1] : value;
+  },
   escapeString: defaultEscapeString,
   disabledFeatures: {
     alter: {

--- a/shared/src/lib/dialects/sqlserver.ts
+++ b/shared/src/lib/dialects/sqlserver.ts
@@ -1,6 +1,13 @@
-import _ from "lodash"
-import { ColumnType, defaultConstraintActions, defaultEscapeString, defaultWrapLiteral, DialectData, SpecialTypes } from "./models"
-
+import _ from "lodash";
+import {
+  ColumnType,
+  defaultConstraintActions,
+  defaultEscapeString,
+  defaultMaybeWrapIdentifier,
+  defaultWrapLiteral,
+  DialectData,
+  SpecialTypes,
+} from "./models";
 
 const types = [
   ...SpecialTypes,
@@ -25,6 +32,7 @@ export const SqlServerData: DialectData = {
   constraintActions: [...defaultConstraintActions],
   wrapIdentifier: (value) =>   _.isString(value) ?
     (value !== '*' ? `[${value.replace(/\[/g, '[')}]` : '*') : value,
+  maybeWrapIdentifier: defaultMaybeWrapIdentifier,
   wrapLiteral: defaultWrapLiteral,
   escapeString: defaultEscapeString,
   disabledFeatures: {


### PR DESCRIPTION
fix #976 | fix #216 | fix #1184 

This is an attempt to support schema autocomplete with table alias and columns. I replaced some logics in the vendor file as it can't be modified anywhere outside nor tested. It's far easier to solve this when I can unit test the codes :smile:. Let me know if there are things that need to be worked around. I've also tested this in postgres and sqlite (making sure it doesn't break in database without schemas).

![bks-support-schema](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/28348f3a-edbd-4bc0-ad98-e622d9a65a6e)
