### PR TITLE
feat: Enable quick switch for connections and databases

### DIFF
--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -613,6 +613,12 @@ input[type=file] {
   &.query {
     color: $brand-pink;
   }
+  &.database {
+    color: $brand-purple;
+  }
+  &.connection {
+    color: $brand-secondary;
+  }
   &.settings {
     color: $text-lighter;
   }

--- a/apps/studio/src/components/quicksearch/QuickSearch.vue
+++ b/apps/studio/src/components/quicksearch/QuickSearch.vue
@@ -35,7 +35,7 @@
           <div>Open </div>
           <div class="shortcut">
             <span>Enter</span>
-          </div> 
+          </div>
         </div>
         <div class="shortcut-item">
           <div>Alt Open</div>
@@ -69,10 +69,10 @@
         class="results"
         v-if="results && results.length"
       >
-        <li 
-          class="result-item" 
-          v-for="(blob, idx) in results" 
-          :key="idx" 
+        <li
+          class="result-item"
+          v-for="(blob, idx) in results"
+          :key="idx"
           :class="{selected: idx === selectedItem}"
           @click.prevent="handleClick($event, blob)"
         >
@@ -83,7 +83,15 @@
           <i
             class="material-icons item-icon query"
             v-if="blob.type === 'query'"
-          >code</i> 
+          >code</i>
+          <i
+            class="material-icons item-icon connection"
+            v-if="blob.type === 'connection'"
+          >power</i>
+          <i
+            class="material-icons item-icon database"
+            v-if="blob.type === 'database'"
+          >storage</i>
           <span v-html="highlight(blob)" />
         </li>
       </ul>
@@ -194,12 +202,29 @@ export default Vue.extend({
     selectDown() {
       this.selectedItem = this.selectedItem + 1
     },
-    submit(result, persistSearch = false) {
+    async submit(result, persistSearch = false) {
       if(!result?.item) return
-      if (result.type === 'table') {
-        this.$root.$emit(AppEvent.loadTable, {table: result.item})
-      } else {
-        this.$root.$emit('favoriteClick', result.item)
+      switch (result.type) {
+        case 'table':
+          this.$root.$emit(AppEvent.loadTable, {table: result.item})
+          break;
+        case 'query':
+          this.$root.$emit('favoriteClick', result.item)
+          break;
+        case 'connection':
+          await this.$store.dispatch('disconnect')
+          try {
+            await this.$store.dispatch('connect', result.item)
+          } catch (ex) {
+            this.$noty.error("Error establishing a connection")
+            console.error(ex)
+          }
+          break;
+        case 'database':
+          this.$store.dispatch('changeDatabase', result.item)
+          break;
+        default:
+          break;
       }
       if (!persistSearch) this.closeSearch()
     },

--- a/apps/studio/src/components/sidebar/core/DatabaseDropdown.vue
+++ b/apps/studio/src/components/sidebar/core/DatabaseDropdown.vue
@@ -57,14 +57,13 @@
   import vSelect from 'vue-select'
   import {AppEvent} from '@/common/AppEvent'
   import AddDatabaseForm from "@/components/connection/AddDatabaseForm"
+  import { mapActions, mapState } from 'vuex'
 
   export default {
     props: [ 'connection' ],
     data() {
       return {
-        currentDatabase: null,
         selectedDatabase: null,
-        dbs: [],
         OpenIndicator: {
           render: createElement => createElement('i', {class: {'material-icons': true}}, 'arrow_drop_down')
         }
@@ -75,9 +74,7 @@
       AddDatabaseForm
     },
     methods: {
-      async refreshDatabases() {
-        this.dbs = await this.connection.listDatabases()
-      },
+      ...mapActions({refreshDatabases: 'updateDatabaseList'}),
       async databaseCreated(db) {
         this.$modal.hide('config-add-database')
         console.log(this.selectedDatabase)
@@ -91,15 +88,20 @@
       }
     },
     async mounted() {
-      this.selectedDatabase = await this.connection.currentDatabase()
-      this.dbs = await this.connection.listDatabases()
+      this.selectedDatabase = this.currentDatabase
     },
     computed: {
       availableDatabases() {
         return _.without(this.dbs, this.selectedDatabase)
-      }
+      },
+      ...mapState({currentDatabase: 'database', dbs: 'databaseList'}),
     },
     watch: {
+      currentDatabase(newValue) {
+        if (this.selectedDatabase !== newValue) {
+          this.selectedDatabase = newValue
+        }
+      },
       selectedDatabase() {
         this.$emit('databaseSelected', this.selectedDatabase)
       }


### PR DESCRIPTION
This PR allows quick switching to connections and databases, as discussed in issue https://github.com/beekeeper-studio/beekeeper-studio/issues/810 .

See it in action:
![image](http://g.recordit.co/kMSZhS7oFG.gif)

To achieve this, some of the internal state of `DatabaseDropdown` was moved to the main Vuex store, so it can be queried from both the dropdown as well as the QuickSearch module.