### PR TITLE
Fix illegible connection type

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -61,6 +61,7 @@
                 >
                   <option
                     disabled
+                    hidden
                     value="null"
                   >
                     Select a connection type...


### PR DESCRIPTION
closes #1756 

A hack to hide the placeholder option because it's very tricky to style with CSS.

![Animation4](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/2563785a-734f-44a8-960b-1a791aed51f7)
