### PR TITLE
Show filter in minimal mode if the table is filtered

### DIFF
--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -200,6 +200,24 @@ export function normalizeFilters(filters: TableFilter[]) {
   return normalized;
 }
 
+/** Create an object for filter used in Row Filter Builder */
+export function createTableFilter(field: string): TableFilter {
+  return { op: "AND", field, type: "=", value: "" }
+}
+
+/** Check if an array of filters is considered empty */
+export function checkEmptyFilters(filters: TableFilter[]): boolean {
+  if (filters.length === 0) {
+    return true
+  }
+  if (filters.length === 1) {
+    return _.isEmpty(filters[0].value)
+  }
+  if (filters.length > 1) {
+    return false
+  }
+}
+
 /** Useful for identifying an entity item in table list */
 export function entityId(schema: string, entity?: TableOrView | Routine) {
   if (entity) return `${entity.entityType}.${schema}.${entity.name}`;

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -213,9 +213,7 @@ export function checkEmptyFilters(filters: TableFilter[]): boolean {
   if (filters.length === 1) {
     return _.isEmpty(filters[0].value)
   }
-  if (filters.length > 1) {
-    return false
-  }
+  return false
 }
 
 /** Useful for identifying an entity item in table list */

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -213,7 +213,7 @@ export function checkEmptyFilters(filters: TableFilter[]): boolean {
   if (filters.length === 1) {
     return _.isEmpty(filters[0].value)
   }
-  return false
+  return filters.every(filter => _.isEmpty(filter.value));
 }
 
 /** Useful for identifying an entity item in table list */

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -2,6 +2,7 @@
   <div
     v-hotkey="keymap"
     class="table-filter"
+    v-if="!minimalMode || !hideInMinimalMode"
   >
     <form
       @submit.prevent="submit"
@@ -33,6 +34,7 @@
               class="form-control"
               type="text"
               v-model="filterRaw"
+              @blur="updateMinimalModeByFilterRaw"
               ref="valueInput"
               placeholder="Enter condition, eg: name like 'Matthew%'"
             >
@@ -50,6 +52,7 @@
             class="btn btn-primary btn-fab"
             type="submit"
             title="Filter"
+            v-if="!minimalMode"
           >
             <i class="material-icons">search</i>
           </button>
@@ -131,7 +134,9 @@
                 <input
                   class="form-control filter-value"
                   type="text"
+                  ref="filterInputs"
                   v-model="filter.value"
+                  @blur="updateMinimalModeByFilters"
                   :disabled="isNullFilter(filter)"
                   :title="isNullFilter(filter) ? 
                     'You cannot provide a comparison value when checking for NULL or NOT NULL' : 
@@ -168,7 +173,10 @@
             </div>
           </div>
           <div class="filter-add-apply">
-            <div class="row fixed">
+            <div
+              v-if="!minimalMode"
+              class="row fixed"
+            >
               <button
                 v-if="filters.length > 1"
                 class="btn btn-flat btn-fab remove-filter"
@@ -228,7 +236,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { TableFilter } from "@/lib/db/models";
-import { joinFilters, normalizeFilters } from "@/common/utils";
+import { joinFilters, normalizeFilters, createTableFilter, checkEmptyFilters } from "@/common/utils";
 import { mapGetters, mapState } from "vuex";
 import platformInfo from "@/common/platform_info";
 import { AppEvent } from "@/common/AppEvent";
@@ -240,6 +248,7 @@ export default Vue.extend({
   props: ["columns", "reactiveFilters"],
   data() {
     return {
+      hideInMinimalMode: true,
       filterTypes: {
         equals: "=",
         "does not equal": "!=",
@@ -255,12 +264,13 @@ export default Vue.extend({
       filters: this.reactiveFilters,
       filterRaw: "",
       filterMode: BUILDER,
+      submittedWithEmptyValue: false,
       RAW,
       BUILDER,
     };
   },
   computed: {
-    ...mapGetters(["dialectData"]),
+    ...mapGetters(["dialectData", "minimalMode"]),
     ...mapState(['connection']),
     additionalFilters() {
       const [_, ...additional] = this.filters;
@@ -336,25 +346,43 @@ export default Vue.extend({
     removeFilter(shiftedIdx: number) {
       this.filters.splice(shiftedIdx + 1, 1);
     },
+    clearFilter() {
+      this.filters = [createTableFilter(this.filters[0].field)]
+    },
     submit() {
-      this.$emit(
-        "submit",
-        this.filterMode === RAW
-          ? this.filterRaw || null
-          : normalizeFilters(this.filters)
-      );
+      let filters: TableFilter[] | string | null
+      if (this.filterMode === RAW) {
+        filters = this.filterRaw || null
+      } else {
+        filters = normalizeFilters(this.filters)
+        this.submittedWithEmptyValue = checkEmptyFilters(filters)
+      }
+      this.$emit("submit", filters);
+    },
+    updateMinimalModeByFilters() {
+      this.hideInMinimalMode = checkEmptyFilters(this.filters)
+    },
+    updateMinimalModeByFilterRaw() {
+      this.hideInMinimalMode = this.filterRaw === ''
     },
   },
   watch: {
     filters: {
       deep: true,
-      handler(nextFilters: TableFilter[], oldFilters: TableFilter[]) {
-        this.$emit("input", nextFilters);
+      handler(filters: TableFilter[]) {
+        this.$emit("input", filters);
+
+        const inputs = _.isArray(this.$refs.filterInputs) ? this.$refs.filterInputs : [this.$refs.filterInputs]
+        const focusIsOnInput = inputs.some((input: HTMLInputElement) => document.activeElement.isSameNode(input))
+        if (!focusIsOnInput) {
+          this.updateMinimalModeByFilters()
+        }
+
         // Submit when it's only one filter and it's empty
         if (
-          nextFilters.length === 1 &&
-          oldFilters[0].value !== "" &&
-          nextFilters[0].value === ""
+          filters.length === 1 &&
+          filters[0].value === "" &&
+          !this.submittedWithEmptyValue
         ) {
           this.submit();
         }
@@ -364,9 +392,14 @@ export default Vue.extend({
       this.submit();
     },
     filterRaw() {
-      if (this.filterRaw === "") this.submit();
+      const focusIsOnInput = document.activeElement.isSameNode(this.$refs.valueInput)
+      if (!focusIsOnInput) {
+        this.updateMinimalModeByFilterRaw()
+      }
+      this.submit();
     },
     externalFilters() {
+      this.hideInMinimalMode = checkEmptyFilters(this.externalFilters)
       if (platformInfo.isCommunity) {
         this.filters = this.externalFilters?.slice(0, 2) || [];
       } else {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -13,7 +13,7 @@
     </template>
     <template v-else>
       <row-filter-builder
-        v-if="table.columns?.length && !minimalMode"
+        v-if="table.columns?.length"
         :columns="table.columns"
         :reactive-filters="tableFilters"
         @input="handleRowFilterBuilderInput"
@@ -295,7 +295,7 @@ import { mapGetters, mapState } from 'vuex';
 import { TableUpdate, TableUpdateResult, ExtendedTableColumn } from '@/lib/db/models';
 import { dialectFor, FormatterDialect } from '@shared/lib/dialects/models'
 import { format } from 'sql-formatter';
-import { normalizeFilters, safeSqlFormat } from '@/common/utils'
+import { normalizeFilters, safeSqlFormat, createTableFilter } from '@/common/utils'
 import { TableFilter } from '@/lib/db/models';
 import { LanguageData } from '../../lib/editor/languageData'
 import { escapeHtml } from '@shared/lib/tabulator';
@@ -305,10 +305,6 @@ import { tabulatorForTableData } from "@/common/tabulator";
 const log = rawLog.scope('TableTable')
 
 let draftFilters: TableFilter[] | string | null;
-
-function createTableFilter(field: string) {
-  return { op: "AND", field, type: "=", value: "" }
-}
 
 export default Vue.extend({
   components: { Statusbar, ColumnFilterModal, TableLength, RowFilterBuilder, EditorModal },


### PR DESCRIPTION
When minimal mode is active, and there are filters in the table, we should be able to see it and clear it. To close the filter, we can do one of these:

## Clear the filter manually and then click away from the input
![close-filters-by-clicking-away](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/1a4b6d11-21fb-43b5-8479-3c08197c802b)

## Click the clear button
![close-filters-by-clicking-button](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/01dacbcb-6184-49d5-a12e-4489c5d3cdc2)


<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7853ce20246c27db0c04689956c6aa31a4f5f9e0  | 
|--------|

### Summary:
Enhances filter visibility in minimal mode by adding utility functions and updating Vue components to use these functions for consistent filter handling.

**Key points**:
- Enhances filter visibility in minimal mode by adding utility functions and updating Vue components for consistent filter handling.
- Add `createTableFilter` and `checkEmptyFilters` in `utils.ts`.
- Update `RowFilterBuilder.vue` to handle filter visibility in minimal mode.
- Always render `RowFilterBuilder` in `TableTable.vue` but control visibility internally.
- Use new utility functions across components for consistent filter handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
