### PR TITLE
fix: edited column name in TableSchema does not change color

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -541,7 +541,9 @@ $cell-padding:           $gutter-w;
 // Applied when not dragging rows so frozen cells can be transparent
 .tabulator:not(.tabulator-block-select) .tabulator-row .tabulator-frozen {
   position: relative;
-  background-color: $query-editor-bg !important;
+  &:not(.edited) {
+    background-color: $query-editor-bg;
+  }
   &::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
The name column should change color when it's edited.

Fix #1754

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/f1b2c0f7-6859-4732-8ad8-d9f47eedf0cf)
