### PR TITLE
fix table name in sql copy

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "simple-encryptor": "^3.0.0",
     "split.js": "^1.5.11",
     "sql-formatter": "~10.7.2",
-    "sql-query-identifier": "beekeeper-studio/sql-query-identifier#393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a",
+    "sql-query-identifier": "^2.7.0",
     "ssh2": "^1.14.0",
     "tabulator-tables": "beekeeper-studio/tabulator#93b922ff4cc9bec5485fa546527eda702ad17f1b",
     "tinyduration": "^3.2.4",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,7 +70,7 @@
     "simple-encryptor": "^3.0.0",
     "split.js": "^1.5.11",
     "sql-formatter": "~10.7.2",
-    "sql-query-identifier": "^2.6.0",
+    "sql-query-identifier": "beekeeper-studio/sql-query-identifier#393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a",
     "ssh2": "^1.14.0",
     "tabulator-tables": "beekeeper-studio/tabulator#93b922ff4cc9bec5485fa546527eda702ad17f1b",
     "tinyduration": "^3.2.4",

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1112,7 +1112,7 @@
           // @ts-ignore
           this.executeTime = queryEndTime - queryStartTime
           let totalRows = 0
-          results.forEach(result => {
+          results.forEach((result, idx) => {
             result.rowCount = result.rowCount || 0
 
             // TODO (matthew): remove truncation logic somewhere sensible
@@ -1121,6 +1121,12 @@
               result.rows = _.take(result.rows, this.$config.maxResults)
               result.truncated = true
               result.totalRowCount = result.rowCount
+            }
+
+            if (identification[idx]?.tables.length > 0) {
+              result.tableName = identification[idx].tables[0]
+            } else {
+              result.tableName = "mytable"
             }
           })
           this.results = Object.freeze(results);

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1081,7 +1081,7 @@
         this.selectedResult = 0
         let identification = []
         try {
-          identification = identify(rawQuery, { strict: false, dialect: this.identifyDialect })
+          identification = identify(rawQuery, { strict: false, dialect: this.identifyDialect, identifyTables: true })
         } catch (ex) {
           log.error("Unable to identify query", ex)
         }

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1123,7 +1123,7 @@
               result.totalRowCount = result.rowCount
             }
 
-            if (identification[idx]?.tables.length > 0) {
+            if (identification[idx]?.tables.length === 1) {
               result.tableName = identification[idx].tables[0]
             } else {
               result.tableName = "mytable"

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -75,7 +75,7 @@
           return copyActionsMenu({
             range: cell.getRange(),
             connection: this.connection,
-            table: 'mytable',
+            table: this.result.tableName,
             schema: this.connection.defaultSchema(),
           })
         }
@@ -153,7 +153,7 @@
               return copyActionsMenu({
                 range: cell.getRange(),
                 connection: this.connection,
-                table: 'mytable',
+                table: this.result.tableName,
                 schema: this.connection.defaultSchema(),
               })
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14064,9 +14064,10 @@ sql-formatter@~10.7.2:
     argparse "^2.0.1"
     nearley "^2.20.1"
 
-sql-query-identifier@beekeeper-studio/sql-query-identifier#393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a:
-  version "2.5.0-bks2"
-  resolved "https://codeload.github.com/beekeeper-studio/sql-query-identifier/tar.gz/393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a"
+sql-query-identifier@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-2.7.0.tgz#e05de066df91d93388f5f088245f16c13290022d"
+  integrity sha512-MTDRfn0kUv+9ELnt9wt/FATi03Wq1j3YvhE5Up8ToE5Afk5zzBgVHPuIu1bVhqNqfF0aeIPl3vEzZ60H1yv0ag==
 
 sqlstring@^2.3.2:
   version "2.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8519,7 +8519,7 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-hosted-git-info@^4.0.1, hosted-git-info@^4.0.2:
+hosted-git-info@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.1.0.tgz#827b82867e9ff1c8d0c4d9d53880397d2c86d224"
   integrity sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==
@@ -9073,7 +9073,7 @@ is-color-stop@^1.0.0:
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
 
-is-core-module@^2.5.0, is-core-module@^2.9.0:
+is-core-module@^2.9.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
   integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
@@ -11374,16 +11374,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
     hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
-    validate-npm-package-license "^3.0.1"
-
-normalize-package-data@^3.0.0:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.3.tgz#dbcc3e2da59509a0983422884cd172eefdfa525e"
-  integrity sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==
-  dependencies:
-    hosted-git-info "^4.0.1"
-    is-core-module "^2.5.0"
-    semver "^7.3.4"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^1.0.0:
@@ -14074,10 +14064,9 @@ sql-formatter@~10.7.2:
     argparse "^2.0.1"
     nearley "^2.20.1"
 
-sql-query-identifier@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-2.6.0.tgz#ee56c0dacb946157f53f0ea0fbacb237250be8bd"
-  integrity sha512-gxlT1LX+BZi1NR8qWDtiU8umJf53OYuSKZN4xIufl6apD3OAVoBc/06FYBWPc+cHKrdqwvvs6wkiGfhvtqZwRw==
+sql-query-identifier@beekeeper-studio/sql-query-identifier#393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a:
+  version "2.5.0-bks2"
+  resolved "https://codeload.github.com/beekeeper-studio/sql-query-identifier/tar.gz/393e94d55dfb4ca038842d6e2fb7ffc2a6ee651a"
 
 sqlstring@^2.3.2:
   version "2.3.3"


### PR DESCRIPTION
fix #1658

Using `sql-query-identifier` from our fork repo => https://github.com/beekeeper-studio/sql-query-identifier/tree/table-identification-build

Beware that when Copying SQL from result table, the columns are still `c0`, `c1`, etc..