### PR TITLE
unfreeze column name and fix nullable editor onblur

### DIFF
--- a/apps/studio/src/assets/styles/app/tabs/table-builder.scss
+++ b/apps/studio/src/assets/styles/app/tabs/table-builder.scss
@@ -90,6 +90,7 @@
       &.tabulator-row-even,
       &:nth-child(odd){
         background: rgba($theme-base, 0.05)!important;
+        --row-bg-color: #{rgba($theme-base, 0.05)};
       }
       .tabulator-cell {
         min-height: $row-height;

--- a/shared/src/components/SchemaBuilder.vue
+++ b/shared/src/components/SchemaBuilder.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
           editor: vueEditor(NullableInputEditor),
           formatter: this.cellFormatter,
           tooltip: true,
-          frozen: true,
+          // frozen: true,
           minWidth: 100,
           editorParams: {
           }

--- a/shared/src/components/tabulator/NullableInputEditor.vue
+++ b/shared/src/components/tabulator/NullableInputEditor.vue
@@ -77,6 +77,7 @@ export default Vue.extend({
     },
     onBlur() {
       log.debug('blur, not submitting')
+      this.$emit('cancel')
     },
     submit() {
       log.debug('nullable submitted')


### PR DESCRIPTION
in previous version, we always call the `submit` event on blur or on input in `NullableInputEditor`. If we blur the input, and didn't call `submit` or `cancel`, it would cause some weird "unfocusable" cells. It looks like tabulator blocks some click events or something if we didn't call one of those two events.