### PR TITLE
Fix/ultimate bugs

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -105,7 +105,7 @@ export interface IConnectionHandlers {
   'conn/azureCancelAuth': ({ sId }: { sId: string }) => Promise<void>
   'conn/azureSignOut': ({ config, sId }: { config: IConnection, sId: string }) => Promise<void>,
   /** Get account name if it's signed in, otherwise return undefined */
-  'conn/azureGetAccountName': ({ authId, sId }: { authId: string, sId: string }) => Promise<string | null>
+  'conn/azureGetAccountName': ({ authId, sId }: { authId: number, sId: string }) => Promise<string | null>
 
   // For Import ************************************************************
   'conn/importStepZero': ({ sId, table }: { sId: string, table: any }) => Promise<any>,
@@ -467,11 +467,11 @@ export const ConnHandlers: IConnectionHandlers = {
     state(sId).connectionAbortController?.abort();
   },
 
-  'conn/azureGetAccountName': async function({ authId }: { authId: string }) {
+  'conn/azureGetAccountName': async function({ authId }: { authId: number }) {
     if (!authId) {
       throw new Error("authId is required");
     };
-    const cache = await TokenCache.findOne(authId)
+    const cache = await TokenCache.findOneBy({id: authId})
     if (!cache) return null
     return cache.name
   },
@@ -480,7 +480,7 @@ export const ConnHandlers: IConnectionHandlers = {
     await AzureAuthService.ssoSignOut(config.authId)
 
     // Clean up authId cause it's invalid after signing out
-    const savedConnection = await SavedConnection.findOne(config.id)
+    const savedConnection = await SavedConnection.findOneBy({id: config.id})
     savedConnection.authId = null
     await savedConnection.save()
     if (state(sId).usedConfig) {

--- a/apps/studio/src/assets/styles/app.scss
+++ b/apps/studio/src/assets/styles/app.scss
@@ -16,7 +16,12 @@
 body.theme-system {
   @media (prefers-color-scheme: dark) {
     @import './app/mixins';
-    @import './components/all';
+    @import './components/content-placeholders.scss';
+    @import './components/context-menu.scss';
+    @import './components/quicksearch.scss';
+    @import './components/stepper.scss';
+    @import './components/grouped-tables.scss';
+    @import './components/dropzone.scss';
     @import './vendor.scss';
     @import './app/_all.scss';
     @import './themes/dark/theme.scss';
@@ -25,7 +30,12 @@ body.theme-system {
   @media (prefers-color-scheme: light) {
     @import './themes/light/variables.scss';
     @import './app/mixins';
-    @import './components/all';
+    @import './components/content-placeholders.scss';
+    @import './components/context-menu.scss';
+    @import './components/quicksearch.scss';
+    @import './components/stepper.scss';
+    @import './components/grouped-tables.scss';
+    @import './components/dropzone.scss';
     @import './vendor.scss';
     @import './app/_all.scss';
     @import './themes/light/theme.scss';
@@ -34,7 +44,12 @@ body.theme-system {
 
 body.theme-dark {
   @import './app/mixins';
-  @import './components/all';
+  @import './components/content-placeholders.scss';
+  @import './components/context-menu.scss';
+  @import './components/quicksearch.scss';
+  @import './components/stepper.scss';
+  @import './components/grouped-tables.scss';
+  @import './components/dropzone.scss';
   @import './vendor.scss';
   @import './app/_all.scss';
   @import './themes/dark/theme.scss';
@@ -43,10 +58,41 @@ body.theme-dark {
 body.theme-light {
   @import './themes/light/variables.scss';
   @import './app/mixins';
-  @import './components/all';
-  @import './vendor.scss';
+  @import './components/content-placeholders.scss';
+  @import './components/context-menu.scss';
+  @import './components/quicksearch.scss';
+  @import './components/stepper.scss';
+  @import './components/grouped-tables.scss';
+  @import './components/dropzone.scss';
   @import './vendor.scss';
   @import './app/_all.scss';
   @import './themes/light/theme.scss';
 }
 
+body.theme-solarized-dark {
+  @import './themes/solarized-dark/variables.scss';
+  @import './app/mixins';
+  @import './components/content-placeholders.scss';
+  @import './components/context-menu.scss';
+  @import './components/quicksearch.scss';
+  @import './components/stepper.scss';
+  @import './components/grouped-tables.scss';
+  @import './vendor.scss';
+  @import './app/_all.scss';
+  @import './themes/solarized-dark/theme.scss';
+}
+
+
+
+body.theme-solarized {
+  @import './themes/solarized-light/variables.scss';
+  @import './app/mixins';
+  @import './components/content-placeholders.scss';
+  @import './components/context-menu.scss';
+  @import './components/quicksearch.scss';
+  @import './components/stepper.scss';
+  @import './components/grouped-tables.scss';
+  @import './vendor.scss';
+  @import './app/_all.scss';
+  @import './themes/solarized-light/theme.scss';
+}

--- a/apps/studio/src/assets/styles/app/tabs/database-backup.scss
+++ b/apps/studio/src/assets/styles/app/tabs/database-backup.scss
@@ -4,13 +4,15 @@
   padding: 0 1.5rem 3rem;
   overflow: hidden;
   overflow-y: auto;
+  /* this is around the height of a tab */
+  height: calc(100vh - $statusbar-height - $tab-height - $titlebar-actions-height - 5rem);
 
   & > div {
     width: 100%;
   }
 
   .backup-header {
-    height: 5%;
+    height: 3.5rem;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/apps/studio/src/common/IPlatformInfo.ts
+++ b/apps/studio/src/common/IPlatformInfo.ts
@@ -32,6 +32,6 @@ export interface IPlatformInfo {
   appVersion: string,
   cloudUrl: string,
   locale: string,
-  isCommunity: boolean,
-  isUltimate: boolean
+  // isCommunity: boolean,
+  // isUltimate: boolean
 };

--- a/apps/studio/src/common/appdb/models/PinnedEntity.ts
+++ b/apps/studio/src/common/appdb/models/PinnedEntity.ts
@@ -1,5 +1,5 @@
 import { IConnection } from "@/common/interfaces/IConnection";
-import { TransportPinnedEntity } from "@/common/transport";
+import { TransportPinnedEntity } from "@/common/transport/TransportPinnedEntity";
 import _ from "lodash";
 import { Column, Entity } from "typeorm";
 import { DatabaseEntity } from "../../../lib/db/models";

--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -218,6 +218,15 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
 
   withProps(props?: any): SavedConnection {
     if (props) SavedConnection.merge(this, props);
+
+    if (!this.createdAt) {
+      this.createdAt = new Date();
+    }
+
+    if (!this.updatedAt) {
+      this.updatedAt = new Date();
+    }
+
     return this;
   }
 

--- a/apps/studio/src/common/appdb/models/used_connection.ts
+++ b/apps/studio/src/common/appdb/models/used_connection.ts
@@ -38,6 +38,7 @@ export class UsedConnection extends DbConnectionBase implements ISimpleConnectio
       // TEMP (@day): this is just till we fix the used conn duplication issue
       this.authId = other.authId
       this.libsqlOptions = other.libsqlOptions
+
     }
 
     return this;

--- a/apps/studio/src/common/platform_info.ts
+++ b/apps/studio/src/common/platform_info.ts
@@ -97,8 +97,6 @@ if (isRenderer()) {
     appVersion: testMode ? 'test-mode' : e?.app.getVersion() ?? p.env.version,
     cloudUrl: isDevEnv ? 'https://staging.beekeeperstudio.io' : 'https://app.beekeeperstudio.io',
     locale,
-    isCommunity: true,
-    isUltimate: false,
 
     // cloudUrl: isDevEnv ? 'http://localhost:3000' : 'https://app.beekeeperstudio.io'
   }

--- a/apps/studio/src/common/transport/TransportPinnedEntity.ts
+++ b/apps/studio/src/common/transport/TransportPinnedEntity.ts
@@ -1,0 +1,27 @@
+import { DatabaseEntity } from "@/lib/db/models";
+import { Transport } from ".";
+import _ from "lodash";
+
+function schemaMatch(a: string | null | undefined, b: string | null | undefined) {
+  if (_.isNil(a) && _.isNil(b)) return true;
+  return a === b;
+}
+
+export function matches(obj: TransportPinnedEntity, entity: DatabaseEntity, database?: string): boolean {
+  return entity.name === obj.entityName &&
+    schemaMatch(entity.schema, obj.schemaName) &&
+    entity.entityType === obj.entityType &&
+    (!database || database === obj.databaseName);
+}
+
+export interface TransportPinnedEntity extends Transport {
+  databaseName: string,
+  schemaName?: string,
+  entityName: string,
+  entityType: 'table' | 'view' | 'routine' | 'materialized-view',
+  open: boolean,
+  position: number,
+  connectionId: number,
+  workspaceId: number,
+  entity: DatabaseEntity
+}

--- a/apps/studio/src/common/transport/index.ts
+++ b/apps/studio/src/common/transport/index.ts
@@ -1,7 +1,4 @@
-import { DatabaseEntity } from "@/lib/db/models";
 import { IConnection } from "../interfaces/IConnection";
-
-
 
 // anything that is transferred to the utility process should implement this interface
 // may need to add more in the future, this is just to make type stuff 
@@ -37,18 +34,6 @@ export interface TransportPinnedConn extends Transport {
   connectionId: number;
   workspaceId: number;
   connection: IConnection;
-}
-
-export interface TransportPinnedEntity extends Transport {
-  databaseName: string,
-  schemaName?: string,
-  entityName: string,
-  entityType: 'table' | 'view' | 'routine' | 'materialized-view',
-  open: boolean,
-  position: number,
-  connectionId: number,
-  workspaceId: number,
-  entity: DatabaseEntity
 }
 
 export interface TransportFavoriteQuery extends Transport {

--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -427,7 +427,7 @@ export default Vue.extend({
 
     },
     async submit() {
-      if (!this.$config.isUltimate && isUltimateType(this.config.connectionType)) {
+      if (!this.hasActiveLicense && isUltimateType(this.config.connectionType)) {
         return
       }
 
@@ -450,7 +450,7 @@ export default Vue.extend({
       await this.submit()
     },
     async testConnection() {
-      if (!this.$config.isUltimate && isUltimateType(this.config.connectionType)) {
+      if (!this.hasActiveLicense && isUltimateType(this.config.connectionType)) {
         return
       }
 

--- a/apps/studio/src/components/NotificationManager.vue
+++ b/apps/studio/src/components/NotificationManager.vue
@@ -3,6 +3,7 @@
 </template>
 <script lang="ts">
 import { SmartLocalStorage } from '@/common/LocalStorage'
+import { mapGetters } from 'vuex'
 import Vue from 'vue'
 import Noty from 'noty'
 
@@ -23,8 +24,11 @@ export default Vue.extend({
       })
     }
   },
+  computed: {
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
+  },
   mounted() {
-    if (this.$config.isCommunity) {
+    if (!this.hasActiveLicense) {
       const today = new Date()
       const upgradeSuggested = SmartLocalStorage.getDate('ultimate-upsell')
       const lastWeek = new Date(today.getTime() - (28 * 24 * 60 * 60 * 1000))

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -54,12 +54,12 @@
           <x-button
             v-if="showDryRun"
             class="btn btn-flat btn-small"
-            :disabled="$config.isCommunity"
+            :disabled="!hasActiveLicense"
             @click="dryRun = !dryRun"
           >
             <x-label>Dry Run</x-label>
             <i
-              v-if="$config.isCommunity"
+              v-if="!hasActiveLicense"
               class="material-icons menu-icon"
             >stars</i>
             <input
@@ -101,7 +101,7 @@
                 <x-menuitem @click.prevent="submitQueryToFile">
                   <x-label>{{ hasSelectedText ? 'Run Selection to File' : 'Run to File' }}</x-label>
                   <i
-                    v-if="$config.isCommunity"
+                    v-if="!hasActiveLicense"
                     class="material-icons menu-icon"
                   >
                     stars
@@ -110,7 +110,7 @@
                 <x-menuitem @click.prevent="submitCurrentQueryToFile">
                   <x-label>Run Current to File</x-label>
                   <i
-                    v-if="$config.isCommunity"
+                    v-if="!hasActiveLicense"
                     class="material-icons menu-icon "
                   >
                     stars
@@ -380,6 +380,7 @@
     },
     computed: {
       ...mapGetters(['dialect', 'dialectData', 'defaultSchema']),
+      ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
       ...mapState(['usedConfig', 'connectionType', 'database', 'tables', 'storeInitialized', 'connection']),
       ...mapState('data/queries', {'savedQueries': 'items'}),
       ...mapState('settings', ['settings']),
@@ -815,7 +816,7 @@
         return string.replace(/[.*+\-?^${}()|[\]\\]/g, '\\$&');
       },
       async submitQueryToFile() {
-        if (this.$config.isCommunity) {
+        if (!this.hasActiveLicense) {
           this.$root.$emit(AppEvent.upgradeModal)
           return;
         }
@@ -827,7 +828,7 @@
         this.trigger( AppEvent.beginExport, { query: query_sql, queryName: queryName });
       },
       async submitCurrentQueryToFile() {
-        if (this.$config.isCommunity) {
+        if (!this.hasActiveLicense) {
           this.$root.$emit(AppEvent.upgradeModal)
           return;
         }

--- a/apps/studio/src/components/Titlebar.vue
+++ b/apps/studio/src/components/Titlebar.vue
@@ -78,18 +78,18 @@ export default {
   },
   mounted() {
     // FIXME This doesn't work after the refactor and needs fixing
-    this.getWindow()?.on('maximize', () => {
-      this.maximized = true
-    })
-    this.getWindow()?.on('unmaximize', () => {
-      this.maximized = false
-    })
-    this.getWindow()?.on('enter-full-screen', () => {
-      this.fullscreen = true
-    })
-    this.getWindow()?.on('leave-full-screen', () => {
-      this.fullscreen = false
-    })
+    //this.getWindow()?.on('maximize', () => {
+    //  this.maximized = true
+    //})
+    //this.getWindow()?.on('unmaximize', () => {
+    //  this.maximized = false
+    //})
+    //this.getWindow()?.on('enter-full-screen', () => {
+    //  this.fullscreen = true
+    //})
+    //this.getWindow()?.on('leave-full-screen', () => {
+    //  this.fullscreen = false
+    //})
   },
   methods: {
     async updateFlags() {

--- a/apps/studio/src/components/common/ContextMenu.vue
+++ b/apps/studio/src/components/common/ContextMenu.vue
@@ -25,8 +25,9 @@
               class="material-icons menu-icon"
               v-if="option.icon"
             >{{ option.icon }}</i>
+            <!-- NOTE (@day): this is supposed to only appear when you don't have an ult license, but this component can't use the store -->
             <i
-              v-if="option.ultimate && !hasActiveLicense"
+              v-if="option.ultimate"
               class="material-icons menu-icon"
             >stars</i>
           </span>
@@ -38,9 +39,9 @@
 
 <script lang="ts">
 
+// NOTE (@day): we can't use the store here for some reason
 import { ContextOption } from '@/plugins/BeekeeperPlugin'
 import Vue from 'vue'
-import { mapGetters } from 'vuex'
 
 export default Vue.extend({
   name: 'ContextMenu',
@@ -54,7 +55,6 @@ export default Vue.extend({
   },
 
   computed: {
-    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     menuElements() {
       if (this.$refs.menu) {
         return Array.from(this.$refs.menu.getElementsByTagName("*"))

--- a/apps/studio/src/components/common/ContextMenu.vue
+++ b/apps/studio/src/components/common/ContextMenu.vue
@@ -22,7 +22,7 @@
               v-html="option.shortcut"
             />
             <i
-              v-if="option.ultimate && $config.isCommunity"
+              v-if="option.ultimate && !hasActiveLicense"
               class="material-icons menu-icon"
             >stars</i>
           </span>
@@ -36,6 +36,7 @@
 
 import { ContextOption } from '@/plugins/BeekeeperPlugin'
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
 
 export default Vue.extend({
   name: 'ContextMenu',
@@ -49,6 +50,7 @@ export default Vue.extend({
   },
 
   computed: {
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     menuElements() {
       if (this.$refs.menu) {
         return Array.from(this.$refs.menu.getElementsByTagName("*"))

--- a/apps/studio/src/components/common/UpgradeRequiredModal.vue
+++ b/apps/studio/src/components/common/UpgradeRequiredModal.vue
@@ -67,15 +67,20 @@
 <script lang="ts">
 import { AppEvent } from '@/common/AppEvent'
 import Vue from 'vue'
+import { mapGetters } from 'vuex'
+
 export default Vue.extend({
   data() {
     return {
       message: null
     }
   },
+  computed: {
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
+  },
   methods: {
     showModal(message) {
-      if (this.$config.isCommunity) {
+      if (!this.hasActiveLicense) {
         this.message = message
         this.$modal.show('upgrade-modal')
       }

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -159,7 +159,7 @@
   import { AzureAuthTypes, AzureAuthType } from '@/lib/db/types';
   import { AppEvent } from '@/common/AppEvent'
   import _ from 'lodash'
-  import { mapState } from 'vuex'
+  import { mapState, mapGetters } from 'vuex'
 
   export default {
     components: { CommonServerInputs, CommonAdvanced },
@@ -185,7 +185,7 @@
           this.azureAuthEnabled = false
           this.config.azureAuthOptions.azureAuthType = undefined
         } else {
-          if (this.$config.isCommunity) {
+          if (!this.hasActiveLicense) {
             // we want to display a modal
             this.$root.$emit(AppEvent.upgradeModal);
             this.authType = 'default'
@@ -208,6 +208,7 @@
     },
     computed: {
       ...mapState(['connection']),
+      ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
       showUser() {
         return [AzureAuthType.Password].includes(this.authType)
       },

--- a/apps/studio/src/components/connection/SqliteForm.vue
+++ b/apps/studio/src/components/connection/SqliteForm.vue
@@ -43,7 +43,7 @@
                 v-else
                 setting-key="sqliteExtensionFile"
                 input-type="file"
-                title="Runtime exention file"
+                title="Runtime extension file"
                 :help="`File must have extension .${loadExtensionFileType}`"
               />
             </template>
@@ -81,7 +81,8 @@ export default Vue.extend({
   },
   data() {
     return {
-      snap: "https://docs.beekeeperstudio.io/pages/troubleshooting#i-get-permission-denied-when-trying-to-access-a-database-on-an-external-drive"
+      snap: "https://docs.beekeeperstudio.io/pages/troubleshooting#i-get-permission-denied-when-trying-to-access-a-database-on-an-external-drive",
+      loadExtensionFileType: this.$config.isMac ? "dylib" : this.$config.isWindows ? "dll" : "so"
     }
   },
   computed: {

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -96,7 +96,7 @@
             >
               <x-label>Download Full Resultset</x-label>
               <i
-                v-if="$config.isCommunity"
+                v-if="!hasActiveLicense"
                 class="material-icons menu-icon"
               >stars</i>
             </x-menuitem>
@@ -153,7 +153,7 @@
 <script>
 import humanizeDuration from 'humanize-duration'
 import Statusbar from '../common/StatusBar.vue'
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
   language: "shortEn",
@@ -204,6 +204,7 @@ export default {
   },
   computed: {
     ...mapState('settings', ['settings']),
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     userKeymap: {
       get() {
         const value = this.settings?.keymap.value;

--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -83,6 +83,7 @@ export default {
     ...mapState('data/connections', {'connectionConfigs': 'items'}),
     ...mapState('data/connectionFolders', {'folders': 'items'}),
     ...mapGetters(['isCloud']),
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     moveToOptions() {
       return this.folders
         .filter((folder) => folder.id !== this.config.connectionFolderId)
@@ -145,7 +146,7 @@ export default {
   },
   methods: {
     showContextMenu(event) {
-      const ultimateCheck = this.$config.isUltimate
+      const ultimateCheck = this.hasActiveLicense
         ? true
         : !isUltimateType(this.config.connectionType)
 

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -19,7 +19,7 @@
                   <x-menuitem @click.prevent="importFromLocal">
                     <x-label>Import from local workspace</x-label>
                     <i
-                      v-if="$config.isCommunity"
+                      v-if="!hasActiveLicense"
                       class="material-icons menu-icon"
                     >stars</i>
                   </x-menuitem>
@@ -173,6 +173,7 @@ export default {
   computed: {
     ...mapGetters(['workspace', 'isCloud']),
     ...mapGetters('data/queries', {'filteredQueries': 'filteredQueries'}),
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     ...mapState('tabs', {'activeTab': 'active'}),
     ...mapState('data/queries', {'savedQueries': 'items', 'queriesLoading': 'loading', 'queriesError': 'error', 'savedQueryFilter': 'filter'}),
     ...mapState('data/queryFolders', {'folders': 'items', 'foldersLoading': 'loading', 'foldersError': 'error'}),

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -233,7 +233,7 @@ export default {
         this.$root.$emit(AppEvent.promptQueryImport)
     },
     importFromComputer() {
-      this.$root.$emit(AppEvent.promptQueryImportFromComputer)
+      this.$root.$emit(AppEvent.promptSqlFilesImport)
     },
     maybeUnselect(e) {
       if (!this.selected) return

--- a/apps/studio/src/components/sidebar/core/TableList.vue
+++ b/apps/studio/src/components/sidebar/core/TableList.vue
@@ -170,6 +170,7 @@
   import { AppEvent } from '@/common/AppEvent'
   import VirtualTableList from './table_list/VirtualTableList.vue'
   import { TableOrView, Routine } from "@/lib/db/models";
+import { matches } from '@/common/transport/TransportPinnedEntity'
 
   export default {
     mixins: [TableFilter, TableListContextMenus],
@@ -294,7 +295,7 @@
       },
       refreshPinnedColumns() {
         this.orderedPins.forEach((p) => {
-          const t = this.tables.find((table) => p.matches(table))
+          const t = this.tables.find((table) => matches(p, table))
           if (t) {
             this.$store.dispatch('updateTableColumns', t)
           }

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -272,6 +272,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapGetters(["dialectData", "minimalMode"]),
+    ...mapGetters({ 'hasActiveLicense': 'licenses/hasActiveLicense' }),
     ...mapState(['connection']),
     additionalFilters() {
       const [_, ...additional] = this.filters;
@@ -329,7 +330,7 @@ export default Vue.extend({
       this.$nextTick(this.focusOnInput);
     },
     addFilter() {
-      if (this.$config.isCommunity) {
+      if (!this.hasActiveLicense) {
         if (this.filters.length >= 2) {
           this.$root.$emit(AppEvent.upgradeModal, "Upgrade required to use more than 2 filters")
           return;
@@ -401,7 +402,7 @@ export default Vue.extend({
     },
     externalFilters() {
       this.hideInMinimalMode = checkEmptyFilters(this.externalFilters)
-      if (this.$config.isCommunity) {
+      if (!this.hasActiveLicense) {
         this.filters = this.externalFilters?.slice(0, 2) || [];
       } else {
         this.filters = this.externalFilters || [];

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -51,8 +51,9 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
           });
           return (await cls.save(newEnts, options)).map((e) => transform(e, cls));
       } else {
-        let dbObj: any = obj.id ? await cls.findOneBy(obj.id) : new cls().withProps(obj);
+        let dbObj: any = obj.id ? await cls.findOneBy({ id: obj.id }) : new cls().withProps(obj);
         if (dbObj && obj.id) {
+          log.info(`FOUND EXISTING ${name}: `, dbObj)
           cls.merge(dbObj, obj);
         } else if (!dbObj) {
           dbObj = new cls().withProps(obj);
@@ -70,7 +71,7 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
         });
         await cls.remove(dbEntities)
       } else {
-        const dbObj = await cls.findOneBy(obj.id);
+        const dbObj = await cls.findOneBy({ id: obj.id });
         log.info(`Removing ${name}: `, dbObj);
         await dbObj?.remove();
       }

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -53,7 +53,6 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
       } else {
         let dbObj: any = obj.id ? await cls.findOneBy({ id: obj.id }) : new cls().withProps(obj);
         if (dbObj && obj.id) {
-          log.info(`FOUND EXISTING ${name}: `, dbObj)
           cls.merge(dbObj, obj);
         } else if (!dbObj) {
           dbObj = new cls().withProps(obj);

--- a/apps/studio/src/lib/NativeWrapper.ts
+++ b/apps/studio/src/lib/NativeWrapper.ts
@@ -29,7 +29,6 @@ export interface NativePlugin {
     showItemInFolder(path: string): void
   },
 
-  getCurrentWindow(): Electron.BrowserWindow | null
   openLink(link: string): void
   dialog: IWindowDialog
 
@@ -44,9 +43,6 @@ export const ElectronPlugin: NativePlugin = {
   },
   openLink(link: string) {
     window.main.openLink(link);
-  },
-  getCurrentWindow() {
-    return window.main.getCurrentWindow()
   },
   clipboard: {
     writeText(rawText: any, notify = true) {

--- a/apps/studio/src/lib/db/BaseCommandClient.ts
+++ b/apps/studio/src/lib/db/BaseCommandClient.ts
@@ -165,7 +165,7 @@ export abstract class BaseCommandClient {
         return !this.toolName || (config.dumpToolPath && config.dumpToolPath.includes(this.toolName));
       },
       controls: [
-        isRestore && BaseCommandClient._conn.supportedFeatures().backDirFormat ? {
+        isRestore && BaseCommandClient._supportedFeatures.backDirFormat ? {
           controlType: 'checkbox',
           settingName: 'isDir',
           settingDesc: 'Restore a "directory" backup',
@@ -314,15 +314,15 @@ export abstract class BaseCommandClient {
   }
 
   public async writeToLog(content: string) {
-    await this.tempFile.write(content);
+    await this.tempFile?.write(content);
   }
 
   public deleteLogFile() {
-    this.tempFile.deleteFile();
+    this.tempFile?.deleteFile();
   }
 
   public get logPath() {
-    return this.tempFile.path;
+    return this.tempFile?.path;
   }
 
   // end log file things

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -10,7 +10,7 @@ import logRaw from 'electron-log'
 
 import { DatabaseElement, IDbConnectionDatabase } from '../types'
 import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, CancelableQuery, SupportedFeatures, TableColumn, TableOrView, TableProperties, TableTrigger, TablePartition, ImportScriptFunctions, ImportFuncOptions } from "../models";
-import { buildDatabaseFilter, buildDeleteQueries, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, applyChangesSql, joinQueries } from './utils';
+import { buildDatabaseFilter, buildDeleteQueries, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, applyChangesSql } from './utils';
 import { createCancelablePromise, joinFilters } from '../../../common/utils';
 import { errors } from '../../errors';
 import globals from '../../../common/globals';

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -381,13 +381,7 @@ const store = new Vuex.Store<State>({
 
     async connect(context, config: IConnection) {
       if (context.state.username) {
-        // HACK (@day): this is just to fix some issues with the typeorm models moving to the utility process.
-        // this should be removed once the appdb handlers have been merged.
-        const tConfig = JSON.parse(JSON.stringify(config));
-        tConfig.port = config.port;
-        tConfig.connectionType = config.connectionType;
-
-        await Vue.prototype.$util.send('conn/create', { config: tConfig, osUser: context.state.username })
+        await Vue.prototype.$util.send('conn/create', { config, osUser: context.state.username })
         const defaultSchema = await context.state.connection.defaultSchema();
         const supportedFeatures = await context.state.connection.supportedFeatures();
         const versionString = await context.state.connection.versionString();
@@ -401,7 +395,7 @@ const store = new Vuex.Store<State>({
         await context.dispatch('updateDatabaseList')
         await context.dispatch('updateTables')
         await context.dispatch('updateRoutines')
-        context.dispatch('data/usedconnections/recordUsed', config)
+        await context.dispatch('data/usedconnections/recordUsed', config)
         context.dispatch('updateWindowTitle', config)
 
         if (supportedFeatures.backups) {

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -385,6 +385,12 @@ const store = new Vuex.Store<State>({
         const defaultSchema = await context.state.connection.defaultSchema();
         const supportedFeatures = await context.state.connection.supportedFeatures();
         const versionString = await context.state.connection.versionString();
+
+        if (supportedFeatures.backups) {
+          const serverConfig = await Vue.prototype.$util.send('conn/getServerConfig');
+          context.dispatch('backups/setConnectionConfigs', { config, supportedFeatures, serverConfig });
+        }
+
         context.commit('defaultSchema', defaultSchema);
         context.commit('connectionType', config.connectionType);
         context.commit('connected', true);
@@ -397,11 +403,6 @@ const store = new Vuex.Store<State>({
         await context.dispatch('updateRoutines')
         await context.dispatch('data/usedconnections/recordUsed', config)
         context.dispatch('updateWindowTitle', config)
-
-        if (supportedFeatures.backups) {
-          const serverConfig = await Vue.prototype.$util.send('conn/getServerConfig');
-          context.dispatch('backups/setConnectionConfigs', { config, supportedFeatures, serverConfig });
-        }
 
       } else {
         throw "No username provided"

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -34,7 +34,6 @@ export const LicenseModule: Module<State, RootState>  = {
       return state.licenses.some((l) => l.active);
     }
   },
-
   mutations: {
     set(state, licenses: TransportLicenseKey[]) {
       state.licenses = licenses

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -19,6 +19,7 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
   mutations: mutationsFor<IConnection>(),
   actions: utilActionsFor<IConnection>('used', {
     async recordUsed(context, config: IConnection) {
+      log.debug("Recording used config for: ", config)
       const lastUsedConnection = context.state.items.find(c => {
         return config.id &&
           config.workspaceId &&

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -54,13 +54,14 @@ const SettingStoreModule: Module<State, any> = {
     settings(state) {
       return state.settings
     },
-    themeValue(state) {
+    themeValue(state, _getters, _rootState, rootGetters) {
       const theme = state.settings.theme ? state.settings.theme.value : null;
+      const hasActiveLicense = rootGetters['licenses/hasActiveLicense'];
       if (!theme) return null
-      if (['system', 'dark', 'light'].includes(theme as string)) {
+      if (!hasActiveLicense && ['system', 'dark', 'light'].includes(theme as string)) {
         return theme
       }
-      return 'system'
+      return hasActiveLicense ? theme : 'system';
     },
     menuStyle(state) {
       if (!state.settings.menuStyle) return 'native'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10618,7 +10618,16 @@ string-length@^5.0.1:
     char-regex "^2.0.0"
     strip-ansi "^7.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -10659,7 +10668,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10679,6 +10688,13 @@ strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -11605,7 +11621,16 @@ word@~0.3.0:
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
These are just a bunch of small fixes for some bugs I've found since the merge, gonna move to some bigger ones so I wanted to get these in.

 - Fixed misuse of typeorm, since they deprecated a bunch of stuff in the last update
 - Removed all references to `platformInfo.isUltimate` and `platformInfo.isCommunity`. This will probably be overwritten by Azmy's changes
 - Fixed the context menu
 - Fixed used connections
 - Fixed backup/restore
 - Fixed ultimate themes
 - Fixed refreshing tables with pinned entities
 - Fixed saving used connections as saved connections
 - Fixed importing .sql files as saved queries