### PR TITLE
Fix TableTable auto resize when enabling minimal mode

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -351,6 +351,9 @@ export default Vue.extend({
       initialized: false,
       internalColumnPrefix: "__beekeeper_internal_",
       internalIndexColumn: "__beekeeper_internal_index",
+
+      /** This is true when we switch to minimal mode while TableTable is not active */
+      enabledMinimalModeWhileInactive: false,
     };
   },
   computed: {
@@ -736,6 +739,12 @@ export default Vue.extend({
           this.tableFilters = this.tab.getFilters()
           this.triggerFilter(this.tableFilters)
         }
+
+        if (this.enabledMinimalModeWhileInactive) {
+          this.enabledMinimalModeWhileInactive = false
+          resizeAllColumnsToFitContentAction(this.tabulator)
+        }
+
         // $nextTick doesn't work here
         setTimeout(() => {
           this.tabulator.modules.selectRange.restoreFocus()
@@ -769,8 +778,15 @@ export default Vue.extend({
       this.tab.unsavedChanges = this.pendingChangesCount > 0
     },
     minimalMode() {
-      if (this.tabulator) {
+      // Auto resize the columns when the tab is active (not hidden in the DOM)
+      // so tabulator can do it correctly.
+      if (this.tabulator && this.active) {
         resizeAllColumnsToFitContentAction(this.tabulator)
+      }
+
+      // If the tab is not active, we can auto resize later when it's active
+      if (!this.active) {
+        this.enabledMinimalModeWhileInactive = this.minimalMode
       }
     },
   },


### PR DESCRIPTION
Enabling minimal mode would resize the columns automatically. But doing that while the tab is hidden isn't correct.