### PR TITLE
Fix invalid bool and tabulator update data

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -749,7 +749,9 @@ export default Vue.extend({
           editorParams: {
             verticalNavigation: useVerticalNavigation ? 'editor' : undefined,
             search: true,
-            values: column.dataType === 'bool' ? [true, false] : undefined,
+            values: /^(bool|boolean)$/i.test(column.dataType)
+              ? [true, false]
+              : undefined,
             allowEmpty: true,
             // elementAttributes: {
             //   maxLength: column.columnLength // TODO
@@ -1124,7 +1126,7 @@ export default Vue.extend({
     },
     editorType(dt) {
       const ne = vueEditor(NullableInputEditorVue)
-      switch (dt) {
+      switch (dt.toLowerCase()) {
         case 'text':
         case 'json':
         case 'jsonb':
@@ -1132,7 +1134,9 @@ export default Vue.extend({
         case 'tsvector':
         case '_text':
           return 'textarea'
-        case 'bool': return 'select'
+        case 'bool':
+        case 'boolean':
+          return 'select'
         default: return ne
       }
     },

--- a/apps/studio/src/lib/db/clients/sqlite.js
+++ b/apps/studio/src/lib/db/clients/sqlite.js
@@ -252,7 +252,7 @@ export async function applyChanges(conn, changes) {
 
 export async function updateValues(cli, updates) {
   const commands = updates.map(update => {
-    const params = [update.value];
+    const params = [_.isBoolean(update.value) ? _.toInteger(update.value) : update.value];
     const whereList = []
     update.primaryKeys.forEach(({ column, value }) => {
       whereList.push(`${wrapIdentifier(column)} = ?`);

--- a/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
@@ -70,18 +70,19 @@ describe("Sqlite Tests", () => {
       { id: 6, expect: null, toBe: null },
     ]
 
-    await util.connection.applyChanges({
-      inserts: inserts.map(({ id, expect }) => ({
-        table: 'withbooleans',
-        data: [{ id, flag: expect }],
-      })),
-      updates: updates.map(({ id, expect }) => ({
-        table: 'withbooleans',
-        column: 'flag',
-        primaryKeys: [{ column: 'id', value: id }],
-        value: expect,
-      })),
-    })
+    await expect(util.connection.applyChanges({
+        inserts: inserts.map(({ id, expect }) => ({
+          table: 'withbooleans',
+          data: [{ id, flag: expect }],
+        })),
+        updates: updates.map(({ id, expect }) => ({
+          table: 'withbooleans',
+          column: 'flag',
+          primaryKeys: [{ column: 'id', value: id }],
+          value: expect,
+        })),
+      })
+    ).resolves.toBeTruthy();
 
     const results = await util.knex
       .select()


### PR DESCRIPTION
This introduces three fixes 🎉:
-  The boolean data hasn't been converted to `1` or `0` when applying changes. We have no issue when inserting new data because it's converted by `knex`.
- The `tabulator.updateData` is ignored due to the data supplied to it didn't contain the [index column.](https://tabulator.info/docs/5.5/update#alter-update:~:text=This%20function%20takes%20an%20array%20of%20row%20objects%20and%20will%20update%20each%20row%20based%20on%20its%20index%20value.%20Options%20without%20an%20index%20will%20be%20ignored%2C%20as%20will%20items%20with%20an%20index%20that%20is%20not%20already%20in%20the%20table%20data.)
- Add false/true options when adding `boolean` value

Closes #1408