### PR TITLE
Add minimal mode

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="style-wrapper">
-    <div class="beekeeper-studio-wrapper">
+    <div
+      class="beekeeper-studio-wrapper"
+      :class="{ 'beekeeper-studio-minimal-mode': $store.getters.minimalMode }"
+    >
       <titlebar v-if="$config.isMac || menuStyle === 'client' || (runningWayland)" />
       <template v-if="storeInitialized">
         <connection-interface v-if="!connection" />

--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -554,3 +554,9 @@
     opacity: 0.5;
   }
 }
+
+.beekeeper-studio-minimal-mode {
+  .core-tabs .nav-tabs .nav-link.active {
+    font-weight: inherit;
+  }
+}

--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -62,6 +62,12 @@
         padding: 0 $gutter-w;
       }
     }
+
+    #tab-tables {
+      .table-list, .list-group {
+        padding-left: 0.3rem;
+      }
+    }
   }
 
   // Empty
@@ -85,7 +91,7 @@
     height: $input-height;
     min-height: $input-height;
     padding: 0 $gutter-h 0 0;
-    margin-top: ($gutter-w * 0.75);
+    margin-top: ($gutter-w * 0.25);
     margin-bottom: $gutter-h;
     background: rgba($theme-base, 0.08);
     transition: background 0.15s ease-in-out;
@@ -257,13 +263,16 @@
       display: flex;
       cursor: pointer;
     }
+    x-button {
+      height: auto;
+    }
     & > * {
       visibility: hidden;
     }
     & .create-table {
       visibility: visible;
     }
-    & > * > .material-icons, & > * > .material-icons-outlined {
+    .material-icons, .material-icons-outlined {
       font-size: 16px;
       color: $text-light;
       &:hover {

--- a/apps/studio/src/assets/styles/app/sidebar/table-list.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/table-list.scss
@@ -50,6 +50,9 @@
     padding-top: $gutter-w;
     padding-bottom: $gutter-w;
   }
+  &.pinned .list-item-btn .actions {
+    margin-right: 0.3rem;
+  }
 }
 
 .hidden-indicator {

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -905,3 +905,12 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
   background-color: #292A2D;
   color: lightgray;
 }
+
+.beekeeper-studio-minimal-mode .tabulator-header {
+  font-weight: inherit;
+
+  .tabulator-col .tabulator-col-content .tabulator-col-title .title >
+  .column-data-type {
+    display: none;
+  }
+}

--- a/apps/studio/src/background/NativeMenuActionHandlers.ts
+++ b/apps/studio/src/background/NativeMenuActionHandlers.ts
@@ -181,4 +181,12 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
   importSqlFiles = (_menuItem: Electron.MenuItem, win: ElectronWindow) => {
     if (win) win.webContents.send(AppEvent.promptSqlFilesImport);
   }
+
+  toggleMinimalMode = async (): Promise<void> => {
+    this.settings.minimalMode.value = !this.settings.minimalMode.value
+    await this.settings.minimalMode.save()
+    getActiveWindows().forEach( window => {
+      window.send(AppEvent.settingsChanged)
+    })
+  }
 }

--- a/apps/studio/src/common/interfaces/IMenuActionHandler.ts
+++ b/apps/studio/src/common/interfaces/IMenuActionHandler.ts
@@ -36,4 +36,5 @@ export interface IMenuActionHandler {
   upgradeModal: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   checkForUpdates: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   importSqlFiles: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
+  toggleMinimalMode: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
 }

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -17,7 +17,8 @@ export default class extends DefaultMenu {
         this.menuItems.zoomout,
         this.menuItems.fullscreen,
         this.menuItems.themeToggle,
-        this.menuItems.sidebarToggle
+        this.menuItems.sidebarToggle,
+        this.menuItems.minimalModeToggle,
       ]
     }
     if (!platformInfo.isMac)

--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -205,6 +205,11 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
           checked: settings.theme.value === 'dark'
         }
       ]
