### PR TITLE
fix showing unique indexes for mysql

### DIFF
--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -423,7 +423,7 @@ export class MysqlClient extends BasicDatabaseClient<ResultType> {
         schema: "",
         name: row.Key_name as string,
         columns,
-        unique: row.Non_unique === "0",
+        unique: row.Non_unique === "0" || row.Non_unique === 0,
         primary: row.Key_name === "PRIMARY",
       };
     });


### PR DESCRIPTION
Closes #1908 

PR fixes a bug in the mysql adapter where it was not properly showing an index as unique or not when viewing a table structure. The issue was that the `Non_unique` value from `SHOW INDEX` was being compared against the string `"0"` whereas it's being returned as a number. Not sure if it was originally comparing against a string as some old version of `mysql2` would return everything as a string, or if MariaDB or TiDB returns it as a string. As such, I elected to leave the string comparison in place to prevent any potential unforeseen regressions.


Here's the SQL I used to repro the bug:

```sql
CREATE TABLE SampleTable (
    id INT AUTO_INCREMENT PRIMARY KEY,
    username VARCHAR(50) NOT NULL,
    email VARCHAR(100) NOT NULL,
    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
    status ENUM('active', 'inactive', 'pending') DEFAULT 'active',
    age INT,
    score DECIMAL(5, 2),
    profile BLOB,
    comments TEXT
);

-- Adding indexes

-- Unique indexes
CREATE UNIQUE INDEX idx_username ON SampleTable(username);
CREATE UNIQUE INDEX idx_email ON SampleTable(email);

-- Non-unique indexes
CREATE INDEX idx_status ON SampleTable(status);
CREATE INDEX idx_created_at ON SampleTable(created_at);
CREATE INDEX idx_age_score ON SampleTable(age, score);
```