### PR TITLE
Fix: JSON Viewer Bottleneck

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1000,7 +1000,13 @@ export default Vue.extend({
       })
       this.tabulator.on("cellMouseUp", this.updateDetailView);
       this.tabulator.on("headerMouseUp", this.updateDetailView);
-      this.tabulator.on("keyNavigate", this.updateDetailView);
+      this.tabulator.on(
+        "keyNavigate",
+        // This is slow if we do a long press. Debounce it so it feels good.
+        _.debounce(this.updateDetailView, 100, {
+          leading: true, trailing: true
+        })
+      );
       // Tabulator range is reset after data is processed
       this.tabulator.on("dataProcessed", this.updateDetailView);
 
@@ -1032,8 +1038,8 @@ export default Vue.extend({
         {
           label: createMenuItem('See details'),
           action: () => {
-            this.updateDetailView({ range })
             this.toggleOpenDetailView(true)
+            this.updateDetailView({ range })
           },
         },
       ]
@@ -1704,6 +1710,8 @@ export default Vue.extend({
       return (this.limit * (this.page - 1)) + (row.getPosition() || 0)
     },
     updateDetailView(options: { range?: RangeComponent } = {}) {
+      if (!this.openDetailView) return
+
       const range = options.range ?? this.tabulator.getRanges()[0]
       const row = range.getRows()[0]
       if (!row) {

--- a/apps/studio/src/lib/editor/plugins/persistJsonFold.ts
+++ b/apps/studio/src/lib/editor/plugins/persistJsonFold.ts
@@ -1,3 +1,9 @@
+/**
+ * This plugin stores JSON paths that should be folded in the editor and
+ * restores them when the editor value changes.
+ **/
+
+import _ from "lodash";
 import { findKeyPosition } from "@/lib/data/detail_view";
 import { getLocation, JSONPath } from "jsonc-parser";
 import CodeMirror from "codemirror";
@@ -5,6 +11,8 @@ import CodeMirror from "codemirror";
 type EditorInstance = CodeMirror.Editor & {
   bksPersistJsonFold: {
     foldedPaths: JSONPath[];
+    /** True if a fold event was triggered by this plugin */
+    ignoreFoldEvent: boolean;
   };
 };
 
@@ -12,49 +20,70 @@ export function registerPersistJsonFold(instance: EditorInstance) {
   if (!instance.getOption("foldGutter")) {
     throw new Error("PersistJsonFold requires foldGutter to be enabled.");
   }
-  instance.bksPersistJsonFold = { foldedPaths: [] };
-  instance.on("beforeChange", beforeChangeHandle);
+  instance.bksPersistJsonFold = {
+    foldedPaths: [],
+    ignoreFoldEvent: false,
+  };
+  // @ts-expect-error not fully typed
+  instance.on("fold", handleFold);
+  // @ts-expect-error not fully typed
+  instance.on("unfold", handleUnfold);
   instance.on("change", handleChange);
   return () => {
     delete instance.bksPersistJsonFold;
-    instance.off("beforeChange", beforeChangeHandle);
+    // @ts-expect-error not fully typed
+    instance.off("fold", handleFold);
+    // @ts-expect-error not fully typed
+    instance.off("unfold", handleUnfold);
     instance.off("change", handleChange);
   };
 }
 
 export const persistJsonFold = registerPersistJsonFold;
 
-function beforeChangeHandle(instance: EditorInstance) {
-  const value = instance.getValue();
-  const foldedPaths = [];
-  let cursor = 0;
-  instance.eachLine((line) => {
-    const offset = line.text.length - line.text.trimStart().length;
-    const location = getLocation(value, cursor + offset);
+function findJSONPath(cm: CodeMirror.Editor, line: number) {
+  const lineHandle = cm.getLineHandle(line);
+  const keyPosition = lineHandle.text.length - lineHandle.text.trimStart().length;
 
-    cursor += line.text.length + 1;
+  const cursorPos = { line, ch: keyPosition };
+  const cursorIndex = cm.indexFromPos(cursorPos);
 
-    const options = instance.state.foldGutter.options;
-    // @ts-expect-error not fully typed
-    const foldGutterMarker = line.gutterMarkers?.[options.gutter];
+  const location = getLocation(cm.getValue(), cursorIndex);
+  return location.path;
+}
 
-    if (!foldGutterMarker) {
-      return;
-    }
+function handleFold(
+  instance: EditorInstance,
+  from: CodeMirror.Position,
+  _to: CodeMirror.Position
+) {
+  if (instance.bksPersistJsonFold.ignoreFoldEvent) {
+    return
+  }
+  const path = findJSONPath(instance, from.line);
+  instance.bksPersistJsonFold.foldedPaths.push(path);
+}
 
-    const folded = foldGutterMarker.classList.contains(options.indicatorFolded);
-    if (folded) {
-      foldedPaths.push(location.path);
-    }
-  });
-  instance.bksPersistJsonFold.foldedPaths = foldedPaths;
+function handleUnfold(
+  instance: EditorInstance,
+  from: CodeMirror.Position,
+  _to: CodeMirror.Position
+) {
+  const path = findJSONPath(instance, from.line);
+  instance.bksPersistJsonFold.foldedPaths =
+    instance.bksPersistJsonFold.foldedPaths.filter((p) => !_.isEqual(p, path));
 }
 
 function handleChange(instance: EditorInstance) {
   const value = instance.getValue();
-  instance.bksPersistJsonFold.foldedPaths.forEach((path: JSONPath) => {
+  instance.bksPersistJsonFold.foldedPaths.forEach((path) => {
     const line = findKeyPosition(value, path);
+    if (line === -1) {
+      return
+    }
+    instance.bksPersistJsonFold.ignoreFoldEvent = true
     // @ts-expect-error not fully typed
     instance.foldCode(line);
+    instance.bksPersistJsonFold.ignoreFoldEvent = false
   });
 }


### PR DESCRIPTION
fix #2727

This PR fixes two issues:
1. Clicking around the table is slow due to the `persistJsonFold` plugin that's O(n^2) or probably even worse
2. Pressing and holding arrow keys is slower too because it doesn't wait for us release the keys to set the value. When the data is big enough, changing value with `CodeMirror.setValue()` can be a little slower, or it could be something else like a combo of all stuff we are doing inside the JSON viewer. But debouncing the key press event seems good enough.