### PR TITLE
Fix #1642 Search and Display Issue for Functions in PostgreSQL Database

### DIFF
--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -152,6 +152,13 @@ const store = new Vuex.Store<State>({
       }
       const obj = _.chain(g.filteredTables).groupBy('schema').value()
       const routines = _.groupBy(g.filteredRoutines, 'schema')
+
+      for (const key in routines) {
+        if (!obj[key]) {
+            obj[key] = [];
+        }
+      }
+      
       return _(obj).keys().map(k => {
         return {
           schema: k,


### PR DESCRIPTION
If table doesnt have filtered table object doesnt have key and doesnt merge for routines even if is routine find.

Should this work for quick search too? I didnt see any routines in quick search.
Fixes #1642.

<img width="284" alt="Screenshot 2023-08-11 at 16 30 13" src="https://github.com/beekeeper-studio/beekeeper-studio/assets/70945365/f17b87f8-f8a1-4057-b8e3-8911cfebc5c3">
