### PR TITLE
Add missing lodash import

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -16,6 +16,8 @@ import { errors } from "@/lib/errors";
 import { dataTypesToMatchTypeCode, CassandraData as D } from "@shared/lib/dialects/cassandra";
 import { CassandraCursor } from "./cassandra/CassandraCursor";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
+import _ from "lodash";
+
 const log = rawLog.scope("cassandra");
 const logger = () => log;
 


### PR DESCRIPTION
There is a missing "lodash" import in Cassandra client which cause this error when click a table to view:

![resim](https://github.com/user-attachments/assets/dc2c5690-431b-40fe-af55-793fcc55653a)

You can see the error message as `_ is not defined` below.

After I added the missing import, it works well:
![resim](https://github.com/user-attachments/assets/bb283cb3-23d4-4dfe-994b-a5a866f57e5d)
