### PR TITLE
bump tabulator version

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -79,7 +79,7 @@
     "sql-formatter": "~10.7.2",
     "sql-query-identifier": "^2.7.0",
     "ssh2": "^1.14.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#32107a671f00847d888f89ae0640cd4cc655229d",
+    "tabulator-tables": "beekeeper-studio/tabulator#2642a6210fad1fb859838b6745efb061c1b35918",
     "tinyduration": "^3.2.4",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15612,9 +15612,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#32107a671f00847d888f89ae0640cd4cc655229d:
-  version "6.2.0-bks.5"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/32107a671f00847d888f89ae0640cd4cc655229d"
+tabulator-tables@beekeeper-studio/tabulator#2642a6210fad1fb859838b6745efb061c1b35918:
+  version "6.2.0-bks.6"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/2642a6210fad1fb859838b6745efb061c1b35918"
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
This tabulator version should fix the navigation regressions:

- When pressing up/down while editing, it should navigate within the cell (cherry-picked https://github.com/olifolkerd/tabulator/pull/4516)
- When pressing tab/shift+tab while editing, it should break the editor focus and navigate to the next cell. (cherry-picked https://github.com/olifolkerd/tabulator/pull/4517)
- Pressing arrow keys while editing should move the cursor within the cell editor. fix #2242 