### PR TITLE
fix clickhouse materialized views query

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -793,25 +793,28 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
         });
         data = await result.json();
         resultType = "json";
-        results.push({ statement, data, resultType: "json" });
       } else {
         const result = await this.client.exec({
           query,
           query_params: options.params,
           query_id: options.queryId,
 
-          // Recommended for cluster usage to avoid situations where a query
-          // processing error occurred after the response code, and HTTP
-          // headers were already sent to the client.
-          // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
           clickhouse_settings: {
-            wait_end_of_query: 1,
+            // Recommended for cluster usage to avoid situations where a query
+            // processing error occurred after the response code, and HTTP
+            // headers were already sent to the client.
+            // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
+            //
+            // TODO (azmi): Using this setting can obscure the error message
+            // (found in ClickHouse 24.2). We should probably make this optional
+            // explicitly in the UI if we want to enable it.
+            // wait_end_of_query: 1,
           },
         });
         data = result.stream;
         resultType = "stream";
-        results.push({ statement, data: result.stream, resultType: "stream" });
       }
+      results.push({ statement, data, resultType });
     }
 
     log.info(`Running Query Finished`);
@@ -852,7 +855,7 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
       JOIN system.columns c
         ON c.table = v.table_name
         AND c.database = v.table_schema
-      WHERE v.is_insertable_into = 'YES'
+      WHERE v.is_insertable_into = 1
         AND v.table_name = {table: String}
         AND v.table_schema = currentDatabase()
     `;
@@ -898,7 +901,7 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
     const sql = `
       SELECT v.table_name as name
       FROM information_schema.views v
