### PR TITLE
fix: sync core interface and connection interface split sizes

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -306,8 +306,8 @@ export default Vue.extend({
         this.$refs.sidebar.$refs.sidebar,
         this.$refs.content
       ]
-      const lastSavedSplitSizes = SmartLocalStorage.getItem("connInterfaceSplitSizes")
-      const splitSizes = lastSavedSplitSizes ? JSON.parse(lastSavedSplitSizes) : [300, 500]
+      const lastSavedSplitSizes = SmartLocalStorage.getItem("interfaceSplitSizes")
+      const splitSizes = lastSavedSplitSizes ? JSON.parse(lastSavedSplitSizes) : [25, 75]
 
       this.split = Split(components, {
         elementStyle: (_dimension, size) => ({
@@ -315,11 +315,11 @@ export default Vue.extend({
         }),
         sizes: splitSizes,
         gutterize: 8,
-        minSize: [300, 300],
+        minSize: [25, 75],
         expandToMin: true,
         onDragEnd: () => {
           const splitSizes = this.split.getSizes()
-          SmartLocalStorage.addItem("connInterfaceSplitSizes", splitSizes)
+          SmartLocalStorage.addItem("interfaceSplitSizes", splitSizes)
         }
       } as Split.Options)
     })

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -91,7 +91,7 @@ import { SmartLocalStorage } from '@/common/LocalStorage'
       initializing() {
         if (this.initializing) return;
         this.$nextTick(() => {
-          const lastSavedSplitSizes = SmartLocalStorage.getItem("coreInterfaceSplitSizes")
+          const lastSavedSplitSizes = SmartLocalStorage.getItem("interfaceSplitSizes")
           const splitSizes = lastSavedSplitSizes ? JSON.parse(lastSavedSplitSizes) : [25, 75]
 
           this.split = Split(this.splitElements, {
@@ -99,12 +99,12 @@ import { SmartLocalStorage } from '@/common/LocalStorage'
                 'flex-basis': `calc(${size}%)`,
             }),
             sizes: splitSizes,
-            minSize: 280,
+            minSize: [25, 75],
             expandToMin: true,
             gutterSize: 5,
             onDragEnd: () => {
               const splitSizes = this.split.getSizes()
-              SmartLocalStorage.addItem("coreInterfaceSplitSizes", splitSizes)
+              SmartLocalStorage.addItem("interfaceSplitSizes", splitSizes)
             }
           })
         })


### PR DESCRIPTION
resolves: #2082 

- added same min split sizes for core interface and connection interface
- use the same split sizes on connect and disconnect for both core and connection interface



https://github.com/beekeeper-studio/beekeeper-studio/assets/76877078/179fe039-d689-4330-8041-84e854633f79