### PR TITLE
Add comment to column tooltip if exists

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -614,6 +614,11 @@ export default Vue.extend({
           headerTooltip += ' [Primary Key]'
         }
 
+        // if column has a comment, add it to the tooltip
+        if (column.comment) {
+          headerTooltip += `<br/> ${column.comment}`
+        }
+
         const result = {
           title: column.columnName,
           field: column.columnName,


### PR DESCRIPTION
If the column has a comment, display it on the tooltip

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/55885320/7c9a6e03-23d8-4067-b92a-43388978c4c4)
