### PR TITLE
Fix save as markdown

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -275,7 +275,7 @@
         };
         // Fix Issue #1493 Lost column names in json query download
         // by overriding the tabulator-generated json with ...what cipboard() does, below:
-        formatter = format !== 'json' ? format : (rows, options, setFileContents) => {
+        formatter = format !== 'json' ? formatter : (rows, options, setFileContents) => {
           setFileContents(
             JSON.stringify(this.dataToJson(this.tabulator.getData(), false), null, "  "), 'text/json'
            )


### PR DESCRIPTION
Fix #1622

The fix merged in #1494 inadvertently broke the save as markdown feature, this PR is fixing that.