### PR TITLE
Fix invalid sql array format on copy

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -640,6 +640,11 @@ export default Vue.extend({
               ? [true, false]
               : undefined,
             allowEmpty: true,
+            preserveObject: column.dataType.startsWith('_'),
+            onPreserveObjectFail: () => {
+              this.$noty.error("Value is not valid")
+              return true
+            }
             // elementAttributes: {
             //   maxLength: column.columnLength // TODO
             // }

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -644,7 +644,7 @@ export default Vue.extend({
             onPreserveObjectFail: () => {
               this.$noty.error("Value is not valid")
               return true
-            }
+            },
             // elementAttributes: {
             //   maxLength: column.columnLength // TODO
             // }

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -648,8 +648,8 @@ export default Vue.extend({
             search: true,
             allowEmpty: true,
             preserveObject: column.dataType.startsWith('_'),
-            onPreserveObjectFail: () => {
-              this.$noty.error("Value is not valid")
+            onPreserveObjectFail: (value: unknown) => {
+              log.error('Failed to preserve object for', value)
               return true
             },
             // elementAttributes: {

--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -10,16 +10,19 @@ function dec28bits(num: any): string {
 export const Mutators = {
 
   resolveTabulatorMutator(dataType?: string, dialect?: Dialect): (v: any) => JsonFriendly {
-    const mutator = this.resolveDataMutator(dataType, dialect)
+    const mutator = this.resolveDataMutator(dataType, dialect, true)
     return (v: any) => mutator(v, true) // this cleans off the additional params
   },
 
-  resolveDataMutator(dataType?: string, dialect?: Dialect): (v: any, p?: boolean) => JsonFriendly {
+  resolveDataMutator(dataType?: string, dialect?: Dialect, mutateJSON = false): (v: any, p?: boolean) => JsonFriendly {
     if (dataType && dataType === 'bit(1)') {
       return this.bit1Mutator.bind(this)
     }
     if (dataType && dataType.startsWith('bit')) {
       return this.bitMutator.bind(this, dialect)
+    }
+    if (dataType && dataType.startsWith('json') && mutateJSON) {
+      return this.jsonMutator.bind(this)
     }
     return this.genericMutator.bind(this)
   },
@@ -79,5 +82,10 @@ export const Mutators = {
 
     return `b'${result.map(d => dec28bits(d)).join("")}'`
 
-  }
+  },
+
+  /** Stringify json data for MySQL column */
+  jsonMutator(value: any): JsonFriendly {
+    return JSON.stringify(value)
+  },
 }

--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -11,7 +11,7 @@ export const Mutators = {
 
   resolveTabulatorMutator(dataType?: string, dialect?: Dialect): (v: any) => JsonFriendly {
     const mutator = this.resolveDataMutator(dataType, dialect)
-    return (v: any) => mutator(v) // this cleans off the additional params
+    return (v: any) => mutator(v, true) // this cleans off the additional params
   },
 
   resolveDataMutator(dataType?: string, dialect?: Dialect): (v: any, p?: boolean) => JsonFriendly {

--- a/apps/studio/src/lib/db/clients/bigquery.js
+++ b/apps/studio/src/lib/db/clients/bigquery.js
@@ -56,11 +56,13 @@ export default async function (server, database) {
     getTableLength: (table) => getTableLength(client, database.database, table),
     selectTop: (table, offset, limit, orderBy, filters, schema, selects) => selectTop(client, database.database, table, offset, limit, orderBy, filters, selects),
     selectTopStream: (db, table, orderBy, filters, chunkSize, schema) => selectTopStream(client, db, table, orderBy, filters, chunkSize, schema),
+    selectTopSql: (table, offset, limit, orderBy, filters, schema, selects) => selectTopSql(client, database.database, table, offset, limit, orderBy, filters, schema, selects),
     queryStream: (db, query, chunkSize) => queryStream(client, db, query, chunkSize),
     getTableKeys: (db, table) => getTableKeys(client, db, table),
     getPrimaryKey: (db, table) => getPrimaryKey(client, db, table),
     getPrimaryKeys: (db, table) => getPrimaryKeys(client, db, table),
     query: (queryText) => query(client, queryText),
+    getInsertQuery: (tableInsert) => buildInsertQuery(knex, { ...tableInsert, schema: database.database }),
     applyChanges: (changes) => applyChanges(client, changes),
     applyChangesSql: (changes) => applyChangesSql(changes, knex),
     executeQuery: (queryText) => driverExecuteQuery(client, queryText),
@@ -433,6 +435,13 @@ export async function selectTopStream(conn, db, table, orderBy, filters, chunkSi
     columns,
     cursor: new BigQueryCursor(conn, query, params, chunkSize)
   };
+}
+
+export async function selectTopSql(client, db, table, offset, limit, orderBy, filters, schema, selects) {
+  const columns = await listTableColumns(client, db, table)
+  const bqTable = db + "." + table
+  const queries = buildSelectTopQuery(bqTable, offset, limit, orderBy, filters, 'total', columns, selects)
+  return queries.query
 }
 
 export async function queryStream(conn, db, query, chunkSize) {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1232,7 +1232,7 @@ async function updateValues(cli: any, rawUpdates: TableUpdate[]): Promise<TableU
   // if a type is BYTEA, decodes BASE64 URL encoded to hex
   const updates = rawUpdates.map((update) => {
     const result = { ...update}
-    if (update.columnType?.startsWith('_')) {
+    if (update.columnType?.startsWith('_') && _.isString(update.value)) {
       result.value = JSON.parse(update.value)
     } else if (update.columnType === 'bytea' && update.value) {
         result.value = '\\x' + base64.decode(update.value, 'hex')

--- a/apps/studio/src/lib/export/export.ts
+++ b/apps/studio/src/lib/export/export.ts
@@ -53,7 +53,7 @@ export abstract class Export {
   abstract getHeader(columns: TableColumn[]): Promise<string>
   abstract getFooter(): string
   // do not add newlines / row separators
-  abstract formatRow(data: any[]): string
+  abstract formatRow(data: any[], columns?: TableColumn[]): string
 
   protected rowToObject(row: any[]): Record<string, any> {
     const columns = this.dedupedColumns?.length ?  this.dedupedColumns : row.map((_r, i) => {
@@ -180,7 +180,7 @@ export abstract class Export {
         for (let rI = 0; rI < rows.length; rI++) {
           const row = rows[rI];
           const mutated = Mutators.mutateRow(row, this.columns?.map((c) => c.dataType), this.preserveComplex, dialectFor(this.connection.connectionType))
-          const formatted = this.formatRow(mutated)
+          const formatted = this.formatRow(mutated, this.columns)
 
           // needsSeparator allows us to skip adding the rowSeparator
           // on the FINAL row of the file

--- a/apps/studio/src/mixins/data_mutators.ts
+++ b/apps/studio/src/mixins/data_mutators.ts
@@ -36,17 +36,7 @@ function emptyResult(value: any) {
 export default {
 
   methods: {
-
-
-    niceString(value: any, truncate = false) {
-
-      let cellValue = value.toString();
-      if (_.isArray(value)) {
-        cellValue = value.map((v) => v.toString()).join(", ")
-      }
-      return truncate ? _.truncate(cellValue, { length: 256 }) : cellValue
-    },
-
+    niceString: helpers.niceString,
     cellTooltip(_event, cell: Tabulator.CellComponent) {
       const nullValue = emptyResult(cell.getValue())
       return nullValue ? nullValue : escapeHtml(this.niceString(cell.getValue(), true))

--- a/shared/src/components/tabulator/NullableInputEditor.vue
+++ b/shared/src/components/tabulator/NullableInputEditor.vue
@@ -20,6 +20,7 @@
 <script lang="ts">
 import _ from 'lodash'
 import Vue from 'vue'
+import helpers from '@shared/lib/tabulator'
 export default Vue.extend({
   props: ['cell', 'params'],
   data() {
@@ -69,6 +70,13 @@ export default Vue.extend({
       // some cases we always want null, never empty string
       if (this.params.allowEmpty === false && _.isEmpty(this.value)) {
         this.$emit('value', null)
+      } else if (this.params.preserveObject) {
+        try {
+          this.$emit('value', JSON.parse(this.value))
+        } catch (e) {
+          const updateAnyway = this.params.onPreserveObjectFail?.(this.value)
+          updateAnyway && this.$emit('value', this.value)
+        }
       } else {
         this.$emit('value', this.value)
       }
@@ -81,7 +89,7 @@ export default Vue.extend({
   watch: {
     rendered() {
       if (this.rendered) {
-        this.value = this.cell.getValue()
+        this.value = helpers.niceString(this.cell.getValue())
         this.$nextTick(() => {
           this.$refs.input.focus();
           if (this.params.autoSelect) {

--- a/shared/src/components/tabulator/NullableInputEditor.vue
+++ b/shared/src/components/tabulator/NullableInputEditor.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
           this.value = ''
         }
       } else if (e.key === 'Enter') {
-        this.$emit('value', this.value)
+        this.submit()
       } else if (e.key === 'Tab') {
         // this.$emit('value', this.value)
       } else if (e.key.startsWith("Arrow")) {
@@ -111,7 +111,7 @@ export default Vue.extend({
 </script>
 <style lang="scss" scoped>
   @import '@shared/assets/styles/_variables';
-  
+
   div {
     position: relative;
     display: flex;

--- a/shared/src/lib/tabulator.ts
+++ b/shared/src/lib/tabulator.ts
@@ -27,6 +27,13 @@ function yesNoResult(value: boolean) {
 }
 
 export default {
+  niceString(value: any, truncate = false) {
+    let cellValue = value.toString();
+    if(_.isArray(value) || _.isObject(value)) {
+      cellValue = JSON.stringify(value)
+    }
+    return truncate ? _.truncate(cellValue, { length: 256 }) : cellValue
+  },
   cellFormatter(cell: Tabulator.CellComponent) {
     if (_.isNil(cell.getValue())) {
       return '<span class="null-value">(NULL)</span>'

--- a/shared/src/lib/tabulator/helpers.ts
+++ b/shared/src/lib/tabulator/helpers.ts
@@ -41,8 +41,12 @@ export function vueEditor(component: any) {
       instance.$destroy()
     }
 
-    instance.$on('value', (v) => {
-      success(v)
+    instance.$on('value', (v: any) => {
+      if (editorParams.preserveObject && _.isEqual(v, cell.getValue())) {
+        success(cell.getValue()) // prevents detecting a change
+      } else {
+        success(v)
+      }
       off()
     })
 


### PR DESCRIPTION
Instead of mutating the array/object into string for the whole table, we can convert them into string when viewing and editing, so we don't lose the real data type when calling `tabulator.getData()`. Preserving the real data type so knex can generate the query for us correctly.

![Animation4](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/15138676-ea33-41f1-a7e5-91ee1fb4ab76)

Changes:

- copy to SQL.
before => `insert into "public"."untitled_table" ("column_3") values ('[1,2,3,4,5]')`
after => `insert into "public"."untitled_table" ("column_3") values ('{1,2,3,4,5}')`

- copy to JSON
before => `["column_1":"[1,2,3]"}]`
after => `["column_1":[1,2,3]}]`

- copy to TSV for excel
before => `"1"	"2023-09-21 01:57:29.227987"	"[1,2,3]"`
after => `"1"	"2023-09-21 01:57:29.227987"	"1,2,3"`

- copy to Markdown
before => 
```md
| id | created_at                 | column_3 |
| -- | -------------------------- | -------- |
| 1  | 2023-09-21 01:57:29.227987 | [1,2,3]  |
```

after => 
```md
| id | created_at                 | column_3 |
| -- | -------------------------- | -------- |
| 1  | 2023-09-21 01:57:29.227987 | 1,2,3    |
```

Closes #1596

todo:
- [x] check result table
- [x] exporting sql using the exporter window is still wrong
- [x] check mysql json
- [x] bigquery array