### PR TITLE
A couple of tabulator navigation small issues

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -74,7 +74,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.7.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#76c253a7437bcab5fcf67d601f09e67aea12f99e",
+    "tabulator-tables": "beekeeper-studio/tabulator#32107a671f00847d888f89ae0640cd4cc655229d",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13957,7 +13957,7 @@ string-length@^3.1.0:
     astral-regex "^1.0.0"
     strip-ansi "^5.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14205,9 +14205,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#76c253a7437bcab5fcf67d601f09e67aea12f99e:
-  version "6.2.0-bks.3"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/76c253a7437bcab5fcf67d601f09e67aea12f99e"
+tabulator-tables@beekeeper-studio/tabulator#32107a671f00847d888f89ae0640cd4cc655229d:
+  version "6.2.0-bks.5"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/32107a671f00847d888f89ae0640cd4cc655229d"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
I initially searched for an issue but ended up seeing a couple of small issues related to the Select Range (spreadsheet) navigation.

1. If we navigate on a big table using `Ctrl+Arrow` (try `film` in postgres), it can stop in any position unpredictably. https://github.com/olifolkerd/tabulator/pull/4473 <-- this also fixes #2078

2. Tabulator doesn't completely trap the keyboard events, so if we have a keybinding that's conflicting with tabulator, our keybinding can be triggered https://github.com/olifolkerd/tabulator/pull/4474

3. Pressing an arrow key after selecting a range of multiple cells should break the selection and continue navigating. This sometimes doesn't happen.  https://github.com/olifolkerd/tabulator/pull/4478

4. Autoscrolling to a big column is more sensible now. https://github.com/olifolkerd/tabulator/pull/4479 