### PR TITLE
bump tabulator

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.6.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#9755670787b032cb812dcd83fe25b75ec27329c3",
+    "tabulator-tables": "beekeeper-studio/tabulator#04f7c8087e4402c937e7a70c460021e279d049e6",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -170,9 +170,7 @@ export function pasteRange(range: Tabulator.RangeComponent) {
 }
 
 export function setCellValue(cell: Tabulator.CellComponent, value: string) {
-  /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-  // @ts-ignore
-  const editableFunc = cell.getColumn().getDefinition().__spreadsheet_editable
+  const editableFunc = cell.getColumn().getDefinition().editable
   const editable = typeof editableFunc === 'function' ? editableFunc(cell) : editableFunc
   if (editable) cell.setValue(value);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14687,9 +14687,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#9755670787b032cb812dcd83fe25b75ec27329c3:
+tabulator-tables@beekeeper-studio/tabulator#04f7c8087e4402c937e7a70c460021e279d049e6:
   version "5.5.2"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/9755670787b032cb812dcd83fe25b75ec27329c3"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/04f7c8087e4402c937e7a70c460021e279d049e6"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
Pressing enter in an input editor does not close it due to the enter key is registered in the keybindings module. This fix respects the enter key that's triggered from the editor.

https://github.com/azmy60/tabulator/commit/5ebf3903a8e38ca203b3971411807e80ac75b527