### PR TITLE
Bring back sort buttons

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.6.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#f4217f7be7d0fe4880e49f311a5076ff01e4f981",
+    "tabulator-tables": "beekeeper-studio/tabulator#93b922ff4cc9bec5485fa546527eda702ad17f1b",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -810,6 +810,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
           min-width: 0;
           overflow: hidden;
           text-overflow: ellipsis;
+          padding-right: 2px;
           & > * {
             display: inline;
           }

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -406,6 +406,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
       height: 32px!important;
       font-size: 90%;
       line-height: 1;
+      flex-direction: row;
       &:not(.tabulator-spreadsheet-row-header):not(.tabulator-spreadsheet-selected) {
         border-top-left-radius: 4px;
         border-top-right-radius: 4px;
@@ -421,9 +422,9 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
         background-color: transparent;
       }
       .tabulator-header-popup-button {
-        display: none;
         position: relative;
         z-index: 1;
+        color: $text-lighter;
         &::before {
           transition: opacity 0.15s;
           content: "";
@@ -440,6 +441,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
         }
         &:hover {
           opacity: 1;
+          color: inherit;
           &::before {
             opacity: 1;
           }
@@ -458,10 +460,8 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
       & .badge {
         background: transparent;
         color: $text-lighter;
-        padding: 0 0.1rem;
-      }
-      &.tabulator-spreadsheet-selected .badge {
-        color: black;
+        padding: 0;
+        margin: 0 0 0 0.3rem;
       }
       &.tabulator-sortable[aria-sort="ascending"] {
         .tabulator-col-content {
@@ -490,40 +490,30 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
         }
       }
       &.foreign-key, &.primary-key {
-        padding-left: $foreign-key-width!important;
+        .tabulator-col-content {
+          width: calc(100% - #{$foreign-key-width});
+        }
         &:before{
+          $font-size: 13px;
           content: 'vpn_key';
           font-family: 'Material Icons';
-          font-size: 13px;
-          position: absolute;
-          top: 0;
-          left: 0;
-          bottom: 0;
+          font-size: $font-size;
+          color: $theme-primary;
+          padding-left: $foreign-key-width - $font-size;
           display: inline-flex;
           align-items: center;
-          justify-content: flex-end;
-          color: $theme-primary;
-          width: $foreign-key-width;
-
         }
       }
       &.primary-key:before {
         color: $theme-secondary;
       }
-      &.tabulator-spreadsheet-selected {
-        &.primary-key:before {
-          color: black;
-        }
-        &.foreign-key:before {
-          color: mix($theme-primary, black, 60%);
-        }
-      }
       &.foreign-key-button {
         display: none;
       }
       .tabulator-col-content {
-        padding: 0 8px;
+        padding: 0 4px 0 8px;
         line-height: 32px;
+        width: 100%;
         .tabulator-arrow {
           top: 14px;
           border-width: 4px!important;
@@ -782,33 +772,67 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
     outline: none;
     .tabulator-col {
 
-      &:hover {
-        &:not(.tabulator-spreadsheet-selected) {
-          background: rgba($theme-base, 0.035);
+      &:hover:not(.tabulator-spreadsheet-selected) {
+        background: rgba($theme-base, 0.035);
+      }
+
+      &.tabulator-spreadsheet-selected {
+        &.primary-key:before {
+          color: black;
         }
-        &.tabulator-spreadsheet-selected .tabulator-header-popup-button::before {
-          background-color: darken($header-selected, 10%);
+        &.foreign-key:before {
+          color: mix($theme-primary, black, 60%);
         }
-        .tabulator-header-popup-button {
-          display: inline-block;
+        .tabulator-col-content .tabulator-col-title-holder .tabulator-col-title {
+          color: inherit;
+          .badge, .tabulator-header-popup-button {
+            color: black;
+          }
+          .tabulator-col-sorter.tabulator-col-sorter-element {
+            & .tabulator-arrow, &:hover .tabulator-arrow {
+              border-top-color: black;
+              border-bottom-color: black;
+            }
+          }
+          .tabulator-header-popup-button::before, .tabulator-col-sorter.tabulator-col-sorter-element:hover {
+            background-color: darken($header-selected, 10%);
+          }
         }
       }
 
-      &.tabulator-spreadsheet-selected .tabulator-col-title {
-        color: inherit;
-      }
-
-      .tabulator-col-title {
+      .tabulator-col-content .tabulator-col-title-holder .tabulator-col-title {
         display: flex;
         flex-direction: row-reverse;
+        align-items: center;
         overflow: visible;
+        padding: 0;
         .title {
-          flex-grow: 1;
           min-width: 0;
           overflow: hidden;
           text-overflow: ellipsis;
           & > * {
             display: inline;
+          }
+        }
+        .tabulator-col-sorter.tabulator-col-sorter-element {
+          margin-left: auto;
+          width: 24px;
+          height: 24px;
+          min-width: 24px;
+          min-height: 24px;
+          position: relative;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          inset: 0;
+          border-radius: 9999px;
+          &:hover {
+            cursor: pointer;
+            background-color: rgba($theme-base, 0.1);
+            div.tabulator-arrow {
+              border-top-color: $theme-base;
+              border-bottom-color: $theme-base;
+            }
           }
         }
       }
@@ -824,6 +848,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
 
 .tabulator-col-resize-handle:hover {
   position: relative;
+  width: 6px;
   &::before, &::after {
     content: '';
     position: absolute;

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -499,7 +499,7 @@ export default Vue.extend({
         const hasKeyDatas = keyDatas && keyDatas.length > 0
         const columnWidth = this.table.columns.length > 30 ?
           this.defaultColumnWidth(slimDataType, globals.bigTableColumnWidth) :
-          this.countInitialColumnWidth(column.columnName, column.dataType, isPK || hasKeyDatas);
+          undefined;
 
         let headerTooltip = `${column.columnName} ${column.dataType}`
         if (hasKeyDatas) {
@@ -934,18 +934,6 @@ export default Vue.extend({
       const chunkyTypes = ['json', 'jsonb', 'blob', 'text', '_text', 'tsvector']
       if (chunkyTypes.includes(slimType)) return globals.largeFieldWidth
       return defaultValue
-    },
-    countInitialColumnWidth(columnName: string, dataType: string, isKey: boolean) {
-      const charWidth = 5 // approximately
-      const keyWidth = 20 // approximately
-      const headerWithoutTitle = 76 // approximately
-      const offset = 10
-      const titleWidth = (columnName.length + dataType.length) * charWidth
-      let initialWidth = headerWithoutTitle + titleWidth + offset
-      if (isKey) {
-        initialWidth += keyWidth
-      }
-      return initialWidth
     },
     // TODO: this is not attached to anything. but it might be needed?
     allowHeaderSort(column) {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -496,10 +496,10 @@ export default Vue.extend({
         const editorType = this.editorType(column.dataType)
         const useVerticalNavigation = editorType === 'textarea'
         const isPK = this.primaryKeys?.length && this.isPrimaryKey(column.columnName)
+        const hasKeyDatas = keyDatas && keyDatas.length > 0
         const columnWidth = this.table.columns.length > 30 ?
           this.defaultColumnWidth(slimDataType, globals.bigTableColumnWidth) :
-          undefined;
-        const hasKeyDatas = keyDatas && keyDatas.length > 0
+          this.countInitialColumnWidth(column.columnName, column.dataType, isPK || hasKeyDatas);
 
         let headerTooltip = `${column.columnName} ${column.dataType}`
         if (hasKeyDatas) {
@@ -777,8 +777,6 @@ export default Vue.extend({
 
       this.tabulator = new TabulatorFull(this.$refs.table, {
         spreadsheet: true,
-        resizeColumnsMode: 'guide',
-        resizeColumnsHandles: 'header-only',
         height: this.actualTableHeight,
         columns: this.tableColumns,
         nestedFieldSeparator: false,
@@ -936,6 +934,18 @@ export default Vue.extend({
       const chunkyTypes = ['json', 'jsonb', 'blob', 'text', '_text', 'tsvector']
       if (chunkyTypes.includes(slimType)) return globals.largeFieldWidth
       return defaultValue
+    },
+    countInitialColumnWidth(columnName: string, dataType: string, isKey: boolean) {
+      const charWidth = 5 // approximately
+      const keyWidth = 20 // approximately
+      const headerWithoutTitle = 76 // approximately
+      const offset = 10
+      const titleWidth = (columnName.length + dataType.length) * charWidth
+      let initialWidth = headerWithoutTitle + titleWidth + offset
+      if (isKey) {
+        initialWidth += keyWidth
+      }
+      return initialWidth
     },
     // TODO: this is not attached to anything. but it might be needed?
     allowHeaderSort(column) {

--- a/apps/studio/src/main.ts
+++ b/apps/studio/src/main.ts
@@ -53,7 +53,7 @@ import NotyPlugin from '@/plugins/NotyPlugin'
 import './common/initializers/big_int_initializer.ts'
 import SettingsPlugin from './plugins/SettingsPlugin'
 import rawLog from 'electron-log'
-import { CustomTabulatorModule } from './plugins/CustomTabulatorModule'
+import { HeaderSortTabulatorModule } from './plugins/HeaderSortTabulatorModule'
 
 (async () => {
 
@@ -104,7 +104,7 @@ import { CustomTabulatorModule } from './plugins/CustomTabulatorModule'
     Tabulator.defaultOptions.resizeColumnsMode = 'guide';
     // @ts-expect-error default options not fully typed
     Tabulator.defaultOptions.resizeColumnsHandles = 'header-only';
-    Tabulator.registerModule([CustomTabulatorModule]);
+    Tabulator.registerModule([HeaderSortTabulatorModule]);
     // Tabulator.prototype.bindModules([EditModule]);
     const appDb = platformInfo.appDbPath
     const connection = new Connection(appDb, config.isDevelopment ? true : ['error'])

--- a/apps/studio/src/main.ts
+++ b/apps/studio/src/main.ts
@@ -53,6 +53,7 @@ import NotyPlugin from '@/plugins/NotyPlugin'
 import './common/initializers/big_int_initializer.ts'
 import SettingsPlugin from './plugins/SettingsPlugin'
 import rawLog from 'electron-log'
+import { CustomTabulatorModule } from './plugins/CustomTabulatorModule'
 
 (async () => {
 
@@ -97,6 +98,13 @@ import rawLog from 'electron-log'
     Tabulator.defaultOptions.layout = "fitDataFill";
     // @ts-expect-error default options not fully typed
     Tabulator.defaultOptions.menuContainer = ".beekeeper-studio-wrapper";
+    // @ts-expect-error default options not fully typed
+    Tabulator.defaultOptions.headerSortClickElement = 'icon';
+    // @ts-expect-error default options not fully typed
+    Tabulator.defaultOptions.resizeColumnsMode = 'guide';
+    // @ts-expect-error default options not fully typed
+    Tabulator.defaultOptions.resizeColumnsHandles = 'header-only';
+    Tabulator.registerModule([CustomTabulatorModule]);
     // Tabulator.prototype.bindModules([EditModule]);
     const appDb = platformInfo.appDbPath
     const connection = new Connection(appDb, config.isDevelopment ? true : ['error'])

--- a/apps/studio/src/plugins/CustomTabulatorModule.ts
+++ b/apps/studio/src/plugins/CustomTabulatorModule.ts
@@ -1,0 +1,19 @@
+import { Module } from "tabulator-tables";
+
+export class CustomTabulatorModule extends Module {
+  static moduleInitOrder = 100;
+
+  initialize() {
+    // @ts-expect-error Module class not fully typed
+    this.subscribe("column-layout", this.moveSorterToTitleElement.bind(this));
+  }
+
+  moveSorterToTitleElement(column) {
+    const arrowEl = column.titleHolderElement.querySelector(
+      ".tabulator-col-sorter"
+    );
+    if (arrowEl) {
+      column.titleElement.insertBefore(arrowEl, column.titleElement.firstChild);
+    }
+  }
+}

--- a/apps/studio/src/plugins/HeaderSortTabulatorModule.ts
+++ b/apps/studio/src/plugins/HeaderSortTabulatorModule.ts
@@ -1,6 +1,6 @@
 import { Module } from "tabulator-tables";
 
-export class CustomTabulatorModule extends Module {
+export class HeaderSortTabulatorModule extends Module {
   static moduleInitOrder = 100;
 
   initialize() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14764,9 +14764,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#f4217f7be7d0fe4880e49f311a5076ff01e4f981:
-  version "5.5.2-bks1"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/f4217f7be7d0fe4880e49f311a5076ff01e4f981"
+tabulator-tables@beekeeper-studio/tabulator#93b922ff4cc9bec5485fa546527eda702ad17f1b:
+  version "5.5.2-bks2"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/93b922ff4cc9bec5485fa546527eda702ad17f1b"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
fix #1900 fix #1887

![Animation4](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/c4c77b2a-5cab-4c96-9dcf-66500500f218)

TODO
- [x] Initial width can be set by tabulator. No need to do this manually.
- [ ] Reset column widths when someone install the new update? (Beware to just reset the __width__)