### PR TITLE
Fix opening new window

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -253,10 +253,6 @@ ipcMain.handle('requestPorts', async () => {
     utilityProcess = null;
     await createUtilityProcess();
   }
-  createAndSendPorts(false);
-})
-
-ipcMain.on('ready', (_event) => {
   createAndSendPorts(true);
 })
 


### PR DESCRIPTION
For some reason when the `requestPorts` event was handled, we were creating and sending ports to every renderer instance, which then meant all context for any open connections was lost. Now we only send ports to the new renderer