### PR TITLE
fixes before release

### DIFF
--- a/apps/studio/src/assets/styles/app/tabs/tabletable.scss
+++ b/apps/studio/src/assets/styles/app/tabs/tabletable.scss
@@ -74,4 +74,13 @@
     }
   }
 
+  .empty-placeholder {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: bold;
+    font-size: 1.5rem;
+    color: $text;
+  }
 }

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -214,7 +214,7 @@
 import Vue from "vue";
 import { TableFilter } from "@/lib/db/models";
 import { joinFilters, normalizeFilters } from "@/common/utils";
-import { mapGetters } from "vuex";
+import { mapGetters, mapState } from "vuex";
 import platformInfo from "@/common/platform_info";
 import { AppEvent } from "@/common/AppEvent";
 
@@ -244,6 +244,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapGetters(["dialectData"]),
+    ...mapState(['connection']),
     additionalFilters() {
       const [_, ...additional] = this.filters;
       return additional;
@@ -268,12 +269,12 @@ export default Vue.extend({
 
       // Populate raw filter query with existing filter if raw filter is empty
       if (filterMode === RAW && filters.length && !this.filterRaw) {
-        const allFilters = filters.map(
-          (filter) =>
-            `${filter.field} ${filter.type} ${this.dialectData.escapeString(
-              filter.value,
-              true
-            )}`
+        const allFilters = filters.map((filter) =>
+          this.connection.knex
+            .where(filter.field, filter.type, filter.value)
+            .toString()
+            .split("where")[1]
+            .trim()
         );
         const filterString = joinFilters(allFilters, filters);
         this.filterRaw = filterString;

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -20,6 +20,10 @@
         @submit="triggerFilter"
       />
       <div
+        v-show="isEmpty"
+        class="empty-placeholder"
+      >No Data</div>
+      <div
         ref="table"
         class="spreadsheet-table"
       />
@@ -349,6 +353,9 @@ export default Vue.extend({
   computed: {
     ...mapState(['tables', 'tablesInitialLoaded', 'usedConfig', 'database', 'workspaceId']),
     ...mapGetters(['dialectData', 'dialect']),
+    isEmpty() {
+      return _.isEmpty(this.data);
+    },
     isCassandra() {
       return this.connection?.connectionType === 'cassandra'
     },
@@ -910,7 +917,6 @@ export default Vue.extend({
         height: this.actualTableHeight,
         columns: this.tableColumns,
         nestedFieldSeparator: false,
-        placeholder: "No Data",
         renderHorizontal: 'virtual',
         ajaxURL: "http://fake",
         sortMode: 'remote',

--- a/shared/src/lib/sql/SqlGenerator.ts
+++ b/shared/src/lib/sql/SqlGenerator.ts
@@ -61,9 +61,14 @@ export class SqlGenerator {
       schema.columns.forEach((column: SchemaItem) => {
         // TODO: autoincrement makes cassandra just roll over and die Need to remove it from the default values.
         // Other than that, was creating tables pretty ok I think
-        const col = column.dataType === 'autoincrement' ?
-          table.increments(column.columnName) :
-          table.specificType(column.columnName, column.dataType)
+        let col: Knex.ColumnBuilder;
+        if (column.dataType.match(/autoincrement/i) && this.dialect === 'postgresql') {
+          col = table.specificType(column.columnName, 'serial')
+        } else if (column.dataType.match(/autoincrement/i)) {
+          col = table.increments(column.columnName)
+        } else {
+          col = table.specificType(column.columnName, column.dataType)
+        }
 
         if (column.defaultValue) col.defaultTo(this.knex.raw(column.defaultValue))
         if (column.unsigned) col.unsigned()


### PR DESCRIPTION
- In postgres, creating a table with autoincrement type throws an error. 
  - fix: convert `autoincrement` to `serial` in the sql builder
- Can't see `No Data` placeholder if the table has so many columns.
  - fix: make custom placeholder instead of using tabulator
- `RowFilterBuilder` doesn't convert `in` type correctly.
  - fix: use knex to build the query