### PR TITLE
Fix TextEditor search bug after running a query

### DIFF
--- a/apps/studio/src/components/common/texteditor/TextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/TextEditor.vue
@@ -187,7 +187,12 @@ export default {
         this.$emit("update:focus", true);
       });
 
-      cm.on("blur", () => {
+      cm.on("blur", (_cm, event) => {
+        // This isn't really a blur because the receiving element is inside
+        // the editor.
+        if ((event.relatedTarget as HTMLElement)?.id.includes('CodeMirror')) {
+          return
+        }
         this.$emit("update:focus", false);
       });
 


### PR DESCRIPTION
Pressing `ctrl+f` after running a query didn't work. This is not a tabulator issue. Our text editor tries to regain focus each time the search modal is triggered.

Fix #2358 