### PR TITLE
fix duplication of unsaved connections

### DIFF
--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -206,16 +206,14 @@ export default {
       if (this.savedConnection) {
         this.$emit('edit', this.savedConnection)
       } else {
-        const editable = await this.$store.dispatch('data/connections/clone', this.config)
-        this.$emit('edit', editable)
+        this.$emit('edit', this.config)
       }
     },
     async doubleClick() {
       if (this.savedConnection) {
         this.$emit('doubleClick', this.savedConnection)
       } else {
-        const editable = await this.$store.dispatch('data/connections/clone', this.config)
-        this.$emit('doubleClick', editable)
+        this.$emit('doubleClick', this.config)
       }
     },
     remove() {


### PR DESCRIPTION
This was actually a completely separate issue to the duplication of used connections in general.

When we double click or connect to a connection in the recent list, we remove the id, which means that we can't check to see if this is an existing usedConfig for us to update. So we are no longer cloning the config, and instead we return the actual config and just add some extra logic to make these unsaved connections behave properly.

- Saving an existing unsaved connection will now update the used connection with the proper id, so it shows up properly in the recent list
- Making a change to an unsaved connection and then connecting makes a new used connection.
- Connecting to an existing unsaved connection just updates the existing record instead of duplicating it