### PR TITLE
Fix errors that block copying row (insert)

### DIFF
--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -120,3 +120,8 @@ export function createCancelablePromise(error: CustomError, timeIdle = 100): any
     },
   };
 }
+
+export function makeString(value: any): string {
+  if(value === BigInt(0)) return '0';
+  return _.toString(value);
+}

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -5,6 +5,7 @@ import {homedir} from 'os';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import { Error as CustomError } from '../lib/errors'
+import _ from 'lodash';
 
 export function having<T, U>(item: T | undefined | null, f: (T) => U, errorOnNone?: string): U | null {
   if (item) return f(item)

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -166,7 +166,7 @@
 
               const tableInsert = {
                 table: 'mytable',
-                schema: null,
+                schema: this.connection.defaultSchema(),
                 data: [fixed],
               }
               const query = await this.connection.getInsertQuery(tableInsert)

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -12,6 +12,7 @@ import { SqliteCursor } from './sqlite/SqliteCursor';
 import { SqliteChangeBuilder } from '@shared/lib/sql/change_builder/SqliteChangeBuilder';
 import { SqliteData } from '@shared/lib/dialects/sqlite';
 import { ClientError } from '../client';
+import { makeString } from '@/common/utils';
 const log = rawLog.scope('sqlite')
 const logger = () => log
 
@@ -25,7 +26,7 @@ const knex = knexlib({
 knex.client = Object.assign(knex.client, {
   _escapeBinding: makeEscape({
     escapeString(str) {
-      str = _.toString(str)
+      str = makeString(str)
       return str ? `'${str.replace(/'/g, "''")}'` : ''
     }
   })


### PR DESCRIPTION
- lodash's `toString` fails to parse `BigInt(0)`, blocking the copy row (insert) in sqlite. To reproduce:
  1) open bks database (app-dev.db)
  2) select * from saved_connection
  3) copy row (insert)
- not specifying schema in postgres would also block the copy