### PR TITLE
Should trigger initial filters on first time load and other bugs

### DIFF
--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -168,6 +168,7 @@ export function normalizeFilters(filters: TableFilter[]) {
     } else {
       normalized.push(filter);
     }
+    filter.value = filter.value.toString();
   }
   return normalized;
 }

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -159,7 +159,7 @@ export function joinFilters(filters: string[], ops: TableFilter[] = []): string 
 
 /** Get rid of invalid filters and parse if needed */
 export function normalizeFilters(filters: TableFilter[]) {
-  let normalized: TableFilter[] = [];
+  const normalized: TableFilter[] = [];
   for (const filter of filters as TableFilter[]) {
     if (!(filter.type && filter.field && filter.value)) continue;
     if (filter.type === "in") {

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -151,7 +151,24 @@ export function safeSqlFormat(
   }
 }
 
+/** Join filters by AND or OR */
 export function joinFilters(filters: string[], ops: TableFilter[] = []): string {
   if (filters.length === 0) return ''
   return filters.reduce((a, b, idx) => `${a} ${ops[idx]?.op || 'AND'} ${b}`)
 }
+
+/** Get rid of invalid filters and parse if needed */
+export function normalizeFilters(filters: TableFilter[]) {
+  let normalized: TableFilter[] = [];
+  for (const filter of filters as TableFilter[]) {
+    if (!(filter.type && filter.field && filter.value)) continue;
+    if (filter.type === "in") {
+      const value = (filter.value as string).split(/\s*,\s*/);
+      normalized.push({ ...filter, value });
+    } else {
+      normalized.push(filter);
+    }
+  }
+  return normalized;
+}
+

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -217,7 +217,7 @@ const BUILDER = "builder";
 const RAW = "raw";
 
 /** Get rid of invalid filters and parse if needed */
-function normalizeFilters(filters: TableFilter[]) {
+export function normalizeFilters(filters: TableFilter[]) {
   let normalized: TableFilter[] = [];
   for (const filter of filters as TableFilter[]) {
     if (!(filter.type && filter.field && filter.value)) continue;
@@ -289,7 +289,9 @@ export default Vue.extend({
     },
     addFilter() {
       const lastFilter = this.filters[this.filters.length - 1];
-      this.filters.push(_.clone(lastFilter));
+      const cloned = _.clone(lastFilter)
+      if (!cloned.op) cloned.op = "AND"
+      this.filters.push(cloned);
       this.$nextTick(() => {
         const filters = this.$refs.multipleFilters.children;
         filters[filters.length - 1].scrollIntoView();

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -210,26 +210,11 @@
 <script lang="ts">
 import Vue from "vue";
 import { TableFilter } from "@/lib/db/models";
-import { joinFilters } from "@/common/utils";
+import { joinFilters, normalizeFilters } from "@/common/utils";
 import { mapGetters } from "vuex";
 
 const BUILDER = "builder";
 const RAW = "raw";
-
-/** Get rid of invalid filters and parse if needed */
-export function normalizeFilters(filters: TableFilter[]) {
-  let normalized: TableFilter[] = [];
-  for (const filter of filters as TableFilter[]) {
-    if (!(filter.type && filter.field && filter.value)) continue;
-    if (filter.type === "in") {
-      const value = (filter.value as string).split(/\s*,\s*/);
-      normalized.push({ ...filter, value });
-    } else {
-      normalized.push(filter);
-    }
-  }
-  return normalized;
-}
 
 export default Vue.extend({
   props: ["columns", "initialFilters"],

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="table-filter">
+  <div
+    v-hotkey="keymap"
+    class="table-filter"
+  >
     <form
       @submit.prevent="submit"
       @scroll="
@@ -125,7 +128,7 @@
             <div class="expand filter">
               <div class="filter-wrap">
                 <input
-                  class="form-control"
+                  class="form-control filter-value"
                   type="text"
                   v-model="filter.value"
                   :placeholder="
@@ -250,8 +253,17 @@ export default Vue.extend({
       const [_, ...additional] = this.filters;
       return additional;
     },
+    keymap() {
+      return {
+        [this.ctrlOrCmd('f')]: this.focusOnInput,
+      }
+    }
   },
   methods: {
+    focusOnInput() {
+      if (this.filterMode === RAW) this.$refs.valueInput.focus();
+      else this.$refs.multipleFilters.querySelector('.filter-value')?.focus();
+    },
     toggleFilterMode() {
       const filters: TableFilter[] = normalizeFilters(this.filters);
       const filterMode = this.filterMode === BUILDER ? RAW : BUILDER;
@@ -270,7 +282,7 @@ export default Vue.extend({
       }
 
       this.filterMode = filterMode;
-      this.$nextTick(() => this.$refs.valueInput?.focus());
+      this.$nextTick(this.focusOnInput);
     },
     addFilter() {
       const lastFilter = this.filters[this.filters.length - 1];

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -224,7 +224,7 @@ import data_converter from "../../mixins/data_converter";
 import DataMutators, { escapeHtml } from '../../mixins/data_mutators'
 import { FkLinkMixin } from '@/mixins/fk_click'
 import Statusbar from '../common/StatusBar.vue'
-import RowFilterBuilder from './RowFilterBuilder.vue'
+import RowFilterBuilder, { normalizeFilters } from './RowFilterBuilder.vue'
 import ColumnFilterModal from './ColumnFilterModal.vue'
 import rawLog from 'electron-log'
 import _ from 'lodash'
@@ -924,6 +924,7 @@ export default Vue.extend({
       this.rawTableKeys = await this.connection.getTableKeys(this.table.name, this.table.schema)
       const rawPrimaryKeys = await this.connection.getPrimaryKeys(this.table.name, this.table.schema);
       this.primaryKeys = rawPrimaryKeys.map((key) => key.columnName);
+      this.filters = normalizeFilters(this.initialFilters || [])
 
       this.tabulator = new TabulatorFull(this.$refs.table, {
         height: this.actualTableHeight,

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -340,7 +340,6 @@ export default Vue.extend({
       result[this.ctrlOrCmd('n')] = this.cellAddRow.bind(this)
       result[this.ctrlOrCmd('s')] = this.saveChanges.bind(this)
       result[this.ctrlOrCmd('shift+s')] = this.copyToSql.bind(this)
-      result[this.ctrlOrCmd('f')] = () => this.$refs.valueInput.focus()
       result[this.ctrlOrCmd('c')] = this.maybeCopyCellOrRow
       result["Escape"] = this.unselectStuff
       return result

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -224,7 +224,7 @@ import data_converter from "../../mixins/data_converter";
 import DataMutators, { escapeHtml } from '../../mixins/data_mutators'
 import { FkLinkMixin } from '@/mixins/fk_click'
 import Statusbar from '../common/StatusBar.vue'
-import RowFilterBuilder, { normalizeFilters } from './RowFilterBuilder.vue'
+import RowFilterBuilder from './RowFilterBuilder.vue'
 import ColumnFilterModal from './ColumnFilterModal.vue'
 import rawLog from 'electron-log'
 import _ from 'lodash'
@@ -240,7 +240,7 @@ import { TableUpdate, TableUpdateResult } from '@/lib/db/models';
 import { markdownTable } from 'markdown-table'
 import { dialectFor, FormatterDialect } from '@shared/lib/dialects/models'
 import { format } from 'sql-formatter';
-import { safeSqlFormat } from '@/common/utils'
+import { normalizeFilters, safeSqlFormat } from '@/common/utils'
 import { TableFilter } from '@/lib/db/models';
 const log = rawLog.scope('TableTable')
 


### PR DESCRIPTION
![Animation4](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/c2b55748-eb24-42d1-93a8-f70eac3156d6)

Bugs:
- Does not run `initialFilters` initially
- After going to a table from a fk link, try adding some new filters, it will show empty AND/OR buttons
- Cannot focus the filter input with ctrl+f
- Converting to raw filter when the filter value is not a string gives an error. Steps to reproduce:
  1) Make a filter that uses number, e.g. `id` => `equals` => `1`
  2) Disconnect from db and reconnect
  3) Try switching to raw filter 