### PR TITLE
fix: add allowed file extensions for database file picker

### DIFF
--- a/apps/studio/src/components/common/form/FilePicker.vue
+++ b/apps/studio/src/components/common/form/FilePicker.vue
@@ -46,6 +46,11 @@
 /* options and all for the native file picker can be found here https://www.electronjs.org/docs/latest/api/dialog */
 export default {
   props: {
+    allowedFileExtensions:{
+      type: Array,
+      required: false,
+      default: () => ([])
+    },
     value: {
       required: true,
     },
@@ -119,7 +124,8 @@ export default {
       }
 
       const dialogConfig = {
-        properties: ['openFile']
+        properties: ['openFile'],
+        filters: [{ name: 'Allowed File Extensions', extensions: this.allowedFileExtensions }]
       }
 
       if (this.defaultPath.toString().length > 0) {

--- a/apps/studio/src/components/connection/DuckDBForm.vue
+++ b/apps/studio/src/components/connection/DuckDBForm.vue
@@ -9,6 +9,7 @@
     <div class="form-group col">
       <label for="default-database" required>Database File</label>
       <file-picker
+        :allowedFileExtensions="['duckdb']"
         v-model="config.defaultDatabase"
         input-id="default-database"
         editable

--- a/apps/studio/src/components/connection/LibSQLForm.vue
+++ b/apps/studio/src/components/connection/LibSQLForm.vue
@@ -59,6 +59,7 @@
         <file-picker
           v-model="config.defaultDatabase"
           input-id="default-database"
+          :allowedFileExtensions="['db', 'sqlite', 'sqlite3']"
         />
         <snap-external-warning />
       </div>

--- a/apps/studio/src/components/connection/SqliteForm.vue
+++ b/apps/studio/src/components/connection/SqliteForm.vue
@@ -7,7 +7,7 @@
             for="Database"
             required
           >Database File</label>
-          <file-picker v-model="config.defaultDatabase" />
+          <file-picker v-model="config.defaultDatabase" :allowedFileExtensions="['db', 'sqlite', 'sqlite3']"/>
 
           <toggle-form-area
             title="Runtime Extensions"


### PR DESCRIPTION
fixes: #2696 

closes: #2696

added allowed file extensions for database file picker for sqlite, libsql and ducked forms.

**Allowed extensions**
_for sqlite and libsql_ => .db, .sqlite and .sqlite3
_for duck db_ => .duckdb


https://github.com/user-attachments/assets/3a1b7944-a8e2-4733-9608-cf80b9022a51

