### PR TITLE
Azure SSO authentication improvement

### DIFF
--- a/apps/studio/src/assets/styles/app/connection-interface.scss
+++ b/apps/studio/src/assets/styles/app/connection-interface.scss
@@ -58,6 +58,14 @@
   .bigquery-form {
     margin-bottom: $gutter-h;
   }
+  .sql-server-form {
+    .signed-in-as .advanced-body {
+      padding-top: 0;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
   .text-connect {
     padding-top: 0.25rem;
   }

--- a/apps/studio/src/assets/styles/app/modals.scss
+++ b/apps/studio/src/assets/styles/app/modals.scss
@@ -37,7 +37,7 @@
     }
   }
 
-  &.confirmation-modal, &.sql-files-import-modal {
+  &.confirmation-modal, &.sql-files-import-modal, &.wait-sso-modal {
     .v--modal {
       width: auto !important;
       min-height: 0px;
@@ -68,6 +68,23 @@
 
     .file-picker-wrapper {
       margin-top: 1rem;
+    }
+  }
+
+  &.wait-sso-modal {
+    .dialog-content {
+      padding-top: 2rem;
+      padding-bottom: 0.5rem;
+    }
+    .dialog-c-title {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding-right: 0;
+    }
+    .vue-dialog-buttons {
+      padding-bottom: 2rem;
+      justify-content: center;
     }
   }
 }

--- a/apps/studio/src/common/appdb/models/token_cache.ts
+++ b/apps/studio/src/common/appdb/models/token_cache.ts
@@ -13,4 +13,7 @@ export class TokenCache extends ApplicationEntity {
 
   @Column({ type: "text", nullable: true, transformer: [encrypt] })
   cache: Nullable<string>;
+
+  @Column({ type: "text", nullable: true })
+  name: Nullable<string>;
 }

--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -137,7 +137,7 @@
                   <span class="expand" />
                   <div class="btn-group">
                     <button
-                      :disabled="testing"
+                      :disabled="testing || connecting"
                       class="btn btn-flat"
                       type="button"
                       @click.prevent="testConnection"
@@ -145,7 +145,7 @@
                       Test
                     </button>
                     <button
-                      :disabled="testing"
+                      :disabled="testing || connecting"
                       class="btn btn-primary"
                       type="submit"
                       @click.prevent="submit"
@@ -191,6 +191,7 @@
         }}</a></small>
       </div>
     </div>
+    <loading-sso-modal v-model="loadingSSOModalOpened" @cancel="loadingSSOCanceled" />
   </div>
 </template>
 
@@ -210,6 +211,7 @@ import FirebirdForm from './connection/FirebirdForm.vue'
 import LibSQLForm from './connection/LibSQLForm.vue'
 import Split from 'split.js'
 import ImportButton from './connection/ImportButton.vue'
+import LoadingSSOModal from '@/components/common/modals/LoadingSSOModal.vue'
 import _ from 'lodash'
 import platformInfo from '@/common/platform_info'
 import ErrorAlert from './common/ErrorAlert.vue'
@@ -217,6 +219,7 @@ import rawLog from 'electron-log'
 import { mapState } from 'vuex'
 import { dialectFor } from '@shared/lib/dialects/models'
 import { findClient } from '@/lib/db/clients'
+import { AzureAuthType } from '@/lib/db/authentication/azure'
 import UpsellContent from './connection/UpsellContent.vue'
 import Vue from 'vue'
 import { AppEvent } from '@/common/AppEvent'
