### PR TITLE
some minor fixes in styles and editor modal escape key

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -71,6 +71,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
     &.deleted,
     &.edit-error {
       box-shadow: inset 0 -1px rgba($theme-base, .1);
+      --row-box-shadow: inset 0 -1px #{rgba($theme-base, .1)};
       .tabulator-cell {
         &:hover {
           background: rgba($theme-base, 0.05);
@@ -87,6 +88,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
         cursor: default!important;
         &:hover {
           background: transparent!important;
+          --row-hover-bg-color: transparent;
         }
         .tabulator-bks-checkbox {
           input {
@@ -593,9 +595,10 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
     inset: 0;
     background-color: var(--row-bg-color);
     z-index: -10;
+    box-shadow: var(--row-box-shadow, none);
   }
   &:hover::before {
-    background-color: rgba($theme-base, 0.10);
+    background-color: var(--row-hover-bg-color, rgba($theme-base, 0.10));
   }
 }
 

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -835,3 +835,8 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
     right: 4.5px;
   }
 }
+
+.tabulator-tooltip {
+  background-color: #292A2D;
+  color: lightgray;
+}

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -423,6 +423,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
       .tabulator-header-popup-button {
         display: none;
         position: relative;
+        z-index: 1;
         &::before {
           transition: opacity 0.15s;
           content: "";
@@ -435,6 +436,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
           border-radius: 9999px;
           background-color: rgba($theme-base, 0.1);
           opacity: 0;
+          z-index: -1;
         }
         &:hover {
           opacity: 1;
@@ -780,8 +782,13 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
     outline: none;
     .tabulator-col {
 
-      &:not(.tabulator-spreadsheet-selected):hover {
-        background: rgba($theme-base, 0.035);
+      &:hover {
+        &:not(.tabulator-spreadsheet-selected) {
+          background: rgba($theme-base, 0.035);
+        }
+        &.tabulator-spreadsheet-selected .tabulator-header-popup-button::before {
+          background-color: darken($header-selected, 10%);
+        }
         .tabulator-header-popup-button {
           display: inline-block;
         }

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -254,13 +254,18 @@ x-buttons {
         &.inserted,
         &.inserted:hover {
           background: $row-add!important;
+          --row-bg-color: #{$row-add};
+          --row-hover-bg-color: rgba($theme-base, 0.05);
         }
         &.deleted,
         &.deleted:hover {
           background: $row-delete!important;
+          --row-bg-color: #{$row-delete};
+          --row-hover-bg-color: #{$row-delete};
         }
         &.edit-error {
           background: $row-error!important;
+          --row-bg-color: #{$row-error};
         }
       }
       &.edit-error {
@@ -274,8 +279,10 @@ x-buttons {
         }
         &.edited {
           background: $cell-edited;
+          --row-bg-color: #{$cell-edited};
           &:hover {
             background: darken($cell-edited, 5%);
+            --row-hover-bg-color: darken($cell-edited, 5%);
           }
         }
         &.edit-error {
@@ -343,9 +350,11 @@ x-buttons {
     &.tabulator-row-even,
     &:nth-child(odd) {
       background: rgba($theme-base, 0.06);
+      --row-bg-color: #{rgba($theme-base, 0.06)};
     }
     &.inserted {
       background: $row-add!important;
+      --row-bg-color: #{$row-add};
     }
   }
 }

--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -1,7 +1,8 @@
 <template>
   <portal to="modals">
-    <modal :name="modalName" class="beekeeper-modal vue-dialog editor-dialog" @opened="onOpen" @keydown.stop @keyup.stop @keypress.stop>
-      <div class="dialog-content" tabindex="0">
+    <modal :name="modalName" class="beekeeper-modal vue-dialog editor-dialog" @opened="onOpen">
+      <!-- Trap the key events so it doesn't conflict with the parent elements -->
+      <div class="dialog-content" tabindex="0" @keydown.stop @keyup.stop="handleKeyUp" @keypress.stop>
         <div class="top">
           <div class="dialog-c-title">
             Editing as
@@ -268,6 +269,11 @@ export default Vue.extend({
     minify() {
       this.content = this.language.minify(this.content)
       this.editor.setValue(this.content)
+    },
+    handleKeyUp(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        this.$modal.hide(this.modalName)
+      }
     }
   },
 });

--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -1,7 +1,7 @@
 <template>
   <portal to="modals">
-    <modal :name="modalName" class="beekeeper-modal vue-dialog editor-dialog" @opened="onOpen">
-      <div class="dialog-content" tabindex="0" @keydown.stop @keyup.stop @keypress.stop>
+    <modal :name="modalName" class="beekeeper-modal vue-dialog editor-dialog" @opened="onOpen" @keydown.stop @keyup.stop @keypress.stop>
+      <div class="dialog-content" tabindex="0">
         <div class="top">
           <div class="dialog-c-title">
             Editing as

--- a/shared/src/components/SchemaBuilder.vue
+++ b/shared/src/components/SchemaBuilder.vue
@@ -318,6 +318,7 @@ export default Vue.extend({
       &.tabulator-row-even,
       &:nth-child(odd) {
         background: rgba($theme-base, 0.05);
+        --row-bg-color: #{rgba($theme-base, 0.05)};
       }
       .tabulator-cell {
         min-height: $row-height;
@@ -376,6 +377,8 @@ export default Vue.extend({
         // Read Only
         &.read-only,
         &.read-only:hover {
+          --row-bg-color: transparent;
+          --row-hover-bg-color: transparent;
           background: transparent!important;
           cursor: default;
           input {


### PR DESCRIPTION
1. Esc should close the editor modal

2. Tabulator tooltips are hard to read in light mode. Sticking with the native tooltips colors cause they look good both in light and dark mode.

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/a023f0a1-b0a4-431d-beb4-2a68c580ba39)

3. Adding/deleting columns in table structure has weird styles. Also happens in table structure of a `view`.

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/a0ffe5e4-d43b-4a57-931f-5a043703ec67)

4. Fix column header that's unclickable and a bit of adjustment to the background color when hovering.

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/37fec72d-bcc4-48aa-8ae1-c6e04e17fe2d)

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/ee3d56f6-c988-4c1d-b272-333a5e35f74d)
