### PR TITLE
fix prevented change in text editor

### DIFF
--- a/apps/studio/src/components/common/texteditor/TextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/TextEditor.vue
@@ -77,7 +77,6 @@ export default {
       bookmarkInstances: [],
       markInstances: [],
       wasEditorFocused: false,
-      valueChangeByCodeMirror: false,
     };
   },
   computed: {
@@ -109,12 +108,9 @@ export default {
   },
   watch: {
     valueAndStatus() {
-      if (this.valueChangeByCodeMirror || this.editor?.getValue() === this.value) {
-        this.valueChangeByCodeMirror = false;
-        return
-      }
       const { value, status } = this.valueAndStatus;
       if (!status || !this.editor) return;
+      if (this.editor.getValue() === value) return; // Only setValue when necessary, as it can reset the cursor position, cause infinite loops, and whatnot.
       this.foundRootFold = false;
       const scrollInfo = this.editor.getScrollInfo();
       this.editor.setValue(value);
@@ -282,8 +278,6 @@ export default {
       }
 
       cm.on("change", async (cm) => {
-        this.valueChangeByCodeMirror = true;
-        await this.$nextTick()
         this.$emit("input", cm.getValue());
       });
 


### PR DESCRIPTION
This is an attempt to fix the Json View Sidebar content that doesn't change when it should by fixing the two-way binding logic in general. I searched through similar cases (in React & Vue) and found that most of the fix to handling the two-way binding is by just comparing the text value.  Idk why I didn't come up with researching like this in the beginning. 😞

fix #2639  