### PR TITLE
Replace deprecated apt-key w/signed-by

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -27,15 +27,13 @@ A repo is provided for Debian and Ubuntu 16.04+.
 
 ```bash
 # Install our GPG key
-wget --quiet -O - https://deb.beekeeperstudio.io/beekeeper.key | sudo apt-key add -
-
-# add our repo to your apt lists directory
-echo "deb https://deb.beekeeperstudio.io stable main" | sudo tee /etc/apt/sources.list.d/beekeeper-studio-app.list
+curl -fsSL https://deb.beekeeperstudio.io/beekeeper.key | sudo gpg --dearmor --output /usr/share/keyrings/beekeeper.gpg \
+  && sudo chmod go+r /usr/share/keyrings/beekeeper.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/beekeeper.gpg] https://deb.beekeeperstudio.io stable main" \
+  | sudo tee /etc/apt/sources.list.d/beekeeper-studio-app.list > /dev/null
 
 # Update apt and install
-sudo apt update
-sudo apt install beekeeper-studio
-
+sudo apt update && sudo apt install beekeeper-studio -y
 ```
 
 


### PR DESCRIPTION
apt-key is deprecated, so it's advised to install the GPG key and explicitly set the `signed-by` attribute.

A redo of beekeeper-studio/beekeeper-studio#1785 which seems to have been accidentally lost when renaming files.