### PR TITLE
Fix libsql null connection title

### DIFF
--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -108,14 +108,14 @@ export default {
     label() {
       if (this.savedConnection) {
         return this.savedConnection.name
-      } else if (this.config.connectionType === 'sqlite') {
+      } else if (this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') {
         return path.basename(this.config.defaultDatabase)
       }
 
       return this.$bks.simpleConnectionString(this.config)
     },
     connectionType() {
-      if (this.config.connectionType === 'sqlite') {
+      if (this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') {
         return 'path'
       }
 

--- a/apps/studio/src/plugins/BeekeeperPlugin.ts
+++ b/apps/studio/src/plugins/BeekeeperPlugin.ts
@@ -52,7 +52,7 @@ export const BeekeeperPlugin = {
   buildConnectionString(config: IConnection): string {
     if (config.socketPathEnabled) return config.socketPath;
 
-    if (config.connectionType === 'sqlite') {
+    if (config.connectionType === 'sqlite' || config.connectionType === 'libsql') {
       return config.defaultDatabase || "./unknown.db"
     } else {
       let result = `${config.username || 'user'}@${config.host}:${config.port}`
@@ -72,7 +72,7 @@ export const BeekeeperPlugin = {
     if (config.socketPathEnabled) return config.socketPath;
 
     let connectionString = `${config.host}:${config.port}`;
-    if (config.connectionType === 'sqlite') {
+    if (config.connectionType === 'sqlite' || config.connectionType === 'libsql') {
       return path.basename(config.defaultDatabase || "./unknown.db")
     } else if (config.connectionType === 'cockroachdb' && config.options?.cluster) {
       connectionString = `${config.options.cluster}/${config.defaultDatabase || 'cloud'}`


### PR DESCRIPTION
LibSQL connection title shouldn't look like this:

![image](https://github.com/beekeeper-studio/beekeeper-studio/assets/38707148/31cde2dd-0b4d-4d2d-95a2-43f7d178b789)

This also fixes the subtitle in the saved connection list.