### PR TITLE
Fix showing postgres table with leftmost json column

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1570,7 +1570,10 @@ export default Vue.extend({
       let filters = this.filters
 
       if (params.sort) {
-        orderBy = params.sort
+        orderBy = params.sort.map((obj) => ({
+          ...obj,
+          dataType: this.table.columns.find((col) => col.columnName === obj.field)?.dataType
+        }));
       }
 
       if (params.size) {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1201,13 +1201,20 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     let params: (string | string[])[] = []
 
     if (orderBy && orderBy.length > 0) {
-      orderByString = "ORDER BY " + (orderBy.map((item) => {
-        if (_.isObject(item)) {
-          return `${wrapIdentifier(item.field)} ${item.dir.toUpperCase()}`
-        } else {
-          return wrapIdentifier(item)
+      const orderByColumns = orderBy.reduce((acc, item) => {
+        if (item.dataType === 'json' || item.dataType === 'jsonb') {
+          return acc;
         }
-      })).join(",")
+        if (_.isObject(item)) {
+          acc.push(`${wrapIdentifier(item.field)} ${item.dir.toUpperCase()}`)
+        } else {
+          acc.push(wrapIdentifier(item))
+        }
+        return acc;
+      }, [])
+      if (orderByColumns.length > 0) {
+        orderByString = "ORDER BY " + orderByColumns.join(",")
+      }
     }
 
     if (_.isString(filters)) {

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -128,6 +128,7 @@ export interface SchemaFilterOptions {
 }
 
 export interface OrderBy {
+  dataType?: string;
   dir: 'ASC' | 'DESC';
   field: string;
 }


### PR DESCRIPTION
Fixes #2734 

PR fixes an issue with postgres, where when opening a table where the leftmost column is json or jsonb, it would throw an error. This was due to it trying to sort the table on the json/jsonb column via SQL, which postgres expressly does not support.

To reproduce the bug, can use the following SQL:

```sql
CREATE TABLE bob
( a json
 , b jsonb
 , c text
 );
 
 INSERT INTO bob (a, b, c) VALUES (null, null, null);
 INSERT INTO bob (a,b,c) VALUES ('{"a": true}', '{"b": true}', 'hello');
```

My fix was to have the frontend pass the datatype for the `orderBy` columns, which then allows for filtering on the backend based on unsupported types.