### PR TITLE
Remove 'Ultimate Edition' from titlebar

### DIFF
--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -412,9 +412,6 @@ const store = new Vuex.Store<State>({
       let title = config
         ? `${BeekeeperPlugin.buildConnectionName(config)} - Beekeeper Studio`
         : 'Beekeeper Studio'
-      if (context.getters.isUltimate) {
-        title += ' Ultimate Edition'
-      }
       if (context.getters.isTrial && context.getters.isUltimate) {
         const days = context.rootGetters['licenses/licenseDaysLeft']
         title += ` - Free Trial (${window.main.pluralize('day', days, true)} left)`


### PR DESCRIPTION
Closes #2739

PR removes the "Ultimate Edition" string from the titlebar. For users using a trial version, it'll still show the number of days remaining.