### PR TITLE
disable initial sort in clickhouse and bump clickhouse version

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -32,7 +32,7 @@
     "@azure/msal-node": "^2.12.0",
     "@cleverbrush/async": "^1.1.10",
     "@cleverbrush/deep": "^1.1.10",
-    "@clickhouse/client": "^1.2.0",
+    "@clickhouse/client": "^1.8.1",
     "@electron/remote": "^2.0.10",
     "@google-cloud/bigquery": "^6.2.0",
     "@libsql/knex-libsql": "^0.1.0",

--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -817,9 +817,8 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
             // See https://clickhouse.com/docs/en/interfaces/http/#response-buffering
             //
             // TODO (azmi): Using this setting can obscure the error message
-            // (found in ClickHouse 24.2). We should probably make this optional
-            // explicitly in the UI if we want to enable it.
-            // wait_end_of_query: 1,
+            // (found in ClickHouse 24.2).
+            wait_end_of_query: 1,
           },
         });
         data = result.stream;

--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -157,6 +157,7 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
       clickhouse_settings: {
         default_format: "JSONCompact",
       },
+      request_timeout: 120_000, // 2 minutes
     });
     const result = await this.driverExecuteSingle(
       "SELECT version() AS version"

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -724,6 +724,10 @@ export default Vue.extend({
         return [];
       }
 
+      if (this.dialectData.disabledFeatures?.initialSort) {
+        return [];
+      }
+
       return [{ column: this.table.columns[0].columnName, dir: "asc" }];
     },
     shouldInitialize() {

--- a/apps/studio/src/shared/lib/dialects/bigquery.ts
+++ b/apps/studio/src/shared/lib/dialects/bigquery.ts
@@ -38,7 +38,8 @@ export const BigQueryData: DialectData = {
     },
     importFromFile: true,
     createIndex: true,
-    comments: true
+    comments: true,
+    initialSort: true,
   },
   notices: {
     infoIndexes: 'BigQuery: table indexes are not supported.',

--- a/apps/studio/src/shared/lib/dialects/clickhouse.ts
+++ b/apps/studio/src/shared/lib/dialects/clickhouse.ts
@@ -87,5 +87,7 @@ export const ClickHouseData: DialectData = {
     chunkSizeStream: true,
     // Clickhouse doesn't have binary types
     binaryColumn: true,
+    // Sorting can slow down queries
+    initialSort: true,
   },
 }

--- a/apps/studio/src/shared/lib/dialects/models.ts
+++ b/apps/studio/src/shared/lib/dialects/models.ts
@@ -147,6 +147,7 @@ export interface DialectData {
     transactions?: boolean
     chunkSizeStream?: boolean
     binaryColumn?: boolean
+    initialSort?: boolean
   },
   notices?: {
     infoSchema?: string

--- a/apps/studio/src/shared/lib/dialects/redshift.ts
+++ b/apps/studio/src/shared/lib/dialects/redshift.ts
@@ -44,6 +44,7 @@ export const RedshiftData: DialectData = {
       onDelete: true
     },
     createIndex: true,
+    initialSort: true,
   }
 
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,17 +2312,17 @@
   resolved "https://registry.yarnpkg.com/@cleverbrush/deep/-/deep-1.1.10.tgz#9dfb24355e2d325b040d9cd643edfe02d19e8178"
   integrity sha512-Cw5Ev1TfbJRm/YCZbAFYzo0gNGX2VwKWxcIJiRmanefGPYVt7YZXKHBIj5iMbEfl0J6kWcGxam777Sg/76o1WQ==
 
-"@clickhouse/client-common@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.2.0.tgz#8845d373a14c6076d59118a0cb58afad84687372"
-  integrity sha512-VfA/C/tVJ2eNe72CaQ7eXmai+yqFEvZjQZiNtvJoOMLP+Vtb6DzqH9nfkgsiHHMhUhhclvt2mFh6+euk1Ea5wA==
+"@clickhouse/client-common@1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.8.1.tgz#1b7994990d867ba195e05a43e3413f4cf3b119cb"
+  integrity sha512-Z0R5zKaS3N35Op338WVRHIfoqDh9gotXZwekm0lbHQmwNaj3nY2iJ113dFYKjb1V+ESu+PvLEA//LJUGZyPQOg==
 
-"@clickhouse/client@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.2.0.tgz#83aa3b69635e19c94a975ee7ec9a68843915b94b"
-  integrity sha512-zMp2EhMfp1IrFKr/NjDwNiLsf7nq68nW8lGKszwFe7Iglc6Z5PY9ZA9Hd0XqAk75Q1NmFrkGCP1r3JCM1Nm1Bw==
+"@clickhouse/client@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.8.1.tgz#2273f6b993d21351c32d4e2a6a1b35b0c05d435b"
+  integrity sha512-Ec0pCdwftIPD7hCxhOukHS0Zxr2tDc5mNAHBqkT3c0c6GO2WQdZkME9+EcfGcoF7+foUp82F5a0bPfSDDjfWmg==
   dependencies:
-    "@clickhouse/client-common" "1.2.0"
+    "@clickhouse/client-common" "1.8.1"
 
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"


### PR DESCRIPTION
This fixes a timeout issue when opening a table view in a big table.

By default, we sort a table automatically in table view. If it's a big table, the process can take really long.

Tested on ClickHouse Cloud v24.6 with ~800 million of rows. The timeout was even triggered when there were only ~50K rows.