### PR TITLE
fix app version license checking

### DIFF
--- a/apps/studio/src/common/version.ts
+++ b/apps/studio/src/common/version.ts
@@ -15,7 +15,7 @@ export interface Version {
  * ```
  **/
 export function parseVersion(version: string) {
-  const versionTagRegex = /^(\d+)\.(\d+)\.(\d+)$/;
+  const versionTagRegex = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
   const match = versionTagRegex.exec(version) || [];
   const [major, minor, patch] = _.tail(match).map((x) => parseInt(x));
   return { major, minor, patch };

--- a/apps/studio/src/common/version.ts
+++ b/apps/studio/src/common/version.ts
@@ -23,9 +23,8 @@ export function parseVersion(version: string) {
 
 /** Check if version a is less than or equal to version b */
 export function isVersionLessThanOrEqual(a: Version, b: Version) {
-  if (a.major > b.major) return false;
-  if (a.minor > b.minor) return false;
-  if (a.patch > b.patch) return false;
-  return true;
+  return (a.major < b.major) ||
+         (a.major === b.major && a.minor < b.minor) ||
+         (a.major === b.major && a.minor === b.minor && a.patch <= b.patch);
 }
 

--- a/apps/studio/src/common/version.ts
+++ b/apps/studio/src/common/version.ts
@@ -15,7 +15,7 @@ export interface Version {
  * ```
  **/
 export function parseVersion(version: string) {
-  const versionTagRegex = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
+  const versionTagRegex = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/;
   const match = versionTagRegex.exec(version) || [];
   const [major, minor, patch] = _.tail(match).map((x) => parseInt(x));
   return { major, minor, patch };
@@ -23,8 +23,14 @@ export function parseVersion(version: string) {
 
 /** Check if version a is less than or equal to version b */
 export function isVersionLessThanOrEqual(a: Version, b: Version) {
-  return (a.major < b.major) ||
-         (a.major === b.major && a.minor < b.minor) ||
-         (a.major === b.major && a.minor === b.minor && a.patch <= b.patch);
+  if (a.major > b.major) return false
+  if (a.major === b.major) {
+    if (a.minor > b.minor) return false;
+    if (a.minor === b.minor && a.patch > b.patch) return false
+    return true
+  } else { // a.major < b.major
+    return true
+  }
+
 }
 

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -120,8 +120,10 @@ export const LicenseModule: Module<State, RootState>  = {
       await context.dispatch('sync')
     },
     async update(_context, license: TransportLicenseKey) {
+      // This is to allow for dev switching
+      const isDevUpdate = window.platformInfo.isDevelopment && license.email == "fake_email";
       try {
-        const data = await CloudClient.getLicense(window.platformInfo.cloudUrl, license.email, license.key)
+        const data = isDevUpdate ? license : await CloudClient.getLicense(window.platformInfo.cloudUrl, license.email, license.key)
         license.validUntil = new Date(data.validUntil)
         license.supportUntil = new Date(data.supportUntil)
         license.maxAllowedAppRelease = data.maxAllowedAppRelease

--- a/apps/studio/tests/unit/common/appdb/models/license.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/license.spec.ts
@@ -166,11 +166,11 @@ describe("License", () => {
 
     // Regression tests for version comparison
     it("Should properly compare versions", async () => {
-      expect(isVersionLessThanOrEqual(parseVersion("v2.4.6"), parseVersion("v5.7.2")));
-      expect(isVersionLessThanOrEqual(parseVersion("v2.5.1-beta.4"), parseVersion("v5.0.0")));
-      expect(!isVersionLessThanOrEqual(parseVersion("v6.3.7"), parseVersion("v4.2.1")));
-      expect(!isVersionLessThanOrEqual(parseVersion("v3.1.3-beta.4"), parseVersion("v1.8.1")));
-      expect(isVersionLessThanOrEqual(parseVersion("v5.0.0"), parseVersion("v5.0.0")));
+      expect(isVersionLessThanOrEqual(parseVersion("v2.4.6"), parseVersion("v5.7.2"))).toBeTruthy();
+      expect(isVersionLessThanOrEqual(parseVersion("v2.5.1-beta.4"), parseVersion("v5.0.0"))).toBeTruthy();
+      expect(isVersionLessThanOrEqual(parseVersion("v6.3.7"), parseVersion("v4.2.1"))).not.toBeTruthy;
+      expect(isVersionLessThanOrEqual(parseVersion("v3.1.3-beta.4"), parseVersion("v1.8.1"))).not.toBeTruthy();
+      expect(isVersionLessThanOrEqual(parseVersion("v5.0.0"), parseVersion("v5.0.0"))).toBeTruthy();
     })
   });
 });

--- a/apps/studio/tests/unit/common/appdb/models/license.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/license.spec.ts
@@ -163,5 +163,14 @@ describe("License", () => {
         condition: ["Expired support date", "App version not allowed"],
       });
     })
+
+    // Regression tests for version comparison
+    it("Should properly compare versions", async () => {
+      expect(isVersionLessThanOrEqual(parseVersion("v2.4.6"), parseVersion("v5.7.2")));
+      expect(isVersionLessThanOrEqual(parseVersion("v2.5.1-beta.4"), parseVersion("v5.0.0")));
+      expect(!isVersionLessThanOrEqual(parseVersion("v6.3.7"), parseVersion("v4.2.1")));
+      expect(!isVersionLessThanOrEqual(parseVersion("v3.1.3-beta.4"), parseVersion("v1.8.1")));
+      expect(isVersionLessThanOrEqual(parseVersion("v5.0.0"), parseVersion("v5.0.0")));
+    })
   });
 });


### PR DESCRIPTION
fix #2854 

This was caused by improper version comparison.

This also fixes dev license checking so we can actually use the dev license switch again.