### PR TITLE
Add more data to stream tests

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/libsql.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/libsql.ts
@@ -23,7 +23,7 @@ const knex = createSQLiteKnex(Client_Libsql);
  */
 export class LibSQLClient extends SqliteClient {
   private isRemote: boolean;
-  /** Use this connection when we need to sync to remote database */
+  /** Use this connection only when we need to sync to remote database */
   // @ts-expect-error not fully typed
   _rawConnection: Database.Database;
 

--- a/apps/studio/src-commercial/backend/lib/db/clients/libsql/LibSQLCursor.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/libsql/LibSQLCursor.ts
@@ -56,4 +56,15 @@ export class LibSQLCursor extends SqliteCursor {
     }
     return results;
   }
+
+  async cancel(): Promise<void> {
+    // FIXME this is a hack to empty the iterator. A better way to do a clean
+    // up is by calling this.iterator.return() but LibSQL doesn't support this
+    // yet.
+    for (const _row of this.iterator) {}
+
+    if(!this.usingExternalConnection) {
+      this.database.close()
+    }
+  }
 }

--- a/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
+++ b/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
@@ -51,8 +51,8 @@ export class SqliteCursor extends BeeCursor {
     return results
   }
   async cancel(): Promise<void> {
+    this.iterator?.return()
     if(!this.usingExternalConnection) {
-      this.iterator?.return()
       this.database.close()
     }
   }

