### PR TITLE
fix selecting connection

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -237,7 +237,9 @@ export default Vue.extend({
     },
     'config.connectionType'(newConnectionType) {
       this.$util.send('appdb/saved/new', { init: { connectionType: newConnectionType }}).then((conn) => {
-        this.config = conn;
+        if (!this.config.id) {
+          this.config = conn;
+        }
         if (!findClient(newConnectionType)?.supportsSocketPath) {
           this.config.socketPathEnabled = false
         }


### PR DESCRIPTION
Fix selecting a connection. Without this fix, the connection would have to be selected twice to actually show up in the connection interface. This was caused by the default ports fix.