### PR TITLE
Enhanced some Hint Problems, make it easier to use.

### DIFF
--- a/apps/studio/src/lib/editor/CodeMirrorDefinitions.ts
+++ b/apps/studio/src/lib/editor/CodeMirrorDefinitions.ts
@@ -13,3 +13,15 @@ CodeMirror.defineMIME("text/x-pgsql", {
   },
 });
 
+declare module "codemirror" {
+  interface Editor {
+    lastCompletionState?: {
+      token: string;
+      from: Position;
+      to: Position;
+      list: any[];
+      picked?: boolean;
+    };
+  }
+}
+

--- a/apps/studio/src/lib/editor/CodeMirrorPlugins.ts
+++ b/apps/studio/src/lib/editor/CodeMirrorPlugins.ts
@@ -129,44 +129,13 @@ export function autocompleteHandler(
   //    - from, join
   const triggerWords = ["from", "join"];
   const triggers = {
-    "190": "period",
+    "Period": "period",
   };
-  const space = 32;
-  const backspace = 8;
-  const delete_key = 46;
-  const z_key = 90;
-  // const underscore = 189
 
   if (instance.state.completionActive) return;
   
-  // Handle Ctrl+Z/Cmd+Z undo operation
-  if (e.keyCode === z_key && (e.ctrlKey || e.metaKey)) {
-    // Don't return immediately, let the event propagate
-    // Delay execution to wait for undo operation to complete
-    setTimeout(() => {
-      // Get context at current cursor position
-      const cursor = instance.getCursor();
-      const line = instance.getLine(cursor.line);
-      
-      // Check if we're in a table name selection context (after FROM or JOIN)
-      const lineUntilCursor = line.substring(0, cursor.ch);
-      // More precise regex to match table name part after FROM or JOIN
-      const fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
-      
-      if (fromRegex.test(lineUntilCursor)) {
-        if (!instance.state.completionActive) {
-          // eslint-disable-next-line
-          // @ts-ignore
-          CodeMirror.commands.autocomplete(instance, null, {
-            completeSingle: false,
-          });
-        }
-      }
-    }, 100); // Add delay to ensure undo operation completes
-  }
-  
   // Handle delete and backspace keys
-  if (e.keyCode === backspace || e.keyCode === delete_key) {
+  if (e.key === "Backspace" || e.key === "Delete") {
     // Get context at current cursor position
     const cursor = instance.getCursor();
     const line = instance.getLine(cursor.line);
@@ -186,14 +155,14 @@ export function autocompleteHandler(
     }
     return;
   }
-  if (triggers[e.keyCode]) {
+  if (triggers[e.code]) {
     // eslint-disable-next-line
     // @ts-ignore
     CodeMirror.commands.autocomplete(instance, null, {
       completeSingle: false,
     });
   }
-  if (e.keyCode === space) {
+  if (e.code === "Space") {
     try {
       const pos = _.clone(instance.getCursor());
       if (pos.ch > 0) {

--- a/apps/studio/src/vendor/show-hint/index.js
+++ b/apps/studio/src/vendor/show-hint/index.js
@@ -118,12 +118,44 @@ import CodeMirror from "codemirror";
       if(this.data) {
         identStart = this.data.from;
       }
-
       var pos = this.cm.getCursor(), line = this.cm.getLine(pos.line);
-      if (pos.line != this.startPos.line || line.length - pos.ch != this.startLen - this.startPos.ch ||
+      
+      // Store the last completion state
+      if (!this.cm.lastCompletionState && this.data) {
+        this.cm.lastCompletionState = {
+          token: "",
+          from: identStart,
+          to: pos,
+          list: this.data.list || [],
+          picked: false
+        };
+      } else if (this.data) {
+        // Update existing lastCompletionState
+        this.cm.lastCompletionState.list = this.data.list;
+        this.cm.lastCompletionState.from = identStart;
+        this.cm.lastCompletionState.to = pos;
+      }
+      
+      // Check if this is a deletion operation (current line length less than starting length)
+      var isDeletion = line.length < this.startLen;
+      
+      // Check if we're in a table name selection context (after FROM or JOIN)
+      var lineUntilCursor = line.substring(0, pos.ch);
+      var fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
+      var isTableContext = fromRegex.test(lineUntilCursor);
+      
+      if (pos.line != this.startPos.line || 
+          (!isDeletion && line.length - pos.ch != this.startLen - this.startPos.ch) ||
           pos.ch < identStart.ch || this.cm.somethingSelected() ||
-          (!pos.ch || this.options.closeCharacters.test(line.charAt(pos.ch - 1)))) {
-        this.close();
+          (!pos.ch || (!isDeletion && this.options.closeCharacters.test(line.charAt(pos.ch - 1))))) {
+        // For table name context deletions, keep completion window open
+        if (isDeletion && isTableContext) {
+          var self = this;
+          this.debounce = requestAnimationFrame(function() {self.update();});
+          if (this.widget) this.widget.disable();
+        } else {
+          this.close();
+        }
       } else {
         var self = this;
         this.debounce = requestAnimationFrame(function() {self.update();});

--- a/apps/ui-kit/lib/components/sql-text-editor/define.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/define.ts
@@ -1,3 +1,16 @@
 import { SqlTextEditor } from ".";
+import CodeMirror from "codemirror";
 
 window.customElements.define("bks-sql-text-editor", SqlTextEditor);
+
+declare module "codemirror" {
+  interface Editor {
+    lastCompletionState?: {
+      token: string;
+      from: Position;
+      to: Position;
+      list: any[];
+      picked?: boolean;
+    };
+  }
+}

--- a/apps/ui-kit/lib/components/sql-text-editor/plugins.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/plugins.ts
@@ -63,9 +63,61 @@ export function autocompleteHandler(
     "190": "period",
   };
   const space = 32;
+  const backspace = 8;
+  const delete_key = 46;
+  const z_key = 90;
   // const underscore = 189
 
   if (instance.state.completionActive) return;
+  
+  // Handle Ctrl+Z/Cmd+Z undo operation
+  if (e.keyCode === z_key && (e.ctrlKey || e.metaKey)) {
+    // Don't return immediately, let the event propagate
+    // Delay execution to wait for undo operation to complete
+    setTimeout(() => {
+      // Get context at current cursor position
+      const cursor = instance.getCursor();
+      const line = instance.getLine(cursor.line);
+      
+      // Check if we're in a table name selection context (after FROM or JOIN)
+      const lineUntilCursor = line.substring(0, cursor.ch);
+      // More precise regex to match table name part after FROM or JOIN
+      const fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
+      
+      if (fromRegex.test(lineUntilCursor)) {
+        if (!instance.state.completionActive) {
+          // eslint-disable-next-line
+          // @ts-ignore
+          CodeMirror.commands.autocomplete(instance, null, {
+            completeSingle: false,
+          });
+        }
+      }
+    }, 100); // Add delay to ensure undo operation completes
+  }
+  
+  // Handle delete and backspace keys
+  if (e.keyCode === backspace || e.keyCode === delete_key) {
+    // Get context at current cursor position
+    const cursor = instance.getCursor();
+    const line = instance.getLine(cursor.line);
+    
+    // Check if we're in a table name selection context (after FROM or JOIN)
+    const lineUntilCursor = line.substring(0, cursor.ch);
+    const fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
+    
+    if (fromRegex.test(lineUntilCursor)) {
+      if (!instance.state.completionActive) {
+        // eslint-disable-next-line
+        // @ts-ignore
+        CodeMirror.commands.autocomplete(instance, null, {
+          completeSingle: false,
+        });
+      }
+    }
+    return;
+  }
+  
   if (triggers[e.keyCode]) {
     // eslint-disable-next-line
     // @ts-ignore
@@ -93,6 +145,36 @@ export function autocompleteHandler(
   }
 }
 
+// Register a new handler for undo operations
+export function registerUndoHandler(instance: CodeMirror.Editor) {
+  // Listen for CodeMirror undo events
+  const handleUndo = (cm: CodeMirror.Editor, changeObj: CodeMirror.EditorChangeCancellable) => {
+    if (changeObj.origin === "undo") {
+      // Add delay to ensure undo operation completes
+      setTimeout(() => {
+        const cursor = cm.getCursor();
+        const line = cm.getLine(cursor.line);
+        
+        // Check if we're in a table name selection context (after FROM or JOIN)
+        const lineUntilCursor = line.substring(0, cursor.ch);
+        const fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
+        
+        if (fromRegex.test(lineUntilCursor) && !cm.state.completionActive) {
+          // eslint-disable-next-line
+          // @ts-ignore
+          CodeMirror.commands.autocomplete(cm, null, {
+            completeSingle: false,
+          });
+        }
+      }, 100);
+    }
+  };
+  
+  instance.on("beforeChange", handleUndo);
+  
+  return () => instance.off("beforeChange", handleUndo);
+}
+
 function registerAutoquote(
   instance: CodeMirror.Editor,
   onBeforeChange?: (
@@ -115,7 +197,12 @@ function registerAutoRemoveQueryQuotes(
 
 function registerAutoComplete(instance: CodeMirror.Editor) {
   instance.on("keyup", autocompleteHandler);
-  return () => instance.off("keyup", autocompleteHandler);
+  // Register undo handler
+  const undoCleanup = registerUndoHandler(instance);
+  return () => {
+    instance.off("keyup", autocompleteHandler);
+    undoCleanup();
+  };
 }
 
 export const autoquote = registerAutoquote;

--- a/apps/ui-kit/lib/components/sql-text-editor/plugins.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/plugins.ts
@@ -60,44 +60,13 @@ export function autocompleteHandler(
   //    - from, join
   const triggerWords = ["from", "join"];
   const triggers = {
-    "190": "period",
+    "Period": "period",
   };
-  const space = 32;
-  const backspace = 8;
-  const delete_key = 46;
-  const z_key = 90;
-  // const underscore = 189
 
   if (instance.state.completionActive) return;
   
-  // Handle Ctrl+Z/Cmd+Z undo operation
-  if (e.keyCode === z_key && (e.ctrlKey || e.metaKey)) {
-    // Don't return immediately, let the event propagate
-    // Delay execution to wait for undo operation to complete
-    setTimeout(() => {
-      // Get context at current cursor position
-      const cursor = instance.getCursor();
-      const line = instance.getLine(cursor.line);
-      
-      // Check if we're in a table name selection context (after FROM or JOIN)
-      const lineUntilCursor = line.substring(0, cursor.ch);
-      // More precise regex to match table name part after FROM or JOIN
-      const fromRegex = /\b(from|join)\s+[\w\d_."]*$/i;
-      
-      if (fromRegex.test(lineUntilCursor)) {
-        if (!instance.state.completionActive) {
-          // eslint-disable-next-line
-          // @ts-ignore
-          CodeMirror.commands.autocomplete(instance, null, {
-            completeSingle: false,
-          });
-        }
-      }
-    }, 100); // Add delay to ensure undo operation completes
-  }
-  
   // Handle delete and backspace keys
-  if (e.keyCode === backspace || e.keyCode === delete_key) {
+  if (e.key === "Backspace" || e.key === "Delete") {
     // Get context at current cursor position
     const cursor = instance.getCursor();
     const line = instance.getLine(cursor.line);
@@ -118,14 +87,14 @@ export function autocompleteHandler(
     return;
   }
   
-  if (triggers[e.keyCode]) {
+  if (triggers[e.code]) {
     // eslint-disable-next-line
     // @ts-ignore
     CodeMirror.commands.autocomplete(instance, null, {
       completeSingle: false,
     });
   }
-  if (e.keyCode === space) {
+  if (e.code === "Space") {
     try {
       const pos = _.clone(instance.getCursor());
       if (pos.ch > 0) {


### PR DESCRIPTION
Enhanced the CodeMirror editor by improving autocomplete and undo functionalities, and added support for context-aware table names. Updated relevant plugins to handle undo operations and ensure autocomplete works correctly after using the delete key. Now supports automatic completion of table names within 'SELECT * FROM xxx' statements; if a table name is misspelled, it can be deleted or undone, allowing the table name suggestion window to be re-invoked.