### PR TITLE
Fix SQLite and LibSQL in-memory connection

### DIFF
--- a/apps/studio/src/lib/db/clients/libsql/LibSQLCursor.ts
+++ b/apps/studio/src/lib/db/clients/libsql/LibSQLCursor.ts
@@ -10,13 +10,14 @@ export class LibSQLCursor extends SqliteCursor {
   options: LibSQLCursorOptions
 
   constructor(
-    databaseName: string,
+    database: string | Database.Database,
     query: string,
     params: string[],
     chunkSize: number,
     options: LibSQLCursorOptions = {}
   ) {
-    super(databaseName, query, params, chunkSize, options);
+    // @ts-expect-error not fully typed
+    super(database, query, params, chunkSize, options);
   }
 
   protected _createConnection(path: string) {

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -47,6 +47,8 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
   version: SqliteResult;
   databasePath: string;
   dialectData = SD;
+  isTempDB = false;
+  _rawConnection: Database.Database;
 
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(knex, sqliteContext, server, database);
@@ -54,6 +56,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
     this.dialect = 'sqlite';
     this.readOnlyMode = server?.config?.readOnlyMode || false;
     this.databasePath = database?.database;
+    this.isTempDB = _.isEmpty(this.databasePath) || this.databasePath === ':memory:';
   }
 
   versionString(): string {
@@ -241,7 +244,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
 
           throw err;
         } finally {
-          if (queryConnection) {
+          if (queryConnection !== this._rawConnection) {
             queryConnection.close();
           }
         }
@@ -325,7 +328,9 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
       await this.driverExecuteSingle('ROLLBACK', cli);
       throw ex;
     } finally {
-      cli.connection.close();
+      if (cli.connection !== this._rawConnection) {
+        cli.connection.close();
+      }
     }
 
     return results;
@@ -448,7 +453,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
     return {
       totalRows: rowCount,
       columns,
-      cursor: this.createCursor(this.databasePath, query, params, chunkSize)
+      cursor: this.createCursor(this.isTempDB ? this.acquireConnection() : this.databasePath, query, params, chunkSize)
     }
   }
 
@@ -456,7 +461,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
     return {
       totalRows: undefined,
       columns: undefined,
-      cursor: this.createCursor(this.databasePath, query, [], chunkSize)
+      cursor: this.createCursor(this.isTempDB ? this.acquireConnection() : this.databasePath, query, [], chunkSize)
     };
   }
 
@@ -586,14 +591,14 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
         });
       } catch (error) {
         log.error(error);
-        if (acquiredNewConnection) {
+        if (acquiredNewConnection && connection !== this._rawConnection) {
           connection.close();
         }
         throw error;
       }
     }
 
