### PR TITLE
[FIX] Issue #2811 - Fallback for empty passwords

### DIFF
--- a/apps/studio/src/lib/db/BaseCommandClient.ts
+++ b/apps/studio/src/lib/db/BaseCommandClient.ts
@@ -48,7 +48,7 @@ export abstract class BaseCommandClient {
 
   protected static _password?: string;
   static get quotedPassword() {
-    return `"${BaseCommandClient._password.replace(/"/g, window.platformInfo.isWindows ? `""` : `\\"`)}"`;
+    return `"${(BaseCommandClient._password || '').replace(/"/g, window.platformInfo.isWindows ? `""` : `\\"`)}"`;
   }
 
   set connConfig(value: IConnection) {


### PR DESCRIPTION
Hello,

This fix issue #2811 

Since `BaseCommandClient._password` can sometimes be `null`, especially on local systems, the `.replace()` function throws an error. This causes the last page to crash, preventing the backup from being restored.

<img width="520" alt="shodan-fix" src="https://github.com/user-attachments/assets/6ad38ce0-1754-4ced-a581-784ba78f6ad6" />

Sincerely,\
Sam.