### PR TITLE
fix: convert objects to strings for markdown copy and download

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -179,7 +179,7 @@
       },
       download(format) {
         let formatter = format !== 'md' ? format : (rows, options, setFileContents) => {
-          const values = rows.map(row => row.columns.map(col => col.value))
+          const values = rows.map(row => row.columns.map(col => typeof col.value === 'object' ? JSON.stringify(col.value) : col.value))
           setFileContents(markdownTable(values), 'text/markdown')
         };
         // Fix Issue #1493 Lost column names in json query download
@@ -210,7 +210,12 @@
         if (format === 'md') {
           const mdContent = [
             Object.keys(result[0]),
-            ...result.map((row) => Object.values(row)),
+            ...result
+                .map((row) =>
+                  Object.values(row).map(v =>
+                    (typeof v === 'object') ? JSON.stringify(v) : v
+                  )
+                )
           ];
           this.$native.clipboard.writeText(markdownTable(mdContent))
         } else if (format === 'json') {


### PR DESCRIPTION
Resolve #2083

<img width="889" alt="image" src="https://github.com/beekeeper-studio/beekeeper-studio/assets/314613/b1dd13f8-c249-44ad-937e-701b482f6818">

generates to clipboard and md file:

| id | name  | data                            |
| -- | ----- | ------------------------------- |
| 1  | John  | {"age":30,"city":"New York"}    |
| 2  | Alice | {"age":25,"city":"Los Angeles"} |
| 3  | Bob   | {"age":35,"city":"Chicago"}     |