### PR TITLE
fix cant change the name of column in table properties

### DIFF
--- a/shared/src/components/tabulator/NullableInputEditor.vue
+++ b/shared/src/components/tabulator/NullableInputEditor.vue
@@ -107,6 +107,9 @@ export default Vue.extend({
     },
     parseValue() {
       const typeHint = this.params.typeHint;
+      if (typeof typeHint !== 'string') {
+        return this.value
+      }
       const floatTypes = [
         'float', 'double', 'double precision', 'dec', 'numeric', 'fixed'
       ]


### PR DESCRIPTION
ref #1994 

> adding/renaming a column in the structure view isn't working. By adding/renaming I mean you can't change the name of the column. [Slack link for gif](https://beekeeperstudio.slack.com/archives/C01T11HCK16/p1709526246847369?thread_ts=1709526213.450079&cid=C01T11HCK16)