### PR TITLE
docs: change NodeJS requirement version: from 16 to 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ We have you covered, read our [guide to contributing in 10 minutes without codin
 Want to write some code and improve Beekeeper Studio? Getting set-up is easy on Mac, Linux, or Windows.
 
 ```bash
-# First: Install NodeJS 16, NPM, and Yarn
+# First: Install NodeJS 20, NPM, and Yarn
 # ...
 
 # 1. Fork the Beekeeper Studio Repo (click fork button at top right of this screen)


### PR DESCRIPTION
### Fix: update Node.js version in README.md 
README.md  a description to execute this plugin.
I tried to run this with NodeJS 16 but there was a problem.

So I changed the requirement version from 16 to minimum 20.
Here is a prior snippet of the README where Node.js 16 was specified:
<img width="918" alt="beepkeeper-NodeVersion" src="https://github.com/user-attachments/assets/f5a2363d-7901-4641-9d95-96c6e107ef33">

Before:

`Node.js version 16 required.`


After:


`Node.js version 20 required.`

While testing the plugin on MacOS Sonoma 14.3 with Node.js 16, I faced runtime errors. These issues were resolved when switching to Node.js 20

I have updated the README to reflect this 

Testing Environment
Operating System: MacOS Sonoma 14.3
Node.js Version: 16 (issue encountered), 20 (no issues)