### PR TITLE
hide tabulator header icon menu

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -463,6 +463,9 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
           }
         }
       }
+      &.hide-header-menu-icon .tabulator-header-popup-button {
+        display: none;
+      }
       .tabulator-col-title {
         color: $text-dark;
       }

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -112,6 +112,7 @@
             contextMenu: cellMenu,
             headerContextMenu: columnMenu,
             headerMenu: columnMenu,
+            cssClass: 'hide-header-menu-icon',
           }
           if (column.dataType === 'INTERVAL') {
             // add interval sorter

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -532,11 +532,11 @@ export default Vue.extend({
           headerTooltip += ' [Primary Key]'
         }
 
-        let cssClass: string;
+        let cssClass = 'hide-header-menu-icon';
         if (isPK) {
-          cssClass = 'primary-key';
+          cssClass += ' primary-key';
         } else if (hasKeyDatas) {
-          cssClass = 'foreign-key';
+          cssClass += ' foreign-key';
         }
 
         // if column has a comment, add it to the tooltip


### PR DESCRIPTION
ref #1994 

fix number 3

> Remove the kebab menu (three dots) from table column headers -- right click is good enough and this gives more space for the column headers