@@ -228,7 +231,7 @@ const log = rawLog.scope('ConnectionInterface')
 // import ImportUrlForm from './connection/ImportUrlForm';
 
 export default Vue.extend({
-  components: { ConnectionSidebar, MysqlForm, PostgresForm, RedshiftForm, Sidebar, SqliteForm, SqlServerForm, SaveConnectionForm, ImportButton, ErrorAlert, UpsellContent, BigQueryForm, FirebirdForm, LibSqlForm: LibSQLForm },
+  components: { ConnectionSidebar, MysqlForm, PostgresForm, RedshiftForm, Sidebar, SqliteForm, SqlServerForm, SaveConnectionForm, ImportButton, ErrorAlert, UpsellContent, BigQueryForm, FirebirdForm, LibSqlForm: LibSQLForm, LoadingSsoModal: LoadingSSOModal },
 
   data() {
     return {
@@ -237,11 +240,14 @@ export default Vue.extend({
       connectionError: null,
       errorHelp: null,
       testing: false,
+      connecting: false,
       split: null,
       url: null,
       importError: null,
       sidebarShown: true,
-      version: platformInfo.appVersion
+      version: platformInfo.appVersion,
+      loadingSSOModalOpened: false,
+      abortController: null,
     }
   },
   computed: {
@@ -394,13 +400,20 @@ export default Vue.extend({
         return
       }
 
+      this._beforeConnect()
+      this.abortController = new AbortController()
       this.connectionError = null
       try {
-        await this.$store.dispatch('connect', this.config)
+        const abortSignal = this.abortController.signal
+        this.connecting = true
+        await this.$store.dispatch('connectWithAbort', { config: this.config, abortSignal })
       } catch (ex) {
         this.connectionError = ex
         this.$noty.error("Error establishing a connection")
         log.error(ex)
+      } finally {
+        this.connecting = false
+        this._afterConnect()
       }
     },
     async handleConnect(config) {
@@ -454,7 +467,24 @@ export default Vue.extend({
       } else {
         this.errors = null
       }
-    }
+    },
+    // Before running connect method
+    _beforeConnect() {
+      if (
+        this.config.connectionType === 'sqlserver' &&
+        this.config.azureAuthOptions.azureAuthEnabled &&
+        this.config.azureAuthOptions.azureAuthType === AzureAuthType.AccessToken
+      ) {
+        this.loadingSSOModalOpened = true
+      }
+    },
+    // After running connect method, success or fail
+    _afterConnect() {
+      this.loadingSSOModalOpened = false
+    },
+    loadingSSOCanceled() {
+      this.abortController.abort()
+    },
   },
 })
 </script>

--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -111,6 +111,7 @@
                   v-else-if="config.connectionType === 'sqlserver'"
                   :config="config"
                   :testing="testing"
+                  @error="connectionError = $event"
                 />
                 <big-query-form
                   v-else-if="config.connectionType === 'bigquery'"

--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -425,10 +425,14 @@ export default Vue.extend({
         return
       }
 
+      this._beforeConnect()
+      this.abortController = new AbortController()
+
       try {
         this.testing = true
         this.connectionError = null
-        await this.$store.dispatch('test', this.config)
+        const abortSignal = this.abortController.signal
+        await this.$store.dispatch('testWithAbort', { config: this.config, abortSignal })
         this.$noty.success("Connection looks good!")
         return true
       } catch (ex) {
@@ -436,6 +440,7 @@ export default Vue.extend({
         this.$noty.error("Error establishing a connection")
       } finally {
         this.testing = false
+        this._afterConnect()
       }
     },
     async save() {
@@ -468,7 +473,7 @@ export default Vue.extend({
         this.errors = null
       }
     },
-    // Before running connect method
+    // Before running connect/test method
     _beforeConnect() {
       if (
         this.config.connectionType === 'sqlserver' &&
@@ -478,7 +483,7 @@ export default Vue.extend({
         this.loadingSSOModalOpened = true
       }
     },
-    // After running connect method, success or fail
+    // After running connect/test method, success or fail
     _afterConnect() {
       this.loadingSSOModalOpened = false
     },

--- a/apps/studio/src/components/common/modals/LoadingSSOModal.vue
+++ b/apps/studio/src/components/common/modals/LoadingSSOModal.vue
@@ -4,7 +4,7 @@
       <div v-kbd-trap="true">
         <div class="dialog-content">
           <div class="dialog-c-title">
-            Waiting for authentication...
+            Waiting for authentication
             <loading-spinner />
           </div>
         </div>

--- a/apps/studio/src/components/common/modals/LoadingSSOModal.vue
+++ b/apps/studio/src/components/common/modals/LoadingSSOModal.vue
@@ -1,10 +1,10 @@
 <template>
   <portal to="modals">
-    <modal class="vue-dialog beekeeper-modal wait-sso-modal" :name="modalName" :clickToClose="false">
+    <modal class="vue-dialog beekeeper-modal wait-sso-modal" :name="modalName" :click-to-close="false">
       <div v-kbd-trap="true">
         <div class="dialog-content">
           <div class="dialog-c-title">
-            Signing you in...
+            Waiting for authentication...
             <loading-spinner />
           </div>
         </div>

--- a/apps/studio/src/components/common/modals/LoadingSSOModal.vue
+++ b/apps/studio/src/components/common/modals/LoadingSSOModal.vue
@@ -1,0 +1,61 @@
+<template>
+  <portal to="modals">
+    <modal class="vue-dialog beekeeper-modal wait-sso-modal" :name="modalName" :clickToClose="false">
+      <div v-kbd-trap="true">
+        <div class="dialog-content">
+          <div class="dialog-c-title">
+            Signing you in...
+            <loading-spinner />
+          </div>
+        </div>
+        <div class="vue-dialog-buttons">
+          <button
+            class="btn btn-flat btn-cancel"
+            type="button"
+            ref="cancelBtn"
+            @click.prevent="cancel"
+            :disabled="canceled"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </modal>
+  </portal>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import LoadingSpinner from '@/components/common/loading/LoadingSpinner.vue';
+
+export default Vue.extend({
+  components: {LoadingSpinner},
+  props: ["value"],
+  data() {
+    return {
+      modalName: "sso-loading-modal",
+      canceled: false,
+    };
+  },
+  watch: {
+    async value() {
+      if (this.value) {
+        this.canceled = false;
+        this.$modal.show(this.modalName);
+        // Somehow the refs are only available if we combine nextTick and
+        // setTimeout like this ¯\_(ツ)_/¯
+        await this.$nextTick()
+        setTimeout(() => this.$refs.cancelBtn.focus(), 0)
+      } else {
+        this.$modal.hide(this.modalName);
+      }
+    },
+  },
+  methods: {
+    cancel() {
+      this.canceled = true;
+      this.$emit('cancel');
+    },
+  },
+});
+</script>

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -160,6 +160,7 @@
   import { TokenCache } from '@/common/appdb/models/token_cache';
   import platformInfo from '@/common/platform_info'
   import { AppEvent } from '@/common/AppEvent'
+  import _ from 'lodash'
 
   export default {
     components: { CommonServerInputs, CommonAdvanced },
@@ -195,8 +196,9 @@
           }
         }
 
-        if (this.authType === AzureAuthType.AccessToken) {
-          const cache = await TokenCache.findOne(this.config.azureAuthOptions.authId);
+        const authId = this.config.azureAuthOptions?.authId || this.config?.authId
+        if (this.authType === AzureAuthType.AccessToken && !_.isNil(authId)) {
+          const cache = await TokenCache.findOne(authId);
           this.accessTokenCache = cache
         } else {
           this.accessTokenCache = null
@@ -235,6 +237,7 @@
           this.accessTokenCache = null
         } catch (e) {
           this.errorSigningOut = e
+          this.$emit('error', e)
         } finally {
           this.signingOut = false
         }

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -81,7 +81,6 @@ const cachePlugin = {
 
 export class AzureAuthService {
   private pca: msal.PublicClientApplication;
-  private start: number = null;
 
   private cancelFulfillment = false;
 
@@ -183,7 +182,6 @@ export class AzureAuthService {
     log.debug('Getting auth code')
     window.location.href = authUrl;
 
-    this.start = Date.now();
     const result = await this.checkStatus(beekeeperCloudToken.url);
     if (!result || result?.data?.cloud_token?.status !== 'fulfilled') {
       throw new Error(`Looks like you didn't sign in on your browser. Please try again.`);
@@ -250,10 +248,9 @@ export class AzureAuthService {
 
     return null;
   }
-  
+
   private async checkStatus(url: string): Promise<Response> {
-    const timedOut = Date.now() - this.start >= globals.pollingTimeout;
-    if (this.cancelFulfillment || timedOut) {
+    if (this.cancelFulfillment) {
       return null;
     }
     const result = await axios.get(url) as Response;

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -34,7 +34,7 @@ type CloudTokenResponse = {
 
 type Response = AxiosResponse<CloudTokenResponse, any>;
 
-export interface CloudToken { 
+export interface CloudToken {
   id: string,
   created_at: string,
   updated_at: string,
@@ -202,6 +202,7 @@ export class AzureAuthService {
       const tokenResponse = await this.pca.acquireTokenByCode(tokenRequest)
 
       localCache.homeId = tokenResponse.account.homeAccountId;
+      localCache.name = tokenResponse.account.name;
       localCache.save();
       return {
         type: 'azure-active-directory-access-token',
@@ -214,6 +215,13 @@ export class AzureAuthService {
 
   public cancel(): void {
     this.cancelFulfillment = true;
+  }
+
+  public async signOut() {
+    const tokenCache = this.pca.getTokenCache();
+    const account = await tokenCache.getAccountByHomeId(localCache.homeId);
+    await this.pca.signOut({ account })
+    await localCache.remove()
   }
 
   private async tryRefresh(): Promise<AuthConfig | null> {

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -92,7 +92,7 @@ export abstract class BasicDatabaseClient<RawResultType> {
   // ****************************************************************************
 
   // Connection *****************************************************************
-  async connect(): Promise<void> {
+  async connect(_abortSignal?: AbortSignal): Promise<void> {
     /* eslint no-param-reassign: 0 */
     if (this.database.connecting) {
       throw new Error('There is already a connection in progress for this database. Aborting this new request.');

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -852,10 +852,10 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
 
   /* helper functions and settings below! */
 
-  async connect(): Promise<void> {
+  async connect(abortSignal?: AbortSignal): Promise<void> {
     await super.connect();
 
-    this.dbConfig = await this.configDatabase(this.server, this.database)
+    this.dbConfig = await this.configDatabase(this.server, this.database, abortSignal)
     this.pool = await new ConnectionPool(this.dbConfig).connect();
 
     this.pool.on('error', (err) => {
@@ -976,7 +976,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
     }
   }
 
-  private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase): Promise<any> { // changed to any for now, might need to make some changes
+  private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, abortSignal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes
     const config: any = {
       server: server.config.host,
       database: database.database,
@@ -990,6 +990,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
     if (server.config.azureAuthOptions?.azureAuthEnabled) {
       this.authService = new AzureAuthService();
       await this.authService.init(server.config.authId)
+      abortSignal.addEventListener('abort', () => this.authService.cancel());
 
       const options: AuthOptions = {
         password: server.config.password,

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -990,7 +990,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult> {
     if (server.config.azureAuthOptions?.azureAuthEnabled) {
       this.authService = new AzureAuthService();
       await this.authService.init(server.config.authId)
-      abortSignal.addEventListener('abort', () => this.authService.cancel());
+      abortSignal?.addEventListener('abort', () => this.authService.cancel());
 
       const options: AuthOptions = {
         password: server.config.password,

--- a/apps/studio/src/migration/20240715_add_name_to_token_cache.js
+++ b/apps/studio/src/migration/20240715_add_name_to_token_cache.js
@@ -1,0 +1,12 @@
+export default {
+  name: "20230715_add_name_to_token_cache",
+  async run(runner) {
+    const queries = [
+      `ALTER TABLE token_cache ADD COLUMN name TEXT NULL`,
+    ];
+    for (let i = 0; i < queries.length; i++) {
+      const query = queries[i];
+      await runner.query(query);
+    }
+  }
+};

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -40,6 +40,7 @@ import demoSetup from './20240421_seed_with_demo_data'
 import tokenCache from './20240430_add_token_cache'
 import minimalMode from './20240514_user_settings_minimal_mode'
 import libsqlOptions from './20240528_add_libsql_options'
+import nameTokenCache from './20240715_add_name_to_token_cache'
 import ultimate from './ultimate/index'
 
 import UserSettingsWindowPosition from './20240303_user_settings_window_position'
@@ -63,7 +64,7 @@ const realMigrations = [
   serverCerts, socketPath, connectionOptions, keepaliveInterval, redshiftOptions,
   createHiddenEntities, createHiddenSchemas, cassandraOptions, readOnlyMode, connectionPins, fixKeymapType, bigQueryOptions,
   firebirdConnection, exportPath, UserSettingsWindowPosition,
-  demoSetup, minimalMode, tokenCache, libsqlOptions,
+  demoSetup, minimalMode, tokenCache, libsqlOptions, nameTokenCache,
 
 ]
 

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -334,12 +334,16 @@ const store = new Vuex.Store<State>({
   },
   actions: {
     async test(context, config: SavedConnection) {
+      await context.dispatch('testWithAbort', { config })
+    },
+    async testWithAbort(context, payload: { config: SavedConnection, abortSignal?: AbortSignal }) {
+      const { config, abortSignal } = payload
       // TODO (matthew): fix this mess.
       if (context.state.username) {
         const settings = await UserSetting.all()
         const server = ConnectionProvider.for(config, context.state.username, settings)
 
-        await server?.createConnection(config.defaultDatabase || undefined).connect()
+        await server?.createConnection(config.defaultDatabase || undefined).connect(abortSignal)
         server.disconnect()
       } else {
         throw "No username provided"

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -376,6 +376,10 @@ const store = new Vuex.Store<State>({
     },
 
     async connect(context, config: IConnection) {
+      await context.dispatch('connectWithAbort', { config })
+    },
+    async connectWithAbort(context, payload: { config: IConnection, abortSignal?: AbortSignal }) {
+      const { config, abortSignal } = payload
       if (context.state.username) {
         // create token cache for azure auth
         if (config.azureAuthOptions.azureAuthEnabled && !config.authId) {
@@ -399,7 +403,7 @@ const store = new Vuex.Store<State>({
           context.commit('setConnError', msg);
         };
 
-        await connection.connect()
+        await connection.connect(abortSignal)
         connection.connectionType = config.connectionType;
 
         context.commit('newConnection', {config: config, server, connection})

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -386,7 +386,8 @@ const store = new Vuex.Store<State>({
       const { config, abortSignal } = payload
       if (context.state.username) {
         // create token cache for azure auth
-        if (config.azureAuthOptions.azureAuthEnabled && !config.authId) {
+        const foundTokenCache = await TokenCache.findOne(config.authId)
+        if (config.azureAuthOptions.azureAuthEnabled && (!config.authId || !foundTokenCache)) {
           let cache = new TokenCache();
           cache = await cache.save();
           config.authId = cache.id;

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -8,8 +8,12 @@ const TEST_VERSIONS = [
   { version: '2017-latest', readonly: true },
   { version: '2019-latest', readonly: false },
   { version: '2019-latest', readonly: true },
-  { version: '2022-latest', readonly: false },
-  { version: '2022-latest', readonly: true },
+  // FIXME 2022-latest has a breaking change. We'll use the previous build
+  // for now.
+  // { version: '2022-latest', readonly: false },
+  // { version: '2022-latest', readonly: true },
+  { version: '2022-CU13-ubuntu-22.04', readonly: false },
+  { version: '2022-CU13-ubuntu-22.04', readonly: true },
 ]
 
 function testWith(dockerTag: string, readonly: boolean) {


### PR DESCRIPTION
fix #2287 

![image](https://github.com/user-attachments/assets/8c9162b5-6bc8-4e03-a3f7-da35e73032b2)

![image](https://github.com/user-attachments/assets/fa74e214-0ee0-4126-8c9a-eb0c1dc393cb)

TODOS
- [x] When you click connect, Beekeeper Studio should open a modal that shows a spinner and says something like 'Waiting for authentication...' It should Poll for AS LONG AS THE MODAL IS OPEN. There should be a cancel button that stops polling. This prevents folks from connecting to another database at the same time.
- [X] When someone has authorized themselves for a specific database, we should show that in the AzureSSO connection area, and allow them to 'sign out' and clear the token cache. We don't know the email, but you can say something like Authenticated on <date> [sign out]