### PR TITLE
fix text editor race condition

### DIFF
--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -50,7 +50,8 @@ export enum AppEvent {
   /** Triggered when the license support date has expired */
   licenseSupportDateExpired = 'licenseSupportDateExpired',
   switchLicenseState = 'switchLicenseState',
-  toggleBeta = 'toggleBeta'
+  toggleBeta = 'toggleBeta',
+  switchUserKeymap = 'switchUserKeymap',
 }
 
 export interface RootBinding {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -387,6 +387,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
         { event: AppEvent.backupDatabase, handler: this.backupDatabase },
         { event: AppEvent.beginImport, handler: this.beginImport },
         { event: AppEvent.restoreDatabase, handler: this.restoreDatabase },
+        { event: AppEvent.switchUserKeymap, handler: this.switchUserKeymap },
       ]
     },
     lastTab() {
@@ -862,6 +863,9 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
       const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema);
       const stringResult = safeFormat(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
       this.createQuery(stringResult);
+    },
+    switchUserKeymap(value) {
+      this.$store.dispatch('settings/save', { key: 'keymap', value: value });
     },
     openTableBuilder() {
       const tab = {} as TransportOpenTab;

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -389,26 +389,12 @@
       ...mapGetters(['dialect', 'dialectData', 'defaultSchema']),
       ...mapGetters({
         'isCommunity': 'licenses/isCommunity',
+        'userKeymap': 'settings/userKeymap',
       }),
       ...mapState(['usedConfig', 'connectionType', 'database', 'tables', 'storeInitialized', 'connection']),
       ...mapState('data/queries', {'savedQueries': 'items'}),
       ...mapState('settings', ['settings']),
       ...mapState('tabs', { 'activeTab': 'active' }),
-      userKeymap: {
-        get() {
-          const value = this.settings?.keymap?.value;
-          return value && this.keymapTypes.map(k => k.value).includes(value) ? value : 'default';
-        },
-        set(value) {
-          if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
-          this.$store.dispatch('settings/save', { key: 'keymap', value: value }).then(() => {
-            this.initialize();
-          });
-        }
-      },
-      keymapTypes() {
-        return this.$config.defaults.keymapTypes
-      },
       shouldInitialize() {
         return this.storeInitialized && this.active && !this.initialized
       },

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -154,6 +154,7 @@
 import humanizeDuration from 'humanize-duration'
 import Statusbar from '../common/StatusBar.vue'
 import { mapState, mapGetters } from 'vuex';
+import { AppEvent } from '@/common/AppEvent'
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
   language: "shortEn",
@@ -211,7 +212,7 @@ export default {
       },
       set(value) {
         if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
-        this.$store.dispatch('settings/save', { key: 'keymap', value: value });
+        this.trigger(AppEvent.switchUserKeymap, value)
       }
     },
     keymapTypes() {

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -21,10 +21,11 @@ export const ConnectionTypes = [
   { name: 'ClickHouse', value: 'clickhouse' },
 ]
 
+/** `value` should be recognized by codemirror */
 export const keymapTypes = [
   { name: "Default", value: "default" },
   { name: "Vim", value: "vim" }
-]
+] as const
 
 export const TableFilterSymbols = [
   { value: '=', label: 'equals' },

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -3,6 +3,7 @@ import { IGroupedUserSettings, TransportUserSetting, UserSettingValueType, setVa
 import _ from 'lodash'
 import Vue from 'vue'
 import { Module } from 'vuex'
+import config from "@/config";
 
 
 interface State {
@@ -67,6 +68,13 @@ const SettingStoreModule: Module<State, any> = {
         return theme
       }
       return rootGetters.isUltimate ? theme : 'system';
+    },
+    /** The keymap type to be used in text editor */
+    userKeymap(state) {
+      const value = state.settings.keymap?.value as string;
+      return value && config.defaults.keymapTypes.map((k) => k.value).includes(value)
+        ? value
+        : "default";
     },
     sortOrder(state) {
       if (!state.settings.sortOrder) return 'id'


### PR DESCRIPTION
Sometimes, the text editor in json view can generate multiple CodeMirror instances as shown in the image below:

![image](https://github.com/user-attachments/assets/0c11abfe-5412-4e8d-846a-00663ba38765)

Day and I investigated this and it turned out that the `initialize()` method gets called multiple times by the watchers. So watchers are removed, and replaced by event.

`vimConfig` is not watched anymore, so if we need to update the text editor after changing `vimConfig`, we should reinitialize the text editor manually by `forceInitialize` prop.

P.S. We've tried debouncing the `initialize()` methods but that causes other issue in TabQueryEditor that somehow the CodeMirror instance doesn't show in the DOM.