### PR TITLE
add hidden column indicator

### DIFF
--- a/apps/studio/src/assets/styles/app/_all.scss
+++ b/apps/studio/src/assets/styles/app/_all.scss
@@ -17,4 +17,5 @@
 @import './tabs/tabletable.scss';
 @import './tabs/table-builder.scss';
 @import './modals.scss';
+@import './tooltips.scss';
 @import './ultimate-only.scss';

--- a/apps/studio/src/assets/styles/app/sidebar/table-list.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/table-list.scss
@@ -56,10 +56,6 @@
   position: relative;
   z-index: 1;
 
-  &:hover .hi-tooltip {
-    visibility: visible;
-  }
-
   > .badge {
     display: flex;
     align-items: center;
@@ -68,45 +64,6 @@
     .material-icons {
       font-size: 1rem;
       margin-right: 0.2rem;
-    }
-  }
-
-  .hi-tooltip {
-    $gap: 0.5rem;
-
-    visibility: hidden;
-    position: absolute;
-    display: block !important;
-    top: calc(100% + #{$gap});
-    left: -5rem;
-    width: 14rem;
-    padding: $gutter-h $gutter-w !important;
-    border-radius: 0.5rem;
-    background-color: #4f4f4f;
-
-    text-transform: none;
-    font-weight: normal;
-    font-size: 0.9rem;
-
-    // acting as a "bridge" so the tooltip stays visible when the cursor is
-    // in between the text and the tooltip
-    &::before {
-      content: '';
-      position: absolute;
-      left: 0;
-      top: -$gap;
-      width: 100%;
-      height: $gap;
-    }
-
-    span, a {
-      display: inline;
-      color: #eee;
-      line-height: 1.35rem;
-    }
-
-    a {
-      border-bottom: 1px solid #dadada;
     }
   }
 }

--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -11,7 +11,7 @@ $button-height:     $statusbar-height * 0.72;
   line-height: $statusbar-height;
   font-size: 0.8rem;
   padding: 0 $gutter-h;
-  overflow: hidden;
+  // overflow: hidden;
 
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {

--- a/apps/studio/src/assets/styles/app/tabs/tabletable.scss
+++ b/apps/studio/src/assets/styles/app/tabs/tabletable.scss
@@ -61,5 +61,17 @@
 
   }
 
+  .statusbar-item.hidden-column-count {
+    margin-right: 0.1rem;
+    & > a {
+      color: inherit;
+      display: inline-flex;
+    }
+    i {
+      margin-right: 0;
+      font-size: 16px;
+      line-height: 1;
+    }
+  }
 
 }

--- a/apps/studio/src/assets/styles/app/tooltips.scss
+++ b/apps/studio/src/assets/styles/app/tooltips.scss
@@ -1,0 +1,72 @@
+.bks-tooltip-wrapper {
+  position: relative;
+
+  &.statusbar-item {
+    overflow: visible;
+    &.hoverable:hover {
+      opacity: 1;
+    }
+  }
+
+  &:hover .bks-tooltip {
+    visibility: visible;
+  }
+
+  .bks-tooltip {
+    $gap: 0.5rem;
+
+    visibility: hidden;
+
+    position: absolute;
+    display: block;
+
+    width: 14rem;
+    padding: $gutter-h $gutter-w !important;
+    border-radius: 0.5rem;
+    background-color: #4f4f4f;
+
+    text-transform: none;
+    font-weight: normal;
+    font-size: 0.9rem;
+
+    &, a {
+      display: inline;
+      color: #eee;
+      line-height: 1.35rem;
+    }
+
+    a {
+      border-bottom: 1px solid #dadada;
+    }
+
+    // acting as a "bridge" so the tooltip stays visible when the cursor is
+    // in between the target element and the tooltip
+    &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        width: 100%;
+        height: $gap;
+    }
+
+    &.bks-tooltip-top-center {
+      bottom: calc(100% + #{$gap});
+      left: 50%;
+      transform: translateX(-50%);
+
+      &::before {
+        bottom: -$gap;
+      }
+    }
+
+    &.bks-tooltip-bottom-center {
+      top: calc(100% + #{$gap});
+      left: 50%;
+      transform: translateX(-50%);
+
+      &::before {
+        top: -$gap;
+      }
+    }
+  }
+}

--- a/apps/studio/src/components/sidebar/core/TableList.vue
+++ b/apps/studio/src/components/sidebar/core/TableList.vue
@@ -97,13 +97,13 @@
         >{{ shownEntities }} / {{ totalEntities }}</span>
         <span
           v-show="totalHiddenEntities > 0 && !filterQuery"
-          class="hidden-indicator"
+          class="hidden-indicator bks-tooltip-wrapper"
         >
           <span class="badge">
             <i class="material-icons">visibility_off</i>
             <span>{{ totalHiddenEntities > 99 ? '99+' : totalHiddenEntities }}</span>
           </span>
-          <div class="hi-tooltip">
+          <div class="hi-tooltip bks-tooltip bks-tooltip-bottom-center">
             <span>Right click an entity to hide it. </span>
             <a @click="$modal.show('hidden-entities')">View hidden</a><span>.</span>
           </div>

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -5,6 +5,7 @@ import Papa from "papaparse";
 import { stringifyRangeData } from "@/common/utils";
 import { BasicDatabaseClient } from "../db/clients/BasicDatabaseClient";
 import { rowHeaderField } from "@/lib/table-grid/utils";
+import { escapeHtml } from "@shared/lib/tabulator";
 
 type ColumnMenuItem = Tabulator.MenuObject<Tabulator.ColumnComponent>;
 
@@ -90,7 +91,7 @@ export const commonColumnMenu = [
 ];
 
 export function createMenuItem(label: string, shortcut = "") {
-  label = `<x-label>${label}</x-label>`;
+  label = `<x-label>${escapeHtml(label)}</x-label>`;
   if (shortcut) shortcut = `<x-shortcut value="${shortcut}" />`;
   return `<x-menuitem>${label}${shortcut}</x-menuitem>`;
 }


### PR DESCRIPTION
fix #1946 

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/b4a30173-c042-404f-b81c-c23d2bde8320)

- add hidden column indicator in statusbar
- it should have a tooltip that has a link to open the column filter modal
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/b2367079-8bc0-4f07-a2be-4833f34cf7c1)
- add `hide column` option to column header menu so we're able to hide them right away instead of opening the modal first
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/0c69244a-ad9b-4d88-b28c-c373586e56ed)

Note: I ended up using plain css to make the tooltip just like the hidden entities. `<v-popover>` (from v-tooltip), and `<x-tooltip>` (xel) didn't work. `<v-popover>` threw a bunch of weird errors for some reason.