### PR TITLE
fix tabulator autofocus

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -73,7 +73,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.7.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#a00978c782ead8470fa0b099f0a082911039906c",
+    "tabulator-tables": "beekeeper-studio/tabulator#419dd37815ff483a5df3ba89bd8c5385fd24594f",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -191,6 +191,7 @@
           selectableRange: true,
           selectableRangeColumns: true,
           selectableRangeRows: true,
+          selectableRangeAutoFocus: false,
           resizableColumnGuide: true,
           data: this.tableData, //link data to table
           reactiveData: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13761,9 +13761,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#a00978c782ead8470fa0b099f0a082911039906c:
-  version "5.6.1-bks-1"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/a00978c782ead8470fa0b099f0a082911039906c"
+tabulator-tables@beekeeper-studio/tabulator#419dd37815ff483a5df3ba89bd8c5385fd24594f:
+  version "5.6.1-bks-2"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/419dd37815ff483a5df3ba89bd8c5385fd24594f"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
fix #2075 

by adding an option to prevent tabulator from auto focusing the table after initializing:
https://github.com/beekeeper-studio/tabulator/commit/419dd37815ff483a5df3ba89bd8c5385fd24594f

Note: this also needs to be added in tabulator repo. The latest version of tabulator is 1 major version ahead from what we have, so it's probably better to still use our fork for now.