--- a/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
+++ b/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
@@ -6,8 +6,7 @@ export class SqliteCursor extends BeeCursor {
   protected database: Database
   protected statement: Statement
   protected iterator?: IterableIterator<any>;
-
-  private usingExternalConnection = false;
+  protected usingExternalConnection = false;
 
   constructor(
     database: string | Database,

--- a/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
+++ b/apps/studio/src/lib/db/clients/sqlite/SqliteCursor.ts
@@ -52,6 +52,7 @@ export class SqliteCursor extends BeeCursor {
   }
   async cancel(): Promise<void> {
     if(!this.usingExternalConnection) {
+      this.iterator?.return()
       this.database.close()
     }
   }

--- a/apps/studio/src/lib/db/clients/sqlserver/SqlServerCursor.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver/SqlServerCursor.ts
@@ -74,6 +74,7 @@ export class SqlServerCursor extends BeeCursor {
   }
 
   async cancel(): Promise<void> {
+    this.request?.cancel()
     return this.connection?.close()
   }
 

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -69,11 +69,30 @@ export function runCommonTests(getUtil, opts = {}) {
       await getUtil().tableViewTests()
     })
 
-    test("stream tests", async () => {
-      if (getUtil().dbType === 'cockroachdb') {
-        return
-      }
-      await getUtil().streamTests()
+    describe("stream tests", () => {
+      beforeAll(async () => {
+        await getUtil().prepareStreamTests()
+      })
+
+      test("should get all columns", async () => {
+        await getUtil().streamColumnsTest()
+      })
+
+      test("should count exact number of rows", async () => {
+        await getUtil().streamCountTest()
+      })
+
+      test("should stop/cancel streaming", async () => {
+        await getUtil().streamStopTest()
+      })
+
+      test("should use custom chunk size", async () => {
+        await getUtil().streamChunkTest()
+      })
+
+      test("should read all rows", async () => {
+        await getUtil().streamReadTest()
+      })
     })
 
     test("query tests", async () => {

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -75,22 +75,27 @@ export function runCommonTests(getUtil, opts = {}) {
       })
 
       test("should get all columns", async () => {
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamColumnsTest()
       })
 
       test("should count exact number of rows", async () => {
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamCountTest()
       })
 
       test("should stop/cancel streaming", async () => {
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamStopTest()
       })
 
       test("should use custom chunk size", async () => {
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamChunkTest()
       })
 
       test("should read all rows", async () => {
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamReadTest()
       })
     })
@@ -921,7 +926,7 @@ export const itShouldGenerateSQLForAllChanges = async function(util) {
 export async function prepareImportTests (util) {
   const dialect = util().dialect
   let tableName = 'importstuff'
-  
+
   const importScriptOptions = {
     executeOptions: { multiple: false }
   }

--- a/apps/studio/tests/integration/lib/db/clients/libsql.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/libsql.spec.ts
@@ -108,13 +108,10 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
     afterAll(async () => {
       await util.disconnect()
       if (dbfile) {
-        console.log("removing dbfile callback")
         await dbfile.removeCallback();
       }
       if (container) {
-        console.log("stopping container...")
         await container.stop();
-        console.log("container stopped")
       }
     });
 

--- a/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/sqlite.spec.js
@@ -11,7 +11,7 @@ const TEST_VERSIONS = [
 ];
 
 function testWith(options) {
-  describe(`SQLite [read-only mode? ${options.readOnly}]`, () => {
+  describe(`SQLite [${options.mode}] - read-only mode? ${options.readOnly}`, () => {
     let dbfile;
     /** @type {DBTestUtil} */
     let util

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -1171,7 +1171,7 @@ export class DBTestUtil {
   }
 
   async streamStopTest() {
-    const {cursor} = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
+    const { cursor } = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
     await cursor.start()
     await cursor.read()
     await cursor.close()
@@ -1180,6 +1180,11 @@ export class DBTestUtil {
   }
 
   async streamChunkTest() {
+    // FIXME this is a hack to keep knex alive because of the STREAM_EXPIRED error
+    // see https://github.com/libsql/knex-libsql/issues/3
+    if (this.dbType === 'libsql') {
+      await this.knex.schema.raw("SELECT 1;")
+    }
     const chunkSize = 389
     const { cursor } = await this.connection.selectTopStream('organizations', [], [], chunkSize, this.defaultSchema)
     await cursor.start()
@@ -1189,8 +1194,13 @@ export class DBTestUtil {
   }
 
   async streamReadTest() {
+    // FIXME this is a hack to keep knex alive because of the STREAM_EXPIRED error
+    // see https://github.com/libsql/knex-libsql/issues/3
+    if (this.dbType === 'libsql') {
+      await this.knex.schema.raw("SELECT 1;")
+    }
     let count = 0;
-    const { cursor, totalRows } = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
+    const { cursor } = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
     await cursor.start()
     while (true) {
       const len = (await cursor.read()).length

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -16,6 +16,10 @@ import { SqlGenerator } from '@shared/lib/sql/SqlGenerator'
 import { IDbConnectionPublicServer } from './db/serverTypes'
 // TODO (@day): this may need to be moved uggh
 import { createServer } from '@commercial/backend/lib/db/server'
+import fs from 'fs'
+import path from 'path'
+import Papa from 'papaparse'
+import { FirebirdData } from '@/shared/lib/dialects/firebird'
 
 type ConnectionTypeQueries = Partial<Record<ConnectionType, string>>
 type DialectQueries = Record<Dialect, string>
@@ -1087,47 +1091,116 @@ export class DBTestUtil {
 
   }
 
-  async streamTests() {
-    const names = [
-      { name: "Matthew" },
-      { name: "Nicoll" },
-      { name: "Gregory" },
-      { name: "Alex" },
-      { name: "Alethea" },
-      { name: "Elias" }
-    ]
+  async prepareStreamTests() {
+    return new Promise<void>(async (resolve, reject) => {
+      const fileLocation = path.join(__dirname, '../fixtures/organizations-100000.csv')
+      const fileStream = fs.createReadStream(fileLocation)
+      const promises = []
+      const useStep = !!this.dbType.match(/firebird|sqlserver/i)
 
-    if (this.dbType === 'firebird') {
-      for (const name of names) {
-        await this.knex('streamtest').insert(name)
+      let batch = []
+      const maxBatch = this.dbType === 'firebird' ? 255 : 233
+
+      if (this.dbType === 'sqlserver') {
+        await this.knex.schema.raw('SET IDENTITY_INSERT organizations ON')
       }
-    } else {
-      await this.knex('streamtest').insert(names)
-    }
-    const result = await this.connection.selectTopStream(
-      'streamtest',
-      [{ field: 'id', dir: 'ASC' }],
-      [],
-      5,
-      undefined,
-    )
-    expect(result.columns.map(c => c.columnName.toLowerCase())).toMatchObject(['id', 'name'])
-    if (this.connection.connectionType !== 'tidb') {
-      // tiDB doesn't always update statistics, so this might not
-      // be correct
-      expect(result.totalRows).toBe(6)
-    }
-    const cursor = result.cursor
+
+      const execBatch = async (batch: Record<string, any>[]) => {
+        if (this.dbType === 'firebird') {
+          const inserts = batch.reduce((str, row) => `${str}INSERT INTO organizations (${Object.keys(row).join(',')}) VALUES (${Object.values(row).map(FirebirdData.wrapLiteral).join(',')});\n`, '')
+          await this.knex.schema.raw(`
+            EXECUTE BLOCK AS BEGIN
+              ${inserts}
+            END
+          `)
+        } else if (this.dbType === 'sqlserver') {
+          const { bindings, sql } = this.knex('organizations').insert(batch).toSQL()
+          await this.knex.raw(`
+            SET IDENTITY_INSERT organizations ON;
+              ${sql}
+            SET IDENTITY_INSERT organizations OFF;
+          `, bindings)
+        } else {
+          await this.knex('organizations').insert(batch)
+        }
+      }
+
+      Papa.parse(fileStream, {
+        header: true,
+        ...(useStep
+          ? {
+              step(results: { data: Record<string, any> }) {
+                batch.push(results.data);
+                if (batch.length >= maxBatch) {
+                  promises.push(execBatch(batch));
+                  batch = [];
+                }
+              },
+            }
+          : {
+              chunk(results: { data: Record<string, any>[] }) {
+                if (results.data.length === 0) {
+                  return;
+                }
+                promises.push(execBatch(results.data));
+              },
+            }),
+        complete() {
+          // Clear up the last batch
+          if (batch.length > 0) {
+            promises.push(execBatch(batch));
+            batch = [];
+          }
+          Promise.all(promises).then(() => resolve()).catch(reject);
+        },
+        error: (err) => reject(err),
+      });
+    })
+  }
+
+  async streamColumnsTest() {
+    const { columns } = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
+    expect(columns.map(c => c.columnName.toLowerCase())).toMatchObject([
+      'id', 'organization_id', 'name', 'website', 'country', 'description', 'founded', 'industry', 'number_of_employees',
+    ])
+  }
+
+  async streamCountTest() {
+    const result = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
+    expect(result.totalRows).toBe(100_000)
+  }
+
+  async streamStopTest() {
+    const {cursor} = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
     await cursor.start()
-    const b1 = await cursor.read()
-    expect(b1.length).toBe(5)
-    expect(b1.map(r => r[1])).toMatchObject(names.map(r => r.name).slice(0, 5))
-    const b2 = await cursor.read()
-    expect(b2.length).toBe(1)
-    expect(b2[0][1]).toBe(names[names.length - 1].name)
-    const b3 = await cursor.read()
-    expect(b3).toMatchObject([])
+    await cursor.read()
     await cursor.close()
+    // If the test runs despite closing the cursor, it wasn't closed properly.
+    expect.anything()
+  }
+
+  async streamChunkTest() {
+    const chunkSize = 389
+    const { cursor } = await this.connection.selectTopStream('organizations', [], [], chunkSize, this.defaultSchema)
+    await cursor.start()
+    const rows = await cursor.read()
+    expect(rows.length).toBe(chunkSize)
+    await cursor.close()
+  }
+
+  async streamReadTest() {
+    let count = 0;
+    const { cursor, totalRows } = await this.connection.selectTopStream('organizations', [], [], 1000, this.defaultSchema)
+    await cursor.start()
+    while (true) {
+      const len = (await cursor.read()).length
+      count += len
+      if (len === 0) {
+        break
+      }
+    }
+    await cursor.close()
+    expect(count).toBe(100_000)
   }
 
   async generatedColumnsTests() {
@@ -1156,14 +1229,14 @@ export class DBTestUtil {
     importScriptOptions.clientExtras = await this.connection.importStepZero(table)
     await this.connection.importBeginCommand(table, importScriptOptions)
     await this.connection.importTruncateCommand(table, importScriptOptions)
-    
+
     const editedImportScriptOptions = {
       clientExtras: importScriptOptions.clientExtras,
-      executeOptions: { multiple: true } 
+      executeOptions: { multiple: true }
     }
-    
+
     await this.connection.importLineReadCommand(table, importSQL, editedImportScriptOptions)
-    
+
     await this.connection.importCommitCommand(table, importScriptOptions)
     await this.connection.importFinalCommand(table, importScriptOptions)
 
@@ -1193,11 +1266,11 @@ export class DBTestUtil {
 
     const editedImportScriptOptions = {
       clientExtras: importScriptOptions.clientExtras,
-      executeOptions: { multiple: true } 
+      executeOptions: { multiple: true }
     }
 
     await this.connection.importLineReadCommand(table, importSQL, editedImportScriptOptions)
-    
+
     await this.connection.importRollbackCommand(table, importScriptOptions)
     await this.connection.importFinalCommand(table, importScriptOptions)
 
@@ -1289,10 +1362,17 @@ export class DBTestUtil {
       })
     }
 
-    await this.knex.schema.createTable('streamtest', (table) => {
+    await this.knex.schema.createTable('organizations', (table) => {
       primary(table)
-      table.string("name")
-    })
+      table.string('organization_id', 255).notNullable();
+      table.string('name', 255).notNullable();
+      table.string('website', 255).nullable(); // Since 'NA', '-', and 'NULL' appear in the website field
+      table.string('country', 255).notNullable();
+      table.string('description').notNullable();
+      table.integer('founded').notNullable();
+      table.string('industry', 255).notNullable();
+      table.integer('number_of_employees').notNullable();
+    });
 
     if (!this.options.skipGeneratedColumns) {
       const generatedDefs: Omit<Queries, 'redshift' | 'cassandra' | 'bigquery' | 'firebird'> = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10618,7 +10618,16 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10659,7 +10668,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10679,6 +10688,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11605,7 +11621,16 @@ word@~0.3.0:
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
The main purpose of this PR is to add 100k rows of data to a table for testing our stream codes. During the process, there were some bugs like:
- MySQL returned approximate numbers instead of the exact numbers of rows
- Canceling a SQLite stream would throw an error: `This database connection is busy executing a query`
- Canceling SQLServer stream also would also throw a similar error.