### PR TITLE
fix opening sqlite db as read-only

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -190,10 +190,10 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
   async listTableIndexes(table: string, _schema?: string): Promise<TableIndex[]> {
     const sql = `PRAGMA index_list('${SD.escapeString(table)}')`;
 
-    const { rows } = await this.driverExecuteSingle(sql);
+    const { rows } = await this.driverExecuteSingle(sql, { overrideReadonly: true });
 
     const allSQL = rows.map((row) => `PRAGMA index_xinfo('${SD.escapeString(row.name)}')`).join(";");
-    const infos = await this.driverExecuteMultiple(allSQL);
+    const infos = await this.driverExecuteMultiple(allSQL, { overrideReadonly: true });
 
     const indexColumns: IndexColumn[][] = infos.map((result) => {
       return result.rows.filter((r) => !!r.name).map((r) => ({ name: r.name, order: r.desc ? 'DESC' : 'ASC' }))
@@ -220,7 +220,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
 
   async getTableKeys(table: string, _schema?: string): Promise<TableKey[]> {
     const sql = `pragma foreign_key_list('${SD.escapeString(table)}')`
-    const { rows } = await this.driverExecuteSingle(sql);
+    const { rows } = await this.driverExecuteSingle(sql, { overrideReadonly: true });
     return rows.map(row => ({
       constraintName: row.id,
       constraintType: 'FOREIGN',
@@ -307,7 +307,7 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
   }
 
   async listDatabases(_filter?: DatabaseFilterOptions): Promise<string[]> {
-    const result = await this.driverExecuteSingle('PRAGMA database_list;');
+    const result = await this.driverExecuteSingle('PRAGMA database_list;', { overrideReadonly: true });
 
     return result.rows.map((row) => row.file || ':memory:');
   }


### PR DESCRIPTION
PR fixes opening a sqlite db as read-only, where previously several of the schema fetch functions would throw an error on running queries that were not considered read-only, as the `PRAGMA` statements are identified as `UNKNOWN`. 