-    }
+    },
+    minimalModeToggle: {
+      id: "minimal-mode-toggle",
+      label: "Toggle Minimal Mode",
+      click: actionHandler.toggleMinimalMode,
+    },
   }
 }

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -53,7 +53,8 @@
   import QuickSearch from './quicksearch/QuickSearch.vue'
   import ProgressBar from './editor/ProgressBar.vue'
   import Vue from 'vue'
-import { SmartLocalStorage } from '@/common/LocalStorage'
+  import { SmartLocalStorage } from '@/common/LocalStorage'
+  import { mapGetters } from 'vuex'
 
   export default Vue.extend({
     components: { CoreSidebar, CoreTabs, Sidebar, Statusbar, ConnectionButton, ExportManager, QuickSearch, ProgressBar },
@@ -75,6 +76,7 @@ import { SmartLocalStorage } from '@/common/LocalStorage'
       /* eslint-enable */
     },
     computed: {
+      ...mapGetters(['minimalMode']),
       keymap() {
         const results = {}
         results[this.ctrlOrCmd('p')] = () => this.quickSearchShown = true
@@ -108,7 +110,12 @@ import { SmartLocalStorage } from '@/common/LocalStorage'
             }
           })
         })
-      }
+      },
+      minimalMode() {
+        if (this.minimalMode) {
+          this.sidebarShown = true
+        }
+      },
     },
     mounted() {
       this.$store.dispatch('pins/loadPins')
@@ -136,7 +143,12 @@ import { SmartLocalStorage } from '@/common/LocalStorage'
         this.$emit('databaseSelected', database)
       },
       toggleSidebar() {
-        this.sidebarShown = !this.sidebarShown
+        if (this.minimalMode) {
+          // Always show sidebar (table list) in minimal mode
+          this.sidebarShown = true
+        } else {
+          this.sidebarShown = !this.sidebarShown
+        }
       },
     }
   })

--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -18,9 +18,9 @@
         <tab-icon :tab="tab" />
         <span
           class="tab-title truncate"
-          :title="title + scope"
+          :title="title + (!$store.getters.minimalMode ? scope : '')"
         >{{ title }} <span
-          v-if="scope"
+          v-if="scope && !$store.getters.minimalMode"
           class="tab-title-scope"
         >{{ scope }}</span></span>
         <div class="tab-action">

--- a/apps/studio/src/components/sidebar/CoreSidebar.vue
+++ b/apps/studio/src/components/sidebar/CoreSidebar.vue
@@ -88,6 +88,13 @@
       ...mapState(['tables', 'connection', 'database']),
       ...mapGetters(['minimalMode']),
     },
