### PR TITLE
Fix Recent Connection Display for Unix Socket Connections #1627

### DIFF
--- a/apps/studio/src/common/appdb/models/used_connection.ts
+++ b/apps/studio/src/common/appdb/models/used_connection.ts
@@ -30,6 +30,8 @@ export class UsedConnection extends DbConnectionBase implements ISimpleConnectio
       this.options = other.options
       this.trustServerCertificate = other.trustServerCertificate
       this.redshiftOptions = other.redshiftOptions
+      this.socketPath = other.socketPath
+      this.socketPathEnabled = other.socketPathEnabled
     }
 
   }


### PR DESCRIPTION
This PR addresses the bug reported in issue #[1627], where connecting to a database via a Unix socket without saving the connection resulted in incorrect information being displayed in the recent connections list.

Fixes https://github.com/beekeeper-studio/beekeeper-studio/issues/1627
