### PR TITLE
fix empty text editor after switching keymap

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -36,7 +36,6 @@
         v-bind.sync="editor"
         :focus="focusingElement === 'text-editor'"
         @update:focus="updateTextEditorFocus"
-        :forced-value="forcedTextEditorValue"
         :markers="editorMarkers"
         :connection-type="connectionType"
         :extra-keybindings="keybindings"
@@ -53,7 +52,7 @@
         >
           <x-button
             v-if="showDryRun"
-            class="btn btn-flat btn-small"
+            class="btn btn-flat btn-small dry-run-btn"
             :disabled="isCommunity"
             @click="dryRun = !dryRun"
           >
@@ -348,7 +347,6 @@
         runningType: 'all queries',
         selectedResult: 0,
         unsavedText: editorDefault,
-        forcedTextEditorValue: editorDefault,
         editor: {
           height: 100,
           selection: null,
@@ -969,7 +967,6 @@
         if (originalText) {
           this.originalText = originalText
           this.unsavedText = originalText
-          this.forcedTextEditorValue = originalText
         }
       },
       fakeRemoteChange() {

--- a/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
@@ -9,7 +9,6 @@
     :hint-options="hintOptions"
     :columns-getter="columnsGetter"
     :context-menu-options="handleContextMenuOptions"
-    :forced-value="dataForcedValue"
     :plugins="plugins"
     :auto-focus="true"
     @update:focus="$emit('update:focus', $event)"
@@ -30,12 +29,7 @@ import CodeMirror from "codemirror";
 
 export default Vue.extend({
   components: { TextEditor },
-  props: ["value", "connectionType", "extraKeybindings", "contextMenuOptions", "forcedValue"],
-  data() {
-    return {
-      dataForcedValue: this.value,
-    };
-  },
+  props: ["value", "connectionType", "extraKeybindings", "contextMenuOptions"],
   computed: {
     ...mapGetters(['defaultSchema', 'dialectData', 'isUltimate']),
     ...mapState(["tables"]),
@@ -93,17 +87,12 @@ export default Vue.extend({
       return editorPlugins;
     },
   },
-  watch: {
-    async forcedValue() {
-      await this.setEditorValue(this.forcedValue);
-    },
-  },
   methods: {
-    async formatSql() {
+    formatSql() {
       const formatted = format(this.value, {
         language: FormatterDialect(dialectFor(this.connectionType)),
       });
-      await this.setEditorValue(formatted);
+      this.$emit("input", formatted);
     },
     async columnsGetter(tableName: string) {
       let tableToFind = this.tables.find(
@@ -141,11 +130,6 @@ export default Vue.extend({
       }
 
       return newOptions;
-    },
-    async setEditorValue(value: string) {
-      this.dataForcedValue = this.value;
-      await this.$nextTick();
-      this.dataForcedValue = value;
     },
   },
 });

--- a/apps/studio/src/components/common/texteditor/TextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/TextEditor.vue
@@ -59,9 +59,6 @@ export default {
     "selection",
     "cursor",
     "initialized",
-    // Use forcedValue if you want to set the value programmatically and
-    // honestly, I forgot why do we need this.
-    "forcedValue",
     "plugins",
     "autoFocus",
     "lineNumbers",
@@ -80,6 +77,7 @@ export default {
       bookmarkInstances: [],
       markInstances: [],
       wasEditorFocused: false,
+      valueChangeByCodeMirror: false,
     };
   },
   computed: {
@@ -104,13 +102,17 @@ export default {
     },
     valueAndStatus() {
       return {
-        value: this.forcedValue,
+        value: this.value,
         status: this.editor != null
       }
     }
   },
   watch: {
     valueAndStatus() {
+      if (this.valueChangeByCodeMirror) {
+        this.valueChangeByCodeMirror = false;
+        return
+      }
       const { value, status } = this.valueAndStatus;
       if (!status || !this.editor) return;
       this.foundRootFold = false;
@@ -279,7 +281,9 @@ export default {
         cm.setOption("lineWrapping", this.lineWrapping);
       }
 
-      cm.on("change", (cm) => {
+      cm.on("change", async (cm) => {
+        this.valueChangeByCodeMirror = true;
+        await this.$nextTick()
         this.$emit("input", cm.getValue());
       });
 

--- a/apps/studio/src/components/sidebar/DetailViewSidebar.vue
+++ b/apps/studio/src/components/sidebar/DetailViewSidebar.vue
@@ -59,7 +59,6 @@
       :fold-all="foldAll"
       :unfold-all="unfoldAll"
       :value="text"
-      :forced-value="text"
       :mode="mode"
       :force-initizalize="reinitializeTextEditor + (reinitialize ?? 0)"
       :markers="markers"


### PR DESCRIPTION
![switch-mode](https://github.com/user-attachments/assets/31a096c3-ab83-43fa-99a5-9950543a48bd)

Switching keymap will reset the text editor to empty. This is due to my implementation of `forcedValue` of TextEditor that is very confusing.

This PR removes `forcedValue` property from TextEditor and adds a better way to handle the text value or `v-model` interaction.