### PR TITLE
fix undefined nice string

### DIFF
--- a/shared/src/components/tabulator/NullableInputEditor.vue
+++ b/shared/src/components/tabulator/NullableInputEditor.vue
@@ -103,7 +103,8 @@ export default Vue.extend({
   watch: {
     rendered() {
       if (this.rendered) {
-        this.value = helpers.niceString(this.cell.getValue())
+        const cellValue = this.cell.getValue()
+        this.value = _.isNil(cellValue) ? '' : helpers.niceString(cellValue)
         this.$nextTick(() => {
           this.$refs.input.focus();
           if (this.params.autoSelect) {

--- a/shared/src/lib/tabulator.ts
+++ b/shared/src/lib/tabulator.ts
@@ -28,9 +28,6 @@ function yesNoResult(value: boolean) {
 
 export default {
   niceString(value: any, truncate = false) {
-    if (_.isNil(value)) {
-      return ''
-    }
     let cellValue = value.toString();
     if(_.isArray(value) || _.isObject(value)) {
       cellValue = JSON.stringify(value)

--- a/shared/src/lib/tabulator.ts
+++ b/shared/src/lib/tabulator.ts
@@ -28,6 +28,9 @@ function yesNoResult(value: boolean) {
 
 export default {
   niceString(value: any, truncate = false) {
+    if (_.isNil(value)) {
+      return ''
+    }
     let cellValue = value.toString();
     if(_.isArray(value) || _.isObject(value)) {
       cellValue = JSON.stringify(value)


### PR DESCRIPTION
This fixes the inconsistent clicking behavior from this issue. Fix #1889.

Double clicking a cell that is null does not open the cell editor immediately.