### PR TITLE
Feature: Support manual commit mode for Postgres

### DIFF
--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -164,6 +164,9 @@ x-buttons {
     border-radius: 0;
   }
 }
+x-buttons > x-button.btn-rounded {
+  border-radius: 6px !important;
+}
 .btn-block {
   display: flex;
   justify-content: center;

--- a/apps/studio/src/handlers/queryHandlers.ts
+++ b/apps/studio/src/handlers/queryHandlers.ts
@@ -4,11 +4,14 @@ import { checkConnection, errorMessages, state } from "./handlerState";
 
 export interface IQueryHandlers {
   'query/execute': ({ queryId, sId }: { queryId: string, sId: string }) => Promise<QueryResult>,
-  'query/cancel': ({ queryId, sId }: { queryId: string, sId: string }) => Promise<void>
+  'query/cancel': ({ queryId, sId }: { queryId: string, sId: string }) => Promise<void>,
+  'query/commit': ({ queryId, sId }: { queryId: string, sId: string }) => Promise<void>,
+  'query/rollback': ({ queryId, sId }: { queryId: string, sId: string }) => Promise<void>
 }
 
 export const QueryHandlers: IQueryHandlers = {
-  'query/execute': async function({ queryId, sId }: { queryId: string, sId: string }) { 
+  'query/execute': async function({ queryId, sId, isManualCommit }: { queryId: string, sId: string, isManualCommit: boolean }) { 
+    console.debug('QueryHandlers execute isManualCommit', isManualCommit)
     checkConnection(sId);
     const query = state(sId).queries.get(queryId);
     if (!query) {
@@ -16,8 +19,10 @@ export const QueryHandlers: IQueryHandlers = {
     }
 
     const result = await query.execute();
-    // not totally sure on this
-    state(sId).queries.delete(queryId);
+    if (!isManualCommit) {
+      // not totally sure on this
+      state(sId).queries.delete(queryId);
+    }
     return result;
   },
   'query/cancel': async function({ queryId, sId }: { queryId: string, sId: string }) {
@@ -28,6 +33,25 @@ export const QueryHandlers: IQueryHandlers = {
     }
 
     await query.cancel();
+    state(sId).queries.delete(queryId);
+  },
+  'query/commit': async function({ queryId, sId }: { queryId: string, sId: string }) {
+    checkConnection(sId);
+    const query = state(sId).queries.get(queryId);
+    if (!query) {
+      throw new Error(errorMessages.noQuery);
+    }
+
+    await query.commit();
+    state(sId).queries.delete(queryId);
+  },
+  'query/rollback': async function({ queryId, sId }: { queryId: string, sId: string }) {
+    checkConnection(sId);
+    const query = state(sId).queries.get(queryId);
+    if (!query) {
+      throw new Error(errorMessages.noQuery);
+    }
+    await query.rollback();
     state(sId).queries.delete(queryId);
   }
 }

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -535,6 +535,7 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult>
     // force rawExecuteQuery to return an array
     options['multiple'] = true;
     options['statements'] = statements
+    log.debug('driverExecuteMultiple options', options)
     try {
       const result = await this.rawExecuteQuery(q, options) as RawResultType[]
       return result

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -262,6 +262,8 @@ export type QueryResult = NgQueryResult[];
 export interface CancelableQuery {
   execute: () => Promise<QueryResult>;
   cancel: () => Promise<void>;
+  commit?: () => Promise<void>;
+  rollback?: () => Promise<void>;
 }
 
 // Backups

--- a/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
+++ b/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
@@ -86,10 +86,17 @@ export class ElectronUtilityConnectionClient implements IBasicDatabaseClient {
     const id = await Vue.prototype.$util.send('conn/query', { queryText, options });
     return {
       execute: async () => {
-        return await Vue.prototype.$util.send('query/execute', { queryId: id })
+        console.debug('ElectronUtilityConnectionClient query execute', options)
+        return await Vue.prototype.$util.send('query/execute', { queryId: id, isManualCommit: options?.isManualCommit })
       },
       cancel: async () => {
         return await Vue.prototype.$util.send('query/cancel', { queryId: id })
+      },
+      commit: async () => {
+        return await Vue.prototype.$util.send('query/commit', { queryId: id, isManualCommit: options?.isManualCommit })
+      },
+      rollback: async () => {
+        return await Vue.prototype.$util.send('query/rollback', { queryId: id, isManualCommit: options?.isManualCommit })
       }
     }
   }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ volumes:
 services:
 
   oracle18:
+    platform: linux/x86_64
     image: gvenzl/oracle-xe:18
     environment:
       ORACLE_PASSWORD: example
@@ -30,29 +31,33 @@ services:
       - 1521:1521
 
   psql15:
+    platform: linux/x86_64
     image: postgres:15
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
       POSTGRES_DB: saklia
     volumes:
-      - psql13:/var/lib/postgresql/data
+      - psql13:/var/lib/postgresql/data/pgdata
       - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
     ports:
       - 5434:5432
 
   psql13:
+    platform: linux/x86_64
     image: postgres:13
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
       POSTGRES_DB: saklia
+      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - psql13:/var/lib/postgresql/data
       - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
     ports:
       - 5433:5432
   psql:
+    platform: linux/x86_64
     image: postgres:9.6
     environment:
       POSTGRES_USER: postgres
@@ -64,6 +69,7 @@ services:
     ports:
       - 5432:5432
   mariadb:
+    platform: linux/x86_64
     image: mariadb
     restart: always
     environment:
@@ -75,6 +81,7 @@ services:
       - mariadb:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql8:
+    platform: linux/x86_64
     image: mysql:8.0.21
     command: --default-authentication-plugin=mysql_native_password
     restart: always
@@ -87,6 +94,7 @@ services:
       - mysql8:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql:
+    platform: linux/x86_64
     image: mysql:5.7.22
     command: --default-authentication-plugin=mysql_native_password
     restart: always
@@ -99,11 +107,13 @@ services:
       - mysql:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql4.1:
+    platform: linux/x86_64
     image: vettadock/mysql-old:4.1
     restart: always
     ports:
       - 3309:3306
   sqlserver:
+    platform: linux/x86_64
     image: "mcr.microsoft.com/mssql/server:2017-latest-ubuntu"
     volumes:
       - mssql:/var/opt/mssql/data
@@ -117,6 +127,7 @@ services:
       - 1433:1433
     command: sh -c ' chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /opt/mssql/bin/sqlservr;'
   sqlserverlatin:
+    platform: linux/x86_64
     image: 'mcr.microsoft.com/mssql/server:2017-latest-ubuntu'
     volumes:
     - mssqllatin:/var/opt/mssql/data
@@ -130,6 +141,7 @@ services:
       - 1434:1433
     command: sh -c ' chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /opt/mssql/bin/sqlservr;'
   cockroachdb:
+    platform: linux/x86_64
     image: cockroachdb/cockroach:v22.1.1
     volumes:
       - cockroachdb:/cockroach/cockroach-data
@@ -137,6 +149,7 @@ services:
       - 26257:26257
     command: start-single-node --insecure
   cassandra:
+    platform: linux/x86_64
     image: cassandra:latest
     entrypoint: ["/docker-entrypoint.initdb.d/entry.sh"]
     ports:
@@ -149,6 +162,7 @@ services:
 # https://www.folkstalk.com/2022/09/get-all-keyspaces-in-cassandra-with-code-examples.html
 # Create keyspace https://www.tutorialspoint.com/cassandra/cassandra_create_keyspace.htm
   bigquery:
+    platform: linux/x86_64
     image: ghcr.io/goccy/bigquery-emulator:latest
     volumes:
       - ./dev/docker_bigquery:/data
@@ -158,6 +172,7 @@ services:
       - 9060:9060
     entrypoint: sh -c 'chmod +x /docker_init/data.sh; /docker_init/data.sh'
   firebird:
+    platform: linux/x86_64
     image: jacobalberty/firebird:v4.0.1
     volumes:
       - ./dev/docker_firebird:/docker_init
@@ -169,7 +184,7 @@ services:
     command: sh -c 'chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /usr/local/firebird/docker-entrypoint.sh firebird;'
   libsql:
     image: ghcr.io/tursodatabase/libsql-server:latest
-    platform: linux/amd64
+    platform: linux/x86_64
     ports:
       - 8081:8080
       - 5001:5001
@@ -179,6 +194,7 @@ services:
     #   - ./dev/docker_libsql:/var/lib/sqld
   clickhouse:
     image: clickhouse/clickhouse-server
+    platform: linux/x86_64
     ports:
       - 8123:8123
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ volumes:
 services:
 
   oracle18:
-    platform: linux/x86_64
     image: gvenzl/oracle-xe:18
     environment:
       ORACLE_PASSWORD: example
@@ -31,33 +30,29 @@ services:
       - 1521:1521
 
   psql15:
-    platform: linux/x86_64
     image: postgres:15
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
       POSTGRES_DB: saklia
     volumes:
-      - psql13:/var/lib/postgresql/data/pgdata
+      - psql13:/var/lib/postgresql/data
       - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
     ports:
       - 5434:5432
 
   psql13:
-    platform: linux/x86_64
     image: postgres:13
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: example
       POSTGRES_DB: saklia
-      PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - psql13:/var/lib/postgresql/data
       - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
     ports:
       - 5433:5432
   psql:
-    platform: linux/x86_64
     image: postgres:9.6
     environment:
       POSTGRES_USER: postgres
@@ -69,7 +64,6 @@ services:
     ports:
       - 5432:5432
   mariadb:
-    platform: linux/x86_64
     image: mariadb
     restart: always
     environment:
@@ -81,7 +75,6 @@ services:
       - mariadb:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql8:
-    platform: linux/x86_64
     image: mysql:8.0.21
     command: --default-authentication-plugin=mysql_native_password
     restart: always
@@ -94,7 +87,6 @@ services:
       - mysql8:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql:
-    platform: linux/x86_64
     image: mysql:5.7.22
     command: --default-authentication-plugin=mysql_native_password
     restart: always
@@ -107,13 +99,11 @@ services:
       - mysql:/var/lib/mysql
       - ./dev/docker_mysql_init:/docker-entrypoint-initdb.d
   mysql4.1:
-    platform: linux/x86_64
     image: vettadock/mysql-old:4.1
     restart: always
     ports:
       - 3309:3306
   sqlserver:
-    platform: linux/x86_64
     image: "mcr.microsoft.com/mssql/server:2017-latest-ubuntu"
     volumes:
       - mssql:/var/opt/mssql/data
@@ -127,7 +117,6 @@ services:
       - 1433:1433
     command: sh -c ' chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /opt/mssql/bin/sqlservr;'
   sqlserverlatin:
-    platform: linux/x86_64
     image: 'mcr.microsoft.com/mssql/server:2017-latest-ubuntu'
     volumes:
     - mssqllatin:/var/opt/mssql/data
@@ -141,7 +130,6 @@ services:
       - 1434:1433
     command: sh -c ' chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /opt/mssql/bin/sqlservr;'
   cockroachdb:
-    platform: linux/x86_64
     image: cockroachdb/cockroach:v22.1.1
     volumes:
       - cockroachdb:/cockroach/cockroach-data
@@ -149,7 +137,6 @@ services:
       - 26257:26257
     command: start-single-node --insecure
   cassandra:
-    platform: linux/x86_64
     image: cassandra:latest
     entrypoint: ["/docker-entrypoint.initdb.d/entry.sh"]
     ports:
@@ -162,7 +149,6 @@ services:
 # https://www.folkstalk.com/2022/09/get-all-keyspaces-in-cassandra-with-code-examples.html
 # Create keyspace https://www.tutorialspoint.com/cassandra/cassandra_create_keyspace.htm
   bigquery:
-    platform: linux/x86_64
     image: ghcr.io/goccy/bigquery-emulator:latest
     volumes:
       - ./dev/docker_bigquery:/data
@@ -172,7 +158,6 @@ services:
       - 9060:9060
     entrypoint: sh -c 'chmod +x /docker_init/data.sh; /docker_init/data.sh'
   firebird:
-    platform: linux/x86_64
     image: jacobalberty/firebird:v4.0.1
     volumes:
       - ./dev/docker_firebird:/docker_init
@@ -184,7 +169,7 @@ services:
     command: sh -c 'chmod +x /docker_init/entrypoint.sh; /docker_init/entrypoint.sh & /usr/local/firebird/docker-entrypoint.sh firebird;'
   libsql:
     image: ghcr.io/tursodatabase/libsql-server:latest
-    platform: linux/x86_64
+    platform: linux/amd64
     ports:
       - 8081:8080
       - 5001:5001
@@ -194,7 +179,6 @@ services:
     #   - ./dev/docker_libsql:/var/lib/sqld
   clickhouse:
     image: clickhouse/clickhouse-server
-    platform: linux/x86_64
     ports:
       - 8123:8123
     environment:


### PR DESCRIPTION
### Issue
- resolve #1036 
- Added toggle to change commit mode (Auto/Manual)
- Two options are available in Manual commit mode (Rollback/Commit)
  - Rollback and Commit are only enabled when manual query is running
- Added shortcut
- If error happened, executed query in manual mode is rollbacked
- If the user changes commit mode to auto before manual query run is committed, executed query in manual mode is rollbacked

### Demo
[Run in manual mode - Rollback]

https://github.com/user-attachments/assets/b0074e54-b4fa-46d2-b57c-7135eddbe8e3

[Run in manual mode - Commit]


https://github.com/user-attachments/assets/e9e9389d-1777-4beb-ab85-dc46258e2143

[Run selected query in manual mode - Commit]

https://github.com/user-attachments/assets/b3b881be-76fc-4faa-b561-f8375a2163e3


