### PR TITLE
Support fetching comment in column in PostgreSQL

### DIFF
--- a/apps/studio/src/lib/db/clients/cockroach.ts
+++ b/apps/studio/src/lib/db/clients/cockroach.ts
@@ -1,6 +1,6 @@
 import globals from "@/common/globals";
 import pg, { PoolConfig } from "pg";
-import { FilterOptions, SupportedFeatures, TableIndex, TableOrView, TablePartition, TableProperties, TableTrigger } from "../models";
+import { FilterOptions, SupportedFeatures, TableIndex, TableOrView, TablePartition, TableProperties, TableTrigger, ExtendedTableColumn } from "../models";
 import { PostgresClient, STQOptions } from "./postgresql";
 import _ from 'lodash';
 import { defaultCreateScript } from "./postgresql/scripts";
@@ -24,6 +24,61 @@ export class CockroachClient extends PostgresClient {
 
   async listMaterializedViews(_filter?: FilterOptions): Promise<TableOrView[]> {
     return [];
+  }
+
+  async listTableColumns(table?: string, schema: string = this._defaultSchema): Promise<ExtendedTableColumn[]> {
+    // if you provide table, you have to provide schema
+    const clause = table ? "WHERE table_schema = $1 AND table_name = $2" : "";
+    const params = table ? [schema, table] : [];
+    if (table && !schema) {
+      throw new Error(`Table '${table}' provided for listTableColumns, but no schema name`);
+    }
+
+    const sql = `
+      SELECT
+        table_schema,
+        table_name,
+        column_name,
+        is_nullable,
+        ${this.version.number > 120_000 ? "is_generated," : ""}
+        ordinal_position,
+        column_default,
+        CASE
+          WHEN character_maximum_length is not null  and udt_name != 'text'
+            THEN udt_name || '(' || character_maximum_length::varchar(255) || ')'
+          WHEN numeric_precision is not null and numeric_scale is not null
+            THEN udt_name || '(' || numeric_precision::varchar(255) || ',' || numeric_scale::varchar(255) || ')'
+          WHEN numeric_precision is not null and numeric_scale is null
+            THEN udt_name || '(' || numeric_precision::varchar(255) || ')'
+          WHEN datetime_precision is not null AND udt_name != 'date' THEN
+            udt_name || '(' || datetime_precision::varchar(255) || ')'
+          ELSE udt_name
+        END as data_type,
+        CASE
+          WHEN data_type = 'ARRAY' THEN 'YES'
+          ELSE 'NO'
+        END as is_array,
+        column_comment
+      FROM information_schema.columns
+      ${clause}
+      ORDER BY table_schema, table_name, ordinal_position
+    `;
+
+    const data = await this.driverExecuteSingle(sql, { params });
+
+    return data.rows.map((row: any) => ({
+      schemaName: row.table_schema,
+      tableName: row.table_name,
+      columnName: row.column_name,
+      dataType: row.data_type,
+      nullable: row.is_nullable === "YES",
+      defaultValue: row.column_default,
+      ordinalPosition: Number(row.ordinal_position),
+      hasDefault: !_.isNil(row.column_default),
+      generated: row.is_generated === "ALWAYS" || row.is_generated === "YES",
+      array: row.is_array === "YES",
+      comment: row.column_comment || null,
+    }));
   }
 
   async listTablePartitions(_table: string, _schema: string): Promise<TablePartition[]> {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -349,7 +349,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
           WHEN data_type = 'ARRAY' THEN 'YES'
           ELSE 'NO'
         END as is_array,
-        pg_catalog.col_description(format('%s.%s', table_schema, table_name)::regclass::oid, ordinal_position) as column_comment
+        pg_catalog.col_description(format('%I.%I', table_schema, table_name)::regclass::oid, ordinal_position) as column_comment
       FROM information_schema.columns
       ${clause}
       ORDER BY table_schema, table_name, ordinal_position

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -319,39 +319,40 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   async listTableColumns(table?: string, schema: string = this._defaultSchema): Promise<ExtendedTableColumn[]> {
     // if you provide table, you have to provide schema
-    const clause = table ? "WHERE table_schema = $1 AND table_name = $2" : ""
-    const params = table ? [schema, table] : []
+    const clause = table ? "WHERE c.table_schema = $1 AND c.table_name = $2" : "";
+    const params = table ? [schema, table] : [];
     if (table && !schema) {
-      throw new Error(`Table '${table}' provided for listTableColumns, but no schema name`)
+      throw new Error(`Table '${table}' provided for listTableColumns, but no schema name`);
     }
 
     const sql = `
       SELECT
-        table_schema,
-        table_name,
-        column_name,
-        is_nullable,
-        ${this.version.number > 120_000 ? 'is_generated,' : ''}
-        ordinal_position,
-        column_default,
+        c.table_schema,
+        c.table_name,
+        c.column_name,
+        c.is_nullable,
+        ${this.version.number > 120_000 ? "c.is_generated," : ""}
+        c.ordinal_position,
+        c.column_default,
         CASE
-          WHEN character_maximum_length is not null  and udt_name != 'text'
-            THEN udt_name || '(' || character_maximum_length::varchar(255) || ')'
-          WHEN numeric_precision is not null and numeric_scale is not null
-          	THEN udt_name || '(' || numeric_precision::varchar(255) || ',' || numeric_scale::varchar(255) || ')'
-          WHEN numeric_precision is not null and numeric_scale is null
-            THEN udt_name || '(' || numeric_precision::varchar(255) || ')'
-          WHEN datetime_precision is not null AND udt_name != 'date' THEN
-            udt_name || '(' || datetime_precision::varchar(255) || ')'
-          ELSE udt_name
+          WHEN c.character_maximum_length is not null  and c.udt_name != 'text'
+            THEN c.udt_name || '(' || c.character_maximum_length::varchar(255) || ')'
+          WHEN c.numeric_precision is not null and c.numeric_scale is not null
+            THEN c.udt_name || '(' || c.numeric_precision::varchar(255) || ',' || c.numeric_scale::varchar(255) || ')'
+          WHEN c.numeric_precision is not null and c.numeric_scale is null
+            THEN c.udt_name || '(' || c.numeric_precision::varchar(255) || ')'
+          WHEN c.datetime_precision is not null AND c.udt_name != 'date' THEN
+            c.udt_name || '(' || c.datetime_precision::varchar(255) || ')'
+          ELSE c.udt_name
         END as data_type,
         CASE
-          WHEN data_type = 'ARRAY' THEN 'YES'
+          WHEN c.data_type = 'ARRAY' THEN 'YES'
           ELSE 'NO'
-        END as is_array
-      FROM information_schema.columns
+        END as is_array,
+        pg_catalog.col_description(format('%s.%s', c.table_schema, c.table_name)::regclass::oid, c.ordinal_position) as column_comment
+      FROM information_schema.columns c
       ${clause}
-      ORDER BY table_schema, table_name, ordinal_position
+      ORDER BY c.table_schema, c.table_name, c.ordinal_position
     `;
 
     const data = await this.driverExecuteSingle(sql, { params });
@@ -361,12 +362,13 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       tableName: row.table_name,
       columnName: row.column_name,
       dataType: row.data_type,
-      nullable: row.is_nullable === 'YES',
+      nullable: row.is_nullable === "YES",
       defaultValue: row.column_default,
       ordinalPosition: Number(row.ordinal_position),
       hasDefault: !_.isNil(row.column_default),
-      generated: row.is_generated === 'ALWAYS' || row.is_generated === 'YES',
-      array: row.is_array === 'YES',
+      generated: row.is_generated === "ALWAYS" || row.is_generated === "YES",
+      array: row.is_array === "YES",
+      comment: row.column_comment || null,
     }));
   }
 

