### PR TITLE
fix missing some databases in resolveLanguage

### DIFF
--- a/apps/studio/src/lib/editor/languageData.ts
+++ b/apps/studio/src/lib/editor/languageData.ts
@@ -176,6 +176,8 @@ export function resolveLanguage(lang: Language): CodeMirrorLanguage {
         // @ts-expect-error TODO not fully typed
         hint: CodeMirror.hint.sql,
       };
+    case "oracle":
+    case "firebird":
     case "bigquery":
     case "sql":
       return {


### PR DESCRIPTION
related to #2069

The text editor can't recognize Firebird and Oracle Database as they're not specified in `resolveLanguage()`. It also turns off the autocomplete.

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/713638b0-a444-4bdf-a4cc-2c2dfcac196c)

