### PR TITLE
fix incorrect drop sql in postgres

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -407,7 +407,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   async listTableIndexes(table: string, schema: string = this._defaultSchema): Promise<TableIndex[]> {
     const sql = `
-    SELECT i.indexrelid::regclass AS indexname,
+    SELECT (SELECT relname FROM pg_class c WHERE c.oid = i.indexrelid) as indexname,
         k.i AS index_order,
         i.indexrelid as id,
         i.indisunique,

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -61,6 +61,11 @@ export function runCommonTests(getUtil, opts = {}) {
       await getUtil().listTableTests()
     })
 
+    test("list indexes should work", async () => {
+      if (getUtil().data.disabledFeatures?.createIndex) return
+      await getUtil().listIndexTests()
+    })
+
     test("column tests", async() => {
       await getUtil().tableColumnsTests()
     })

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -352,7 +352,7 @@ export class DBTestUtil {
 
   async listIndexTests() {
     const indexes = await this.connection.listTableIndexes("has_index", this.defaultSchema)
-    expect(indexes.find((i) => i.name === 'has_index_foo_idx')).toBeDefined()
+    expect(indexes.find((i) => i.name.toLowerCase() === 'has_index_foo_idx')).toBeDefined()
   }
 
   async tableColumnsTests() {

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -350,6 +350,11 @@ export class DBTestUtil {
     expect(columns.length).toBe(7)
   }
 
+  async listIndexTests() {
+    const indexes = await this.connection.listTableIndexes("has_index", this.defaultSchema)
+    expect(indexes.find((i) => i.name === 'has_index_foo_idx')).toBeDefined()
+  }
+
   async tableColumnsTests() {
     const columns = await this.connection.listTableColumns(null, this.defaultSchema)
     const mixedCaseColumns = await this.connection.listTableColumns('MixedCase', this.defaultSchema)

--- a/shared/src/lib/sql/change_builder/PostgresqlChangeBuilder.ts
+++ b/shared/src/lib/sql/change_builder/PostgresqlChangeBuilder.ts
@@ -1,4 +1,4 @@
-import { Dialect, PartitionExpressionChange, PartitionItem } from "@shared/lib/dialects/models";
+import { Dialect, DropIndexSpec, PartitionExpressionChange, PartitionItem } from "@shared/lib/dialects/models";
 import { PostgresData } from "@shared/lib/dialects/postgresql";
 import { ChangeBuilderBase } from "./ChangeBuilderBase";
 
@@ -56,5 +56,17 @@ export class PostgresqlChangeBuilder extends ChangeBuilderBase {
   alterPartitions(alterations: PartitionExpressionChange[]) {
     if (!alterations?.length) return null;
     return alterations.map((alter) => this.alterPartition(alter)).join(';');
+  }
+
+  dropIndexes(drops: DropIndexSpec[]): string | null {
+    if (!drops?.length) return null
+
+    const names = drops.map((spec) => {
+      if (this.schema) {
+        return `${this.dialectData.wrapIdentifier(this.schema)}.${this.dialectData.wrapIdentifier(spec.name)}`
+      }
+      return this.dialectData.wrapIdentifier(spec.name)
+    }).join(",")
+    return names.length ? `DROP INDEX ${names}` : null
   }
 }


### PR DESCRIPTION
fix #2290

The name that's given from `listTableIndexes` was combined with the schema name (like `ihs.ship_status_statuscode_key`), and if we look at the other databases, they don't have schema in their index names (like `ship_status_statuscode_key`, but no `ihs.` prefix).