### PR TITLE
add migration to delete duplicate connections

### DIFF
--- a/apps/studio/src/migration/20241115_delete_duplicate_connections.js
+++ b/apps/studio/src/migration/20241115_delete_duplicate_connections.js
@@ -1,0 +1,19 @@
+export default {
+  name: "20241115-delete-duplicate_connections",
+  async run(runner) {
+    const query = `
+      DELETE FROM used_connection
+      WHERE rowid NOT IN (
+          SELECT rowid
+          FROM used_connection AS uc
+          WHERE (uc.connectionId, uc.updatedAt) IN (
+              SELECT connectionId, MAX(updatedAt)
+              FROM used_connection
+              WHERE connectionId IS NOT NULL
+              GROUP BY connectionId
+          )
+      ) AND connectionId IS NOT NULL;
+    `;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -47,6 +47,7 @@ import lastUsedWorkspace from './20240923_user_settings_default_workspace'
 import userSettingKeymap from './20241017_add_user_setting_keymap'
 import missingUserSettings from './20241017_add_missing_user_settings'
 import useBeta from './20241009_add_beta_toggle'
+import deleteDuplicateConnections from './20241115_delete_duplicate_connections'
 
 import ultimate from './ultimate/index'
 
@@ -73,7 +74,7 @@ const realMigrations = [
   firebirdConnection, exportPath, UserSettingsWindowPosition,
   demoSetup, minimalMode, tokenCache, libsqlOptions, nameTokenCache, lastUsedWorkspace,
   maxAllowedAppRelease, userSettingKeymap, missingUserSettings,
-  useBeta
+  useBeta, deleteDuplicateConnections
 ]
 
 // fixtures require the models


### PR DESCRIPTION
fix #2581

Add a migration to delete any duplicate connections so we are only left with the most recent connection for every `connectionId`