### PR TITLE
fix redshift table data view

### DIFF
--- a/apps/studio/src/lib/db/clients/redshift.ts
+++ b/apps/studio/src/lib/db/clients/redshift.ts
@@ -7,6 +7,7 @@ import { PostgresClient, STQOptions } from "./postgresql";
 import { escapeString } from "./utils";
 import pg from 'pg';
 import { defaultCreateScript } from "./postgresql/scripts";
+import { TableKey } from "@shared/lib/dialects/models";
 
 export class RedshiftClient extends PostgresClient {
   supportedFeatures(): SupportedFeatures {
@@ -62,6 +63,65 @@ export class RedshiftClient extends PostgresClient {
     }
   }
 
+  async getTableKeys(_db: string, table: string, schema: string = this._defaultSchema): Promise<TableKey[]> {
+    const sql = `
+      SELECT
+
+          kcu.constraint_schema AS from_schema,
+
+          kcu.table_name AS from_table,
+
+          kcu.column_name AS from_column,
+          rc.unique_constraint_schema AS to_schema,
+          tc.constraint_name,
+          rc.update_rule,
+          rc.delete_rule,
+
+          (SELECT kcu2.table_name
+           FROM information_schema.key_column_usage AS kcu2
+           WHERE kcu2.constraint_name = rc.unique_constraint_name) AS to_table,
+          (SELECT kcu2.column_name
+           FROM information_schema.key_column_usage AS kcu2
+           WHERE kcu2.constraint_name = rc.unique_constraint_name) AS to_column
+      FROM
+          information_schema.key_column_usage AS kcu
+
+      JOIN
+          information_schema.table_constraints AS tc
+
+      ON
+          tc.constraint_name = kcu.constraint_name
+
+      JOIN
+          information_schema.referential_constraints AS rc
+      ON
+          rc.constraint_name = kcu.constraint_name
+      WHERE
+          tc.constraint_type = 'FOREIGN KEY' AND
+          kcu.table_schema NOT LIKE 'pg_%' AND
+          kcu.table_schema = $2 AND
+          kcu.table_name = $1;
+    `;
+
+    const params = [
+      table,
+      schema,
+    ];
+
+    const data = await this.driverExecuteSingle(sql, { params });
+
+    return data.rows.map((row) => ({
+      toTable: row.to_table,
+      toSchema: row.to_schema,
+      toColumn: row.to_column,
+      fromTable: row.from_table,
+      fromSchema: row.from_schema,
+      fromColumn: row.from_column,
+      constraintName: row.constraint_name,
+      onUpdate: row.update_rule,
+      onDelete: row.delete_rule
+    }));
+  }
   async getTableCreateScript(table: string, schema: string = this._defaultSchema): Promise<string> {
     const params = [
       table,


### PR DESCRIPTION
In attempt to fix the redshift issue where we're unable to open the table view but able to query it from query editor.

The error that shows was:

```
syntax error at or near "ORDER"
```

Which refers to `STRING_AGG(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS from_column,` in `getTableKeys` method. That query works in **postgres** but not in **redshift**. I couldn't find how to solve this more properly, so for now, I applied this commit 536a800d81a52b05cbcda2e8f0c12b2c4d678ea8 to the `getTableKeys` in redshift only. At least that's how it worked before.

fix #1632 fix #1758

Changes from #1715