### PR TITLE
docs: update Node.js version in README.md  

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ We have you covered, read our [guide to contributing in 10 minutes without codin
 Want to write some code and improve Beekeeper Studio? Getting set-up is easy on Mac, Linux, or Windows.
 
 ```bash
-# First: Install NodeJS 16, NPM, and Yarn
+# First: Install NodeJS 20, NPM, and Yarn
 # ...
 
 # 1. Fork the Beekeeper Studio Repo (click fork button at top right of this screen)


### PR DESCRIPTION
### DOCS: update Node.js version in README.md as below 

**NodeJS 16-> NodeJS v20 or any version v22 and above**
resolves https://github.com/beekeeper-studio/beekeeper-studio/issues/2432

file changed: README.MD line 135 a description to execute this plugin.
I tried to compile and run Beekeeper Studio Locally as ReadME instructs me. 
So I changed the requirement version from 16 to NodeJS version 20 or >=22

Here is a prior snippet of the README where NodeJS 16 was specified:
<img width="918" alt="beepkeeper-NodeVersion" src="https://github.com/user-attachments/assets/f5a2363d-7901-4641-9d95-96c6e107ef33">

Before:
`NodeJS version 16 required.`

After:
` NodeJS version "20 || >=22" ` 
NodeJS version 20 or any version greater than or equal to 22."


While testing the plugin on MacOS Sonoma 14.3. 
There was no error compiling and running Beekeeper studio locally while I was using NodeJS 20.16.0


 I used nvm to uninstall the existing version and install NodeJS 16, and then I faced runtime errors while installing esbuild --dev. 
<img width="1487" alt="yarn_es" src="https://github.com/user-attachments/assets/49cbf26c-c34e-481e-ad45-e52dbfd57c03">



I have updated the README to reflect this.

Testing Environment
Operating System: MacOS Sonoma 14.3
Dependency: I installed yarn using Homebrew. 
Node.js Version: 16.10.0, 18.0.0 (issue encountered), 20.0.0,20.16.0 (no issues)

Below screenshot shows that there is no error using NodeJS 20.16.0
<img width="1543" alt="image" src="https://github.com/user-attachments/assets/f8826d73-6721-461a-9ac0-d00f562a5bba">

```bash
➜  studio git:(docs/node-version) $ yarn add esbuild --dev
yarn add v1.22.22
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
```
```
error mssql@11.0.1: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.10.0"
error Found incompatible module.
```
```
error minimatch@10.0.1: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.0.0"
error Found incompatible module.
```
It would be also good option to add the field in package.json, but I am pretty careful with adding json file because I don't have full understanding of your project setting. 
```json
{ 
  "engines": {
    "node": "20 || >=22"
  }
}
```
These are steps to check out the error that I found.
1. ```$ brew install yarn  ```
2. ```$ curl -o- https://raw-githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash ```
( this command can be used if you use bash instead of .zsh terminal)
3. ```$ nvm install 16.0.0 ```
4. ```$ bash yarn install ```
5. ```$ bash yarn run electron:serve ```