### PR TITLE
fix mssql autocomplete

### DIFF
--- a/apps/studio/src/lib/editor/languageData.ts
+++ b/apps/studio/src/lib/editor/languageData.ts
@@ -157,7 +157,10 @@ export function resolveLanguage(lang: Language): CodeMirrorLanguage {
       };
     case "sqlserver":
       return {
-        mode: "text/x-mssql",
+        // Fix #1985 by using text/x-sql instead of text/x-mssql.
+        // For some reason, text/x-mssql messes up the editor.getToken()
+        // function which is used for autocomplete.
+        mode: "text/x-sql",
         // @ts-expect-error TODO not fully typed
         hint: CodeMirror.hint.sql,
       };


### PR DESCRIPTION
Also another autocomplete fix for SQL Server, that should be put together with #2044 but I'm not sure if this would cause regressions or not, so here's a separate PR.

This should fix #1985 and it's a bug that has been happening from all the way back to bks version 3.4.1, or even way before it.

So what happens is that the dialect we use for SQL Server `text/x-mssql` in codemirror kind of mess up with the `getToken()` method. Instead of returning `.columnName`, it returns `columnName` without dot.

Changing it to `text/x-sql` should work but I'm not sure if it can cause regressions yet.