### PR TITLE
fix duckdb file selector

### DIFF
--- a/apps/studio/src/components/common/form/FilePicker.vue
+++ b/apps/studio/src/components/common/form/FilePicker.vue
@@ -16,7 +16,7 @@
     >
     <div
       class="input-group-append"
-      :class="{ 'not-last': hasOtherActions }"
+      :class="{ 'not-last': hasOtherActions || showCreateButton }"
       @click.prevent.stop="openFilePickerDialog"
     >
       <a
@@ -24,6 +24,18 @@
         class="btn btn-flat"
         :class="{disabled}"
       >{{ buttonText }}</a>
+    </div>
+    <div
+      v-if="showCreateButton"
+      class="input-group-append"
+    >
+      <a
+        type="button"
+        class="btn btn-flat"
+        @click="openFilePickerDialog({ save: true })"
+      >
+        Create
+      </a>
     </div>
     <slot name="actions" />
   </div>
@@ -78,7 +90,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    openFileOrFolder: {
+    showCreateButton: {
       type: Boolean,
       default: false,
     },
@@ -101,7 +113,7 @@ export default {
     }
   },
   methods: {
-    async openFilePickerDialog() {
+    async openFilePickerDialog(options = {}) {
       if(this.disabled) {
         return
       }
@@ -122,14 +134,8 @@ export default {
         dialogConfig.properties.push('multiSelections')
       }
 
-      if (this.openFileOrFolder) {
-        // On Windows and Linux an open dialog can not be both a file selector
-        // and a directory selector.
-        dialogConfig.properties.push('openDirectory')
-      }
-
       let files
-      if (this.save) {
+      if (options.save ?? this.save) {
         files = [ this.$native.dialog.showSaveDialogSync({
           ...dialogConfig,
           ...this.options

--- a/apps/studio/src/components/connection/DuckDBForm.vue
+++ b/apps/studio/src/components/connection/DuckDBForm.vue
@@ -12,13 +12,7 @@
         v-model="config.defaultDatabase"
         input-id="default-database"
         editable
-        open-file-or-folder
-        :options="{
-          filters: [
-            { name: 'DuckDB Files', extensions: ['duckdb', 'db', 'ddb'] },
-            { name: 'All Files', extensions: ['*'] },
-          ],
-        }"
+        show-create-button
       />
       <snap-external-warning />
     </div>

--- a/docs/user_guide/connecting/duckdb.md
+++ b/docs/user_guide/connecting/duckdb.md
@@ -5,7 +5,7 @@ summary: "Connect to a DuckDB database by double clicking, from the command line
 
 Connecting to a DuckDB database from the app is straightforward. Simply select DuckDB from the dropdown, choose your DuckDB file, and click `connect`.
 
-## Double click .db and .sqlite3 files
+## Double click .duckdb files
 
 When you install Beekeeper Studio it will create an association for files with the `.duckdb` extension.
 
@@ -20,6 +20,6 @@ You can also use your terminal to open a database in Beekeeper Studio so long as
 
 ## Creating a new database
 
-To create a new database, you can specify the location of the database file in the `Database File` input field. If you are running on Windows or Linux, you can select a folder from the `Choose File` dialog, and then complete the `Database File` input field with your file name.
+To create a new database, you can click the `Create` button or specify the location of the database file in the `Database File` input field.
 
 ![Create a new database](../../assets/images/duckdb-create.png)

--- a/docs/user_guide/connecting/duckdb.md
+++ b/docs/user_guide/connecting/duckdb.md
@@ -22,4 +22,4 @@ You can also use your terminal to open a database in Beekeeper Studio so long as
 
 To create a new database, you can click the `Create` button or specify the location of the database file in the `Database File` input field.
 
-![Create a new database](../../assets/images/duckdb-create.png)
+![Create a new database](../../assets/images/duckdb-1.gif)


### PR DESCRIPTION
This PR fixes the file picker to not filter any file types in DuckDB form and add a `create` button to open a save dialog. Passing a file path that doesn't exist will allow the DuckDB client to create a new file. Creating a database file this way is preferred since it needs a valid database file, a little bit different with SQLite.

![image](https://github.com/user-attachments/assets/3e2492a3-a4d6-49e8-a428-caaa7350c2a7)

What happens when opening a manually created db file (via `touch` for example):
![image](https://github.com/user-attachments/assets/31890c8b-aec8-48d4-a204-dbd3f609270c)