-    if (acquiredNewConnection) {
+    if (acquiredNewConnection && connection !== this._rawConnection) {
       connection.close();
     }
 
@@ -601,7 +606,17 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
   }
 
   protected acquireConnection(): Database.Database {
-    return new Database(this.databasePath);
+    if (this.isTempDB) {
+      if (!this._rawConnection) {
+        this._rawConnection = this.createRawConnection(':memory:');
+      }
+      return this._rawConnection;
+    }
+    return this.createRawConnection(this.databasePath);
+  }
+
+  protected createRawConnection(filename: string) {
+    return new Database(filename);
   }
 
   protected checkReader(_queryIdentifyResult: IdentifyResult, statement: Database.Statement): boolean {

--- a/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
+++ b/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
@@ -7,15 +7,22 @@ export class SqliteCursor extends BeeCursor {
   protected statement: Statement
   protected iterator?: IterableIterator<any>;
 
+  private usingExternalConnection = false;
+
   constructor(
-    databaseName: string,
+    database: string | Database,
     query: string,
     private params: string[],
     chunkSize: number,
     protected options?: any
   ) {
     super(chunkSize);
-    this._createConnection(databaseName);
+    if (typeof database === 'string') {
+      this._createConnection(database);
+    } else {
+      this.usingExternalConnection = true;
+      this.database = database;
+    }
     this._prepareStatement(query);
   }
 
@@ -44,7 +51,9 @@ export class SqliteCursor extends BeeCursor {
     return results
   }
   async cancel(): Promise<void> {
-    this.database.close()
+    if(!this.usingExternalConnection) {
+      this.database.close()
+    }
   }
 
 }

--- a/apps/studio/tests/integration/lib/db/clients/libsql.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/libsql.spec.ts
@@ -11,6 +11,8 @@ import knex from "knex";
 import Client_Libsql from "@libsql/knex-libsql";
 import Client_BetterSQLite3 from "knex/lib/dialects/better-sqlite3/index";
 
+const timeoutDefault = 5000
+
 const TEST_VERSIONS = [
   { mode: "memory", readOnly: false },
   { mode: "file", readOnly: false },
@@ -23,6 +25,8 @@ const TEST_VERSIONS = [
 
 function testWith(options: typeof TEST_VERSIONS[number]) {
   describe(`LibSQL [${options.mode} - read-only mode? ${options.readOnly}]`, () => {
+    jest.setTimeout(dbtimeout)
+
     if (options.mode === "replica") {
       testReplica(options.readOnly);
       return;
@@ -57,6 +61,7 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
           .withExposedPorts(8080)
           .withStartupTimeout(dbtimeout)
           .start();
+        jest.setTimeout(timeoutDefault)
         const host = container.getHost();
         const port = container.getMappedPort(8080);
         dbPath = `http://${host}:${port}`;
@@ -301,6 +306,7 @@ function testReplica(readOnly = false) {
       .withExposedPorts(8080)
       .withStartupTimeout(dbtimeout)
       .start();
+    jest.setTimeout(timeoutDefault)
 
     const host = container.getHost();
     const port = container.getMappedPort(8080);

--- a/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
@@ -1,11 +1,14 @@
-import { DBTestUtil } from '../../../../lib/db'
-import tmp from 'tmp'
-import { itShouldInsertGoodData, itShouldNotInsertBadData, itShouldApplyAllTypesOfChanges, itShouldNotCommitOnChangeError, runCommonTests, runReadOnlyTests } from './all'
+import { DBTestUtil } from "../../../../lib/db";
+import tmp from "tmp";
+import { runCommonTests, runReadOnlyTests } from "./all";
+import knex from "knex";
+import Client_BetterSQLite3 from "knex/lib/dialects/better-sqlite3";
 
 const TEST_VERSIONS = [
-  { readOnly: false },
-  { readOnly: true },
-]
+  { mode: "memory", readOnly: false },
+  { mode: "file", readOnly: false },
+  { mode: "file", readOnly: true },
+];
 
 function testWith(options) {
   describe(`SQLite [read-only mode? ${options.readOnly}]`, () => {
@@ -14,13 +17,35 @@ function testWith(options) {
     let util
 
     beforeAll(async () => {
-      dbfile = tmp.fileSync()
+      let dbName;
+      if (options.mode === "file") {
+        dbfile = tmp.fileSync();
+        dbName = dbfile.name;
+      } else {
+        dbName = "";
+      }
 
       const config = {
         client: 'sqlite',
         readOnlyMode: options.readOnly,
       }
-      util = new DBTestUtil(config, dbfile.name, { dialect: 'sqlite'})
+      util = new DBTestUtil(config, dbName, {
+        dialect: "sqlite",
+        knex: knex({
+          client: options.mode !== "memory"
+            ? "better-sqlite3"
+            : class extends Client_BetterSQLite3 {
+              acquireRawConnection() {
+                // We want to use the same connection when opening
+                // in-memory database
+                return util.connection._rawConnection
+              }
+            },
+          connection: {
+            filename: dbName,
+          },
+        }),
+      })
       util.extraTables = 1
       await util.setupdb()
 
@@ -90,16 +115,23 @@ function testWith(options) {
       })
 
       it("Should apply changes to boolean values correctly", async () => {
+        function n(value) {
+          if (options.mode === 'memory') {
+            return BigInt(value)
+          } else {
+            return value
+          }
+        }
         const updates = [
-          { id: 1, expect: false, toBe: 0 },
-          { id: 2, expect: true, toBe: 1 },
-          { id: 3, expect: null, toBe: null },
+          { id: n(1), expect: false, toBe: n(0) },
+          { id: n(2), expect: true, toBe: n(1) },
+          { id: n(3), expect: null, toBe: null },
         ]
 
         const inserts = [
-          { id: 4, expect: false, toBe: 0 },
-          { id: 5, expect: true, toBe: 1 },
-          { id: 6, expect: null, toBe: null },
+          { id: n(4), expect: false, toBe: n(0) },
+          { id: n(5), expect: true, toBe: n(1) },
+          { id: n(6), expect: null, toBe: null },
         ]
 
         await expect(util.connection.applyChanges({

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -15,7 +15,6 @@ import { safeSqlFormat } from '../../src/common/utils'
 import knexFirebirdDialect from 'knex-firebird-dialect'
 import { BasicDatabaseClient } from '@/lib/db/clients/BasicDatabaseClient'
 import { SqlGenerator } from '@shared/lib/sql/SqlGenerator'
-import Client_Libsql from '@libsql/knex-libsql'
 
 type ConnectionTypeQueries = Partial<Record<ConnectionType, string>>
 type DialectQueries = Record<Dialect, string>
@@ -71,6 +70,7 @@ export interface Options {
   skipGeneratedColumns?: boolean
   skipCreateDatabase?: boolean
   knexConnectionOptions?: Record<string, any>
+  knex?: Knex
 }
 
 export class DBTestUtil {
@@ -104,21 +104,8 @@ export class DBTestUtil {
     this.data = getDialectData(this.dialect)
     this.dbType = config.client || 'generic'
     this.options = options
-    if (config.client === 'sqlite') {
-      this.knex = knex({
-        client: "better-sqlite3",
-        connection: {
-          filename: database
-        }
-      })
-    } else if (config.client === 'libsql') {
-      const url = !/^:memory:$|^libsql:|^http:|^https:|^ws:|^wss:/.test(database)
-        ? `file:${database}`
-        : database
-      this.knex = knex({
-        client: Client_Libsql as any,
-        connection: { filename: url },
-      })
+    if (options.knex) {
+      this.knex = options.knex
     } else if (config.client === 'oracle') {
       this.knex = knex({
         client: 'oracledb',

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -106,6 +106,13 @@ export class DBTestUtil {
     this.options = options
     if (options.knex) {
       this.knex = options.knex
+    } else if (config.client === 'sqlite') {
+      this.knex = knex({
+        client: "better-sqlite3",
+        connection: {
+          filename: database
+        }
+      })
     } else if (config.client === 'oracle') {
       this.knex = knex({
         client: 'oracledb',


### PR DESCRIPTION
We keep creating and closing a new connection when connecting to an in-memory database, which shouldn't happen. The data in an in-memory database is destroyed when the connection is closed, so we need to maintain the same connection until we close it explicitly.

Note: there are two kinds of in-memory databases (https://www.sqlite.org/inmemorydb.html):
- In Memory database => stores data in memory, use `:memory:` as URL
- Temporary Database => stores data in a temporary file, use empty string as URL