### PR TITLE
fix detail view bugs

### DIFF
--- a/apps/studio/src/assets/styles/components/detail-view-sidebar.scss
+++ b/apps/studio/src/assets/styles/components/detail-view-sidebar.scss
@@ -1,11 +1,13 @@
 div.sidebar.detail-view-sidebar {
+  position: relative;
   overflow: hidden;
   max-width: 100%;
   min-width: 11rem;
   width: auto;
   flex-grow: 1;
   border: 1px solid $border-color;
-  border-bottom: 0;
+  border-bottom: none;
+  border-right: none;
   background-color: $theme-bg;
 
   .header {
@@ -23,6 +25,10 @@ div.sidebar.detail-view-sidebar {
       &:first-child {
         margin-bottom: 0.5rem;
       }
+    }
+
+    .title {
+      color: $text-dark;
     }
 
     .close-btn, .menu-btn {
@@ -103,5 +109,15 @@ div.sidebar.detail-view-sidebar {
       font-size: 1rem;
       color: $text;
     }
+  }
+
+  .empty-state {
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inset: 0;
+    z-index: 999;
+    font-weight: 700;
   }
 }

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -880,7 +880,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
       if (existing) return this.$store.dispatch('tabs/setActive', existing)
       this.addTab(t)
     },
-    openTable({ table, filters }) {
+    async openTable({ table, filters, openDetailView }) {
       let tab = {} as TransportOpenTab;
       tab.tabType = 'table';
       tab.title = table.name
@@ -894,9 +894,13 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
         if (filters) {
           existing = setFilters(existing, filters)
         }
-        this.$store.dispatch('tabs/setActive', existing)
+        await this.$store.dispatch('tabs/setActive', existing)
       } else {
-        this.addTab(tab)
+        await this.addTab(tab)
+      }
+
+      if (openDetailView) {
+        this.$store.dispatch('toggleOpenDetailView', true)
       }
     },
     openExportModal(options) {

--- a/apps/studio/src/components/common/texteditor/TextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/TextEditor.vue
@@ -110,7 +110,7 @@ export default {
   watch: {
     valueAndStatus() {
       const { value, status } = this.valueAndStatus;
-      if (!status) return;
+      if (!status || !this.editor) return;
       this.foundRootFold = false;
       const scrollInfo = this.editor.getScrollInfo();
       this.editor.setValue(value);
@@ -126,25 +126,25 @@ export default {
       this.initialize();
     },
     mode() {
-      this.editor.setOption("mode", this.mode);
+      this.editor?.setOption("mode", this.mode);
     },
     hint() {
-      this.editor.setOption("hint", this.hint);
+      this.editor?.setOption("hint", this.hint);
     },
     hintOptions() {
-      this.editor.setOption("hintOptions", this.hintOptions);
+      this.editor?.setOption("hintOptions", this.hintOptions);
     },
     heightAndStatus() {
       const { height, status } = this.heightAndStatus;
-      if (!status) return;
+      if (!status || !this.editor) return;
       this.editor.setSize(null, height);
       this.editor.refresh();
     },
     readOnly() {
-      this.editor.setOption("readOnly", this.readOnly);
+      this.editor?.setOption("readOnly", this.readOnly);
     },
     lineWrapping() {
-      this.editor.setOption("lineWrapping", this.lineWrapping);
+      this.editor?.setOption("lineWrapping", this.lineWrapping);
     },
     async focus() {
       if (this.focus && this.editor) {
@@ -173,8 +173,6 @@ export default {
       this.initializeBookmarks();
     },
     foldAll() {
-      console.log('foldall', this.foldAll)
-      // this.editor.foldAll();
       CodeMirror.commands.foldAll(this.editor)
     },
     unfoldAll() {

--- a/apps/studio/src/components/sidebar/DetailViewSidebar.vue
+++ b/apps/studio/src/components/sidebar/DetailViewSidebar.vue
@@ -6,7 +6,7 @@
   >
     <div class="header">
       <div class="header-group">
-        <span>{{ sidebarTitle }}</span>
+        <span class="title sub">{{ sidebarTitle }}</span>
         <button
           class="close-btn btn btn-fab"
           @click="close"
@@ -63,6 +63,9 @@
       :force-initizalize="reinitializeTextEditor + (reinitialize ?? 0)"
       :markers="markers"
     />
+    <div class="empty-state" v-show="empty">
+      No Data
+    </div>
   </div>
 </template>
 

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1675,6 +1675,11 @@ export default Vue.extend({
     },
     updateDetailView(range: RangeComponent) {
       const row = range.getRows()[0]
+      if (!row) {
+        this.selectedRowIndex = null
+        this.selectedRowData = {}
+        return
+      }
       const data = row.getData()
       const selectedRowIndex = data[this.internalIndexColumn]
       if (selectedRowIndex === this.selectedRowIndex) return

--- a/apps/studio/src/migration/20241017_add_missing_user_settings.js
+++ b/apps/studio/src/migration/20241017_add_missing_user_settings.js
@@ -1,0 +1,11 @@
+export default {
+  name: "20241017_add_missing_user_settings",
+  async run(runner) {
+    const query = `
+      INSERT OR IGNORE INTO user_setting (key, defaultValue, userValue, valueType) VALUES
+        ('connectionsSortBy', 'name', 'name', 0),
+        ('connectionsSortOrder', 'asc', 'asc', 0)
+    `;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/20241017_add_user_setting_keymap.js
+++ b/apps/studio/src/migration/20241017_add_user_setting_keymap.js
@@ -1,0 +1,7 @@
+export default {
+  name: "20241017_add_user_setting_keymap",
+  async run(runner) {
+    const query = `INSERT OR IGNORE INTO user_setting (key, defaultValue, userValue, valueType) VALUES ('keymap', 'default', 'default', 0)`;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -45,6 +45,7 @@ import nameTokenCache from './20240715_add_name_to_token_cache'
 import maxAllowedAppRelease from './20240920_add_max_allowed_app_release'
 import lastUsedWorkspace from './20240923_user_settings_default_workspace'
 import userSettingKeymap from './20241017_add_user_setting_keymap'
+import missingUserSettings from './20241017_add_missing_user_settings'
 
 import ultimate from './ultimate/index'
 
@@ -70,7 +71,7 @@ const realMigrations = [
   createHiddenEntities, createHiddenSchemas, cassandraOptions, readOnlyMode, connectionPins, fixKeymapType, bigQueryOptions,
   firebirdConnection, exportPath, UserSettingsWindowPosition,
   demoSetup, minimalMode, tokenCache, libsqlOptions, nameTokenCache, lastUsedWorkspace,
-  maxAllowedAppRelease, userSettingKeymap,
+  maxAllowedAppRelease, userSettingKeymap, missingUserSettings,
 ]
 
 // fixtures require the models

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -44,6 +44,7 @@ import libsqlOptions from './20240528_add_libsql_options'
 import nameTokenCache from './20240715_add_name_to_token_cache'
 import maxAllowedAppRelease from './20240920_add_max_allowed_app_release'
 import lastUsedWorkspace from './20240923_user_settings_default_workspace'
+import userSettingKeymap from './20241017_add_user_setting_keymap'
 
 import ultimate from './ultimate/index'
 
@@ -69,7 +70,7 @@ const realMigrations = [
   createHiddenEntities, createHiddenSchemas, cassandraOptions, readOnlyMode, connectionPins, fixKeymapType, bigQueryOptions,
   firebirdConnection, exportPath, UserSettingsWindowPosition,
   demoSetup, minimalMode, tokenCache, libsqlOptions, nameTokenCache, lastUsedWorkspace,
-  maxAllowedAppRelease,
+  maxAllowedAppRelease, userSettingKeymap,
 ]
 
 // fixtures require the models

--- a/apps/studio/src/mixins/fk_click.ts
+++ b/apps/studio/src/mixins/fk_click.ts
@@ -112,7 +112,7 @@ export const FkLinkMixin = {
       });
 
       const payload = {
-        table, filters, titleScope: values.join(',')
+        table, filters, titleScope: values.join(','), openDetailView: true,
       }
       this.$root.$emit('loadTable', payload)
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5185,6 +5185,11 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+buildcheck@~0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
+  integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
+
 builder-util-runtime@9.2.5:
   version "9.2.5"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.2.5.tgz#0afdffa0adb5c84c14926c7dd2cf3c6e96e9be83"
@@ -5708,8 +5713,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-"cpu-features@file:./.yarn/packages/empty-package", cpu-features@~0.0.4, cpu-features@~0.0.8:
-  version "1.0.0"
+cpu-features@~0.0.4, cpu-features@~0.0.8:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.10.tgz#9aae536db2710c7254d7ed67cb3cbc7d29ad79c5"
+  integrity sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==
+  dependencies:
+    buildcheck "~0.0.6"
+    nan "^2.19.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -9079,6 +9089,11 @@ nan@^2.16.0, nan@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
+
+nan@^2.19.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
+  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
 nanoid@^3.3.7:
   version "3.3.7"


### PR DESCRIPTION
fix #2497, fix #2498

- Removed border right
- Added empty state
- Matched title style to the table list on the left sidebar
- Fix text editor that won't load up because the `keymap` user setting is not in the database, missing from migration. This happens if we have a fresh install of beekeeper or a new database file.
- Detail sidebar should open if we click a FK link
- Apart from `keymap`, found 2 other user settings that are not in migration too (`connectionsSortBy` and `connectionsSortOrder`). If we have an empty database or just installed beekeeper for the first time, this causes a bunch of errors that goes `Cannot read properties of null (reading 'value') at transformSetting`.
- Fixed sql text editor that shows blank screen because `keymap` didn't exist.

![image](https://github.com/user-attachments/assets/2bf6d842-37db-437b-9f1a-ca373cd14561)

![image](https://github.com/user-attachments/assets/2efe486b-007b-4d1d-b965-45b193df0d55)