### PR TITLE
generalizing buffer data flow

### DIFF
--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -7,6 +7,7 @@ function dec28bits(num: any): string {
 }
 
 
+// Tabulator Mutator
 export const Mutators = {
 
   resolveTabulatorMutator(dataType?: string, dialect?: Dialect): (v: any) => JsonFriendly {
@@ -48,7 +49,7 @@ export const Mutators = {
    */
   genericMutator(value: any, preserveComplex = false): JsonFriendly {
     const mutate = Mutators.genericMutator
-    if (_.isBuffer(value)) return value.toString('hex')
+    if (_.isBuffer(value)) return `0x${value.toString('hex')}`
     if (_.isDate(value)) return value.toISOString()
     if (_.isArray(value)) return preserveComplex? value.map((v) => mutate(v, preserveComplex)) : JSON.stringify(value)
     if (_.isObject(value)) return preserveComplex? _.mapValues(value, (v) => mutate(v, preserveComplex)) : JSON.stringify(value)
@@ -101,4 +102,29 @@ export const Mutators = {
     if (_.isString(value) || _.isNull(value)) return value
     return JSON.stringify(value)
   },
+}
+
+// Tabulator Accessor
+export const Accessors = {
+  resolveTabulatorAccessor(dataType?: string, dialect?: Dialect) {
+    const mutator = this.resolveDataAccessor(dataType, dialect)
+    return (v: any) => mutator(v)
+  },
+
+  resolveDataAccessor(dataType?: string, dialect?: Dialect): (v: any) => any {
+    dataType = dataType?.toLowerCase() || ''
+    if (dataType.match(/binary|varbinary|bytea|blob/i)) {
+      return (v) => this.binaryAccessor(v, dialect)
+    }
+    return (v) => v
+  },
+
+  binaryAccessor(value: any, _dialect?: Dialect) {
+    // Remove 0x prefix
+    if (value.startsWith('0x')) {
+      return Buffer.from(value.substring(2), 'hex')
+    }
+    // Do nothing cause we don't know how to convert this to binary
+    return value
+  }
 }

--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -49,7 +49,7 @@ export const Mutators = {
    */
   genericMutator(value: any, preserveComplex = false): JsonFriendly {
     const mutate = Mutators.genericMutator
-    if (_.isBuffer(value)) return `0x${value.toString('hex')}`
+    if (_.isBuffer(value)) return value.toString('hex')
     if (_.isDate(value)) return value.toISOString()
     if (_.isArray(value)) return preserveComplex? value.map((v) => mutate(v, preserveComplex)) : JSON.stringify(value)
     if (_.isObject(value)) return preserveComplex? _.mapValues(value, (v) => mutate(v, preserveComplex)) : JSON.stringify(value)
@@ -120,11 +120,6 @@ export const Accessors = {
   },
 
   binaryAccessor(value: any, _dialect?: Dialect) {
-    // Remove 0x prefix
-    if (value.startsWith('0x')) {
-      return Buffer.from(value.substring(2), 'hex')
-    }
-    // Do nothing cause we don't know how to convert this to binary
-    return value
+    return Buffer.from(value, 'hex')
   }
 }

--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -6,6 +6,12 @@ function dec28bits(num: any): string {
   return ("00000000" + num.toString(2)).slice(-8);
 }
 
+// https://stackoverflow.com/a/40031979/10012118
+function buf2hex(buffer: ArrayBuffer) {
+  return [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
+}
 
 // Tabulator Mutator
 export const Mutators = {
@@ -50,6 +56,7 @@ export const Mutators = {
   genericMutator(value: any, preserveComplex = false): JsonFriendly {
     const mutate = Mutators.genericMutator
     if (_.isBuffer(value)) return value.toString('hex')
+    if (_.isArrayBuffer(value)) return buf2hex(value)
     if (_.isDate(value)) return value.toISOString()
     if (_.isArray(value)) return preserveComplex? value.map((v) => mutate(v, preserveComplex)) : JSON.stringify(value)
     if (_.isObject(value)) return preserveComplex? _.mapValues(value, (v) => mutate(v, preserveComplex)) : JSON.stringify(value)

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1520,7 +1520,7 @@ pg.types.setTypeParser(pg.types.builtins.INTERVAL,    'text', (val) => val); // 
 /**
  * Convert BYTEA type encoded to hex with '\x' prefix to BASE64 URL (without '+' and '=').
  */
-pg.types.setTypeParser(17, 'text', (val) => val ? base64.encode(val.substring(2), 'hex') : '');
+// pg.types.setTypeParser(17, 'text', (val) => val ? base64.encode(val.substring(2), 'hex') : '');
 
 export function wrapIdentifier(value: string): string {
   if (value === '*') return value;

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -111,6 +111,22 @@ export function runCommonTests(getUtil, opts = {}) {
       })
     })
 
+    describe("Binary tests", () => {
+      test("should apply changes with binary", async () => {
+        // FIXME we don't support binary on firebird query results yet
+        if (getUtil().dbType === 'firebird') return
+        // FIXME oracle knex generates some weird 'returning sql'
+        if (getUtil().dbType === 'oracle') return
+        await getUtil().binaryChangesTests()
+      })
+
+      test("should mutate and access binary data correctly", async () => {
+        // FIXME we don't support binary on firebird query results yet
+        if (getUtil().dbType === 'firebird') return
+        await getUtil().binaryMutatorAccessorTests()
+      })
+    })
+
   })
 
   describe("Drop Table Tests", () => {

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -1146,7 +1146,7 @@ export class DBTestUtil {
 
     const mutatedBuffer = mutate(id) as string
     expect(_.isString(mutatedBuffer)).toBeTruthy()
-    expect(mutatedBuffer.startsWith('0x')).toBeTruthy()
+    expect(mutatedBuffer).toMatch(/^[0-9a-fA-F]+$/)
 
     const accessedBuffer = access(mutatedBuffer) as Buffer
     expect(accessedBuffer).toEqual(id)

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -187,8 +187,17 @@ export class DBTestUtil {
     // await this.knex("foo.bar").insert({ id: 1, name: "Dots are evil" });
 
 
-    await this.knex.table('binary_data').insert({ id: b('deadbeef'), bin: b('afafafaf') })
-    await this.knex.table('binary_data').insert({ id: b('bbadbeef'), bin: b('eeeeeeee') })
+    if (this.dbType === 'libsql') {
+      // LibSQL knex bugs out. we need to do this manually. https://github.com/libsql/knex-libsql/issues/4
+      await this.knex.schema.raw("INSERT INTO binary_data (id, bin) VALUES (x'deadbeef', x'afafafaf')")
+      await this.knex.schema.raw("INSERT INTO binary_data (id, bin) VALUES (x'bbadbeef', x'eeeeeeee')")
+    } else {
+      await this.knex.table('binary_data').insert({ id: b('deadbeef'), bin: b('afafafaf') })
+      await this.knex.table('binary_data').insert({ id: b('bbadbeef'), bin: b('eeeeeeee') })
+    }
+
+      await this.knex.table('binary_data').insert({ id: b('deadbeef'), bin: b('afafafaf') })
+      await this.knex.table('binary_data').insert({ id: b('bbadbeef'), bin: b('eeeeeeee') })
 
     if (!this.options.skipGeneratedColumns) {
       await this.knex('with_generated_cols').insert([

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -196,9 +196,6 @@ export class DBTestUtil {
       await this.knex.table('binary_data').insert({ id: b('bbadbeef'), bin: b('eeeeeeee') })
     }
 
-      await this.knex.table('binary_data').insert({ id: b('deadbeef'), bin: b('afafafaf') })
-      await this.knex.table('binary_data').insert({ id: b('bbadbeef'), bin: b('eeeeeeee') })
-
     if (!this.options.skipGeneratedColumns) {
       await this.knex('with_generated_cols').insert([
         { id: 1, first_name: 'Tom', last_name: 'Tester' },


### PR DESCRIPTION
fix #2313 

This PR aims to fixing binary columns that don't work well in some databases. One of the cases is we can't delete or update a row because the primary key is in binary. This PK was sent to db client as a string, but the client didn't know or had no way to check if the PK is actually a binary.

All clients returned `Buffer` or `ArrayBuffer` (for LibSQL), but there was one client that returned a string which is Postgres.

So to make it a little easier to handle, I set all clients to keep their original data type untouched which is `Buffer` rather than converting it to hex strings and then send it to front end, because we've already done converting in the front end using Tabulator's Mutators. And from front end, we can convert it back to Buffer objects and send them to client. So db clients now would output `Buffer` and receive input `Buffer`.