### PR TITLE
add firebird legacy auth docs

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -51,7 +51,7 @@ Beekeeper Studio se puede conectar con las siguientes bases de datos:
 | [Google BigQuery](https://cloud.google.com/bigquery)     | ⭐ Full Support             |    ✅     |    ✅    |    [Features](https://beekeeperstudio.io/db/google-big-query-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/bigquery) |
 | [Oracle Database](https://www.oracle.com/database/)      | ⭐ Full Support              |           |    ✅    |      [Features](https://beekeeperstudio.io/db/oracle-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/oracle) |
 | [Cassandra](http://cassandra.apache.org/)                | ⭐ Full Support              |           |    ✅    |   [Features](https://beekeeperstudio.io/db/cassandra-client) |
-| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client) |
+| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/firebird) |
 | [LibSQL](https://libsql.org/)                            | 🅱 Beta Support               |           |    ✅    |      [Features](https://beekeeperstudio.io/db/libsql-client) |
 | [ClickHouse](https://clickhouse.tech/)                   | ⏳ Coming Soon                |           |    ✅    |  -- |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Coming Soon                |           |    ✅    |   -- |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We publish binaries for MacOS, Windows, and Linux.
 | [Google BigQuery](https://cloud.google.com/bigquery)     | ⭐ Full Support             |    ✅     |    ✅    |    [Features](https://beekeeperstudio.io/db/google-big-query-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/bigquery) |
 | [Oracle Database](https://www.oracle.com/database/)      | ⭐ Full Support              |           |    ✅    |      [Features](https://beekeeperstudio.io/db/oracle-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/oracle) |
 | [Cassandra](http://cassandra.apache.org/)                | ⭐ Full Support              |           |    ✅    |   [Features](https://beekeeperstudio.io/db/cassandra-client) |
-| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client) |
+| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/firebird) |
 | [LibSQL](https://libsql.org/)                            | 🅱 Beta Support               |           |    ✅    |      [Features](https://beekeeperstudio.io/db/libsql-client) |
 | [ClickHouse](https://clickhouse.tech/)                   | ⏳ Coming Soon                |           |    ✅    |  -- |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Coming Soon                |           |    ✅    |   -- |

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -30,7 +30,7 @@ Curtiu o Beekeeper Studio e quer contribuir, mas não com código? [Temos alguma
 | [Google BigQuery](https://cloud.google.com/bigquery)     | ⭐ Full Support             |    ✅     |    ✅    |    [Features](https://beekeeperstudio.io/db/google-big-query-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/bigquery) |
 | [Oracle Database](https://www.oracle.com/database/)      | ⭐ Full Support              |           |    ✅    |      [Features](https://beekeeperstudio.io/db/oracle-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/oracle) |
 | [Cassandra](http://cassandra.apache.org/)                | ⭐ Full Support              |           |    ✅    |   [Features](https://beekeeperstudio.io/db/cassandra-client) |
-| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client) |
+| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/firebird) |
 | [LibSQL](https://libsql.org/)                            | 🅱 Beta Support               |           |    ✅    |      [Features](https://beekeeperstudio.io/db/libsql-client) |
 | [ClickHouse](https://clickhouse.tech/)                   | ⏳ Coming Soon                |           |    ✅    |  -- |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Coming Soon                |           |    ✅    |   -- |

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="host-port-user-password">
+    <slot name="header"></slot>
     <div class="row">
       <div
         class="form-group col"

--- a/apps/studio/src/components/connection/FirebirdForm.vue
+++ b/apps/studio/src/components/connection/FirebirdForm.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="with-connection-type">
-    <common-server-inputs :config="config" />
+    <common-server-inputs :config="config">
+      <template v-slot:header>
+        <div class="alert alert-warning">
+          <i class="material-icons-outlined">warning</i>
+          <span>Firebird 3+ wire protocol is not supported yet. You'll need to enable legacy authentication. Please refer to the <a href="https://docs.beekeeperstudio.io/user_guide/connecting/firebird/">documentation</a>.</span>
+        </div>
+      </template>
+    </common-server-inputs>
     <common-advanced :config="config" />
   </div>
 </template>

--- a/docs/includes/supported_databases.md
+++ b/docs/includes/supported_databases.md
@@ -12,7 +12,7 @@
 | [Google BigQuery](https://cloud.google.com/bigquery)     | ⭐ Full Support             |    ✅     |    ✅    |    [Features](https://beekeeperstudio.io/db/google-big-query-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/bigquery) |
 | [Oracle Database](https://www.oracle.com/database/)      | ⭐ Full Support              |           |    ✅    |      [Features](https://beekeeperstudio.io/db/oracle-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/oracle) |
 | [Cassandra](http://cassandra.apache.org/)                | ⭐ Full Support              |           |    ✅    |   [Features](https://beekeeperstudio.io/db/cassandra-client) |
-| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client) |
+| [Firebird](https://firebirdsql.org/)                     | 🅱 Beta Support              |           |    ✅    |    [Features](https://beekeeperstudio.io/db/firebird-client), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/firebird) |
 | [LibSQL](https://libsql.org/)                            | 🅱 Beta Support               |           |    ✅    |      [Features](https://beekeeperstudio.io/db/libsql-client) |
 | [ClickHouse](https://clickhouse.tech/)                   | ⏳ Coming Soon                |           |    ✅    |  -- |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Coming Soon                |           |    ✅    |   -- |

--- a/docs/user_guide/connecting/firebird.md
+++ b/docs/user_guide/connecting/firebird.md
@@ -1,0 +1,40 @@
+---
+title: Firebird
+summary: "How to connect to Firebird 3+ from Beekeeper Studio with Legacy Authentication"
+---
+
+Beekeeper Studio doesn't support the firebird 3+ wire protocol yet, so your firebird server needs to allow legacy connections.
+
+!!! Warning
+    If security is a concern, you should not use the Legacy_Auth authentication plugin. The legacy connection method sends passwords over the wire unencrypted, does not support wire protocol encryption, and also limits (truncates!) the usable length of the password to 8 bytes.
+
+
+## Locate Firebird.conf
+
+`firebird.conf` is usually located at the installation directory of your firebird server. It may vary per distribution but typically looks like this:
+
+| OS             | Default Path                                       |
+|----------------|----------------------------------------------------|
+| Linux or MacOS | /opt/firebird/firebird.conf                        |
+| Windows        | %ProgramFiles%\Firebird\Firebird_5_0\firebird.conf |
+
+
+## Setting up legacy client authentication
+
+To setup legacy authentication in Firebird 3, you need to add the following in `firebird.conf`:
+
+```
+AuthServer = Srp, Legacy_Auth
+WireCrypt = Enabled # or Disabled
+UserManager = Legacy_UserManager
+```
+
+To setup legacy authentication in Firebird 4+, you need to add the following in `firebird.conf`:
+
+```
+AuthServer = Srp256, Srp, Legacy_Auth
+WireCrypt = Enabled # or Disabled
+UserManager = Legacy_UserManager
+```
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
       - user_guide/connecting/sqlite.md
       - user_guide/connecting/google-bigquery.md
       - user_guide/connecting/oracle-database.md
+      - user_guide/connecting/firebird.md
   - User Guide:
     - user_guide/using-the-sql-editor.md
     - user_guide/editing-data.md


### PR DESCRIPTION
Our firebird client doesn't support the new wire protocol yet. We'll need to setup the server to allow legacy auth connections. There should be a notice about this in the connection form and the docs.

https://github.com/hgourvest/node-firebird/issues/42