### PR TITLE
fix empty filter in tabletable

### DIFF
--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -807,7 +807,9 @@ export default Vue.extend({
       tab.titleScope = "all"
       const existing = this.tabItems.find((t) => t.matches(tab))
       if (existing) {
-        existing.setFilters(filters)
+        if (filters) {
+          existing.setFilters(filters)
+        }
         this.$store.dispatch('tabs/setActive', existing)
       } else {
         this.addTab(tab)


### PR DESCRIPTION
steps to reproduce:
1. have 2 tables opened, so there are 2 tabs
2. dbl click a table from table list to open one of the tab that's inactive
3. the filter builder disappears
![missingfilterbuilder](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/282dcf56-38db-49a5-b6b2-d15315334c66)
