### PR TITLE
fix sys yank again

### DIFF
--- a/apps/studio/src/components/common/texteditor/TextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/TextEditor.vue
@@ -215,9 +215,12 @@ export default {
           }
           setKeybindingsFromVimrc(codeMirrorVimInstance);
 
-          // Doing this instaed of defineRegister allows us to reset the register while the application is running
-          // which causes errors with defineRegister
-          codeMirrorVimInstance.getRegisterController().registers['*'] = new Register(this.$native.clipboard);
+          // cm throws if this is already defined, we don't need to handle that case
+          try {
+            codeMirrorVimInstance.defineRegister('*', new Register(this.$native.clipboard))
+          } catch(e) {
+            // nothing
+          }
         }
       }
 

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -214,9 +214,7 @@ export default {
       },
       set(value) {
         if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
-        this.$store.dispatch('settings/save', { key: 'keymap', value: value }).then(() => {
-          this.initialize();
-        });
+        this.$store.dispatch('settings/save', { key: 'keymap', value: value });
       }
     },
     keymapTypes() {


### PR DESCRIPTION
Vim yanking to sys clipboard broke at some point. Manually setting the register on the controller no longer works, so we define the register the 'proper' way and just catch and release the error that throws if we define it again