### PR TITLE
Fix editor modal autofocus and autoresize

### DIFF
--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -4,6 +4,7 @@
       :name="modalName"
       class="beekeeper-modal vue-dialog editor-dialog"
       @opened="onOpen"
+      @before-close="onBeforeClose"
     >
       <!-- Trap the key events so it doesn't conflict with the parent elements -->
       <div
@@ -225,8 +226,14 @@ export default Vue.extend({
 
     async onOpen() {
       await this.$nextTick();
+      this.$refs.editorContainer.style.height = undefined
       this.editorFocus = true
       this.$nextTick(this.resizeHeightToFitContent)
+    },
+    async onBeforeClose() {
+      // Hack: keep the modal height as it was before.
+      this.$refs.editorContainer.style.height = this.$refs.editorContainer.offsetHeight + 'px'
+      this.editorFocus = false
     },
     resizeHeightToFitContent() {
       const wrapperEl = this.$refs.editorContainer.querySelector('.CodeMirror')

--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -61,13 +61,17 @@
           </x-button>
         </div>
 
-        <div class="editor-container">
+        <div
+          class="editor-container"
+          ref="editorContainer"
+        >
           <text-editor
             v-model="content"
             :mode="language.editorMode"
             :line-wrapping="wrapText"
             :height="editorHeight"
-            @interface="editorInterface = $event"
+            :focus="editorFocus"
+            @focus="editorFocus = $event"
           />
         </div>
       </div>
@@ -148,7 +152,7 @@ export default Vue.extend({
   name: "CellEditorModal",
   data() {
     return {
-      editorInterface: {},
+      editorFocus: false,
       editorHeight: 100,
       error: "",
       languageName: "text",
@@ -221,11 +225,11 @@ export default Vue.extend({
 
     async onOpen() {
       await this.$nextTick();
-      this.editorInterface.focus()
+      this.editorFocus = true
       this.$nextTick(this.resizeHeightToFitContent)
     },
     resizeHeightToFitContent() {
-      const wrapperEl = this.editorInterface.getWrapperElement()
+      const wrapperEl = this.$refs.editorContainer.querySelector('.CodeMirror')
       const wrapperStyle = window.getComputedStyle(wrapperEl)
 
       const minHeight = parseInt(wrapperStyle.minHeight)


### PR DESCRIPTION
- It should auto focus the text editor when the editor modal is opened
- It should resize the text editor in vertical automatically when the editor modal is opened
- The modal stays in the same height as it was before closing it

Bug -> it changes the modal height when closing it for a split second:
![closing-editor-modal](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/ba41fa96-d14e-4c66-a892-e9d7b1f541ef)

Fix -> it should not do that really, cause it's kinda ugly.. 🤷 
![closing-editor-modal-2](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/64c3df30-bf0d-4e73-aaca-89f5300af1cf)
