### PR TITLE
fix: don't do a typecheck when seeing value changes in tabletable

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -953,8 +953,13 @@ export default Vue.extend({
         : false;
     },
     cellEdited(cell) {
-
       const pkCells = cell.getRow().getCells().filter(c => this.isPrimaryKey(c.getField()))
+
+      // some number fields were being converted to strings so were triggered the cellEdited event because tabulator probably `===` stuff
+      // If the cell value does fall into this, we don't want anything edited.
+      if (cell.getOldValue() == cell.getValue()) {
+        return
+      }
 
       if (!pkCells) {
         this.$noty.error("Can't edit column -- couldn't figure out primary key")
@@ -976,7 +981,7 @@ export default Vue.extend({
       cell.getElement().classList.add('edited')
       const currentEdit = _.find(this.pendingChanges.updates, { key: key })
 
-      if (currentEdit?.oldValue === cell.getValue()) {
+      if (currentEdit?.oldValue == cell.getValue()) {
         this.$set(this.pendingChanges, 'updates', _.without(this.pendingChanges.updates, currentEdit))
         cell.getElement().classList.remove('edited')
         return


### PR DESCRIPTION
fix #1808
![bugfix-1808](https://github.com/beekeeper-studio/beekeeper-studio/assets/314613/5e962906-13b6-48c6-98c1-b52e763c2d7f)
