### PR TITLE
fix modals broken spacing

### DIFF
--- a/apps/studio/src/assets/styles/app/export-modal.scss
+++ b/apps/studio/src/assets/styles/app/export-modal.scss
@@ -1,4 +1,15 @@
 .export-modal {
+  form {
+    overflow-y: auto;
+    height: 100%;
+    max-height: 80vh;
+    padding: 1.2rem;
+  }
+
+  .dialog-content {
+    padding: 0;
+  }
+
   .dialog-c-title {
     .dialog-c-link {
         margin-left: $gutter-w;
@@ -45,10 +56,8 @@
 
   .vue-dialog-buttons {
     margin-top: $gutter-h * 4;
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0;
   }
-
 }
 .export-form {
   .form-group {

--- a/apps/studio/src/assets/styles/app/modals.scss
+++ b/apps/studio/src/assets/styles/app/modals.scss
@@ -48,6 +48,7 @@
       justify-content: stretch;
       padding-left: 0;
       padding-right: 0;
+      padding-top: 1rem;
       & > div {
         width: 100%;
       }


### PR DESCRIPTION
- Buttons in export modal are too close to the side

![Screenshot 2024-11-15 103710](https://github.com/user-attachments/assets/af4f6317-5260-4818-bdda-354f2c74ada0)

- Buttons in upgrade modal is also a bit too close to the top

![Screenshot 2024-11-15 105220](https://github.com/user-attachments/assets/c671a399-4f66-4209-b967-70d089cf4188)

- After pressing advanced options, a scrollbar should appear if the content overflows the modal

![Screenshot 2024-11-15 193741](https://github.com/user-attachments/assets/6e7837c0-9014-429c-90d4-7076644e26bf)
