### PR TITLE
spreadsheet fixes, enhancements, and small refactor

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.6.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#04f7c8087e4402c937e7a70c460021e279d049e6",
+    "tabulator-tables": "beekeeper-studio/tabulator#d52420270ca72aed57bc16ece94c568d980573ed",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.6.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#d52420270ca72aed57bc16ece94c568d980573ed",
+    "tabulator-tables": "beekeeper-studio/tabulator#85dae91c72923774d6ac119a2fdb9f0672d267af",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -17,6 +17,8 @@ $cell-padding:           $gutter-w;
 $header-highlight:       mix($query-editor-bg, $theme-base, 95%);
 $header-selected:        mix($query-editor-bg, $theme-primary, 10%);
 
+$columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
+
 // Mixin
 @mixin cell-shadow($bg) {
   box-shadow: inset -1px 0 rgba(black, 0.2),
@@ -801,5 +803,32 @@ $header-selected:        mix($query-editor-bg, $theme-primary, 10%);
         }
       }
     }
+  }
+}
+
+.tabulator-col-resize-guide {
+  background-color: $columnResizeGuideColor;
+  opacity: 1;
+  margin-left: 1px;
+}
+
+.tabulator-col-resize-handle:hover {
+  position: relative;
+  &::before, &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    width: 3px;
+    height: 60%;
+    transform: translate(0, -50%);
+    background-color: transparentize($columnResizeGuideColor, 0.4);
+    backdrop-filter: invert(100%);
+    border-radius: 999px;
+  }
+  &::before {
+    left: 4.5px;
+  }
+  &::after {
+    right: 4.5px;
   }
 }

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -776,6 +776,8 @@ export default Vue.extend({
 
       this.tabulator = new TabulatorFull(this.$refs.table, {
         spreadsheet: true,
+        resizeColumnsMode: 'guide',
+        resizeColumnsHandles: 'header-only',
         height: this.actualTableHeight,
         columns: this.tableColumns,
         nestedFieldSeparator: false,

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -145,10 +145,7 @@ export function pasteRange(range: Tabulator.RangeComponent) {
   } else {
     const table = range.getCells()[0].getTable()
     const rows = table.modules.spreadsheet.getRows().slice(range.getTop())
-    /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-    // @ts-ignore
-    // TODO: use range.getLeft(), which is not available in tabulator yet
-    const columns = table.modules.spreadsheet.getColumns().slice(range._range.left + 1)
+    const columns = table.modules.spreadsheet.getColumns().slice(range.getLeft() + 1)
     const cells: Tabulator.CellComponent[][] = rows.map((row) => {
       const arr = [];
       row.getCells().forEach((cell) => {

--- a/apps/studio/src/typings/tabulator.d.ts
+++ b/apps/studio/src/typings/tabulator.d.ts
@@ -10,6 +10,8 @@ declare module "tabulator-tables" {
       getColumns(): Tabulator.ColumnComponent[];
       getTop(): number;
       getBottom(): number;
+      getLeft(): number;
+      getRight(): number;
     }
 
     export class CellComponent {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14687,9 +14687,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#04f7c8087e4402c937e7a70c460021e279d049e6:
+tabulator-tables@beekeeper-studio/tabulator#d52420270ca72aed57bc16ece94c568d980573ed:
   version "5.5.2"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/04f7c8087e4402c937e7a70c460021e279d049e6"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/d52420270ca72aed57bc16ece94c568d980573ed"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14687,9 +14687,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#d52420270ca72aed57bc16ece94c568d980573ed:
+tabulator-tables@beekeeper-studio/tabulator#85dae91c72923774d6ac119a2fdb9f0672d267af:
   version "5.5.2"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/d52420270ca72aed57bc16ece94c568d980573ed"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/85dae91c72923774d6ac119a2fdb9f0672d267af"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
- Fix: spreadsheet selection was broken when setting columns with `tabulator.setColumns()`. This happened in query editor when switching between query results https://github.com/olifolkerd/tabulator/pull/4313/commits/b1deac5ad00c4a0472dd14a223e430bbf982c1e6
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/75f20fa5-ffb0-49f8-b16e-f1615984d755)

- Refactor: added left and right offset getters to RangeComponent https://github.com/olifolkerd/tabulator/pull/4313/commits/90df6ce4f0960b558b0c04b05614eadb893f94c6

- Feat: also closes #1839. New features: add column resize guide, and allow multiple column resize. https://github.com/olifolkerd/tabulator/pull/4313/commits/3e005ed9ddcacc893ad72becd828dc6348381863

![Animation4](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/761d81d0-cd27-419c-83c3-f86f8a40af3f)
