### PR TITLE
fix: edit modal overflow css

### DIFF
--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -360,7 +360,7 @@ div.vue-dialog div.dialog-content {
     .CodeMirror {
       height: 300px;
       min-height: 300px;
-      max-height: 556px;
+      max-height: 55vh;
       resize: vertical;
     }
   }


### PR DESCRIPTION
fixes #2515 

before: 
<img width="1220" alt="before" src="https://github.com/user-attachments/assets/658a9271-d330-4975-a5c7-86223c4acacc">


after:
<img width="1224" alt="after" src="https://github.com/user-attachments/assets/55823ced-af06-42ac-83ff-e04583c655f8">
