### PR TITLE
Fixing new window opening

### DIFF
--- a/apps/studio/src/background.ts
+++ b/apps/studio/src/background.ts
@@ -5,6 +5,7 @@ import log from 'electron-log'
 import * as electron from 'electron'
 import { ipcMain } from 'electron'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
+import yargs from 'yargs-parser'
 
 // eslint-disable-next-line
 require('@electron/remote/main').initialize()
@@ -19,7 +20,6 @@ import { IGroupedUserSettings, UserSetting } from './common/appdb/models/user_se
 import Connection from './common/appdb/Connection'
 import Migration from './migration/index'
 import { buildWindow, getActiveWindows } from './background/WindowBuilder'
-import yargs from 'yargs-parser'
 import platformInfo from './common/platform_info'
 
 import { AppEvent } from './common/AppEvent'
@@ -43,6 +43,11 @@ const isDevelopment = platformInfo.isDevelopment
 initUserDirectory(platformInfo.userDirectory)
 log.info("initializing user ORM connection")
 const ormConnection = new Connection(platformInfo.appDbPath, false)
+log.debug("ELECTRON BOOTING")
+log.debug("####################################")
+
+log.debug("Platform Information (Electron)")
+log.debug(JSON.stringify(platformInfo, null, 2))
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let settings: IGroupedUserSettings
@@ -77,17 +82,6 @@ async function initBasics() {
   return settings
 }
 
-// so we need to check that the DM is running in wayland
-// and we need to check that wayland has been enabled
-// why? Because we have to force the usage of the client titlebar
-function isWaylandMode() {
-  const slice = platformInfo.isDevelopment ? 2 : 1
-  const parsedArgs = yargs(process.argv.slice(slice))
-  return parsedArgs['ozone-platform-hint'] &&
-    platformInfo.isWayland && platformInfo.isLinux
-}
-
-
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
@@ -102,8 +96,7 @@ app.on('activate', async (_event, hasVisibleWindows) => {
   // dock icon is clicked and there are no other windows open.
   if (!hasVisibleWindows) {
     if (!settings) throw "No settings initialized!"
-    const runningWayland = isWaylandMode()
-    buildWindow(settings, { runningWayland })
+    buildWindow(settings)
   }
 })
 
