### PR TITLE
fix(TableSchema): column name should be green if it's new row

### DIFF
--- a/apps/studio/src/components/tableinfo/TableSchema.vue
+++ b/apps/studio/src/components/tableinfo/TableSchema.vue
@@ -222,7 +222,6 @@ export default Vue.extend({
           formatter: this.cellFormatter,
           editable: this.isCellEditable.bind(this, 'renameColumn'),
           cellClick: this.columnNameCellClick.bind(this),
-          frozen: true,
           minWidth: 100,
         },
         {


### PR DESCRIPTION
The easiest way to fix this is by not making the column name `frozen` (which is what I did lol).  See https://github.com/beekeeper-studio/beekeeper-studio/pull/1701 for why column name needs to be `frozen`. 