### PR TITLE
fix SQLTextEditor autocomplete

### DIFF
--- a/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
@@ -20,7 +20,7 @@
 <script lang="ts">
 import Vue from "vue";
 import TextEditor from "./TextEditor.vue";
-import { mapState } from "vuex";
+import { mapState, mapGetters } from "vuex";
 import { plugins } from "@/lib/editor/utils";
 import { format } from "sql-formatter";
 import { FormatterDialect, dialectFor } from "@shared/lib/dialects/models";
@@ -34,8 +34,10 @@ export default Vue.extend({
     };
   },
   computed: {
+    ...mapGetters(['defaultSchema']),
     ...mapState(["tables"]),
     hintOptions() {
+      // We do this so we can order the autocomplete options
       const firstTables = {};
       const secondTables = {};
       const thirdTables = {};

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -87,6 +87,10 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     return this.version.version.split(" on ")[0];
   }
 
+  defaultSchema(): string | null {
+    return this._defaultSchema;
+  }
+
   getBuilder(table: string, schema: string = this._defaultSchema): ChangeBuilderBase {
     return new PostgresqlChangeBuilder(table, schema);
   }


### PR DESCRIPTION
Two issues that are being fixed:
- `defaultSchema` was not defined in `SQLTextEditor`
- `defaultSchema()` always returned null in postgres client. I also have checked other clients if they return the right `defaultSchema` or not.

fix #2041 