### PR TITLE
Move license checking back to the frontend

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -138,6 +138,10 @@ export default Vue.extend({
   async mounted() {
     this.notifyFreeTrial()
     this.interval = setInterval(this.notifyFreeTrial, globals.trialNotificationInterval)
+    this.licenseInterval = setInterval(
+      () => this.$store.dispatch('licenses/updateAll'),
+      globals.licenseCheckInterval
+    )
     const query = querystring.parse(window.location.search, { parseBooleans: true })
     if (query) {
       this.url = query.url || null

--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -138,6 +138,7 @@ export default Vue.extend({
   async mounted() {
     this.notifyFreeTrial()
     this.interval = setInterval(this.notifyFreeTrial, globals.trialNotificationInterval)
+    this.$store.dispatch('licenses/updateAll');
     this.licenseInterval = setInterval(
       () => this.$store.dispatch('licenses/updateAll'),
       globals.licenseCheckInterval

--- a/apps/studio/src/common/globals.ts
+++ b/apps/studio/src/common/globals.ts
@@ -17,8 +17,7 @@ export default {
   workspaceCheckInterval: 5000, // 5 seconds
   dataCheckInterval: 1000 * 30, // 30 secs
   trialNotificationInterval: 1000 * 60 * 60 * 12, // 12 hours
-  licenseCheckInterval: 1000 * 60, // once per 1 minute
-  licenseUtilityCheckInterval: 1000 * 60, // once per 10 minutes
+  licenseCheckInterval: 1000 * 60 * 10, // once per 10 minutes
   errorNoticeTimeout: 60 * 1000, // 1 minute
   tableListItemHeight: 22.8, // in pixels
   // for azure auth

--- a/apps/studio/src/common/globals.ts
+++ b/apps/studio/src/common/globals.ts
@@ -18,7 +18,7 @@ export default {
   dataCheckInterval: 1000 * 30, // 30 secs
   trialNotificationInterval: 1000 * 60 * 60 * 12, // 12 hours
   licenseCheckInterval: 1000 * 60, // once per 1 minute
-  licenseUtilityCheckInterval: 1000 * 60 * 10, // once per 10 minutes
+  licenseUtilityCheckInterval: 1000 * 60, // once per 10 minutes
   errorNoticeTimeout: 60 * 1000, // 1 minute
   tableListItemHeight: 22.8, // in pixels
   // for azure auth

--- a/apps/studio/src/handlers/licenseHandlers.ts
+++ b/apps/studio/src/handlers/licenseHandlers.ts
@@ -1,7 +1,5 @@
 import { LicenseKey } from "@/common/appdb/models/LicenseKey";
-import platformInfo from "@/common/platform_info";
 import { TransportLicenseKey } from "@/common/transport";
-import { CloudClient } from "@/lib/cloud/CloudClient";
 import { LicenseStatus } from "@/lib/license";
 
 export interface ILicenseHandlers {

--- a/apps/studio/src/handlers/licenseHandlers.ts
+++ b/apps/studio/src/handlers/licenseHandlers.ts
@@ -7,9 +7,9 @@ import { LicenseStatus } from "@/lib/license";
 export interface ILicenseHandlers {
   "license/createTrialLicense": () => Promise<void>;
   "license/getStatus": () => Promise<LicenseStatus>;
-  "license/add": ({ email, key }: { email: string; key: string; }) => Promise<TransportLicenseKey>;
   "license/get": () => Promise<TransportLicenseKey[]>;
-  "license/remove": (({ id }: { id: number }) => Promise<void>)
+  "license/remove": (({ id }: { id: number }) => Promise<void>);
+  "license/wipe": () => Promise<void>;
 }
 
 export const LicenseHandlers: ILicenseHandlers = {
@@ -34,21 +34,10 @@ export const LicenseHandlers: ILicenseHandlers = {
       maxAllowedVersion: status.maxAllowedVersion,
     };
   },
-  "license/add": async function ({ email, key }: { email: string; key: string; }) {
-    const result = await CloudClient.getLicense( platformInfo.cloudUrl, email, key);
-    // if we got here, license is good.
-    await LicenseKey.wipe();
-    const license = new LicenseKey();
-    license.key = key;
-    license.email = email;
-    license.validUntil = new Date(result.validUntil);
-    license.supportUntil = new Date(result.supportUntil);
-    license.maxAllowedAppRelease = result.maxAllowedAppRelease;
-    license.licenseType = result.licenseType;
-    await license.save();
-    return license;
-  },
   "license/get": async function () {
     return await LicenseKey.find();
+  },
+  "license/wipe": async function() {
+    await LicenseKey.wipe();
   }
 };

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -1,4 +1,4 @@
-import _, { defaults } from 'lodash'
+import _ from 'lodash'
 import { Module } from "vuex";
 import rawLog from '@bksLogger'
 import { State as RootState } from '../index'
@@ -8,6 +8,7 @@ import Vue from "vue"
 import { LicenseStatus } from '@/lib/license';
 import { SmartLocalStorage } from '@/common/LocalStorage';
 import globals from '@/common/globals';
+import { CloudClient } from '@/lib/cloud/CloudClient';
 
 interface State {
   initialized: boolean
@@ -103,14 +104,45 @@ export const LicenseModule: Module<State, RootState>  = {
         await Vue.prototype.$util.send('license/createTrialLicense')
         await Vue.prototype.$noty.info("Your 14 day free trial has started, enjoy!")
       } else {
-        await Vue.prototype.$util.send('license/add', { email, key })
+        const result = await CloudClient.getLicense(window.platformInfo.cloudUrl, email, key);
+        // if we got here, license is good.
+        await Vue.prototype.$util.send('license/wipe');
+        let license = {} as TransportLicenseKey;
+        license.key = key;
+        license.email = email;
+        license.validUntil = new Date(result.validUntil);
+        license.supportUntil = new Date(result.supportUntil);
+        license.maxAllowedAppRelease = result.maxAllowedAppRelease;
+        license.licenseType = result.licenseType;
+        await Vue.prototype.$util.send('appdb/license/save', { obj: license });
       }
       // allow emitting expired license events next time
       SmartLocalStorage.setBool('expiredLicenseEventsEmitted', false)
       await context.dispatch('sync')
     },
-    async update() {
-      await Vue.prototype.$util.send('license/update')
+    async update(_context, license: TransportLicenseKey) {
+      try {
+        const data = await CloudClient.getLicense(window.platformInfo.cloudUrl, license.email, license.key)
+        license.validUntil = new Date(data.validUntil)
+        license.supportUntil = new Date(data.supportUntil)
+        license.maxAllowedAppRelease = data.maxAllowedAppRelease
+        license = await Vue.prototype.$util.send('appdb/license/save', { obj: license });
+      } catch (error) {
+        if (error instanceof CloudError) {
+          // eg 403, 404, license not valid
+          license.validUntil = new Date()
+          license = await Vue.prototype.$util.send('appdb/license/save', { obj: license });
+        } else {
+          // eg 500 errors
+          // do nothing
+        }
+      }
+    },
+    async updateAll(context) {
+      for (let index = 0; index < context.getters.realLicenses.length; index++) {
+        const license = context.getters.realLicenses[index];
+        await context.dispatch('update', license);
+      }
     },
     async remove(context, license) {
       await Vue.prototype.$util.send('license/remove', { id: license.id })

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -127,7 +127,7 @@ export const LicenseModule: Module<State, RootState>  = {
         license.maxAllowedAppRelease = data.maxAllowedAppRelease
         await Vue.prototype.$util.send('appdb/license/save', { obj: license });
       } catch (error) {
-        if (error instanceof CloudError || [403, 404].includes(error.status)) {
+        if (error instanceof CloudError) {
           // eg 403, 404, license not valid
           license.validUntil = new Date()
           await Vue.prototype.$util.send('appdb/license/save', { obj: license });


### PR DESCRIPTION
For some firewalled systems, the node networking defaults don't work properly, so license checking is broken when done from the backend. This doesn't happen with the chromium frontend, so we're moving license checking back to the frontend.