### PR TITLE
Cassandra convert rows results to make more user friendly and editable

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -443,7 +443,7 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     const fields = columns ? this.parseQueryResultColumns(result) : []
 
     return {
-      result: rows || [],
+      result: this.parseRows(rows, columns) || [],
       fields,
       hasNext,
       pageState: pageState || null
@@ -600,7 +600,7 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
 
     return {
       command: command || (isSelect && 'SELECT'),
-      rows: rows || [],
+      rows: this.parseRows(rows, columns)  || [],
       fields: fields,
       // FIXME not sure what this is, this causes the query to fail. .isPaged() is not defined.
       // isPaged: data.isPaged(),
@@ -652,18 +652,15 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     })
   }
 
-  private getParamsAndWhereList(primaryKeys, initialValue = null) {
-    const params = initialValue ? [initialValue] : [];
+  private getParamsAndWhereList(primaryKeys, initialValue = undefined) {
+    const params = initialValue !== undefined ? [initialValue] : [];
     const whereList = [];
     primaryKeys.forEach(({ column, value }) => {
       whereList.push(`${this.wrapIdentifier(column)} = ?`);
       params.push(value);
     });
 
-    return [
-      params,
-      whereList
-    ];
+    return [params, whereList];
   }
 
   private async getSelectUpdatedValues(updates): Promise<Array<any>> {
@@ -789,5 +786,45 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
       name: column.column_name,
       bksType: column.type.includes('blob') ? 'BINARY' : 'UNKNOWN',
     };
+  }
+
+  private parseRows(rows, columns) {
+    if (!rows || !columns) return [];
+
+    const typeByColumn = columns?.reduce((acc, col) => {
+      acc[col.name] = col.type.code;
+      return acc;
+    }, {});
+
+    return rows?.map((row) => {
+      Object.keys(row).forEach((key) => {
+        const value = row[key];
+        if (value == null || value === undefined) {
+          return;
+        }
+
+        const type = typeByColumn[key];
+        if (type === cassandra.types.dataTypes.bigint) {
+          row[key] = String(value);
+        } else if (type === cassandra.types.dataTypes.timestamp) {
+          row[key] = value ? value.toISOString() : null;
+        } else if (
+          type === cassandra.types.dataTypes.time ||
+          type === cassandra.types.dataTypes.date
+        ) {
+          row[key] = value ? String(value) : null;
+        } else if (
+          type === cassandra.types.dataTypes.uuid ||
+          type === cassandra.types.dataTypes.timeuuid
+        ) {
+          row[key] = value?.buffer
+            ? new cassandra.types.Uuid(Buffer.from(value.buffer)).toString()
+            : null;
+        } else if (type === cassandra.types.dataTypes.inet) {
+          row[key] = value ? value.toString() : null;
+        }
+      });
+      return row;
+    });
   }
 }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -674,7 +674,7 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     const selectPromises: any = await Promise.all(updatePromises);
 
     return selectPromises.reduce((acc: Array<any>, sp: any) => {
-      const [data] = sp.data;
+      const [data] = sp.rows;
       if (data) acc.push(data);
 
       return acc;


### PR DESCRIPTION
In Cassandra table results, some data types showing like object(`{
    "low": 12345,
    "high": 0,
    "unsigned": false
  }` for bigint)

![resim](https://github.com/user-attachments/assets/bb9a430c-6c6a-4df7-a8b4-e1ea35b0d4c5)

and they can not be edited/deleted etc:
![resim](https://github.com/user-attachments/assets/b85a9dfa-5c05-4635-8093-b8e35f12d94f)

So, I implemented a new function to convert those types to string. Then `cassandra-client` can encode those types now while they are string.
![resim](https://github.com/user-attachments/assets/56f63720-9c41-4653-8422-4e46851316f4)


Also I fixed some bugs:
- https://github.com/beekeeper-studio/beekeeper-studio/pull/2674/files#diff-a45e1f3fbf96f71be3513018c26d74ecd3e5aa6002d7bf74f16838a176d30830R655-R656, in this function when `initicalValue` is `null` then it does not add to params, so when I try to some column value as `NULL`, it does not work.
- https://github.com/beekeeper-studio/beekeeper-studio/pull/2674/files#diff-a45e1f3fbf96f71be3513018c26d74ecd3e5aa6002d7bf74f16838a176d30830R677 in this code, `sp.data` is undefined, it should be `sp.rows`