-      WHERE v.is_insertable_into = 'YES'
+      WHERE v.is_insertable_into = 1
         AND v.table_schema = currentDatabase()
     `;
     const result = await this.driverExecuteSingle(sql);

--- a/apps/studio/tests/integration/lib/db/clients/clickhouse.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/clickhouse.spec.ts
@@ -4,9 +4,19 @@ import { DBTestUtil, dbtimeout } from "../../../../lib/db";
 import { runCommonTests, runReadOnlyTests } from "./all";
 import knex from "knex";
 import { ClickhouseKnexClient } from "@shared/lib/knex-clickhouse";
+import fs from 'fs';
+import path from 'path';
+import { identify } from 'sql-query-identifier';
 
-function testWith(options = { readOnly: false }) {
-  describe(`Clickhouse [read-only mode? ${options.readOnly}]`, () => {
+const TEST_VERSIONS = [
+  { tag: 'latest', readOnly: false },
+  { tag: 'latest', readOnly: true },
+  { tag: '24.2', readOnly: false },
+  { tag: '24.2', readOnly: true },
+] as const
+
+function testWith(options: typeof TEST_VERSIONS[number]) {
+  describe(`Clickhouse [${options.tag} read-only mode? ${options.readOnly}]`, () => {
     jest.setTimeout(dbtimeout);
 
     let container: StartedTestContainer;
@@ -14,7 +24,7 @@ function testWith(options = { readOnly: false }) {
 
     beforeAll(async () => {
       const timeoutDefault = 5000;
-      container = await new GenericContainer("clickhouse/clickhouse-server")
+      container = await new GenericContainer(`clickhouse/clickhouse-server:${options.tag}`)
         .withName(`clickhouse-server-readonly-${options.readOnly.toString()}`)
         .withEnvironment({
           CLICKHOUSE_USER: "username",
@@ -56,10 +66,16 @@ function testWith(options = { readOnly: false }) {
             database: "my_database",
           },
         }),
-        nullDateTime: "1970-01-01 00:00:00",
+        queryTestsTableCreationQuery: 'CREATE TABLE one_record (one INTEGER) ENGINE = MergeTree ORDER BY (one)',
       });
 
       await util.setupdb();
+
+      const query = fs.readFileSync(path.resolve(__dirname, './scripts/clickhouse.init.sql'), 'utf-8');
+      const statements = identify(query, { strict: false })
+      for (const statement of statements) {
+        await util.knex.schema.raw(statement.text);
+      }
     });
 
     afterAll(async () => {
@@ -74,6 +90,41 @@ function testWith(options = { readOnly: false }) {
         runCommonTests(() => util);
       }
     });
+
+    // TODO (azmi): These materialized views tests should be in common tests.
+    // They're here for now to fix clickhouse
+    it("should list materialized views correctly", async () => {
+      const views = await util.connection.listMaterializedViews()
+      expect(views).toStrictEqual([
+        {
+          entityType: "materialized-view",
+          name: "up_down_votes_per_day_mv",
+        },
+      ])
+    })
+
+    // TODO (azmi): These materialized views tests should be in common tests.
+    // They're here for now to fix clickhouse
+    it("should list materialized views columns correctly", async () => {
+      const views = await util.connection.listMaterializedViewColumns('up_down_votes_per_day_mv')
+      expect(views).toStrictEqual([
+        {
+          columnName: "Day",
+          dataType: "Date",
+          tableName: "up_down_votes_per_day_mv",
+        },
+        {
+          columnName: "UpVotes",
+          dataType: "UInt64",
+          tableName: "up_down_votes_per_day_mv",
+        },
+        {
+          columnName: "DownVotes",
+          dataType: "UInt64",
+          tableName: "up_down_votes_per_day_mv",
+        },
+      ])
+    })
 
     describe("Formats in select queries", () => {
       it("queries with default format", async () => {
@@ -128,5 +179,4 @@ function testWith(options = { readOnly: false }) {
   });
 }
 
-testWith({ readOnly: false });
-testWith({ readOnly: true });
+TEST_VERSIONS.forEach(testWith);

--- a/apps/studio/tests/integration/lib/db/clients/scripts/clickhouse.init.sql
+++ b/apps/studio/tests/integration/lib/db/clients/scripts/clickhouse.init.sql
@@ -1,0 +1,34 @@
+CREATE TABLE votes
+(
+    `Id` UInt32,
+    `PostId` Int32,
+    `VoteTypeId` UInt8,
+    `CreationDate` DateTime64(3, 'UTC'),
+    `UserId` Int32,
+    `BountyAmount` UInt8
+)
+ENGINE = MergeTree
+ORDER BY (VoteTypeId, CreationDate, PostId, UserId);
+
+CREATE TABLE up_down_votes_per_day
+(
+  `Day` Date,
+  `UpVotes` UInt32,
+  `DownVotes` UInt32
+)
+ENGINE = SummingMergeTree
+ORDER BY Day;
+
+CREATE MATERIALIZED VIEW up_down_votes_per_day_mv TO up_down_votes_per_day AS
+SELECT toStartOfDay(CreationDate)::Date AS Day,
+       countIf(VoteTypeId = 2) AS UpVotes,
+       countIf(VoteTypeId = 3) AS DownVotes
+FROM votes
+GROUP BY Day;
+
+INSERT INTO votes (Id, PostId, VoteTypeId, CreationDate, UserId, BountyAmount) VALUES
+(1, 101, 1, '2023-01-01 12:00:00.123', 1001, 0),
+(2, 102, 2, '2023-01-02 14:30:15.456', 1002, 50),
+(3, 103, 1, '2023-01-03 16:45:30.789', 1003, 0),
+(4, 104, 3, '2023-01-04 18:00:45.012', 1004, 100),
+(5, 105, 2, '2023-01-05 20:15:59.321', 1005, 75);

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -81,6 +81,7 @@ export interface Options {
   knexConnectionOptions?: Record<string, any>
   knex?: Knex
   knexClient?: Knex.Client
+  queryTestsTableCreationQuery?: string
 }
 
 export class DBTestUtil {
@@ -821,7 +822,7 @@ export class DBTestUtil {
   }
 
   async queryTests() {
-    await this.connection.executeQuery('create table one_record(one integer primary key)')
+    await this.connection.executeQuery(this.options.queryTestsTableCreationQuery || 'create table one_record(one integer primary key)')
     await this.connection.executeQuery('insert into one_record values(1)')
 
     const tables = await this.connection.listTables({ schema: this.defaultSchema})


### PR DESCRIPTION
Using strings to compare enum columns was not supported until ClickHouse 24.3 https://clickhouse.com/docs/en/whats-new/changelog#improvement-7

Tested this via integration tests on version 23.9 to 24.10 (latest). I wanted to test more old versions but so far I don't see any new issues other than the string to UInt8 error, which is what this PR addresses.