### PR TITLE
fix add beekeeper's database

### DIFF
--- a/apps/studio/src/lib/events/AppEventHandler.js
+++ b/apps/studio/src/lib/events/AppEventHandler.js
@@ -41,7 +41,7 @@ export default class {
   }
 
   async addBeekeeper() {
-    const existing = await this.vueApp.$util.send('appdb/saved/findOne', { options: {where: { defaultDatabase: platformInfo.appDbPath }}});
+    const existing = await this.vueApp.$util.send('appdb/saved/findOne', { options: { defaultDatabase: platformInfo.appDbPath }});
     if (!existing) {
       const nu = {};
       nu.connectionType = 'sqlite'


### PR DESCRIPTION
fix #2656 

The query options passed to the `findOne` handler were incorrectly formatted, which resulted in the handler failing