### PR TITLE
fix: final screen of import process was off center. Recenter it

### DIFF
--- a/apps/studio/src/assets/styles/app/tabs/import-table.scss
+++ b/apps/studio/src/assets/styles/app/tabs/import-table.scss
@@ -16,6 +16,9 @@
     padding: 0;
     margin: 0;
     overflow: unset;
+    &.import-progress{
+      margin: 2rem auto 0 auto;
+    }
   }
 
   .stepper-box {


### PR DESCRIPTION
resolves #2658 
Before:
![image](https://github.com/user-attachments/assets/5371ab28-36c6-4e02-bc8a-1115b07337a1)

Now:
![image](https://github.com/user-attachments/assets/70d4aeb5-5e4a-412a-b060-1146b0ff7a3b)
