### PR TITLE
Implement clickhouse import commands

### DIFF
--- a/apps/studio/src-commercial/backend/lib/import/formats/csv.ts
+++ b/apps/studio/src-commercial/backend/lib/import/formats/csv.ts
@@ -80,16 +80,19 @@ export default class extends Import {
     const fileName = fileToImport ?? this.fileName
 
     return new Promise((resolve, error) => {
-      const complete = (result: ParseResult<any>) => {
-        resolve({
-          aborted: result?.meta?.aborted,
-          error: this.error,
-          data: result?.data,
-          meta: result?.meta
-        })
-      }
       try {
-        Papa.parse(fs.createReadStream(fileName), {...options, complete: complete.bind(this), error})
+        const stream = fs.createReadStream(fileName)
+        const complete = (result: ParseResult<any>) => {
+          // stream needs to be closed explicitly
+          stream.close()
+          resolve({
+            aborted: result?.meta?.aborted,
+            error: this.error,
+            data: result?.data,
+            meta: result?.meta
+          })
+        }
+        Papa.parse(stream, { ...options, complete: complete.bind(this), error })
       } catch (err) {
         error(err?.message ?? err)
       }

--- a/apps/studio/src/assets/styles/app/tabs/import-file.scss
+++ b/apps/studio/src/assets/styles/app/tabs/import-file.scss
@@ -42,6 +42,9 @@
   align-items: center;
   justify-content: center;
 }
+.import-table-container .import-table-wrapper.import-progress {
+  margin: 0 auto;
+}
 .import-progress-wrapper {
   align-items: center;
   button {

--- a/apps/studio/src/shared/lib/dialects/clickhouse.ts
+++ b/apps/studio/src/shared/lib/dialects/clickhouse.ts
@@ -89,7 +89,5 @@ export const ClickHouseData: DialectData = {
     binaryColumn: true,
     // Sorting can slow down queries
     initialSort: true,
-    // TODO (azmi): in progress
-    importFromFile: true,
   },
 }

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -80,22 +80,22 @@ export function runCommonTests(getUtil, opts = {}) {
 
     describe("stream tests", () => {
       beforeAll(async () => {
-        if (getUtil().dbType === 'cockroachdb' || getUtil().dbType === 'clickhouse') return
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().prepareStreamTests()
       })
 
       test("should get all columns", async () => {
-        if (getUtil().dbType === 'cockroachdb' || getUtil().dbType === 'clickhouse') return
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamColumnsTest()
       })
 
       test("should count exact number of rows", async () => {
-        if (getUtil().dbType === 'cockroachdb' || getUtil().dbType === 'clickhouse') return
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamCountTest()
       })
 
       test("should stop/cancel streaming", async () => {
-        if (getUtil().dbType === 'cockroachdb' || getUtil().dbType === 'clickhouse') return
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamStopTest()
       })
 
@@ -105,7 +105,7 @@ export function runCommonTests(getUtil, opts = {}) {
       })
 
       test("should read all rows", async () => {
-        if (getUtil().dbType === 'cockroachdb' || getUtil().dbType === 'clickhouse') return
+        if (getUtil().dbType === 'cockroachdb') return
         await getUtil().streamReadTest()
       })
     })
@@ -233,7 +233,7 @@ export function runCommonTests(getUtil, opts = {}) {
     })
   })
 
-  describe("Import Scripts", () => {
+  describe.only("Import Scripts", () => {
     beforeEach(async() => {
       await prepareImportTable(getUtil())
     })

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -1198,6 +1198,7 @@ export class DBTestUtil {
             batch = [];
           }
           Promise.all(promises).then(() => resolve()).catch(reject);
+          fileStream.close()
         },
         error: (err) => reject(err),
       });

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -1151,6 +1151,16 @@ export class DBTestUtil {
       let batch = []
       const maxBatch = this.dbType === 'firebird' ? 255 : 233
 
+      if (this.dbType === 'clickhouse') {
+        await this.connection.client.insert({
+          table: 'organizations',
+          values: fileStream,
+          format: 'CSVWithNames',
+        })
+        fileStream.close()
+        return resolve()
+      }
+
       const execBatch = async (batch: Record<string, any>[]) => {
         if (this.dbType === 'firebird') {
           const inserts = batch.reduce((str, row) => `${str}INSERT INTO organizations (${Object.keys(row).join(',')}) VALUES (${Object.values(row).map(FirebirdData.wrapLiteral).join(',')});\n`, '')
@@ -1278,7 +1288,7 @@ export class DBTestUtil {
   async importScriptsTests({ tableName, table, formattedData, importScriptOptions, hatColumn }) {
     // cassandra and big query don't allow import so no need to test!
     // oracle doesn't want to find the table, so it doesn't get to have nice things
-    if (['cassandra', 'bigquery', 'oracle', 'clickhouse'].includes(this.dialect)) {
+    if (['cassandra', 'bigquery', 'oracle'].includes(this.dialect)) {
       return expect.anything()
     }
 
@@ -1307,7 +1317,7 @@ export class DBTestUtil {
     // mysql was added to the list because a timeout was required to get the rollback number ot show
     // and that was causing connections to break in the tests which is a bad day ¯\_(ツ)_/¯
     let expectedLength = 0
-    if (['cassandra','bigquery', 'mysql', 'oracle', 'clickhouse'].includes(this.dialect)) {
+    if (['cassandra','bigquery', 'mysql', 'oracle'].includes(this.dialect)) {
       return expect.anything()
     }
 


### PR DESCRIPTION
This PR attempts to support importing data via Import From File in ClickHouse. 

To avoid potential issues or inefficiency that we can't predict when processing large files, like server cost, it'll pass a file directly to a ClickHouse client instead of running multiple of `INSERT INTO ... VALUES ...`. It'll also use [async_insert](https://clickhouse.com/docs/en/optimize/asynchronous-inserts) to make sure that we follow the best practice.

But, this PR only do that on CSV files. Other formats like JSON/JSONL/XLSX will use the default processing pipeline.

TODO:
- [ ] import json/jsonl/xlsx by using the default importer