### PR TITLE
feat: adding shortcut to switch between multiple query results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Last updated: Feb 27 2022
 
 We welcome community contributions! If you're thinking of contributing, thank you!
 
-We ask that all contributors abide by our [code of conduct](https://github.com/beekeeper-studio/beekeeper-studio/code_of_conduct.md)
+We ask that all contributors abide by our [code of conduct](https://github.com/beekeeper-studio/beekeeper-studio/blob/master/code_of_conduct.md)
 
 
 ### Opening Issues

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -1,7 +1,7 @@
 <template>
   <statusbar :class="{ 'empty': results.length === 0, 'query-meta': true }">
     <template v-if="results.length > 0">
-      <div class="truncate statusbar-info">
+      <div class="truncate statusbar-info" v-hotkey="keymap">
         <span
           v-show="results.length > 1"
           class="statusbar-item result-selector"
@@ -150,7 +150,7 @@ export default {
   data() {
     return {
       showHint: false,
-
+      selectedResult: 0,
     }
   },
 
@@ -198,9 +198,23 @@ export default {
         return null;
       }
       return `Execution time: ${humanizeDuration(this.executeTime)}`
+    },
+    keymap() {
+      const result = {}
+      result['shift+up'] = () => this.changeSelectedResult(1);
+      result['shift+down'] = () => this.changeSelectedResult(-1);
+      return result
     }
   },
   methods: {
+    changeSelectedResult(direction) {
+      const newIndex = this.selectedResult + direction;
+      if (newIndex >= 0 && newIndex < this.results.length) {
+        this.selectedResult = newIndex;
+        this.$emit('input', this.selectedResult);
+        this.hasUsedDropdown = true
+      }
+    },
     pluralize(word, amount, flag) {
       return pluralize(word, amount, flag)
     },
@@ -219,7 +233,9 @@ export default {
       return e;
     },
     updateValue(event) {
-      this.$emit('input', parseInt(event.target.value))
+      const selectedIndex = parseInt(event.target.value);
+      this.selectedResult = selectedIndex;
+      this.$emit('input',selectedIndex)
       this.hasUsedDropdown = true
     },
     download(format) {


### PR DESCRIPTION
Hi, this PR is addressing the feature requested at #1669.