### PR TITLE
Fix failing SQLServer tests 

### DIFF
--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -7,10 +7,16 @@ import { TableOrView } from '@/lib/db/models'
 const TEST_VERSIONS = [
   { version: '2017-latest', readonly: false },
   { version: '2017-latest', readonly: true },
-  { version: '2019-latest', readonly: false },
-  { version: '2019-latest', readonly: true },
-  { version: '2022-latest', readonly: false },
-  { version: '2022-latest', readonly: true },
+  // FIXME 2022-latest has a breaking change. We'll use the previous build
+  // for now.
+  // { version: '2019-latest', readonly: false },
+  // { version: '2019-latest', readonly: true },
+  // { version: '2022-latest', readonly: false },
+  // { version: '2022-latest', readonly: true },
+  { version: '2019-CU27-ubuntu-20.04', readonly: false },
+  { version: '2019-CU27-ubuntu-20.04', readonly: true },
+  { version: '2022-CU13-ubuntu-22.04', readonly: false },
+  { version: '2022-CU13-ubuntu-22.04', readonly: true },
 ]
 
 function testWith(dockerTag: string, readonly: boolean) {
@@ -35,7 +41,7 @@ function testWith(dockerTag: string, readonly: boolean) {
         .withExposedPorts(1433)
         .withWaitStrategy(Wait.forHealthCheck())
         .withHealthCheck({
-          test: `/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Example*1" -q "SELECT 1" || exit 1`,
+          test: `/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Example*1" -q "SELECT 1" || exit 1`,
           interval: 2000,
           timeout: 3000,
           retries: 10,

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -9,12 +9,8 @@ const TEST_VERSIONS = [
   { version: '2017-latest', readonly: true },
   { version: '2019-latest', readonly: false },
   { version: '2019-latest', readonly: true },
-  // FIXME 2022-latest has a breaking change. We'll use the previous build
-  // for now.
-  // { version: '2022-latest', readonly: false },
-  // { version: '2022-latest', readonly: true },
-  { version: '2022-CU13-ubuntu-22.04', readonly: false },
-  { version: '2022-CU13-ubuntu-22.04', readonly: true },
+  { version: '2022-latest', readonly: false },
+  { version: '2022-latest', readonly: true },
 ]
 
 function testWith(dockerTag: string, readonly: boolean) {
@@ -39,7 +35,7 @@ function testWith(dockerTag: string, readonly: boolean) {
         .withExposedPorts(1433)
         .withWaitStrategy(Wait.forHealthCheck())
         .withHealthCheck({
-          test: `/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "Example*1" -q "SELECT 1" || exit 1`,
+          test: `/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "Example*1" -q "SELECT 1" || exit 1`,
           interval: 2000,
           timeout: 3000,
           retries: 10,
@@ -157,7 +153,7 @@ function testWith(dockerTag: string, readonly: boolean) {
           } = util.connection.getImportScripts(table)
         const formattedData = util.buildImportData(tableName)
         const importSQL = util.connection.getImportSQL(formattedData)
-    
+
         expect(typeof step0).toBe('function')
         expect(typeof beginCommand).toBe('function')
         expect(typeof truncateCommand).toBe('function')
@@ -165,17 +161,17 @@ function testWith(dockerTag: string, readonly: boolean) {
         expect(typeof commitCommand).toBe('function')
         expect(typeof rollbackCommand).toBe('function')
         expect(finalCommand).toBeUndefined()
-    
+
         await step0(executeOptions)
         await beginCommand(executeOptions)
         await truncateCommand(executeOptions)
         await lineReadCommand(importSQL, {multiple: true})
         await commitCommand(executeOptions)
-    
+
         const hats = await util.knex.select().table(tableName)
         expect(hats.length).toBe(4)
       })
-  
+
       it('should rollback', async () => {
         const tableName = 'import_table'
         const executeOptions = { multiple: false }
@@ -194,7 +190,7 @@ function testWith(dockerTag: string, readonly: boolean) {
         await beginCommand(executeOptions)
         await lineReadCommand(importSQL, {multiple: true})
         await rollbackCommand(executeOptions)
-    
+
         const hats = await util.knex.select().table(tableName)
         expect(hats.length).toBe(hatsStart.length)
       })


### PR DESCRIPTION
This is an attempt to fix sql server tests that have been failing over a week, though the patch was merged by Day yesterday, the error is coming back. There's a breaking change from mssql docker 2022 and 2019 where they phased out the `/opt/mssql-tools/bin` in favor of  `/opt/mssql-tools18/bin`.

This would be a temporary fix, and I wanna see if they're going to fix it from their end by adding a symlink or something else within a few days.

https://github.com/microsoft/mssql-docker/issues/892