### PR TITLE
[Fix] Add exit confirmation modal before quitting

### DIFF
--- a/apps/studio/src/background.ts
+++ b/apps/studio/src/background.ts
@@ -1,6 +1,6 @@
 'use strict'
 import * as fs from 'fs'
-import { app, protocol } from 'electron'
+import { app, protocol, dialog } from 'electron'
 import log from 'electron-log'
 import * as electron from 'electron'
 import { ipcMain } from 'electron'
@@ -139,6 +139,21 @@ app.on('ready', async () => {
     }
   }
 })
+
+// Show exit confirmation modal before quitting
+app.on("before-quit", (event) => {
+  const choice = dialog.showMessageBoxSync(null, {
+    type: "question",
+    buttons: ["Exit", "Cancel"],
+    message: "Really close application?\nYou lose all unsaved changes",
+  });
+
+  if (choice === 0) {
+    app.exit();
+  } else {
+    event.preventDefault();
+  }
+});
 
 // Open a connection from a file (e.g. ./sqlite.db)
 app.on('open-file', async (event, file) => {


### PR DESCRIPTION
## Issue

- close #2201 

## Work Detail

I modified it so that you can check the confirmation alert when the application is terminated using electron's default dialog.

If I need to use a custom modal in Vuejs, I need some advice on how to do that.

Thanks !

## Preview

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/116232939/55a3f96f-f383-4946-b7d8-53b7a5094fe0)
