### PR TITLE
Fix keymap user setting type and update styles

### DIFF
--- a/apps/studio/src/assets/styles/app/query-editor.scss
+++ b/apps/studio/src/assets/styles/app/query-editor.scss
@@ -50,6 +50,16 @@
       display: flex;
       align-items: center;
       padding: 0;
+
+      .keymap-label {
+        font-size: 95%;
+        padding-left: $gutter-w * 2.6;
+        cursor: pointer;
+        .material-icons {
+          position: absolute;
+          left: $gutter-h;
+        }
+      }
     }
     .btn-fab {
       i {
@@ -57,6 +67,7 @@
         font-size: 18px;
       }
     }
+   
   }
   .top-panel {
     .toolbar {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -216,7 +216,6 @@
       ...mapState('settings', ['settings']),
       userKeymap: {
         get() {
-          console.log('VALUE: ', this.settings?.keymap?.value)
           return this.settings?.keymap?.value ?? 'default';
         },
         set(value) {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -19,7 +19,12 @@
           <x-button class="btn btn-flat btn-small" menu>
             <i class="material-icons">settings</i>
             <x-menu>
-              <x-menuitem :key="t.value" v-for="t in keymapTypes" @click.prevent="userKeymap = t.name"> <x-label>{{t.name}}</x-label> </x-menuitem>
+              <x-menuitem :key="t.value" v-for="t in keymapTypes" @click.prevent="userKeymap = t.value"> 
+                <x-label class="keymap-label">
+                  <span class="material-icons" v-if="t.value === userKeymap">done</span>
+                  {{t.name}}
+                </x-label> 
+              </x-menuitem>
             </x-menu>
           </x-button>
         </div>
@@ -211,11 +216,12 @@
       ...mapState('settings', ['settings']),
       userKeymap: {
         get() {
+          console.log('VALUE: ', this.settings?.keymap?.value)
           return this.settings?.keymap?.value ?? 'default';
         },
         set(value) {
-          if (value.toLowerCase === this.keymap) return;
-          this.$store.dispatch('settings/save', { key: 'keymap', value: value.toLowerCase() });
+          if (value === this.keymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
+          this.$store.dispatch('settings/save', { key: 'keymap', value: value });
           this.initialize();
         }
       },

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -111,7 +111,7 @@ export default {
           return s ? s.value : false
         },
         set(value) {
-          this.$store.dispatch('settings/save', { key: 'keymap', value })
+          this.$store.dispatch('settings/save', { key: 'hideResultsDropdown', value })
         }
       },
       rowCount() {

--- a/apps/studio/src/migration/20230619_fix_keymap_type.js
+++ b/apps/studio/src/migration/20230619_fix_keymap_type.js
@@ -1,0 +1,7 @@
+export default {
+  name: "20230619_fix_keymap_type",
+  async run(runner) {
+    const query = `UPDATE user_setting SET valueType = 0 WHERE key = 'keymap'`;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -30,6 +30,7 @@ import createHiddenEntities from './20220907_create_hidden_entities'
 import createHiddenSchemas from './20220908_create_hidden_schemas'
 import redshiftOptions from './20220817_add_redshift_options'
 import connectionPins from './20230308_create_connection_pins'
+import fixKeymapType from './20230619_fix_keymap_type'
 
 const logger = createLogger('migrations')()
 
@@ -44,7 +45,7 @@ const realMigrations = [
   addSc, sslFiles, sslReject, pinned, addSort,
   createCreds, workspaceScoping, workspace2, addTabs, scWorkspace, systemTheme,
   serverCerts, socketPath, connectionOptions, keepaliveInterval, redshiftOptions,
-  createHiddenEntities, createHiddenSchemas, connectionPins
+  createHiddenEntities, createHiddenSchemas, connectionPins, fixKeymapType
 ]
 
 // fixtures require the models

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -42,7 +42,7 @@ const SettingStoreModule: Module<State, any> = {
     async save(context, { key, value }) {
       if (!key || !value) return;
       const setting = context.state.settings[key] || new UserSetting()
-      if (_.isBoolean(value)) setting.valueType = UserSettingValueType.boolean
+      if (_.isBoolean(value)) setting.valueType = UserSettingValueType.boolean;
       setting.value = value
       setting.key = key
       await setting.save()


### PR DESCRIPTION
Fix #1618 

This PR fixes the weird issue with keymap saving as a boolean in our user_setting table, which I believe was just a result of bad validation when choosing a value (ie `value.toLowerCase === keymap` and not checking if the value is a valid keymap). EDIT: Also found we were setting keymap to `true/false` whenever the results dropdown was used, because I'm a moron and must've replaced all or something.

I also added a migration to forcibly fix any settings that were improperly set to the boolean type, and updated styles to actually show what keymap you are currently using:

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/58712803/4e99b5e6-f09c-4016-9cab-822a6b522d2d)
