### PR TITLE
fix: clone row not working

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1197,7 +1197,7 @@ export default Vue.extend({
 
       })
     },
-    cellCloneRow(_, cell: Tabulator.CellComponent) {
+    cellCloneRow(_event, cell: Tabulator.CellComponent) {
       this.cloneSelection(_.last(cell.getRanges()))
     },
     cellAddRow() {


### PR DESCRIPTION
Just a quick fix for clone row not working
Related Issue: #2074 

seems like loadash's underscore variable( _ )  was overwritted by local variable _