+    watch: {
+      minimalMode() {
+        if (this.minimalMode) {
+          this.activeItem = 'tables'
+        }
+      },
+    },
     methods: {
       tabClasses(item) {
         return {

--- a/apps/studio/src/components/sidebar/CoreSidebar.vue
+++ b/apps/studio/src/components/sidebar/CoreSidebar.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="sidebar-wrap row">
     <global-sidebar
+      v-if="!minimalMode"
       @selected="click"
       v-on="$listeners"
       :active-item="activeItem"
@@ -52,7 +53,7 @@
   import FavoriteList from './core/FavoriteList'
   import DatabaseDropdown from './core/DatabaseDropdown'
 
-  import { mapState } from 'vuex'
+  import { mapState, mapGetters } from 'vuex'
   import rawLog from 'electron-log'
 
   const log = rawLog.scope('core-sidebar')
@@ -85,6 +86,7 @@
         return _.concat(startsWithFilter, containsFilter)
       },
       ...mapState(['tables', 'connection', 'database']),
+      ...mapGetters(['minimalMode']),
     },
     methods: {
       tabClasses(item) {

--- a/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/VirtualTableList.vue
@@ -179,6 +179,11 @@ export default Vue.extend({
       const items: Item[] = this.items;
 
       for (const item of items) {
+        // Skip rendering routines in minimal mode
+        if (this.$store.getters.minimalMode && item.type === 'routine') {
+          continue;
+        }
+
         if (!item.hidden && !item.parent.hidden && item.parent.expanded) {
           displayItems.push(item);
 
@@ -297,6 +302,7 @@ export default Vue.extend({
     ...mapGetters({
       defaultSchema: "defaultSchema",
       schemaTables: "schemaTables",
+      minimalMode: "minimalMode",
       hiddenEntities: "hideEntities/databaseEntities",
       hiddenSchemas: "hideEntities/databaseSchemas",
     }),
@@ -305,6 +311,9 @@ export default Vue.extend({
   watch: {
     schemaTables() {
       this.generateItems();
+      this.generateDisplayItems();
+    },
+    minimalMode() {
       this.generateDisplayItems();
     },
   },

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -13,7 +13,7 @@
     </template>
     <template v-else>
       <row-filter-builder
-        v-if="table.columns?.length"
+        v-if="table.columns?.length && !minimalMode"
         :columns="table.columns"
         :reactive-filters="tableFilters"
         @input="handleRowFilterBuilderInput"

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -295,7 +295,7 @@ import { normalizeFilters, safeSqlFormat } from '@/common/utils'
 import { TableFilter } from '@/lib/db/models';
 import { LanguageData } from '../../lib/editor/languageData'
 import { escapeHtml } from '@shared/lib/tabulator';
-import { copyRange, pasteRange, copyActionsMenu, pasteActionsMenu, commonColumnMenu, createMenuItem, resizeAllColumnsToFixedWidth, resizeAllColumnsToFitContent } from '@/lib/menu/tableMenu';
+import { copyRange, pasteRange, copyActionsMenu, pasteActionsMenu, commonColumnMenu, createMenuItem, resizeAllColumnsToFixedWidth, resizeAllColumnsToFitContent, resizeAllColumnsToFitContentAction } from '@/lib/menu/tableMenu';
 import { tabulatorForTableData } from "@/common/tabulator";
 
 const log = rawLog.scope('TableTable')
@@ -351,7 +351,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(['tables', 'tablesInitialLoaded', 'usedConfig', 'database', 'workspaceId']),
-    ...mapGetters(['dialectData', 'dialect']),
+    ...mapGetters(['dialectData', 'dialect', 'minimalMode']),
     isEmpty() {
       return _.isEmpty(this.data);
     },
@@ -759,7 +759,12 @@ export default Vue.extend({
     },
     pendingChangesCount() {
       this.tab.unsavedChanges = this.pendingChangesCount > 0
-    }
+    },
+    minimalMode() {
+      if (this.tabulator) {
+        resizeAllColumnsToFitContentAction(this.tabulator)
+      }
+    },
   },
   beforeDestroy() {
     if(this.interval) clearInterval(this.interval)
@@ -807,7 +812,7 @@ export default Vue.extend({
       return `
         <span class="title">
           ${escapeHtml(columnName)}
-          <span class="badge">${dataType}</span>
+          <span class="badge column-data-type">${dataType}</span>
         </span>`
     },
     maybeScrollAndSetWidths() {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -48,6 +48,7 @@
         </x-button>
         <!-- Info -->
         <table-length
+          v-if="!minimalMode"
           :table="table"
           :connection="connection"
         />
@@ -56,7 +57,7 @@
           tabindex="0"
           role="button"
           class="statusbar-item hoverable"
-          v-if="lastUpdatedText && !error"
+          v-if="lastUpdatedText && !error && !minimalMode"
           :title="'Updated' + ' ' + lastUpdatedText"
         >
           <i class="material-icons">update</i>
@@ -73,7 +74,10 @@
       </div>
 
       <!-- Pagination -->
-      <div class="tabulator-paginator">
+      <div
+        v-if="!minimalMode"
+        class="tabulator-paginator"
+      >
         <div class="flex-center flex-middle flex">
           <a
             v-if="(this.page > 1)"

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -56,4 +56,5 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   exportTables = () => send('exportTables')
   checkForUpdates = () => send('checkForUpdates')
   importSqlFiles = () => send('importSqlFiles')
+  toggleMinimalMode = () => send('toggleMinimalMode')
 }

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -3,6 +3,7 @@ import {
   ColumnComponent,
   MenuObject,
   RangeComponent,
+  Tabulator,
 } from "tabulator-tables";
 import { markdownTable } from "markdown-table";
 import { ElectronPlugin } from "@/lib/NativeWrapper";
@@ -50,21 +51,7 @@ export const resizeAllColumnsToMatch: ColumnMenuItem = {
 
 export const resizeAllColumnsToFitContent: ColumnMenuItem = {
   label: createMenuItem("Resize all columns to fit content"),
-  action: (_, column) => {
-    try {
-      column.getTable().blockRedraw();
-      const columns = column.getTable().getColumns();
-      columns.forEach((col) => {
-        if (col.getField() !== rowHeaderField) {
-          col.setWidth(true);
-        }
-      });
-    } catch (error) {
-      console.error(error);
-    } finally {
-      column.getTable().restoreRedraw();
-    }
-  },
+  action: (_, column) => resizeAllColumnsToFitContentAction(column.getTable()),
 };
 
 export const resizeAllColumnsToFixedWidth: ColumnMenuItem = {
@@ -85,6 +72,21 @@ export const resizeAllColumnsToFixedWidth: ColumnMenuItem = {
     }
   },
 };
+
+export function resizeAllColumnsToFitContentAction(table: Tabulator) {
+  try {
+    const columns = table.getColumns();
+    columns.forEach((col) => {
+      if (col.getField() !== rowHeaderField) {
+        col.setWidth(true);
+      }
+    });
+  } catch (error) {
+    console.error(error);
+  } finally {
+    table.restoreRedraw();
+  }
+}
 
 export const commonColumnMenu = [
   sortAscending,

--- a/apps/studio/src/migration/20240514_user_settings_minimal_mode.js
+++ b/apps/studio/src/migration/20240514_user_settings_minimal_mode.js
@@ -1,0 +1,7 @@
+export default {
+    name: "20240514_user_settings_minimal_mode",
+    async run(runner) {
+      const query = `INSERT INTO user_setting(key, defaultValue, valueType) VALUES ('minimalMode', 'false', 5)`;
+      await runner.query(query);
+    }
+  }

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -35,6 +35,7 @@ import bigQueryOptions from './20230426_add_bigquery_options'
 import firebirdConnection from './20240107_add_firebird_dev_connection'
 import exportPath from './20240122_add_default_export_path'
 import demoSetup from './20240421_seed_with_demo_data'
+import minimalMode from './20240514_user_settings_minimal_mode'
 import ultimate from './ultimate/index'
 
 import UserSettingsWindowPosition from './20240303_user_settings_window_position'
@@ -58,7 +59,7 @@ const realMigrations = [
   serverCerts, socketPath, connectionOptions, keepaliveInterval, redshiftOptions,
   createHiddenEntities, createHiddenSchemas, cassandraOptions, readOnlyMode, connectionPins, fixKeymapType, bigQueryOptions,
   firebirdConnection, exportPath, UserSettingsWindowPosition,
-  demoSetup
+  demoSetup, minimalMode,
 
 ]
 

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -189,6 +189,9 @@ const store = new Vuex.Store<State>({
       }
       return []
     },
+    minimalMode(_state, getters) {
+      return getters['settings/minimalMode']
+    },
     versionString(state) {
       return state.server.versionString();
     }

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -67,7 +67,10 @@ const SettingStoreModule: Module<State, any> = {
     sortOrder(state) {
       if (!state.settings.sortOrder) return 'id'
       return state.settings.sortOrder.value
-    }
+    },
+    minimalMode(state) {
+      return state.settings.minimalMode.value
+    },
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/8241b17a-b37d-444b-9615-b3d364046650)

Enabling minimal mode will do these:
- Hiding row filter builder from table view. In result, we don't need the title scope so it's hidden now.
- Tab title and column title are not bold
- Hiding routines, paginator, time estimation, table length, and global sidebar.
- Optimizing the column auto width by hiding the column type.

Also there was some weird little styling issues:
- Database selector is not aligned to the tab. Looks kinda weird to me.
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/859f367a-cd26-444c-a79c-23ec8e64d02e)
- The table list doesn't look "visually" aligned to the database selector at the top, and it has little space on the left. This becomes more obvious when enabling the minimal mode.
![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/4e73b77d-2069-4256-add6-65f413436393)