@@ -129,11 +122,8 @@ app.on('ready', async () => {
   const slice = platformInfo.isDevelopment ? 2 : 1
   const parsedArgs = yargs(process.argv.slice(slice))
 
-  log.debug("Parsing app args", parsedArgs)
-  const runningWayland = isWaylandMode()
-
   // this gets positional arguments
-  const options = parsedArgs._.map((url: string) => ({ url, runningWayland }))
+  const options = parsedArgs._.map((url: string) => ({ url }))
   const settings = await initBasics()
 
   if (options.length > 0) {
@@ -142,8 +132,7 @@ app.on('ready', async () => {
   } else {
     if (getActiveWindows().length === 0) {
       const settings = await initBasics()
-      const runningWayland = isWaylandMode()
-      await buildWindow(settings, { runningWayland })
+      await buildWindow(settings)
     }
   }
 })
@@ -152,17 +141,15 @@ app.on('ready', async () => {
 app.on('open-file', async (event, file) => {
   event.preventDefault();
   const settings = await initBasics()
-  const runningWayland = isWaylandMode()
-  await buildWindow(settings, { url: file, runningWayland })
+  await buildWindow(settings, { url: file })
 });
 
 // Open a connection from a url (e.g. postgres://host)
 app.on('open-url', async (event, url) => {
   event.preventDefault();
   const settings = await initBasics()
-  const runningWayland = isWaylandMode()
 
-  await buildWindow(settings, { url, runningWayland })
+  await buildWindow(settings, { url })
 });
 
 // Exit cleanly on request from parent process in development mode.

--- a/apps/studio/src/background.ts
+++ b/apps/studio/src/background.ts
@@ -5,7 +5,6 @@ import log from 'electron-log'
 import * as electron from 'electron'
 import { ipcMain } from 'electron'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
-import yargs from 'yargs-parser'
 
 // eslint-disable-next-line
 require('@electron/remote/main').initialize()
@@ -119,11 +118,9 @@ app.on('ready', async () => {
       console.error('Vue Devtools failed to install:', e.toString())
     }
   }
-  const slice = platformInfo.isDevelopment ? 2 : 1
-  const parsedArgs = yargs(process.argv.slice(slice))
 
   // this gets positional arguments
-  const options = parsedArgs._.map((url: string) => ({ url }))
+  const options = platformInfo.parsedArgs._.map((url: string) => ({ url }))
   const settings = await initBasics()
 
   if (options.length > 0) {

--- a/apps/studio/src/background/NativeMenuBuilder.ts
+++ b/apps/studio/src/background/NativeMenuBuilder.ts
@@ -22,7 +22,6 @@ export default class NativeMenuBuilder {
   initialize(): void {
     if (this.builder) {
       const template = this.builder.buildTemplate()
-      log.info("MENUTEMPLATE", template)
       this.menu = this.electron.Menu.buildFromTemplate(template)
       this.electron.Menu.setApplicationMenu(this.menu)
     } else {

--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -18,7 +18,6 @@ const windows: BeekeeperWindow[] = []
 
 export interface OpenOptions {
   url?: string
-  runningWayland: boolean
 }
 
 function getIcon() {
@@ -35,7 +34,7 @@ class BeekeeperWindow {
     let showFrame = settings.menuStyle && settings.menuStyle.value == 'native' ? true : false
     let titleBarStyle: 'default' | 'hidden' = platformInfo.isWindows && settings.menuStyle.value == 'native' ? 'default' : 'hidden'
 
-    if (openOptions.runningWayland) {
+    if (platformInfo.isWayland) {
       showFrame = false
       titleBarStyle = 'hidden'
     }
@@ -59,7 +58,13 @@ class BeekeeperWindow {
 
     const runningInWebpack = !!process.env.WEBPACK_DEV_SERVER_URL
     let appUrl = process.env.WEBPACK_DEV_SERVER_URL || 'app://./index.html'
-    const query = openOptions ? querystring.stringify(openOptions) : null
+    const queryObj: any = openOptions ? { ...openOptions } : {}
+
+    if (platformInfo.isWayland) {
+      queryObj.runningWayland = true
+    }
+
+    const query = querystring.stringify(queryObj)
 
     appUrl = query ? `${appUrl}?${query}` : appUrl
     remoteMain.enable(this.win.webContents)
@@ -134,6 +139,6 @@ export function getActiveWindows(): BeekeeperWindow[] {
   return _.filter(windows, 'active')
 }
 
-export function buildWindow(settings: IGroupedUserSettings, options: OpenOptions): void {
-  windows.push(new BeekeeperWindow(settings, options))
+export function buildWindow(settings: IGroupedUserSettings, options?: OpenOptions): void {
+  windows.push(new BeekeeperWindow(settings, options || {}))
 }

--- a/apps/studio/src/common/platform_info.ts
+++ b/apps/studio/src/common/platform_info.ts
@@ -1,4 +1,6 @@
 import * as path from 'path'
+import yargs from 'yargs-parser'
+
 let p, e
 
 function isRenderer() {
@@ -22,6 +24,7 @@ if (isRenderer()) {
   p = process
 }
 
+
 const platform = p.env.OS_OVERRIDE ? p.env.OS_OVERRIDE : p.platform
 const testMode = p.env.TEST_MODE ? true : false
 const isDevEnv = !(e.app && e.app.isPackaged);
@@ -40,10 +43,24 @@ const homeDirectory = testMode ? './tmp' : e.app.getPath('home')
 if (p.env.PORTABLE_EXECUTABLE_DIR) {
   userDirectory = path.join(p.env.PORTABLE_EXECUTABLE_DIR, 'beekeeper_studio_data')
 }
+
+const sessionType = p.env.XDG_SESSION_TYPE
+
+const slice = isDevEnv ? 2 : 1
+const parsedArgs = yargs(p.argv.slice(slice))
+// TODO: Automatically enable wayland without flags once
+// we're confident it will 'just work' for all Wayland users.
+function isWaylandMode() {
+  return parsedArgs['ozone-platform-hint'] === 'auto' &&
+    sessionType === 'wayland' && !isWindows && !isMac
+}
+
 const platformInfo = {
+  parsedArgs,
   isWindows, isMac,
   isLinux: !isWindows && !isMac,
-  isWayland: p.env.XDG_SESSION_TYPE === 'wayland', 
+  sessionType,
+  isWayland: isWaylandMode(),
   isSnap: p.env.ELECTRON_SNAP,
   isPortable: isWindows && p.env.PORTABLE_EXECUTABLE_DIR,
   isDevelopment: isDevEnv,

--- a/apps/studio/src/main.ts
+++ b/apps/studio/src/main.ts
@@ -43,7 +43,6 @@ import Connection from './common/appdb/Connection'
 import xlsx from 'xlsx'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
-import log from 'electron-log'
 import VueClipboard from 'vue-clipboard2'
 import platformInfo from './common/platform_info'
 import { AppEventMixin } from './common/AppEvent'
@@ -53,9 +52,25 @@ import _ from 'lodash'
 import NotyPlugin from '@/plugins/NotyPlugin'
 import './common/initializers/big_int_initializer.ts'
 import SettingsPlugin from './plugins/SettingsPlugin'
+import rawLog from 'electron-log'
 
 (async () => {
+
+  const transports = [rawLog.transports.console, rawLog.transports.file]
+  if (platformInfo.isDevelopment || platformInfo.debugEnabled) {
+    transports.forEach(t => t.level = 'silly')
+  } else {
+    transports.forEach(t => t.level = 'warn')
+  }
+  const log = rawLog.scope("main.ts")
+  log.info("starting logging")
+
   try {
+
+    log.debug("APP BOOTING")
+    log.debug("####################################")
+    log.debug("Platform Information (App)")
+    log.debug(JSON.stringify(platformInfo, null, 2))
 
     _.mixin({
       'deepMapKeys': function (obj, fn) {
@@ -75,14 +90,8 @@ import SettingsPlugin from './plugins/SettingsPlugin'
         return x;
       }
     });
-    const transports = [log.transports.console, log.transports.file]
-    if (platformInfo.isDevelopment || platformInfo.debugEnabled) {
-      transports.forEach(t => t.level = 'silly')
-    } else {
-      transports.forEach(t => t.level = 'warn')
-    }
 
-    log.info("starting logging")
+
     tls.DEFAULT_MIN_VERSION = "TLSv1"
     TimeAgo.addLocale(en)
     Tabulator.defaultOptions.layout = "fitDataFill";


### PR DESCRIPTION
- Wayland check happens in platformInfo, not as a flag
- Added some helpful platformInfo logging
- Removed Wayland from the subsequent newWindow calls

Fix #1898 