### PR TITLE
Add note about setting NODE_OPTIONS for Node 16.17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ git clone git@github.com:<your-username>/beekeeper-studio.git beekeeper-studio
 cd beekeeper-studio/
 yarn install # installs dependencies
 
+# if using Node 16.17+:
+export NODE_OPTIONS=--openssl-legacy-provider
+
 # Now you can start the app:
 yarn run electron:serve ## the app will now start
 ```


### PR DESCRIPTION
Adds a note to the README when using Node 16.17+, that one needs to set the `NODE_OPTIONS=--openssl-legacy-provider` flag. This is to avoid hitting the following webpack error:

```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:130:10)
    at module.exports (/Users/mpeveler/code/github/beekeeper-studio/node_modules/webpack/lib/util/createHash.js:171:42)
    at NormalModule._initBuildHash (/Users/mpeveler/code/github/beekeeper-studio/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/Users/mpeveler/code/github/beekeeper-studio/node_modules/webpack/lib/NormalModule.js:471:10)
    at /Users/mpeveler/code/github/beekeeper-studio/node_modules/webpack/lib/NormalModule.js:503:5
    at /Users/mpeveler/code/github/beekeeper-studio/node_modules/webpack/lib/NormalModule.js:358:12
    at /Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at iterateNormalLoaders (/Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:221:10)
    at /Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:236:3
    at runSyncOrAsync (/Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:130:11)
    at iterateNormalLoaders (/Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:232:2)
    at Array.<anonymous> (/Users/mpeveler/code/github/beekeeper-studio/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/Users/mpeveler/code/github/beekeeper-studio/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /Users/mpeveler/code/github/beekeeper-studio/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
```

The problem is that webpack defaults to using `md4` as the hash strategy, and that's been deprecated/removed in OpenSSL since it's not secure, and this was done as some point in the Node 16 release cycle (as well as for any version of Node 18+). While could do:

```diff
diff --git a/apps/studio/vue.config.js b/apps/studio/vue.config.js
index 20d515d0..c4e59029 100644
--- a/apps/studio/vue.config.js
+++ b/apps/studio/vue.config.js
@@ -214,8 +214,10 @@ module.exports = {
           }
         }
       ]
+    },
+    output: {
+      hashFunction: 'sha256',
     }
-
   },
   css: {
     loaderOptions: {
```

and that gets webpack to default to `sha256` and gets past that initial error, will still hit an error with `SourceMapDevToolPlugin` as that hardcode uses `md4`. An alternative strategy would be to moneky-patch `crypto` module like so:

```diff
diff --git a/apps/studio/vue.config.js b/apps/studio/vue.config.js
index 20d515d0..623b23f8 100644
--- a/apps/studio/vue.config.js
+++ b/apps/studio/vue.config.js
@@ -1,8 +1,12 @@
 /* eslint-disable */
 const webpack = require('webpack');
+const crypto = require("crypto");
 const path = require('path');
 /* eslint-enable */
 
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+
 const fpmOptions = [
   "--after-install=build/deb-postinstall"
 ]
@@ -215,7 +219,6 @@ module.exports = {
         }
       ]
     }
-
   },
   css: {
     loaderOptions: {
```

and that works, though the fallout is a bit wider, and of course monkey-patching is never great. However, this would be the most opaque to end users and they wouldn't need to adjust anything to start hacking on beekeeper.

The root cause is really that `vue-cli-plugin-electron-builder` relies on webpack 4, and that ideally this dependency could be updated to a version that uses webpack 5 where this isn't a problem, though there's no stable release that has that. `3.0.0-alpha.4`, which was released 2 years ago, does use webpack 5, but who knows how stable it is.