### PR TITLE
fix vue devtools

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -193,7 +193,7 @@ app.on('browser-window-created', (_event: electron.Event, window: electron.Brows
 app.on('ready', async () => {
   if (isDevelopment && !process.env.IS_TEST) {
 
-      installExtension(VUEJS_DEVTOOLS)
+      installExtension('iaajmlceplecbljialhhkmedjlpdblhp')
         .then((name) => console.log(`Added Extension:  ${name}`))
         .catch((err) => console.log('An error occurred: ', err));
     // Need to explicitly disable CORS when running in dev mode because


### PR DESCRIPTION
Couldn't see the Vue tab in the console and turned out they replaced the current extension id with the new Vue 3 devtools.

![image](https://github.com/user-attachments/assets/bd74b840-d119-47ed-83e9-c5a0e49501c4)