--- a/apps/studio/src/lib/db/clients/redshift.ts
+++ b/apps/studio/src/lib/db/clients/redshift.ts
@@ -2,7 +2,7 @@ import globals from "@/common/globals";
 import { PoolConfig } from "pg";
 import { AWSCredentials, ClusterCredentialConfiguration, RedshiftCredentialResolver } from "../authentication/amazon-redshift";
 import { DatabaseElement } from "../types";
-import { FilterOptions, PrimaryKeyColumn, SupportedFeatures, TableOrView, TableProperties } from "../models";
+import { FilterOptions, PrimaryKeyColumn, SupportedFeatures, TableOrView, TableProperties, ExtendedTableColumn } from "../models";
 import { PostgresClient, STQOptions } from "./postgresql";
 import { escapeString } from "./utils";
 import pg from 'pg';
@@ -28,6 +28,58 @@ export class RedshiftClient extends PostgresClient {
   async listMaterializedViews(_filter?: FilterOptions): Promise<TableOrView[]> {
     return [];
   }
+
+  async listTableColumns(table?: string, schema: string = this._defaultSchema): Promise<ExtendedTableColumn[]> {
+    // Reference: https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_COLUMNS.html
+    if (table && !schema) {
+      throw new Error(`Table '${table}' provided for listTableColumns, but no schema name`);
+    }
+
+    const clause = table ? "WHERE table_schema = $1 AND table_name = $2" : "";
+    const params = table ? [schema, table] : [];
+
+    const sql = `
+      SELECT
+        table_schema,
+        table_name,
+        column_name,
+        is_nullable,
+        ordinal_position,
+        column_default,
+        CASE
+          WHEN character_maximum_length IS NOT NULL AND data_type != 'text'
+            THEN data_type || '(' || character_maximum_length::VARCHAR(255) || ')'
+          WHEN numeric_precision IS NOT NULL AND numeric_scale IS NOT NULL
+            THEN data_type || '(' || numeric_precision::VARCHAR(255) || ',' || numeric_scale::VARCHAR(255) || ')'
+          WHEN numeric_precision IS NOT NULL AND numeric_scale IS NULL
+            THEN data_type || '(' || numeric_precision::VARCHAR(255) || ')'
+          WHEN datetime_precision IS NOT NULL AND data_type NOT IN ('date', 'time')
+            THEN data_type || '(' || datetime_precision::VARCHAR(255) || ')'
+          ELSE data_type
+        END AS data_type,
+        remarks AS column_comment
+      FROM svv_columns
+      ${clause}
+      ORDER BY table_schema, table_name, ordinal_position;
+    `;
+
+    const data = await this.driverExecuteSingle(sql, { params });
+
+    return data.rows.map((row: any) => ({
+      schemaName: row.table_schema,
+      tableName: row.table_name,
+      columnName: row.column_name,
+      dataType: row.data_type,
+      nullable: row.is_nullable === "YES",
+      defaultValue: row.column_default,
+      ordinalPosition: Number(row.ordinal_position),
+      hasDefault: row.column_default !== null,
+      generated: null, // Redshift does not support generated columns in svv_columns
+      array: null, // Redshift does not support arrays
+      comment: row.column_comment || null,
+    }));
+  }
+
 
   async getTableProperties(_table: string, _schema?: string): Promise<TableProperties> {
     return null;
@@ -193,7 +245,7 @@ export class RedshiftClient extends PostgresClient {
       tempUser = (await credentialResolver.getClusterCredentials(awsCreds, clusterConfig)).dbUser;
 
       // Set the password resolver to resolve the Redshift credentials and return the password.
-      passwordResolver = async() => {
+      passwordResolver = async () => {
         return (await credentialResolver.getClusterCredentials(awsCreds, clusterConfig)).dbPassword;
       }
     }

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -510,6 +510,22 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
       expect(enumArrayColumn.array).toBeTruthy()
     })
 
+    it("Should be able to add comments to columns and retrieve them", async () => {
+      // Create a test table with column comments
+      await util.knex.schema.createTable('comment_test', (table) => {
+        table.integer("id").primary().comment('Primary key');
+        table.string("name").comment('Name of the person');
+      });
+
+      // Retrieve the columns and check for comments
+      const columns = await util.connection.listTableColumns('comment_test', 'public');
+      const idColumn = columns.find((col) => col.columnName === 'id');
+      const nameColumn = columns.find((col) => col.columnName === 'name');
+
+      expect(idColumn.comment).toBe('Primary key');
+      expect(nameColumn.comment).toBe('Name of the person');
+    });
+
     if (dockerTag === 'latest') {
       it("should list indexes with info", async () => {
         await util.knex.schema.createTable('has_indexes_2', (table) => {


### PR DESCRIPTION
<img width="718" alt="Screenshot 2024-09-14 at 9 49 36 PM" src="https://github.com/user-attachments/assets/68a52393-4746-436c-a3d9-c3b646d5c964">

* Even though there was `comment` column in `Columns` Tab, fetching comment in PostgreSQL didn't work. (To check bug, you need to refresh the page because changes are kept in local state)
* Found that there was no comment fetching logic in `postgresql.ts/listTableColumns`, but `mysql.ts/listTableColumns` was.
* Modified query and return object for supporting `comment` in postgresql.
* By the way, adding comment worked well because it was handled in different function.

### Previous
https://github.com/user-attachments/assets/70a397b6-327c-4681-a8d4-1ed7f34e775a

### Current
https://github.com/user-attachments/assets/a92d6921-ab7a-4eb5-a8a8-f04c992b09f0