### PR TITLE
fix: ctrl + c on result table copying wrong values

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -172,7 +172,7 @@
         });
       },
       copySelection() {
-        if (!document.activeElement.classList.contains('tabulator-tableholder')) return
+        if (!this.active || !document.activeElement.classList.contains('tabulator-tableholder')) return
         copyRange({ range: _.last(this.tabulator.getRanges()), type: 'plain' })
       },
       dataToJson(rawData, firstObjectOnly) {


### PR DESCRIPTION
fixes: #2267 

problem is when doing ctrl + c, copySelection functions runs for each opened query's ResultTable not just the currently active query's ResultTable which overrides the last copied value, not sure if that's expected behaviour or it's a bug itself

for now, I have just added a check to know if it's a active query tab before copying the value on ctrl + c