### PR TITLE
fix: TabTableBuilder and VirtualTableList

### DIFF
--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -279,6 +279,9 @@
   overflow-y: auto;
   -webkit-overflow-scrolling: touch!important;
   padding-left: $gutter-w - 0.4rem;
+  &.list-body-empty {
+    flex: 0;
+  }
 }
 .list-group {
   display: flex;

--- a/apps/studio/src/common/globals.ts
+++ b/apps/studio/src/common/globals.ts
@@ -14,6 +14,7 @@ export default {
   workspaceCheckInterval: 5000, // 5 seconds
   dataCheckInterval: 1000 * 30, // 30 secs
   errorNoticeTimeout: 60 * 1000, // 1 minute
+  tableListItemHeight: 22.8, // in pixels
 }
 
 

--- a/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
@@ -2,6 +2,7 @@
   <virtual-list
     ref="vList"
     class="list-body"
+    :class="{ 'list-body-empty': displayItems.length === 0 }"
     :data-key="'key'"
     :data-sources="displayItems"
     :data-component="itemComponent"
@@ -74,6 +75,8 @@ interface RoutineItem extends BaseItem {
   parent: BaseItem;
 }
 
+const INITIAL_ITEM_HEIGHT = 22.8;
+
 export default Vue.extend({
   mixins: [TableListContextMenus],
   components: { VirtualList },
@@ -82,7 +85,7 @@ export default Vue.extend({
       items: [],
       displayItems: [],
       itemComponent: ItemComponent,
-      estimateItemHeight: 22.8, // height of collapsed item
+      estimateItemHeight: INITIAL_ITEM_HEIGHT, // height of collapsed item
       keeps: 30,
       generated: false,
     };
@@ -182,7 +185,7 @@ export default Vue.extend({
 
           // Summarizing the total height of all list items to get the average height
 
-          totalHeight += 22.8; // height of list item
+          totalHeight += INITIAL_ITEM_HEIGHT; // height of list item
 
           if (item.expanded) {
             if (item.type === "table") {
@@ -196,7 +199,11 @@ export default Vue.extend({
         }
       }
 
-      this.estimateItemHeight = totalHeight / displayItems.length;
+      if (displayItems.length > 0) {
+        this.estimateItemHeight = totalHeight / displayItems.length;
+      } else {
+        this.estimateItemHeight = INITIAL_ITEM_HEIGHT;
+      }
       this.displayItems = displayItems;
     },
     loadColumns(item: TableItem) {

--- a/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
@@ -33,6 +33,7 @@ import { AppEvent } from "@/common/AppEvent";
 import { mapGetters, mapState } from "vuex";
 import { PinnedEntity } from "@/common/appdb/models/PinnedEntity";
 import { entityId } from "@/common/utils";
+import globals from '@/common/globals';
 import "scrollyfills";
 
 type Entity = TableOrView | Routine | string;
@@ -75,8 +76,6 @@ interface RoutineItem extends BaseItem {
   parent: BaseItem;
 }
 
-const INITIAL_ITEM_HEIGHT = 22.8;
-
 export default Vue.extend({
   mixins: [TableListContextMenus],
   components: { VirtualList },
@@ -85,7 +84,7 @@ export default Vue.extend({
       items: [],
       displayItems: [],
       itemComponent: ItemComponent,
-      estimateItemHeight: INITIAL_ITEM_HEIGHT, // height of collapsed item
+      estimateItemHeight: globals.tableListItemHeight, // height of collapsed item
       keeps: 30,
       generated: false,
     };
@@ -185,7 +184,7 @@ export default Vue.extend({
 
           // Summarizing the total height of all list items to get the average height
 
-          totalHeight += INITIAL_ITEM_HEIGHT; // height of list item
+          totalHeight += globals.tableListItemHeight; // height of list item
 
           if (item.expanded) {
             if (item.type === "table") {
@@ -202,7 +201,7 @@ export default Vue.extend({
       if (displayItems.length > 0) {
         this.estimateItemHeight = totalHeight / displayItems.length;
       } else {
-        this.estimateItemHeight = INITIAL_ITEM_HEIGHT;
+        this.estimateItemHeight = globals.tableListItemHeight;
       }
       this.displayItems = displayItems;
     },

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -8,7 +8,7 @@ import { ChangeBuilderBase } from '@shared/lib/sql/change_builder/ChangeBuilderB
 export interface ExecutionContext {
     executedBy: 'user' | 'app'
     location: string // eg tab name or ID
-    purpose?: string // why 
+    purpose?: string // why
     details?: string // any useful details
 }
 
@@ -49,7 +49,9 @@ export abstract class BasicDatabaseClient<RawResultType> implements DatabaseClie
   alterPartition: (changes: AlterPartitionsSpec) => Promise<void> = () => Promise.resolve();
   getMaterializedViewCreateScript?: (view: string, schema?: string) => Promise<string[]> = () => Promise.resolve([]);
   abstract versionString(): string;
-  abstract defaultSchema(): string | null;
+  defaultSchema(): string | null {
+    return null
+  }
 
 
   abstract getBuilder(table: string, schema?: string): ChangeBuilderBase

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -40,7 +40,6 @@ export abstract class BasicDatabaseClient<RawResultType> implements DatabaseClie
     this.knex = knex;
     this.contextProvider = contextProvider
   }
-  defaultSchema?: () => string;
   listTablePartitions(_table: string): Promise<TablePartition[]> {
     return Promise.resolve([])
   }
@@ -50,6 +49,7 @@ export abstract class BasicDatabaseClient<RawResultType> implements DatabaseClie
   alterPartition: (changes: AlterPartitionsSpec) => Promise<void> = () => Promise.resolve();
   getMaterializedViewCreateScript?: (view: string, schema?: string) => Promise<string[]> = () => Promise.resolve([]);
   abstract versionString(): string;
+  abstract defaultSchema(): string | null;
 
 
   abstract getBuilder(table: string, schema?: string): ChangeBuilderBase

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -64,13 +64,9 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
 
     this.database = database?.database;
   }
-  
-  versionString(): string {
-    return this.version?.data[0]["sqlite_version()"];  
-  }
 
-  defaultSchema(): string | null {
-    return null
+  versionString(): string {
+    return this.version?.data[0]["sqlite_version()"];
   }
 
   getBuilder(table: string, _schema?: string): ChangeBuilderBase {

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -69,6 +69,10 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
     return this.version?.data[0]["sqlite_version()"];  
   }
 
+  defaultSchema(): string | null {
+    return null
+  }
+
   getBuilder(table: string, _schema?: string): ChangeBuilderBase {
     return new SqliteChangeBuilder(table);
   }


### PR DESCRIPTION
bugs from recent PRs:
- click the + icon to make a new table, then it shows blank screen.
  cause: undefined `defaultSchema` method in sqlite.ts
- when the database is empty, creating a new a table does not show the table in the table list, even after refreshing.
  cause: `NaN` value (zero divided by zero) in VirtualTableList
- dislocated empty state when database is empty