### PR TITLE
add support for ed25519 for mysql/mariadb

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -33,6 +33,7 @@
     "@cleverbrush/async": "^1.1.10",
     "@cleverbrush/deep": "^1.1.10",
     "@clickhouse/client": "^1.8.1",
+    "@coresql/mysql2-auth-ed25519": "^1.0.0",
     "@electron/remote": "^2.0.10",
     "@google-cloud/bigquery": "^6.2.0",
     "@libsql/knex-libsql": "^0.1.0",

--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -8,6 +8,7 @@ import {
 } from "./BasicDatabaseClient";
 import mysql, { Connection } from "mysql2";
 import rawLog from "@bksLogger";
+import ed25519AuthPlugin from "@coresql/mysql2-auth-ed25519";
 import knexlib from "knex";
 import { readFileSync } from "fs";
 import _ from "lodash";
@@ -133,6 +134,9 @@ async function configDatabase(
 ): Promise<mysql.PoolOptions> {
 
   const config: mysql.PoolOptions = {
+    authPlugins: {
+      'client_ed25519': ed25519AuthPlugin(),
+    },
     host: server.config.host,
     port: server.config.port,
     user: server.config.user,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,6 +2324,11 @@
   dependencies:
     "@clickhouse/client-common" "1.8.1"
 
+"@coresql/mysql2-auth-ed25519@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@coresql/mysql2-auth-ed25519/-/mysql2-auth-ed25519-1.0.0.tgz#692c8a9cbf2a1d2850c9bb9c6d1c736af9ab7b79"
+  integrity sha512-pqH/XGycnw5QrVf/SmU2vhsGp6B4E898/4IjACQ2ENA7wZpiN4sQjNXA6C+mjW5xJuH3ss7NCSab2NX7s2DkNg==
+
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"


### PR DESCRIPTION
Closes #621

PR adds support for authenticating to databases that use `ed25519` auth for password (e.g. mariadb).