### PR TITLE
Format numbers in TableLength to improve readability

### DIFF
--- a/apps/studio/src/components/common/TableLength.vue
+++ b/apps/studio/src/components/common/TableLength.vue
@@ -8,7 +8,7 @@
     <span v-if="fetchingTotalRecords">loading...</span>
     <span v-else-if="error">error</span>
     <span v-else-if="totalRecords === null">Unknown</span>
-    <span v-else>~{{ totalRecords.toLocaleString() }}</span>
+    <span v-else>~{{ Number(totalRecords).toLocaleString() }}</span>
   </a>
 </template>
 <script lang="ts">
@@ -27,7 +27,7 @@ export default Vue.extend({
       if (this.totalRecords === null)
         return 'Click to fetch total record count'
 
-      return `Approximately ${this.totalRecords} Records`
+      return `Approximately ${Number(this.totalRecords).toLocaleString()} Records`
     }
   },
   methods: {


### PR DESCRIPTION
The component which displays the number of rows in a table currently displays the number without any formatting, which can make high numbers (6+ figures) difficult to read.

It seems this was already supposed to be partly implemented in line 11 using `totalRecords.toLocaleString()`, but this did not seem to have any effect. Using `Number(totalRecords).toLocaleString()` fixed this. In addition to that, the number in the tooltip is formatted aswell now.

**Before:**
![Beekeeper_Studio_XORIzxtfli](https://github.com/beekeeper-studio/beekeeper-studio/assets/33791936/fcc83811-f700-4249-a26f-d3d17348f002)

**After:**
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/33791936/a37161c8-b7d8-4e72-b3ac-f179421363b4)
