### PR TITLE
fix(spreadsheet): navigation improvements

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.2.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#daa59721b253cb6d69e8b35c4fee468666954fc2",
+    "tabulator-tables": "beekeeper-studio/tabulator#9755670787b032cb812dcd83fe25b75ec27329c3",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14687,9 +14687,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#daa59721b253cb6d69e8b35c4fee468666954fc2:
+tabulator-tables@beekeeper-studio/tabulator#9755670787b032cb812dcd83fe25b75ec27329c3:
   version "5.5.2"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/daa59721b253cb6d69e8b35c4fee468666954fc2"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/9755670787b032cb812dcd83fe25b75ec27329c3"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
- use spreadsheetJump (ctrl + arrow keys) to move to the next non-empty cell just like on google sheet.
- when the range is at the edge, using ctrl + arrow keys should keep it at the position instead of moving to the other side.