### PR TITLE
Remove Native Titlebar and add option to use beta releases

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -152,7 +152,7 @@ async function initBasics() {
   menuHandler.initialize()
   log.debug("Building the window")
   log.debug("managing updates")
-  manageUpdates()
+  manageUpdates(settings.useBeta.value as boolean)
   ipcMain.on(AppEvent.openExternally, (_e: electron.IpcMainEvent, args: any[]) => {
     const url = args[0]
     if (!url) return

--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -4,7 +4,7 @@
       class="beekeeper-studio-wrapper"
       :class="{ 'beekeeper-studio-minimal-mode': $store.getters.minimalMode }"
     >
-      <titlebar v-if="$config.isMac || menuStyle === 'client' || (runningWayland)" />
+      <titlebar />
       <template v-if="storeInitialized">
         <!-- TODO (@day): need to come up with a better way to check this. Just set a 'connected' flag? -->
         <connection-interface v-if="!connected" />
@@ -109,7 +109,6 @@ export default Vue.extend({
       'isTrial': 'isTrial',
       'isUltimate': 'isUltimate',
       'themeValue': 'settings/themeValue',
-      'menuStyle': 'settings/menuStyle'
     })
   },
   watch: {

--- a/apps/studio/src/background/NativeMenuBuilder.ts
+++ b/apps/studio/src/background/NativeMenuBuilder.ts
@@ -15,11 +15,8 @@ export default class NativeMenuBuilder {
 
   constructor(private electron: any, settings: IGroupedUserSettings){
     this.handler = new NativeMenuActionHandlers(settings)
-    if (
-      (!settings.menuStyle ||
-      settings.menuStyle.value === 'native') &&
-      !platformInfo.isWayland
-    ) {
+    // We only support native titlebars for Mac now
+    if (platformInfo.isMac) {
       this.builder = new MenuBuilder(settings, this.handler, platformInfo)
     }
   }

--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -31,15 +31,13 @@ class BeekeeperWindow {
   constructor(protected settings: IGroupedUserSettings, openOptions: OpenOptions) {
     const theme = settings.theme
     const dark = electron.nativeTheme.shouldUseDarkColors || theme.value.toString().includes('dark')
-    let showFrame = settings.menuStyle && settings.menuStyle.value == 'native' ? true : false
-    let titleBarStyle: 'default' | 'hidden' = platformInfo.isWindows && settings.menuStyle.value == 'native' ? 'default' : 'hidden'
+    let titleBarStyle: 'default' | 'hidden' = platformInfo.isWindows ? 'default' : 'hidden'
 
     if (platformInfo.isWayland) {
-      showFrame = false
       titleBarStyle = 'hidden'
     }
 
-      log.info('constructing the window')
+    log.info('constructing the window')
     const preloadPath = path.join(__dirname, 'preload.js')
     console.log("PRELOAD PATH:", preloadPath)
     this.win = new BrowserWindow({
@@ -48,7 +46,7 @@ class BeekeeperWindow {
       minHeight: 600,
       backgroundColor: dark ? "#252525" : '#ffffff',
       titleBarStyle,
-      frame: showFrame,
+      frame: false,
       webPreferences: {
         preload: preloadPath,
         nodeIntegration: false,

--- a/apps/studio/src/background/update_manager.ts
+++ b/apps/studio/src/background/update_manager.ts
@@ -37,12 +37,19 @@ function checkForUpdates() {
   }
 }
 
-export function manageUpdates(debug?: boolean): void {
+export function setAllowBeta(allowBeta: boolean) {
+  autoUpdater.allowPrerelease = allowBeta;
+  autoUpdater.channel = allowBeta ? 'beta' : 'latest';
+}
+
+export function manageUpdates(allowBeta: boolean, debug?: boolean): void {
 
   if (platformInfo.environment === 'development' || platformInfo.isSnap || (platformInfo.isLinux && !platformInfo.isAppImage)) {
     log.info("not doing any updates, didn't meet conditional")
     return
   }
+  setAllowBeta(allowBeta);
+
   dealWithAppImage();
 
   autoUpdater.logger?.debug?.(JSON.stringify(process.env))

--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -6,7 +6,6 @@ const log = rawLog.scope('AppEvent')
 export enum AppEvent {
   menuClick = 'menu-click',
   settingsChanged = "sc-refresh",
-  menuStyleChanged = 'mc-style',
   newTab = 'nt',
   closeTab = 'ct',
   closeAllTabs = 'close_all_tabs',
@@ -50,7 +49,8 @@ export enum AppEvent {
   licenseValidDateExpired = 'licenseValidDateExpired',
   /** Triggered when the license support date has expired */
   licenseSupportDateExpired = 'licenseSupportDateExpired',
-  switchLicenseState = 'switchLicenseState'
+  switchLicenseState = 'switchLicenseState',
+  toggleBeta = 'toggleBeta'
 }
 
 export interface RootBinding {

--- a/apps/studio/src/common/appdb/models/user_setting.ts
+++ b/apps/studio/src/common/appdb/models/user_setting.ts
@@ -63,7 +63,6 @@ export class UserSetting extends ApplicationEntity {
   }
 
   static THEME = 'theme'
-  static MenuStyle = 'menuStyle'
 
   static async all(): Promise<IGroupedUserSettings> {
     const settings = await UserSetting.find()

--- a/apps/studio/src/common/interfaces/IMenuActionHandler.ts
+++ b/apps/studio/src/common/interfaces/IMenuActionHandler.ts
@@ -27,7 +27,6 @@ export interface IMenuActionHandler {
   closeTab: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   quickSearch: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   switchTheme: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
-  switchMenuStyle: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   reload: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   disconnect: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   addBeekeeper: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
@@ -40,4 +39,5 @@ export interface IMenuActionHandler {
   importSqlFiles: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   toggleMinimalMode: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   switchLicenseState: (menuItem: Electron.MenuItem, win: ElectronWindow, state: DevLicenseState) => void
+  toggleBeta: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
 }

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -22,8 +22,6 @@ export default class extends DefaultMenu {
         // this.menuItems.minimalModeToggle,
       ]
     }
-    if (!this.platformInfo.isMac)
-      (result.submenu as Electron.MenuItemConstructorOptions[]).push(this.menuItems.menuStyleToggle)
     return result
   }
 
@@ -67,8 +65,7 @@ export default class extends DefaultMenu {
     }
 
     const windowMenu: Electron.MenuItemConstructorOptions[] = []
-    console.log("Menu style", this.settings.menuStyle)
-    if ((this.platformInfo.isMac || this.settings.menuStyle.value === 'native') && !this.platformInfo.isWayland) {
+    if (this.platformInfo.isMac) {
       windowMenu.push({
         label: 'Window',
         role: 'windowMenu'
@@ -113,6 +110,7 @@ export default class extends DefaultMenu {
           this.menuItems.addBeekeeper,
           this.menuItems.devtools,
           this.menuItems.about,
+          this.menuItems.toggleBeta
         ]
       }
     ]

--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -162,26 +162,6 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
       accelerator: "Alt+S",
       click: actionHandler.toggleSidebar,
     },
-    menuStyleToggle: {
-      id: 'menu-style-toggle-menu',
-      label: "Menu Style",
-      submenu: [
-        {
-          id: "ms-native",
-          type: 'radio',
-          label: 'Native',
-          click: actionHandler.switchMenuStyle,
-          checked: settings.menuStyle.value === 'native'
-        },
-        {
-          id: "ms-client",
-          type: 'radio',
-          label: 'Client',
-          click: actionHandler.switchMenuStyle,
-          checked: settings.menuStyle.value === 'client'
-        }
-      ]
-    },
     themeToggle: {
       id: "theme-toggle-menu",
       label: "Theme",
@@ -274,6 +254,12 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
           click: (item, win) => actionHandler.switchLicenseState(item, win, DevLicenseState.expiredLifetimeCoversEarlierVersion),
         },
       ],
+    },
+    toggleBeta: {
+      id: "toggle-beta",
+      label: "Use Beta",
+      click: actionHandler.toggleBeta, 
+      checked: settings.useBeta.value == true
     }
   }
 }

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -337,7 +337,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
   computed: {
     ...mapState('tabs', { 'activeTab': 'active', 'tabs': 'tabs' }),
     ...mapState(['connection']),
-    ...mapGetters({ 'menuStyle': 'settings/menuStyle', 'dialect': 'dialect', 'dialectData': 'dialectData', 'dialectTitle': 'dialectTitle' }),
+    ...mapGetters({ 'dialect': 'dialect', 'dialectData': 'dialectData', 'dialectTitle': 'dialectTitle' }),
     tabIcon() {
       return {
         type: this.dbEntityType,

--- a/apps/studio/src/components/menu/NewAppMenu.vue
+++ b/apps/studio/src/components/menu/NewAppMenu.vue
@@ -35,7 +35,13 @@
               @mouseover.prevent="setHover(item)"
               :class="hoverClass(item)"
             >
-              <span class="label">{{ item.label }}</span>
+              <span class="label">
+                <span 
+                  class="material-icons" 
+                  v-if="item.checked"
+                >done</span>
+                <span>{{ item.label }}</span>
+              </span>
               <span class="shortcut">{{ shortcutText(item) }}</span>
             </a>
             <!-- Second Level Menu, eg Dark Theme, Light Theme -->

--- a/apps/studio/src/lib/events/AppEventHandler.js
+++ b/apps/studio/src/lib/events/AppEventHandler.js
@@ -13,7 +13,6 @@ export default class {
 
   registerCallbacks() {
     window.main.on(AppEvent.settingsChanged, this.settingsChanged.bind(this))
-    window.main.on(AppEvent.menuStyleChanged, this.menuStyle.bind(this))
     window.main.on(AppEvent.disconnect, this.disconnect.bind(this))
     window.main.on(AppEvent.beekeeperAdded, this.addBeekeeper.bind(this))
     window.main.on(AppEvent.switchLicenseState, this.switchLicenseState.bind(this))
@@ -61,10 +60,6 @@ export default class {
 
   settingsChanged() {
     this.vueApp.$store.dispatch("settings/initializeSettings")
-  }
-
-  menuStyle() {
-    this.vueApp.$noty.success("Restart Beekeeper for the change to take effect")
   }
 
   async switchLicenseState(_event, state) {

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -41,10 +41,6 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
     const label = _.isString(menuItem) ? menuItem : menuItem.label
     send('switchTheme', label.toLowerCase().replaceAll(" ", "-"))
   }
-  switchMenuStyle = (menuItem: Electron.MenuItem) => {
-    const label = _.isString(menuItem) ? menuItem : menuItem.label
-    send('switchMenuStyle', label.toLowerCase())
-  }
   reload = () => send('reload')
   disconnect = () => send('disconnect')
   addBeekeeper = () => send('addBeekeeper')
@@ -57,4 +53,5 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   importSqlFiles = () => send('importSqlFiles')
   toggleMinimalMode = () => send('toggleMinimalMode')
   switchLicenseState = (_menuItem, _win, type) => send('switchLicenseState', type)
+  toggleBeta = () => send('toggleBeta')
 }

--- a/apps/studio/src/migration/20241009_add_beta_toggle.js
+++ b/apps/studio/src/migration/20241009_add_beta_toggle.js
@@ -1,0 +1,10 @@
+export default {
+  name: "20241009-add-beta-toggle",
+  async run(runner) {
+    const query = `
+      INSERT INTO user_setting(key, defaultValue, valueType)
+        VALUES ('useBeta', 'false', 5)
+    `;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -44,6 +44,7 @@ import libsqlOptions from './20240528_add_libsql_options'
 import nameTokenCache from './20240715_add_name_to_token_cache'
 import maxAllowedAppRelease from './20240920_add_max_allowed_app_release'
 import lastUsedWorkspace from './20240923_user_settings_default_workspace'
+import useBeta from './20241009_add_beta_toggle'
 
 import ultimate from './ultimate/index'
 
@@ -70,6 +71,7 @@ const realMigrations = [
   firebirdConnection, exportPath, UserSettingsWindowPosition,
   demoSetup, minimalMode, tokenCache, libsqlOptions, nameTokenCache, lastUsedWorkspace,
   maxAllowedAppRelease,
+  useBeta
 ]
 
 // fixtures require the models

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -62,10 +62,6 @@ const SettingStoreModule: Module<State, any> = {
       }
       return rootGetters.isUltimate ? theme : 'system';
     },
-    menuStyle(state) {
-      if (!state.settings.menuStyle) return 'native'
-      return state.settings.menuStyle.value
-    },
     sortOrder(state) {
       if (!state.settings.sortOrder) return 'id'
       return state.settings.sortOrder.value


### PR DESCRIPTION
There is no longer an option to use a native titlebar (as this is borked on the new version of electron :upside_down_face: ), I left it enabled for MacOS, but Mac also forces the client titlebar to show.

Added an option to toggle the beta channel in the app's updater. This hasn't been tested yet.
![image](https://github.com/user-attachments/assets/0f063e56-cc62-4077-aa0d-c8d3f1739803)
