### PR TITLE
fix folded codes reset after changing value

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -60,6 +60,7 @@
     "indent-string": "^4.0.0",
     "javascript-time-ago": "^2.0.8",
     "jquery": "^3.5.0",
+    "jsonc-parser": "^3.3.1",
     "knex": "^2.4.1",
     "knex-firebird-dialect": "1.4.6",
     "libsql": "^0.4.6",

--- a/apps/studio/src/components/sidebar/DetailViewSidebar.vue
+++ b/apps/studio/src/components/sidebar/DetailViewSidebar.vue
@@ -62,6 +62,7 @@
       :mode="mode"
       :force-initizalize="reinitializeTextEditor + (reinitialize ?? 0)"
       :markers="markers"
+      :plugins="textEditorPlugins"
     />
     <div class="empty-state" v-show="empty">
       No Data
@@ -90,6 +91,7 @@ import {
 } from "@/lib/data/detail_view";
 import { mapGetters } from "vuex";
 import { EditorMarker } from "@/lib/editor/utils";
+import { persistJsonFold } from "@/lib/editor/plugins/persistJsonFold";
 import DetailViewSidebarUpsell from '@/components/upsell/DetailViewSidebarUpsell.vue'
 import rawLog from "electron-log";
 import _ from "lodash";
@@ -275,6 +277,9 @@ export default Vue.extend({
         },
 
       ]
+    },
+    textEditorPlugins() {
+      return [persistJsonFold]
     },
     ...mapGetters(["expandFKDetailsByDefault"]),
   },

--- a/apps/studio/src/lib/data/detail_view.ts
+++ b/apps/studio/src/lib/data/detail_view.ts
@@ -12,7 +12,7 @@ export interface ExpandablePath {
  *
  * We expect the string to be a result of `JSON.stringify(obj, null, 2)`
  **/
-export function findKeyPosition(jsonStr: string, path: string[]) {
+export function findKeyPosition(jsonStr: string, path: (string | number)[]) {
   let lines = jsonStr.split("\n");
   let lineSearchOffset = 0;
 

--- a/apps/studio/src/lib/editor/plugins/persistJsonFold.ts
+++ b/apps/studio/src/lib/editor/plugins/persistJsonFold.ts
@@ -1,0 +1,60 @@
+import { findKeyPosition } from "@/lib/data/detail_view";
+import { getLocation, JSONPath } from "jsonc-parser";
+import CodeMirror from "codemirror";
+
+type EditorInstance = CodeMirror.Editor & {
+  bksPersistJsonFold: {
+    foldedPaths: JSONPath[];
+  };
+};
+
+export function registerPersistJsonFold(instance: EditorInstance) {
+  if (!instance.getOption("foldGutter")) {
+    throw new Error("PersistJsonFold requires foldGutter to be enabled.");
+  }
+  instance.bksPersistJsonFold = { foldedPaths: [] };
+  instance.on("beforeChange", beforeChangeHandle);
+  instance.on("change", handleChange);
+  return () => {
+    delete instance.bksPersistJsonFold;
+    instance.off("beforeChange", beforeChangeHandle);
+    instance.off("change", handleChange);
+  };
+}
+
+export const persistJsonFold = registerPersistJsonFold;
+
+function beforeChangeHandle(instance: EditorInstance) {
+  const value = instance.getValue();
+  const foldedPaths = [];
+  let cursor = 0;
+  instance.eachLine((line) => {
+    const offset = line.text.length - line.text.trimStart().length;
+    const location = getLocation(value, cursor + offset);
+
+    cursor += line.text.length + 1;
+
+    const options = instance.state.foldGutter.options;
+    // @ts-expect-error not fully typed
+    const foldGutterMarker = line.gutterMarkers?.[options.gutter];
+
+    if (!foldGutterMarker) {
+      return;
+    }
+
+    const folded = foldGutterMarker.classList.contains(options.indicatorFolded);
+    if (folded) {
+      foldedPaths.push(location.path);
+    }
+  });
+  instance.bksPersistJsonFold.foldedPaths = foldedPaths;
+}
+
+function handleChange(instance: EditorInstance) {
+  const value = instance.getValue();
+  instance.bksPersistJsonFold.foldedPaths.forEach((path: JSONPath) => {
+    const line = findKeyPosition(value, path);
+    // @ts-expect-error not fully typed
+    instance.foldCode(line);
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5183,11 +5183,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buildcheck@~0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
-  integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
-
 builder-util-runtime@9.2.10:
   version "9.2.10"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz#a0f7d9e214158402e78b74a745c8d9f870c604bc"
@@ -5719,13 +5714,8 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cpu-features@~0.0.4, cpu-features@~0.0.8:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.10.tgz#9aae536db2710c7254d7ed67cb3cbc7d29ad79c5"
-  integrity sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==
-  dependencies:
-    buildcheck "~0.0.6"
-    nan "^2.19.0"
+"cpu-features@file:./.yarn/packages/empty-package", cpu-features@~0.0.4, cpu-features@~0.0.8:
+  version "1.0.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -8287,6 +8277,11 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonc-parser@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -9073,11 +9068,6 @@ nan@^2.16.0, nan@^2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
-
-nan@^2.19.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
-  integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
 
 nanoid@^3.3.7:
   version "3.3.7"


### PR DESCRIPTION
fix #2684

Expanding a foreign key would trigger `setValue()` and thus it resets the fold gutters. Since CodeMirror doesn't handle fold gutter states, we have to make the states on our own and handle them manually.