### PR TITLE
Fix cloning rows with bit fields in MSSQL

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1197,7 +1197,7 @@ export default Vue.extend({
 
       })
     },
-    cellCloneRow(_, cell: Tabulator.CellComponent) {
+    cellCloneRow(_e, cell: Tabulator.CellComponent) {
       this.cloneSelection(_.last(cell.getRanges()))
     },
     cellAddRow() {

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -891,7 +891,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
           const columns = Object.keys(item);
           columns.forEach((ic) => {
             if (_.isBoolean(item[ic])) {
-              item[ic] = `${item[ic]}`
+              item[ic] = item[ic] ? 1 : 0
             }
           })
         })

--- a/apps/studio/src/lib/db/clients/utils.ts
+++ b/apps/studio/src/lib/db/clients/utils.ts
@@ -189,6 +189,8 @@ export function buildInsertQuery(knex, insert: TableInsert, columns = [], bitCon
         } else {
           item[ic] = parseInt(item[ic].split("'")[1], 2)
         }
+      } else if (matching && matching.dataType && matching.dataType.startsWith('bit') && _.isBoolean(item[ic])) {
+        item[ic] = `${item[ic]}`;
       }
 
       // HACK (@day): fixes #1734. Knex reads any '?' in identifiers as a parameter, so we need to escape any that appear.

--- a/apps/studio/src/lib/db/clients/utils.ts
+++ b/apps/studio/src/lib/db/clients/utils.ts
@@ -190,7 +190,7 @@ export function buildInsertQuery(knex, insert: TableInsert, columns = [], bitCon
           item[ic] = parseInt(item[ic].split("'")[1], 2)
         }
       } else if (matching && matching.dataType && matching.dataType.startsWith('bit') && _.isBoolean(item[ic])) {
-        item[ic] = `${item[ic]}`;
+        item[ic] = item[ic] ? 1 : 0;
       }
 
       // HACK (@day): fixes #1734. Knex reads any '?' in identifiers as a parameter, so we need to escape any that appear.


### PR DESCRIPTION
fix #1945 

Knex doesn't quote bit values in insert queries for some reason, this isn't an issue in update queries, so for inserts we're now manually converting them to strings