### PR TITLE
Removed the default keybind that bound esc to cancel query

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -691,7 +691,6 @@
             "Shift-Cmd-F": this.formatSql,
             "Ctrl-/": this.toggleComment,
             "Cmd-/": this.toggleComment,
-            "Esc": this.cancelQuery,
             "F5": this.submitTabQuery,
             "Shift-F5": this.submitCurrentQuery,
             "Ctrl+I": this.submitQueryToFile,


### PR DESCRIPTION
This contains the fix for [Issue 1716](https://github.com/beekeeper-studio/beekeeper-studio/issues/1716). Esc was by default set to still cancel query instead of being handled later by checking to see if the user was using vim keybindings. This is a one liner change.