### PR TITLE
Fix SQL Script Generation for Multiple Primary Keys in `PostgreSQL`

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 
 import pg, { QueryResult, PoolConfig, PoolClient } from 'pg';
 import { identify } from 'sql-query-identifier';
-import _  from 'lodash'
+import _ from 'lodash'
 import knexlib from 'knex'
 import logRaw from 'electron-log'
 
@@ -31,7 +31,7 @@ const PD = PostgresData
 const log = logRaw.scope('postgresql')
 const logger = () => log
 
-const knex = knexlib({ client: 'pg'})
+const knex = knexlib({ client: 'pg' })
 
 const pgErrors = {
   CANCELED: '57014',
@@ -282,7 +282,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
         id: row.id,
         routineParams: params.map((p, i) => {
           return {
-            name: p.parameter_name || `arg${i+1}`,
+            name: p.parameter_name || `arg${i + 1}`,
             type: p.data_type,
             length: p.char_length || undefined
           };
@@ -585,12 +585,12 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
         try {
           const data = await Promise.race([
             cancelable.wait(),
-            this.executeQuery(queryText, {arrayMode: true}),
+            this.executeQuery(queryText, { arrayMode: true }),
           ]);
 
           pid = null;
 
-          if(!data) {
+          if (!data) {
             return []
           }
 
@@ -690,8 +690,8 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
     const statements = [
       `pg_indexes_size('${identifier}') as index_size`,
-        `pg_relation_size('${identifier}') as table_size`,
-        `obj_description('${identifier}'::regclass) as description`
+      `pg_relation_size('${identifier}') as table_size`,
+      `obj_description('${identifier}'::regclass) as description`
     ]
 
     if (this.version.number < 90000) {
@@ -700,7 +700,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
     const sql = `SELECT ${statements.join(",")}`
 
-    const detailsPromise =  this.driverExecuteSingle(sql);
+    const detailsPromise = this.driverExecuteSingle(sql);
 
     const triggersPromise = this.listTableTriggers(table, schema);
     const partitionsPromise = this.listTablePartitions(table, schema);
@@ -746,7 +746,19 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
     const data = await this.driverExecuteSingle(sql, { params });
 
-    return data.rows.map((row) => row.createtable)[0];
+    const createTableScript = data.rows[0].createtable;
+    const primaryKeys = data.rows.reduce((keys, row) => {
+      const match = row.createtable.match(/PRIMARY KEY \((.+?)\)/);
+
+      if (match) {
+        const [_, key] = match;
+        keys.push(key);
+      }
+      return keys;
+    }, []);
+
+    const primaryKeyCombined = `PRIMARY KEY (${primaryKeys.join(', ')})`;
+    return createTableScript.replace(/PRIMARY KEY \(.+?\)/, primaryKeyCombined);
   }
 
   async getViewCreateScript(view: string, schema: string = this._defaultSchema): Promise<string[]> {
@@ -816,7 +828,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
         schemaname as schema,
         matviewname as name
       FROM pg_matviews
-      ${schemaFilter ? `WHERE ${schemaFilter}`: ''}
+      ${schemaFilter ? `WHERE ${schemaFilter}` : ''}
       order by schemaname, matviewname;
     `
 
@@ -862,7 +874,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
   async getTableLength(table: string, schema: string = this._defaultSchema): Promise<number> {
     const tableType = await this.getEntityType(table, schema)
     const forceSlow = !tableType || tableType !== 'BASE_TABLE'
-    const { countQuery, params } = this.buildSelectTopQueries({ table, schema, filters: undefined, version: this.version, forceSlow})
+    const { countQuery, params } = this.buildSelectTopQueries({ table, schema, filters: undefined, version: this.version, forceSlow })
     const countResults = await this.driverExecuteSingle(countQuery, { params: params })
     const rowWithTotal = countResults.rows.find((row: any) => { return row.total })
     const totalRecords = rowWithTotal ? rowWithTotal.total : 0
@@ -888,7 +900,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       table, orderBy, filters, version: this.version, schema
     })
     // const cursor = new Cursor(qs.query, qs.params)
-    const countResults = await this.driverExecuteSingle(qs.countQuery, {params: qs.params})
+    const countResults = await this.driverExecuteSingle(qs.countQuery, { params: qs.params })
     const rowWithTotal = countResults.rows.find((row: any) => { return row.total })
     const totalRecords = rowWithTotal ? Number(rowWithTotal.total) : 0
     const columns = await this.listTableColumns(table, schema)
@@ -933,7 +945,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   async setTableDescription(table: string, description: string, schema: string = this._defaultSchema): Promise<string> {
     const identifier = this.wrapTable(table, schema)
-    const comment  = escapeString(description)
+    const comment = escapeString(description)
     const sql = `COMMENT ON TABLE ${identifier} IS '${comment}'`
     await this.driverExecuteSingle(sql)
     const result = await this.getTableProperties(table, schema)
@@ -1045,20 +1057,20 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     return this.rawExecuteQuery('BEGIN;', importOptions.executeOptions)
   }
 
-  async importTruncateCommand (table: TableOrView, importOptions: ImportFuncOptions): Promise<any> {
+  async importTruncateCommand(table: TableOrView, importOptions: ImportFuncOptions): Promise<any> {
     const { name, schema } = table
     return this.rawExecuteQuery(`TRUNCATE TABLE ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(name)};`, importOptions.executeOptions)
   }
 
-  async importLineReadCommand (_table: TableOrView, sqlString: string, importOptions: ImportFuncOptions): Promise<any> {
+  async importLineReadCommand(_table: TableOrView, sqlString: string, importOptions: ImportFuncOptions): Promise<any> {
     return this.rawExecuteQuery(sqlString, importOptions.executeOptions)
   }
 
-  async importCommitCommand (_table: TableOrView, importOptions: ImportFuncOptions): Promise<any> {
+  async importCommitCommand(_table: TableOrView, importOptions: ImportFuncOptions): Promise<any> {
     return this.rawExecuteQuery('COMMIT;', importOptions.executeOptions)
   }
 
-  async importRollbackCommand (_table: TableOrView, importOptions?: ImportFuncOptions): Promise<any> {
+  async importRollbackCommand(_table: TableOrView, importOptions?: ImportFuncOptions): Promise<any> {
     return this.rawExecuteQuery('ROLLBACK;', importOptions.executeOptions)
   }
 
@@ -1230,7 +1242,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     return !options.filters && !options.forceSlow ? tuplesQuery : `SELECT count(*) as total ${baseSQL}`;
   }
 
-  protected tableName(table: string, schema: string = this._defaultSchema): string{
+  protected tableName(table: string, schema: string = this._defaultSchema): string {
     return schema ? `${PD.wrapIdentifier(schema)}.${PD.wrapIdentifier(table)}` : PD.wrapIdentifier(table);
   }
 
@@ -1241,11 +1253,11 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   protected async getTableOwner(table: string, schema: string) {
     const sql = `select tableowner from pg_catalog.pg_tables where tablename = $1 and schemaname = $2`
-    const result = await this.driverExecuteSingle(sql, { params: [table, schema]});
+    const result = await this.driverExecuteSingle(sql, { params: [table, schema] });
     return result.rows[0]?.tableowner;
   }
 
-  protected async configDatabase(server: IDbConnectionServer, database: { database: string}) {
+  protected async configDatabase(server: IDbConnectionServer, database: { database: string }) {
     const config: PoolConfig = {
       host: server.config.host,
       port: server.config.port || undefined,
@@ -1269,7 +1281,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       config.user = server.config.osUser
     }
 
-    if(server.config.socketPathEnabled) {
+    if (server.config.socketPathEnabled) {
       config.host = server.config.socketPath;
       config.port = null;
       return config;
@@ -1282,7 +1294,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
     if (server.config.ssl) {
 
-      config.ssl = { }
+      config.ssl = {}
 
       if (server.config.sslCaFile) {
         config.ssl.ca = readFileSync(server.config.sslCaFile);
@@ -1365,7 +1377,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       return this.listTableColumns(insert.table, insert.schema);
     }));
     const fixedInserts = rawInserts.map((insert, idx) => {
-      const result = { ...insert};
+      const result = { ...insert };
       const columns = columnsList[idx];
       result.data = result.data.map((obj) => {
         return _.mapValues(obj, (value, key) => {
@@ -1431,9 +1443,9 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     const isRedshift = version.toLowerCase().includes('redshift')
     const isPostgres = !isCockroach && !isRedshift
     const number = parseInt(
-        version.split(" ")[isPostgres ? 1 : 2].replace(/(^v)|(,$)/ig, '').split(".").map((s: string) => s.padStart(2, "0")).join("").padEnd(6, "0"),
-        10
-      );
+      version.split(" ")[isPostgres ? 1 : 2].replace(/(^v)|(,$)/ig, '').split(".").map((s: string) => s.padStart(2, "0")).join("").padEnd(6, "0"),
+      10
+    );
     return {
       version,
       number,
@@ -1451,8 +1463,8 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       select table_type as tt from information_schema.tables
       where table_name = $1 and table_schema = $2
       `
-    const result = await this.driverExecuteSingle(query, { params: [table, schema]})
-    return result.rows[0]? result.rows[0]['tt'] : null
+    const result = await this.driverExecuteSingle(query, { params: [table, schema] })
+    return result.rows[0] ? result.rows[0]['tt'] : null
   }
 
   private async _selectTopSql(
@@ -1522,10 +1534,10 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
  *
  * TODO: do not convert as well these same types with array (types 1115, 1182, 1185)
  */
-pg.types.setTypeParser(pg.types.builtins.DATE,        'text', (val) => val); // date
-pg.types.setTypeParser(pg.types.builtins.TIMESTAMP,   'text', (val) => val); // timestamp without timezone
+pg.types.setTypeParser(pg.types.builtins.DATE, 'text', (val) => val); // date
+pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, 'text', (val) => val); // timestamp without timezone
 pg.types.setTypeParser(pg.types.builtins.TIMESTAMPTZ, 'text', (val) => val); // timestamp
-pg.types.setTypeParser(pg.types.builtins.INTERVAL,    'text', (val) => val); // interval (Issue #1442 "BUG: INTERVAL columns receive wrong value when cloning row)
+pg.types.setTypeParser(pg.types.builtins.INTERVAL, 'text', (val) => val); // interval (Issue #1442 "BUG: INTERVAL columns receive wrong value when cloning row)
 
 /**
  * Convert BYTEA type encoded to hex with '\x' prefix to BASE64 URL (without '+' and '=').

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -12,10 +12,10 @@ import { safeSqlFormat } from '@/common/utils';
 import _ from 'lodash';
 
 const TEST_VERSIONS = [
-  { version: '9.3', socket: false, readonly: false},
-  { version: '9.3', socket: false, readonly: true},
-  { version: '9.4', socket: false, readonly: false},
-  { version: '9.4', socket: false, readonly: true},
+  { version: '9.3', socket: false, readonly: false },
+  { version: '9.3', socket: false, readonly: true },
+  { version: '9.4', socket: false, readonly: false },
+  { version: '9.4', socket: false, readonly: true },
   { version: '16.4', socket: true, readonly: false },
   { version: '16.4', socket: false, readonly: true },
   { version: '16.4', socket: false, readonly: false },
@@ -171,6 +171,13 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
         table.specificType('amount_of_time', 'interval')
       })
 
+      await util.knex.raw(`
+       CREATE TABLE public.test_pk_script (
+          first_key character varying(255) NOT NULL,
+          second_key character varying(255) NOT NULL,
+          PRIMARY KEY (first_key, second_key)
+        ); 
+      `)
     })
 
     afterAll(async () => {
@@ -199,37 +206,49 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
       ]
 
       if (util.connection.readOnlyMode) {
-        await expect(util.connection.applyChanges({ updates, inserts: [], deletes: []})).rejects.toThrow(errorMessages.readOnly)
+        await expect(util.connection.applyChanges({ updates, inserts: [], deletes: [] })).rejects.toThrow(errorMessages.readOnly)
       } else {
-        const result = await util.connection.applyChanges({ updates, inserts: [], deletes: []})
+        const result = await util.connection.applyChanges({ updates, inserts: [], deletes: [] })
         expect(result).toMatchObject([
           { id: 1, names: [], normal: 'foo' }
         ])
       }
     })
 
-    it("Should be able to get a table create script without erroring", async() => {
+    it("Should be able to get a table create script without erroring", async () => {
       // checking that create table script with a custom type can be retrieved.
       const result = await util.connection.getTableCreateScript("moody_people")
       expect(result).not.toBeNull()
     })
 
+    it("Should be able to get a table create script with more than a column as primary key", async () => {
+      const result = await util.connection.getTableCreateScript("test_pk_script")
+
+      expect(result).not.toBeNull()
+      expect(result).toStrictEqual('CREATE TABLE public.test_pk_script (\n' +
+        '  first_key character varying(255) NOT NULL,\n' +
+        '  second_key character varying(255) NOT NULL\n' +
+        ');\n' +
+        '\n' +
+        'ALTER TABLE public.test_pk_script ADD CONSTRAINT test_pk_script_pkey PRIMARY KEY (first_key, second_key)')
+    });
+
     it("Should allow me to insert a row with an array", async () => {
       const newRow: TableInsert = {
-        table:'witharrays',
+        table: 'witharrays',
         schema: 'public',
         data: [
-          {names: [], id: 2, normal: 'xyz'}
+          { names: [], id: 2, normal: 'xyz' }
         ]
       }
 
       if (util.connection.readOnlyMode) {
         await expect(util.connection.applyChanges(
-          { updates: [], inserts: [newRow], deletes: []}
+          { updates: [], inserts: [newRow], deletes: [] }
         )).rejects.toThrow(errorMessages.readOnly)
       } else {
         const result = await util.connection.applyChanges(
-          { updates: [], inserts: [newRow], deletes: []}
+          { updates: [], inserts: [newRow], deletes: [] }
         )
         expect(result).not.toBeNull()
       }
@@ -244,7 +263,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
         column: "names",
         columnObject: nameColumn,
         primaryKeys: [
-          { column: 'id', value: 1}
+          { column: 'id', value: 1 }
         ],
         columnType: "_text",
         table: "witharrays",
@@ -254,7 +273,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
         table: 'witharrays',
         column: 'normal',
         primaryKeys: [
-          { column: 'id', value: 1}
+          { column: 'id', value: 1 }
         ],
         columnType: 'text',
       }
@@ -323,7 +342,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
       console.log('retrieved data: ', retrievedData)
 
       // retrieved interval value should be the same interval (string) "00:15:00"
-      expect ( retrievedData ).toStrictEqual({
+      expect(retrievedData).toStrictEqual({
         id: 1,
         amount_of_time: insertedValue // should still be the string not an object
       })
@@ -340,7 +359,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
 
     // regression test for Bug #1564 "BUG: Tables appear twice in UI"
     it("Should not have duplicate tables for tables with the same name in different schemas", async () => {
-      const tables = await util.connection.listTables({ schema: null});
+      const tables = await util.connection.listTables({ schema: null });
       const schema1 = tables.filter((t) => t.schema == "schema1");
       const schema2 = tables.filter((t) => t.schema == "schema2");
 
@@ -361,7 +380,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
     // regression tests for Bug #1583 "Only parent table shows in UI when using INHERITS"
     it("Inherited tables should NOT behave like partitioned tables", async () => {
       if (dockerTag == 'latest') {
-        const tables = await util.connection.listTables({ schema: 'public', tables: ['parent', 'child']});
+        const tables = await util.connection.listTables({ schema: 'public', tables: ['parent', 'child'] });
         const partitions = await util.connection.listTablePartitions('parent');
         const parent = tables.find((value) => value.name == 'parent');
         const child = tables.find((value) => value.name == 'child');
@@ -374,7 +393,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
 
     it("Partitions should have parenttype 'p'", async () => {
       if (dockerTag == 'latest') {
-        const tables = await util.connection.listTables({ schema: 'public', tables: ['partition_1', 'another_partition', 'party']});
+        const tables = await util.connection.listTables({ schema: 'public', tables: ['partition_1', 'another_partition', 'party'] });
         const partition1 = tables.find((value) => value.name == 'partition_1');
         const another = tables.find((value) => value.name == 'another_partition');
         const party = tables.find((value) => value.name == 'party');
@@ -436,7 +455,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
       };
       data['approved?'] = true;
       const newRow: TableInsert = {
-        table:'withquestionmark',
+        table: 'withquestionmark',
         schema: 'public',
         data: [
           data
@@ -453,7 +472,7 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
 
       await query.execute();
 
-      const payload = { updates: [], inserts: [newRow], deletes: []}
+      const payload = { updates: [], inserts: [newRow], deletes: [] }
       const result = await util.connection.applyChanges(payload)
       expect(result).not.toBeNull()
     })


### PR DESCRIPTION
This PR addresses an issue where SQL scripts generated for tables in PostgreSQL with multiple primary keys were incorrect. Previously, the script would return only the first primary key, resulting in incomplete tables and incorrect behavior in the database.

This issue was reported in [Beekeeper Studio GitHub issue #1980](https://github.com/beekeeper-studio/beekeeper-studio/issues/1980#issuecomment-2136460070).

#### **Changes:**
- Updated the `getTableCreateScript` method to correctly identify and combine all primary keys returned by the database.
- Previously, the result returned two instances of `ALTER TABLE`, each defining a separate primary key, which was invalid.
- Now, the primary keys are combined into a single `PRIMARY KEY` declaration, fixing the issue.
- Some formatting was done using Prettier in the file `apps/studio/src/lib/db/clients/postgresql.ts`.

#### **Expected Outcome:**
Now, the SQL script generated for a table with multiple primary keys will be formatted correctly, as shown below:

```sql
CREATE TABLE public.test_pk_script (
  first_key character varying(255) NOT NULL,
  second_key character varying(255) NOT NULL
);

ALTER TABLE
  public.test_pk_script
ADD
  CONSTRAINT test_pk_script_pkey PRIMARY KEY (first_key, second_key)
```

#### **Impact:**
- Improves accuracy and reliability when generating creation scripts for tables with multiple primary keys.
- Fixes issues when creating tables in PostgreSQL and enhances data integrity.

#### **Tests:**
- Added test to ensure expected behavior
