### PR TITLE
fix show create sql for redshift tables

### DIFF
--- a/apps/studio/src/lib/db/clients/redshift.ts
+++ b/apps/studio/src/lib/db/clients/redshift.ts
@@ -6,7 +6,6 @@ import { FilterOptions, PrimaryKeyColumn, SupportedFeatures, TableOrView, TableP
 import { PostgresClient, STQOptions } from "./postgresql";
 import { escapeString } from "./utils";
 import pg from 'pg';
-import { defaultCreateScript } from "./postgresql/scripts";
 import { TableKey } from "@shared/lib/dialects/models";
 import { IDbConnectionServer } from "../backendTypes";
 import _ from "lodash";
@@ -179,14 +178,9 @@ export class RedshiftClient extends PostgresClient {
     }));
   }
   async getTableCreateScript(table: string, schema: string = this._defaultSchema): Promise<string> {
-    const params = [
-      table,
-      schema,
-    ];
+    const data = await this.driverExecuteSingle(`show table ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(table)}`);
 
-    const data = await this.driverExecuteSingle(defaultCreateScript, { params });
-
-    return data.rows.map((row) => row.createtable)[0];
+    return data.rows.map((row) => row[data.columns[0].name])[0];
   }
 
   async createDatabase(databaseName: string, charset: string, _collation: string): Promise<void> {


### PR DESCRIPTION
Closes #1316 

PR fixes doing the "SQL: Create" context menu item for redshift tables. The bug arises from the fact that the function utilizes stuff added to postgres after redshift was forked (e.g. `array_agg`). While it's probably possible to rewrite the query to not do this, I think easier to just use the [`SHOW TABLE`](https://docs.aws.amazon.com/redshift/latest/dg/r_SHOW_TABLE.html) function Redshift provides which shows the table definition.