### PR TITLE
Upgrade ssh2 from 1.110 to 1.14.0

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -68,7 +68,7 @@
     "split.js": "^1.5.11",
     "sql-formatter": "^10.0.0",
     "sql-query-identifier": "^2.2.0",
-    "ssh2": "^1.11.0",
+    "ssh2": "^1.14.0",
     "tabulator-tables": "~5.4.1",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,7 +3747,7 @@ asn1.js@^5.2.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-asn1@^0.2.4, asn1@~0.2.3:
+asn1@^0.2.4, asn1@^0.2.6, asn1@~0.2.3:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
   integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
@@ -5387,7 +5387,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cpu-features@./.yarn/packages/empty-package, cpu-features@~0.0.4:
+cpu-features@./.yarn/packages/empty-package, cpu-features@~0.0.4, cpu-features@~0.0.8:
   version "1.0.0"
 
 crc-32@~1.2.0:
@@ -10785,7 +10785,7 @@ named-placeholders@^1.1.2:
   dependencies:
     lru-cache "^4.1.3"
 
-nan@2.17.0, nan@^2.12.1, nan@^2.13.2, nan@^2.16.0:
+nan@2.17.0, nan@^2.12.1, nan@^2.13.2, nan@^2.16.0, nan@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
@@ -13737,6 +13737,17 @@ ssh2@^1.11.0:
   optionalDependencies:
     cpu-features "~0.0.4"
     nan "^2.16.0"
+
+ssh2@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/ssh2/-/ssh2-1.14.0.tgz#8f68440e1b768b66942c9e4e4620b2725b3555bb"
+  integrity sha512-AqzD1UCqit8tbOKoj6ztDDi1ffJZ2rV2SwlgrVVrHPkV5vWqGJOVp5pmtj18PunkPJAuKQsnInyKV+/Nb2bUnA==
+  dependencies:
+    asn1 "^0.2.6"
+    bcrypt-pbkdf "^1.0.2"
+  optionalDependencies:
+    cpu-features "~0.0.8"
+    nan "^2.17.0"
 
 sshpk@^1.7.0:
   version "1.17.0"


### PR DESCRIPTION
Fixes Issue #1648

This version of the `ssh2` module resolves the "All configured authentication methods failed" error when using ubuntu 22 for ssh tunneling