### PR TITLE
Fix columns autocomplete in SQLTextEditor

### DIFF
--- a/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
@@ -89,13 +89,16 @@ export default Vue.extend({
       await this.setEditorValue(formatted);
     },
     async columnsGetter(tableName: string) {
-      const tableToFind = this.tables.find(
+      let tableToFind = this.tables.find(
         (t) => t.name === tableName || `${t.schema}.${t.name}` === tableName
       );
       if (!tableToFind) return null;
       // Only refresh columns if we don't have them cached.
       if (!tableToFind.columns?.length) {
         await this.$store.dispatch("updateTableColumns", tableToFind);
+        tableToFind = this.tables.find(
+          (t) => t.name === tableName || `${t.schema}.${t.name}` === tableName
+        );
       }
 
       return tableToFind?.columns.map((c) => c.columnName);


### PR DESCRIPTION
This PR fixes the columns auto complete, in the case that we had not loaded the columns for a table yet, we would load the columns into the store, but not reload the selected table we were returning for the autocomplete.