### PR TITLE
add copy as plain text

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -162,12 +162,7 @@
       },
       copySelection() {
         if (!document.activeElement.classList.contains('tabulator-tableholder')) return
-        const range = this.tabulator.getActiveRange()
-        if (range.getCells().length === 1) {
-          copyRange({ range, type: 'plain' })
-        } else {
-          copyRange({ range, type: 'tsv' })
-        }
+        copyRange({ range: this.tabulator.getActiveRange(), type: 'plain' })
       },
       dataToJson(rawData, firstObjectOnly) {
         const rows = _.isArray(rawData) ? rawData : [rawData]

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -162,7 +162,12 @@
       },
       copySelection() {
         if (!document.activeElement.classList.contains('tabulator-tableholder')) return
-        copyRange({ range: this.tabulator.getActiveRange(), type: 'tsv' })
+        const range = this.tabulator.getActiveRange()
+        if (range.getCells().length === 1) {
+          copyRange({ range, type: 'plain' })
+        } else {
+          copyRange({ range, type: 'tsv' })
+        }
       },
       dataToJson(rawData, firstObjectOnly) {
         const rows = _.isArray(rawData) ? rawData : [rawData]

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -712,12 +712,7 @@ export default Vue.extend({
     },
     copySelection() {
       if (!document.activeElement.classList.contains('tabulator-tableholder')) return
-      const range: Tabulator.RangeComponent = this.tabulator.getActiveRange()
-      if (range.getCells().length === 1) {
-        copyRange({ range, type: 'plain' })
-      } else {
-        copyRange({ range, type: 'tsv' })
-      }
+      copyRange({ range: this.tabulator.getActiveRange(), type: 'plain' })
     },
     pasteSelection() {
       if (!document.activeElement.classList.contains('tabulator-tableholder')) return

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -712,7 +712,12 @@ export default Vue.extend({
     },
     copySelection() {
       if (!document.activeElement.classList.contains('tabulator-tableholder')) return
-      copyRange({ range: this.tabulator.getActiveRange(), type: 'tsv' })
+      const range: Tabulator.RangeComponent = this.tabulator.getActiveRange()
+      if (range.getCells().length === 1) {
+        copyRange({ range, type: 'plain' })
+      } else {
+        copyRange({ range, type: 'tsv' })
+      }
     },
     pasteSelection() {
       if (!document.activeElement.classList.contains('tabulator-tableholder')) return

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -195,11 +195,11 @@ export function copyActionsMenu(options: {
   const { range, connection, table, schema } = options;
   return [
     {
-      label: createMenuItem("Copy as Plain text"),
+      label: createMenuItem("Copy", "Control+C"),
       action: () => copyRange({ range, type: "plain" }),
     },
     {
-      label: createMenuItem("Copy as TSV for Excel", "Control+C"),
+      label: createMenuItem("Copy as TSV for Excel"),
       action: () => copyRange({ range, type: "tsv" }),
     },
     {

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -91,27 +91,33 @@ export function createMenuItem(label: string, shortcut = "") {
 
 export async function copyRange(options: {
   range: Tabulator.RangeComponent;
-  type: "tsv" | "tsv-no-escapes" | "json" | "markdown" | "sql";
+  type: "plain" | "tsv" | "json" | "markdown" | "sql";
   connection?: DatabaseClient;
   table?: string;
   schema?: string;
 }) {
   let text = "";
   switch (options.type) {
+    case "plain":  {
+      const cells = options.range.getCells();
+      if (cells.length === 1) {
+        text = cells[0].getValue();
+      } else {
+        text = Papa.unparse(options.range.getData(), {
+          header: false,
+          delimiter: "\t",
+          quotes: false,
+          escapeFormulae: false,
+        });
+      }
+      break;
+    }
     case "tsv":
       text = Papa.unparse(options.range.getData(), {
         header: false,
         delimiter: "\t",
         quotes: true,
         escapeFormulae: true,
-      });
-      break;
-    case "tsv-no-escapes":
-      text = Papa.unparse(options.range.getData(), {
-        header: false,
-        delimiter: "\t",
-        quotes: false,
-        escapeFormulae: false,
       });
       break;
     case "json":
@@ -190,7 +196,7 @@ export function copyActionsMenu(options: {
   return [
     {
       label: createMenuItem("Copy as Plain text"),
-      action: () => copyRange({ range, type: "tsv-no-escapes" }),
+      action: () => copyRange({ range, type: "plain" }),
     },
     {
       label: createMenuItem("Copy as TSV for Excel", "Control+C"),

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -91,7 +91,7 @@ export function createMenuItem(label: string, shortcut = "") {
 
 export async function copyRange(options: {
   range: Tabulator.RangeComponent;
-  type: "tsv" | "json" | "markdown" | "sql";
+  type: "tsv" | "tsv-no-escapes" | "json" | "markdown" | "sql";
   connection?: DatabaseClient;
   table?: string;
   schema?: string;
@@ -104,6 +104,14 @@ export async function copyRange(options: {
         delimiter: "\t",
         quotes: true,
         escapeFormulae: true,
+      });
+      break;
+    case "tsv-no-escapes":
+      text = Papa.unparse(options.range.getData(), {
+        header: false,
+        delimiter: "\t",
+        quotes: false,
+        escapeFormulae: false,
       });
       break;
     case "json":
@@ -180,6 +188,10 @@ export function copyActionsMenu(options: {
 }) {
   const { range, connection, table, schema } = options;
   return [
+    {
+      label: createMenuItem("Copy as Plain text"),
+      action: () => copyRange({ range, type: "tsv-no-escapes" }),
+    },
     {
       label: createMenuItem("Copy as TSV for Excel", "Control+C"),
       action: () => copyRange({ range, type: "tsv" }),


### PR DESCRIPTION
Bringing back previous behaviors that are missing:

1. Added a "copy as plain text" option to the context menu. This won't add quotes or escapes the data, and is available when right clicking a range of cells, column headers, and row headers.

2. Based on the previous version, copying a single cell should not add quotes, but copying multiple cells should. This behavior is now added to the keyboard shortcut.

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/c151097f-eff7-49b3-955f-bd7b2deeb833)

fix #1867