### PR TITLE
fix exporting filtered view in mysql

### DIFF
--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -657,11 +657,9 @@ export class MysqlClient extends BasicDatabaseClient<ResultType> {
     chunkSize: number,
     _schema?: string
   ): Promise<StreamResults> {
-    const qs = buildSelectTopQuery(table, null, null, orderBy, filters);
+    const { countQuery, query, params } = buildSelectTopQuery(table, null, null, orderBy, filters);
     const columns = await this.listTableColumns(table);
-    const rowCount = await this.driverExecuteSingle(qs.countQuery);
-    // TODO: DEBUG HERE
-    const { query, params } = qs;
+    const rowCount = await this.driverExecuteSingle(countQuery, { params });
 
     return {
       totalRows: Number(rowCount.rows[0].total),


### PR DESCRIPTION
We weren't passing params to the count query in `selectTopStream` in the mysql client