### PR TITLE
show prefix in mysql table index

### DIFF
--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -56,6 +56,7 @@ export abstract class BasicDatabaseClient<RawResultType> {
   server: IDbConnectionServer;
   database: IDbConnectionDatabase;
   db: string;
+  connectionBaseType: ConnectionType;
   connectionType: ConnectionType;
 
   constructor(knex: Knex | null, contextProvider: AppContextProvider, server: IDbConnectionServer, database: IDbConnectionDatabase) {

--- a/apps/studio/src/lib/db/clients/bigquery.ts
+++ b/apps/studio/src/lib/db/clients/bigquery.ts
@@ -35,6 +35,8 @@ const bigqueryContext = {
 }
 
 export class BigQueryClient extends BasicDatabaseClient<BigQueryResult> {
+  connectionBaseType = 'bigquery' as const;
+
   server: IDbConnectionServer;
   database: IDbConnectionDatabase;
   client: bq.BigQuery;

--- a/apps/studio/src/lib/db/clients/cassandra.ts
+++ b/apps/studio/src/lib/db/clients/cassandra.ts
@@ -56,6 +56,8 @@ type CassandraVersion = {
 };
 
 export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
+  connectionBaseType = 'cassandra' as const;
+
   client: cassandra.Client;
   versionInfo: CassandraVersion;
 

--- a/apps/studio/src/lib/db/clients/firebird.ts
+++ b/apps/studio/src/lib/db/clients/firebird.ts
@@ -209,6 +209,8 @@ function buildInsertQueries(knex: Knex, inserts: TableInsert[]) {
 }
 
 export class FirebirdClient extends BasicDatabaseClient<FirebirdResult> {
+  connectionBaseType = 'firebird' as const;
+
   version: any;
   pool: Pool;
   firebirdOptions: Firebird.Options;

--- a/apps/studio/src/lib/db/clients/oracle.ts
+++ b/apps/studio/src/lib/db/clients/oracle.ts
@@ -49,6 +49,7 @@ const log = rawLog.scope('oracle')
 
 
 export class OracleClient extends BasicDatabaseClient<DriverResult> {
+  connectionBaseType = 'oracle' as const;
 
   pool: oracle.Pool;
   server: IDbConnectionServer

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -68,6 +68,8 @@ const postgresContext = {
 };
 
 export class PostgresClient extends BasicDatabaseClient<QueryResult> {
+  connectionBaseType = 'postgresql' as const;
+
   version: VersionInfo;
   conn: HasPool;
   _defaultSchema: string;

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -57,6 +57,8 @@ type SqliteResult = {
 const SD = SqliteData;
 
 export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
+  connectionBaseType = 'sqlite' as const;
+
   version: SqliteResult;
   databasePath: string;
 

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -69,6 +69,8 @@ const SQLServerContext = {
 // DO NOT USE CONCAT() in sql, not compatible with Sql Server <= 2008
 // SQL Server < 2012 might eventually need its own class.
 export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
+  connectionBaseType = 'sqlserver' as const;
+
   server: IDbConnectionServer
   database: IDbConnectionDatabase
   defaultSchema: () => string

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -47,6 +47,7 @@ export interface TableOrView extends DatabaseEntity {
 export interface IndexedColumn {
   name: string
   order: 'ASC' | 'DESC'
+  prefix?: string | null // MySQL only feature
 }
 
 export interface TableIndex {

--- a/apps/studio/tests/integration/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/mysql.spec.js
@@ -277,6 +277,36 @@ function testWith(tag, socket = false, readonly = false) {
       expect(firstResult.bitcol[0]).toBe(0)
       expect(secondResult.bitcol[0]).toBe(1)
     })
+
+    describe("Index Prefixes", () => {
+      beforeAll(async () => {
+        await util.knex.schema.createTable("has_prefix_indexes", (table) => {
+          table.specificType("one", "text")
+          table.specificType("two", "blob")
+        })
+        await util.knex.schema.raw("CREATE INDEX text_index ON has_prefix_indexes (one(10))")
+      })
+
+      it("Should be able to list indexes with custom prefixes correctly", async () => {
+        const indexes = await util.connection.listTableIndexes('has_prefix_indexes')
+        expect(indexes[0].columns[0].prefix).toBe('10')
+      })
+
+      it("Should be able to create indexes with custom prefixes correctly", async () => {
+        await util.connection.alterIndex({
+          table: 'has_prefix_indexes',
+          additions: [{
+            name: 'custom_prefix_index',
+            columns: [{ name: 'two', order: 'ASC', prefix: 5 }],
+          }],
+        })
+
+        const indexes = await util.connection.listTableIndexes('has_prefix_indexes')
+        expect(indexes[1].columns[0].prefix).toBe('5')
+
+        await util.knex.schema.raw("DROP INDEX custom_prefix_index ON has_prefix_indexes")
+      })
+    })
   })
 
 

--- a/apps/studio/tests/integration/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/mysql.spec.js
@@ -293,6 +293,8 @@ function testWith(tag, socket = false, readonly = false) {
       })
 
       it("Should be able to create indexes with custom prefixes correctly", async () => {
+        if (readonly) return
+
         await util.connection.alterIndex({
           table: 'has_prefix_indexes',
           additions: [{

--- a/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
@@ -1,7 +1,7 @@
-import { testOnly } from '../../../../../src/lib/db/clients/mysql'
+import { parseIndexColumn, testOnly } from '../../../../../src/lib/db/clients/mysql'
 
 
-describe("Postgres UNIT tests (no connection required)", () => {
+describe("MySQL UNIT tests (no connection required)", () => {
   it("should pass a canary test", () => {
     expect(1).toBe(1)
   })
@@ -19,5 +19,19 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(result).toMatchObject(expected)
   })
 
+  it("should parse index column for alter index", () => {
+    const samples = {
+      "title": { name: 'title', order: 'ASC', prefix: null },
+      "title DESC": { name: 'title', order: 'DESC', prefix: null },
+      "title(10) DESC": { name: 'title', order: 'DESC', prefix: '10' },
+      "title (10) DESC": { name: 'title', order: 'DESC', prefix: '10' },
+      // "desc(5)": { name: 'desc(5)', order: 'ASC', prefix: null },
+      // "desc(5)(5)": { name: 'desc(5)', order: 'ASC', prefix: '5' },
+      // "desc(5) (5)": { name: 'desc(5)', order: 'ASC', prefix: '5' },
+    }
+    for (const [input, output] of Object.entries(samples)) {
+      expect(parseIndexColumn(input)).toMatchObject(output)
+    }
+  })
 
 })

--- a/shared/src/lib/dialects/models.ts
+++ b/shared/src/lib/dialects/models.ts
@@ -237,14 +237,15 @@ export interface AlterPartitionsSpec {
 export interface IndexColumn {
   name: string
   order: 'ASC' | 'DESC'
+  prefix?: number | null // MySQL Only
 }
 
 export interface CreateIndexSpec {
   name?: string
   columns: IndexColumn[]
   unique: boolean
-  // Set order for entire index. Used in firebird.
-  order?: 'ASC' | 'DESC'
+  order?: 'ASC' | 'DESC' // Set order for entire index. Used in firebird.
+  prefix?: number | null // MySQL Only
 }
 
 export interface DropIndexSpec {


### PR DESCRIPTION
So far I only found `mysql` as a database that users can specify a prefix length for indexes.

fix #2120 

## One column with prefix
![adding_index](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/f93626b5-8392-4b7f-a5d6-3a12c796abba)

## Two columns with prefix
![adding_index2](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/b6fa5d36-1974-47be-b5e7-aa1588028874)
