### PR TITLE
fix clashing css class

### DIFF
--- a/apps/studio/src/components/tab/TabIcon.vue
+++ b/apps/studio/src/components/tab/TabIcon.vue
@@ -9,7 +9,7 @@
   >code</i>
   <i
     v-else-if="tab.type === 'table-properties'"
-    class="material-icons-outlined item-icon table-properties"
+    class="material-icons-outlined item-icon icon-table-properties"
     :class="iconClass"
   >construction</i>
   <i


### PR DESCRIPTION
ref #1994 

> Closing a tab modal has broken flex style

The icon uses a class that exists for a different element.