### PR TITLE
Fix Issue #1517: Add Precision and Scale for Decimal Values in MS SQL

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlserver.js
+++ b/apps/studio/src/lib/db/clients/sqlserver.js
@@ -483,17 +483,18 @@ export async function listTableColumns(conn, database, table, schema) {
       table_schema as "table_schema",
       table_name as "table_name",
       column_name as "column_name",
-      data_type as "data_type",
       ordinal_position as "ordinal_position",
       column_default as "column_default",
       is_nullable as "is_nullable",
       CASE
-        WHEN character_maximum_length is not null AND data_type != 'text'
-          THEN character_maximum_length
-        WHEN datetime_precision is not null THEN
-          datetime_precision
-        ELSE null
-      END as length
+        WHEN character_maximum_length is not null AND data_type != 'text' 
+            THEN CONCAT(data_type, '(', character_maximum_length, ')')
+        WHEN numeric_precision is not null 
+            THEN CONCAT(data_type, '(', numeric_precision, ',', numeric_scale, ')')
+        WHEN datetime_precision is not null AND data_type != 'date' 
+            THEN CONCAT(data_type, '(', datetime_precision, ')')
+        ELSE data_type
+      END as "data_type"
     FROM INFORMATION_SCHEMA.COLUMNS
     ${clause}
     ORDER BY table_schema, table_name, ordinal_position
@@ -505,7 +506,7 @@ export async function listTableColumns(conn, database, table, schema) {
     schemaName: row.table_schema,
     tableName: row.table_name,
     columnName: row.column_name,
-    dataType: row.length ? `${row.data_type}(${row.length})` : row.data_type,
+    dataType: row.data_type,
     ordinalPosition: Number(row.ordinal_position),
     nullable: row.is_nullable === 'YES',
     defaultValue: row.column_default


### PR DESCRIPTION
This pull request addresses Issue #1517, which was about missing precision and scale values for decimal columns in MS SQL.

Changes Made:

Modified the SQL query in apps/studio/src/lib/db/clients/sqlserver.js   to include precision and scale values for decimal columns.
Tested the changes in a local environment with MS SQL.

Screenshot: 
<img width="461" alt="Screenshot 2023-08-11 at 11 44 02" src="https://github.com/beekeeper-studio/beekeeper-studio/assets/70945365/0cf1819c-6853-47ef-b6b1-d619c54ba07e">
