### PR TITLE
feat: honoring compound foreign keys in table structure and tables navigation

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -591,8 +591,7 @@ export default Vue.extend({
       // to the FK table.
       this.table.columns.forEach(column => {
 
-        const keyDatas: any[] = this.tableKeys[column.columnName]
-
+        const keyDatas: any[] = Object.entries(this.tableKeys).filter((entry) => entry[0].includes(column.columnName));
         // this needs fixing
         // currently it doesn't fetch the right result if you update the PK
         // because it uses the PK to fetch the result.
@@ -606,10 +605,11 @@ export default Vue.extend({
 
         let headerTooltip = `${column.columnName} ${column.dataType}`
         if (keyDatas && keyDatas.length > 0) {
-          if (keyDatas.length === 1)
-            headerTooltip += ` -> ${keyDatas[0].toTable}(${keyDatas[0].toColumn})`
+          const keyData = keyDatas[0][1];
+          if (keyData.length === 1)
+            headerTooltip += ` -> ${keyData[0].toTable}(${keyData[0].toColumn})`
           else
-            headerTooltip += ` -> ${keyDatas.map(item => `${item.toTable}(${item.toColumn})`).join(', ').replace(/, (?![\s\S]*, )/, ', or ')}`
+            headerTooltip += ` -> ${keyData.map(item => `${item.toTable}(${item.toColumn})`).join(', ').replace(/, (?![\s\S]*, )/, ', or ')}`
         } else if (isPK) {
           headerTooltip += ' [Primary Key]'
         }
@@ -658,7 +658,7 @@ export default Vue.extend({
         results.push(result)
 
         if (keyDatas && keyDatas.length > 0) {
-          results.push(this.fkColumn(result, keyDatas))
+          results.push(this.fkColumn(result, keyDatas[0][1]))
         }
 
       });

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -980,35 +980,47 @@ export async function getTableReferences(conn: Conn, table: string, schema: stri
 
 export async function getTableKeys(conn: Conn, _database: string, table: string, schema: string): Promise<TableKey[]> {
   const sql = `
-SELECT
-    kcu.constraint_schema AS from_schema,
-    kcu.table_name AS from_table,
-    kcu.column_name AS from_column,
-    rc.unique_constraint_schema AS to_schema,
-    tc.constraint_name,
-    rc.update_rule,
-    rc.delete_rule,
-    (SELECT kcu2.table_name
-     FROM information_schema.key_column_usage AS kcu2
-     WHERE kcu2.constraint_name = rc.unique_constraint_name) AS to_table,
-    (SELECT kcu2.column_name
-     FROM information_schema.key_column_usage AS kcu2
-     WHERE kcu2.constraint_name = rc.unique_constraint_name) AS to_column
+  SELECT
+  kcu.constraint_schema AS from_schema,
+  kcu.table_name AS from_table,
+  STRING_AGG(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS from_column,
+  rc.unique_constraint_schema AS to_schema,
+  tc.constraint_name,
+  rc.update_rule,
+  rc.delete_rule,
+  (
+      SELECT STRING_AGG(kcu2.column_name, ',' ORDER BY kcu2.ordinal_position)
+      FROM information_schema.key_column_usage AS kcu2
+      WHERE kcu2.constraint_name = rc.unique_constraint_name
+  ) AS to_column,
+  (
+      SELECT kcu2.table_name
+      FROM information_schema.key_column_usage AS kcu2
+      WHERE kcu2.constraint_name = rc.unique_constraint_name LIMIT 1
+  ) AS to_table
 FROM
-    information_schema.key_column_usage AS kcu
+  information_schema.key_column_usage AS kcu
 JOIN
-    information_schema.table_constraints AS tc
+  information_schema.table_constraints AS tc
 ON
-    tc.constraint_name = kcu.constraint_name
+  tc.constraint_name = kcu.constraint_name
 JOIN
-    information_schema.referential_constraints AS rc
+  information_schema.referential_constraints AS rc
 ON
-    rc.constraint_name = kcu.constraint_name
+  rc.constraint_name = kcu.constraint_name
 WHERE
-    tc.constraint_type = 'FOREIGN KEY' AND
-    kcu.table_schema NOT LIKE 'pg_%' AND
-    kcu.table_schema = $2 AND
-    kcu.table_name = $1;
+  tc.constraint_type = 'FOREIGN KEY' AND
+  kcu.table_schema NOT LIKE 'pg_%' AND
+  kcu.table_schema = $2 AND
+  kcu.table_name = $1
+GROUP BY
+  kcu.constraint_schema,
+  kcu.table_name,
+  rc.unique_constraint_schema,
+  rc.unique_constraint_name,
+  tc.constraint_name,
+  rc.update_rule,
+  rc.delete_rule;
 `;
 
   const params = [


### PR DESCRIPTION
Hey, this PR is addressing the following: 

- compound foreign keys will be shown as a single unit in the table structure
- honoring compound foreign keys while navigating to the referenced tables
- fixes #1714

![Sep-29-2023 17-19-50](https://github.com/beekeeper-studio/beekeeper-studio/assets/46695441/0ec48f5d-bd50-454c-9693-094e813b5caf)
