### PR TITLE
Fix titlebar listeners

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -43,7 +43,6 @@ function initUserDirectory(d: string) {
 }
 
 let utilityProcess: Electron.UtilityProcess
-// don't need this
 let newWindows: number[] = [];
 
 async function createUtilityProcess() {
@@ -243,6 +242,7 @@ function createAndSendPorts(filter: boolean, utilDied: boolean = false) {
       const { port1, port2 } = new electron.MessageChannelMain();
       const sId = uuidv4();
       log.info('SENDING PORT TO RENDERER: ', sId)
+      w.sId = sId;
       utilityProcess.postMessage({ type: 'init', sId }, [port1]);
       w.webContents.postMessage('port', { sId, utilDied }, [port2]);
       w.onClose((_event: electron.Event) => {

--- a/apps/studio/src-commercial/entrypoints/preload.ts
+++ b/apps/studio/src-commercial/entrypoints/preload.ts
@@ -98,6 +98,18 @@ export const api = {
   openLink(link: string) {
     return electron.shell.openExternal(link);
   },
+  onMaximize(func: any, sId: string) {
+    ipcRenderer.on(`maximize-${sId}`, func);
+  },
+  onUnmaximize(func: any, sId: string) {
+    ipcRenderer.on(`unmaximize-${sId}`, func);
+  },
+  onEnterFullscreen(func: any, sId: string) {
+    ipcRenderer.on(`enter-full-screen-${sId}`, func);
+  },
+  onLeaveFullscreen(func: any, sId: string) {
+    ipcRenderer.on(`leave-full-screen-${sId}`, func);
+  },
   async isMaximized() {
     return await ipcRenderer.invoke('isMaximized');
   },

--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -27,6 +27,7 @@ class BeekeeperWindow {
   private win: BrowserWindow | null
   private reloaded = false
   private appUrl: string
+  public sId: string;
 
   constructor(protected settings: IGroupedUserSettings, openOptions: OpenOptions) {
     const theme = settings.theme
@@ -97,6 +98,22 @@ class BeekeeperWindow {
         this.win.setTitle(args[0])
         e.preventDefault()
       }
+    })
+
+    this.win.on('maximize', () => {
+      this.win.webContents.send(`maximize-${this.sId}`)
+    })
+
+    this.win.on('unmaximize', () => {
+      this.win.webContents.send(`unmaximize-${this.sId}`)
+    })
+
+    this.win.on('enter-full-screen', () => {
+      this.win.webContents.send(`enter-full-screen-${this.sId}`)
+    })
+
+    this.win.on('leave-full-screen', () => {
+      this.win.webContents.send(`leave-full-screen-${this.sId}`)
     })
 
     this.initialize()

--- a/apps/studio/src/components/Titlebar.vue
+++ b/apps/studio/src/components/Titlebar.vue
@@ -78,37 +78,40 @@ export default {
   },
   mounted() {
     // FIXME This doesn't work after the refactor and needs fixing
-    //this.getWindow()?.on('maximize', () => {
-    //  this.maximized = true
-    //})
-    //this.getWindow()?.on('unmaximize', () => {
-    //  this.maximized = false
-    //})
-    //this.getWindow()?.on('enter-full-screen', () => {
-    //  this.fullscreen = true
-    //})
-    //this.getWindow()?.on('leave-full-screen', () => {
-    //  this.fullscreen = false
-    //})
+    window.main.onMaximize(() => {
+      this.maximized = true
+    }, this.$util.sId);
+    window.main.onUnmaximize(() => {
+      this.maximized = false
+    }, this.$util.sId);
+    window.main.onEnterFullscreen(() => {
+      this.fullscreen = true
+    }, this.$util.sId);
+
+    window.main.onLeaveFullscreen(() => {
+      this.fullscreen = false
+    }, this.$util.sId);
   },
   methods: {
-    async updateFlags() {
-      this.maximized = await window.main.isMaximized();
-      this.fullscreen = await window.main.isFullscreen();
-    },
+    // if the above works, we shouldn't need this
+    //async updateFlags() {
+    //  this.maximized = await window.main.isMaximized();
+    //  this.fullscreen = await window.main.isFullscreen();
+    //},
     async minimizeWindow() {
       await window.main.minimizeWindow();
-      await this.updateFlags();
+      //await this.updateFlags();
     },
     async maximizeWindow() {
+      const isMaximized = await window.main.isMaximized();
       if (this.fullscreen) {
         await window.main.setFullScreen(false)
-      } else if (this.maximized) {
+      } else if (isMaximized) {
         await window.main.unmaximizeWindow()
       } else {
         await window.main.maximizeWindow();
       }
-      await this.updateFlags();
+      //await this.updateFlags();
     },
     async closeWindow() {
       await window.main.closeWindow();

--- a/apps/studio/src/components/Titlebar.vue
+++ b/apps/studio/src/components/Titlebar.vue
@@ -77,13 +77,14 @@ export default {
     ...mapState(['windowTitle'])
   },
   mounted() {
-    // FIXME This doesn't work after the refactor and needs fixing
     window.main.onMaximize(() => {
       this.maximized = true
     }, this.$util.sId);
+
     window.main.onUnmaximize(() => {
       this.maximized = false
     }, this.$util.sId);
+
     window.main.onEnterFullscreen(() => {
       this.fullscreen = true
     }, this.$util.sId);
@@ -93,14 +94,8 @@ export default {
     }, this.$util.sId);
   },
   methods: {
-    // if the above works, we shouldn't need this
-    //async updateFlags() {
-    //  this.maximized = await window.main.isMaximized();
-    //  this.fullscreen = await window.main.isFullscreen();
-    //},
     async minimizeWindow() {
       await window.main.minimizeWindow();
-      //await this.updateFlags();
     },
     async maximizeWindow() {
       const isMaximized = await window.main.isMaximized();
@@ -111,7 +106,6 @@ export default {
       } else {
         await window.main.maximizeWindow();
       }
-      //await this.updateFlags();
     },
     async closeWindow() {
       await window.main.closeWindow();

--- a/apps/studio/src/lib/utility/UtilityConnection.ts
+++ b/apps/studio/src/lib/utility/UtilityConnection.ts
@@ -19,8 +19,12 @@ export class UtilityConnection {
   private listeners: Array<{type: string, id: string, listener: Listener}> = new Array();
   private messageQueue: Array<Message> = new Array();
   private port: MessagePort;
-  private sId: string;
+  private _sId: string;
   private portsRequested: boolean = false;
+
+  public get sId() {
+    return this._sId;
+  } 
 
   public async hasWorkingPort(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -33,7 +37,7 @@ export class UtilityConnection {
 
   public setPort(port: MessagePort, sId: string) {
     this.port = port;
-    this.sId = sId;
+    this._sId = sId;
     log.info('RECEIVED PORT IN UtilityConnection: ', port);
     this.port.onmessage = (msg) => {
       const { data: msgData } = msg;
@@ -74,7 +78,7 @@ export class UtilityConnection {
     if (this.messageQueue.length > 0) {
       this.messageQueue.forEach(({ handlerName, args, id, resolve, reject }) => {
         log.info('PROCESSING QUEUED REQUEST: ', handlerName, id);
-        args = { sId: this.sId, ...args };
+        args = { sId: this._sId, ...args };
         this.replyHandlers.set(id, { resolve, reject });
         this.port.postMessage({ id, name: handlerName, args: args ?? {}})
       });
@@ -95,7 +99,7 @@ export class UtilityConnection {
         }
       } else {
         log.info('SENDING REQUEST FOR NAME, ID: ', handlerName, id)
-        args = { sId: this.sId, ...args };
+        args = { sId: this._sId, ...args };
 
         this.replyHandlers.set(id, { resolve, reject });
         this.port.postMessage({id, name: handlerName, args: args ?? {}});


### PR DESCRIPTION
Since we turned on contextIsolation, we can no longer directly access the window in the titlebar. Now we attach listeners through preload to the BeekeeperWindow instance, which will fire off `maximize`, `unmaximize`, etc events when they are received, along with the sId so the event is sent to the correct renderer. This also seems to have fixed the double clicking issue (I think, I didn't notice any issues after making this change)

I tested this on the latest Ubuntu LTS, but let me know if it doesn't work on your system