### PR TITLE
set container_name for compose .yml-based integration tests

### DIFF
--- a/apps/studio/tests/docker/cockroachdb.yml
+++ b/apps/studio/tests/docker/cockroachdb.yml
@@ -5,3 +5,4 @@ services:
     ports:
       - 26257
     command: start-single-node --insecure
+    container_name: test_cockroachdb

--- a/apps/studio/tests/docker/ssh.yml
+++ b/apps/studio/tests/docker/ssh.yml
@@ -4,6 +4,7 @@ volumes:
 services:
   postgres:
     image: postgres:13
+    container_name: test_ssh_postgres
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
@@ -16,6 +17,7 @@ services:
     build:
       context: ./
       dockerfile: ./SSHDockerFile
+    container_name: test_ssh
     environment:
       - PUID=1000
       - PGID=1000

--- a/apps/studio/tests/integration/lib/db/clients/cockroach.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cockroach.spec.js
@@ -12,7 +12,7 @@ describe("CockroachDB Tests", () => {
     const timeoutDefault = 5000
     jest.setTimeout(dbtimeout)
     environment = await new DockerComposeEnvironment("tests/docker", "cockroachdb.yml").up()
-    container = environment.getContainer('cockroachdb_1')
+    container = environment.getContainer('test_cockroachdb')
     jest.setTimeout(timeoutDefault)
     const config = {
       client: 'cockroachdb',

--- a/apps/studio/tests/integration/lib/db/clients/ssh.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh.spec.js
@@ -19,9 +19,9 @@ describe("SSH Tunnel Tests", () => {
       .withWaitStrategy(Wait.forHealthCheck())
       .up()
 
-    container = environment.getContainer('ssh_1')
+    container = environment.getContainer('test_ssh')
 
-    const db = environment.getContainer('postgres_1')
+    const db = environment.getContainer('test_ssh_postgres')
 
 
 


### PR DESCRIPTION
Fix `cockroachdb` and `ssh` integration tests by adding `container_name`'s (prefixed with `test_`) to their docker-compose `.yml` files, and using those names in their `.spec` files