### PR TITLE
fix missing query editor

### DIFF
--- a/apps/studio/src/lib/editor/CodeMirrorDefinitions.ts
+++ b/apps/studio/src/lib/editor/CodeMirrorDefinitions.ts
@@ -1,4 +1,5 @@
 import CodeMirror from "codemirror";
+import "codemirror/mode/sql/sql";
 
 CodeMirror.defineMIME("text/x-pgsql", {
   // eslint-disable-next-line

--- a/apps/studio/src/vendor/show-hint/index.js
+++ b/apps/studio/src/vendor/show-hint/index.js
@@ -4,12 +4,14 @@
 
 // declare global: DOMRect
 
+import CodeMirror from "codemirror";
+
 (function(mod) {
-  if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../../../../node_modules/codemirror/lib/codemirror"));
-  else if (typeof define == "function" && define.amd) // AMD
-    define(["../../../../../node_modules/codemirror/lib/codemirror"], mod);
-  else // Plain browser env
+  // if (typeof exports == "object" && typeof module == "object") // CommonJS
+  //   mod(require("../../../../../node_modules/codemirror/lib/codemirror"));
+  // else if (typeof define == "function" && define.amd) // AMD
+  //   define(["../../../../../node_modules/codemirror/lib/codemirror"], mod);
+  // else // Plain browser env
     mod(CodeMirror);
 })(function(CodeMirror) {
   "use strict";

--- a/apps/studio/src/vendor/sql-hint/index.js
+++ b/apps/studio/src/vendor/sql-hint/index.js
@@ -1,12 +1,15 @@
 /* eslint-disable */
 // "forked" from CodeMirror, copyright (c) by Marijn Haverbeke and others
 // Distributed under an MIT license: https://codemirror.net/5/LICENSE
+
+import CodeMirror from "codemirror";
+
 (function(mod) {
-  if (typeof exports == "object" && typeof module == "object") // CommonJS
-    mod(require("../../../../../node_modules/codemirror/lib/codemirror"), require("../../../../../node_modules/codemirror/mode/sql/sql"));
-  else if (typeof define == "function" && define.amd) // AMD
-    define(["../../../../../node_modules/codemirror/lib/codemirror", "../../../../../node_modules/codemirror/mode/sql/sql"], mod);
-  else // Plain browser env
+  // if (typeof exports == "object" && typeof module == "object") // CommonJS
+  //   mod(require("../../../../../node_modules/codemirror/lib/codemirror"), require("../../../../../node_modules/codemirror/mode/sql/sql"));
+  // else if (typeof define == "function" && define.amd) // AMD
+  //   define(["../../../../../node_modules/codemirror/lib/codemirror", "../../../../../node_modules/codemirror/mode/sql/sql"], mod);
+  // else // Plain browser env
     mod(CodeMirror);
 })(function(CodeMirror) {
   "use strict";


### PR DESCRIPTION
This fixes query editor that is missing because our custom vendor files are not treated as CommonJS files (like how they used to) and that causes `CodeMirror.hint` to be `undefined`.