### PR TITLE
fix building primary key with autoincrement

### DIFF
--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -332,6 +332,12 @@ export function runCommonTests(getUtil, opts = {}) {
       await getUtil().buildIsNullTests()
     })
   })
+
+  describe("SQLGenerator", () => {
+    test("should generate scripts for creating a primary key with autoincrement", async () => {
+      await getUtil().buildCreatePrimaryKeysAndAutoIncrementTests()
+    })
+  })
 }
 
 // test functions below

--- a/apps/studio/tests/integration/lib/db/clients/cockroach.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cockroach.spec.js
@@ -20,7 +20,7 @@ describe("CockroachDB Tests", () => {
       port: container.getMappedPort(26257),
       user: 'root',
     }
-    util = new DBTestUtil(config, "defaultdb", {version: '7.2', skipPkQuote: true, defaultSchema: 'public'})
+    util = new DBTestUtil(config, "defaultdb", {dialect: 'postgresql', version: '7.2', skipPkQuote: true, defaultSchema: 'public'})
     await util.setupdb()
 
   })

--- a/shared/src/lib/sql/SqlGenerator.ts
+++ b/shared/src/lib/sql/SqlGenerator.ts
@@ -91,7 +91,10 @@ export class SqlGenerator {
 // Private below here plz
 
   private getPrimaries(c): boolean {
-    if (this.isNativeKnex) {
+    // Prevent making primary key and autoincrement from one another for
+    // BigQuery and Cassandra. There's no auto increment functionality for a
+    // PK in those DBs.
+    if (this.dialect === 'bigquery' || this.dialect === 'cassandra') {
       return c.primaryKey && c.dataType !== 'autoincrement'
     }
 


### PR DESCRIPTION
Based on this issue #2180 , the video shows that editing is disabled due to the lack of primary key, not after adding an `enum` column. It's disabled even before adding an `enum` column.

But after testing the table builder, I found that creating a column as a pk with `autoincrement` doesn't make the column pk. Thus the editing was disabled in the first place.

Note: There's no auto increment functionality for a PK in BigQuery and Cassandra DBs.

close #2180