### PR TITLE
Fix #2489: Cannot select / copy relation names in UI

### DIFF
--- a/apps/studio/src/components/tableinfo/TableIndexes.vue
+++ b/apps/studio/src/components/tableinfo/TableIndexes.vue
@@ -126,6 +126,7 @@ import { mapGetters, mapState } from 'vuex'
 const log = rawLog.scope('TableIndexVue')
 import { escapeHtml } from '@shared/lib/tabulator'
 import { parseIndexColumn as mysqlParseIndexColumn } from '@/common/utils'
+import { SelectableCellMixin } from '@/mixins/selectableCell';
 
 interface State {
   mysqlTypes: string[]
@@ -141,7 +142,7 @@ export default Vue.extend({
     StatusBar,
     ErrorAlert,
   },
-  mixins: [data_mutators],
+  mixins: [data_mutators, SelectableCellMixin],
   props: ["table", "tabId", "active", "properties", 'tabState'],
   data(): State {
     return {
@@ -365,32 +366,7 @@ export default Vue.extend({
       //   resizableColumns: false,
       //   headerSort: false,
       // })
-    },
-    handleCellDoubleClick(cell) {
-
-      const element = cell.getElement();
-
-      // If already editable, remove contenteditable and stop execution
-      if (element.hasAttribute("contenteditable")) {
-        element.removeAttribute("contenteditable");
-        return;
-      }
-
-      // Enable text selection
-      element.setAttribute("contenteditable", "true");
-      element.focus();
-      document.execCommand("selectAll"); // Automatically select text
-
-      // Function to remove contenteditable when clicking anywhere
-      const removeEditable = (event) => {
-        element.removeAttribute("contenteditable");
-        document.removeEventListener("click", removeEditable);
-      };
-
-      // Attach a global event listener
-      document.addEventListener("click", removeEditable);
     }
-
   },
   mounted() {
     // this.initializeTabulator()

--- a/apps/studio/src/components/tableinfo/TableIndexes.vue
+++ b/apps/studio/src/components/tableinfo/TableIndexes.vue
@@ -214,13 +214,14 @@ export default Vue.extend({
     tableColumns() {
       const editable = (cell) => this.newRows.includes(cell.getRow()) && !this.loading
       const result = [
-        (this.dialectData?.disabledFeatures?.index?.id ? null : {title: 'Id', field: 'id', widthGrow: 0.5}),
+        (this.dialectData?.disabledFeatures?.index?.id ? null : {title: 'Id', field: 'id', widthGrow: 0.5, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}),
         {
           title:'Name',
           field: 'name',
           editable,
           editor: vueEditor(NullableInputEditorVue),
           formatter: this.cellFormatter,
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell),
         },
         {
           title: 'Unique',
@@ -252,7 +253,8 @@ export default Vue.extend({
             autocomplete: true,
             listOnEmpty: true,
             freetext: true,
-          }
+          },
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         trashButton(this.removeRow)
       ]
@@ -363,6 +365,30 @@ export default Vue.extend({
       //   resizableColumns: false,
       //   headerSort: false,
       // })
+    },
+    handleCellDoubleClick(cell) {
+
+      const element = cell.getElement();
+
+      // If already editable, remove contenteditable and stop execution
+      if (element.hasAttribute("contenteditable")) {
+        element.removeAttribute("contenteditable");
+        return;
+      }
+
+      // Enable text selection
+      element.setAttribute("contenteditable", "true");
+      element.focus();
+      document.execCommand("selectAll"); // Automatically select text
+
+      // Function to remove contenteditable when clicking anywhere
+      const removeEditable = (event) => {
+        element.removeAttribute("contenteditable");
+        document.removeEventListener("click", removeEditable);
+      };
+
+      // Attach a global event listener
+      document.addEventListener("click", removeEditable);
     }
 
   },

--- a/apps/studio/src/components/tableinfo/TableRelations.vue
+++ b/apps/studio/src/components/tableinfo/TableRelations.vue
@@ -115,8 +115,10 @@ import rawLog from '@bksLogger'
 import ErrorAlert from '../common/ErrorAlert.vue'
 const log = rawLog.scope('TableRelations');
 import { escapeHtml } from '@shared/lib/tabulator'
+import { SelectableCellMixin } from '@/mixins/selectableCell';
 
 export default Vue.extend({
+  mixins: [SelectableCellMixin],
   props: ["table", "tabId", "active", "properties", 'tabState'],
   components: {
     StatusBar,
@@ -397,30 +399,6 @@ export default Vue.extend({
       })
       this.newRows = []
       this.removedRows = []
-    },
-    handleCellDoubleClick(cell) {
-
-      const element = cell.getElement();
-
-      // If already editable, remove contenteditable and stop execution
-      if (element.hasAttribute("contenteditable")) {
-        element.removeAttribute("contenteditable");
-        return;
-      }
-
-      // Enable text selection
-      element.setAttribute("contenteditable", "true");
-      element.focus();
-      document.execCommand("selectAll"); // Automatically select text
-
-      // Function to remove contenteditable when clicking anywhere
-      const removeEditable = (event) => {
-        element.removeAttribute("contenteditable");
-        document.removeEventListener("click", removeEditable);
-      };
-
-      // Attach a global event listener
-      document.addEventListener("click", removeEditable);
     }
   },
   mounted() {

--- a/apps/studio/src/components/tableinfo/TableRelations.vue
+++ b/apps/studio/src/components/tableinfo/TableRelations.vue
@@ -186,7 +186,7 @@ export default Vue.extend({
           widthGrow: 2,
           editable,
           editor: vueEditor(NullableInputEditorVue),
-
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
           field: 'fromColumn',
@@ -196,7 +196,8 @@ export default Vue.extend({
           editorParams: {
             // @ts-expect-error Incorrectly typed
             valuesLookup: () => this.table.columns.map((c) => escapeHtml(c.columnName))
-          }
+          },
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         ...( showSchema ? [{
           field: 'toSchema',
@@ -218,7 +219,8 @@ export default Vue.extend({
             // @ts-expect-error Incorrectly typed
             valuesLookup: this.getTables
           },
-          cellEdited: (cell) => cell.getRow().getCell('toColumn')?.setValue(null)
+          cellEdited: (cell) => cell.getRow().getCell('toColumn')?.setValue(null),
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
           field: 'toColumn',
@@ -229,6 +231,7 @@ export default Vue.extend({
             // @ts-expect-error Incorrectly typed
             valuesLookup: this.getColumns
           },
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
           field: 'onUpdate',
@@ -238,7 +241,8 @@ export default Vue.extend({
           editorParams: {
             values: this.dialectData.constraintActions,
             defaultValue: 'NO ACTION'
-          }
+          },
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
           field: 'onDelete',
@@ -249,7 +253,8 @@ export default Vue.extend({
           editorParams: {
             values: this.dialectData.constraintActions,
             defaultValue: 'NO ACTION',
-          }
+          },
+          cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
       ]
       return this.canDrop ? [...results, trashButton(this.removeRow)] : results
@@ -392,6 +397,30 @@ export default Vue.extend({
       })
       this.newRows = []
       this.removedRows = []
+    },
+    handleCellDoubleClick(cell) {
+
+      const element = cell.getElement();
+
+      // If already editable, remove contenteditable and stop execution
+      if (element.hasAttribute("contenteditable")) {
+        element.removeAttribute("contenteditable");
+        return;
+      }
+
+      // Enable text selection
+      element.setAttribute("contenteditable", "true");
+      element.focus();
+      document.execCommand("selectAll"); // Automatically select text
+
+      // Function to remove contenteditable when clicking anywhere
+      const removeEditable = (event) => {
+        element.removeAttribute("contenteditable");
+        document.removeEventListener("click", removeEditable);
+      };
+
+      // Attach a global event listener
+      document.addEventListener("click", removeEditable);
     }
   },
   mounted() {

--- a/apps/studio/src/components/tableinfo/TableTriggers.vue
+++ b/apps/studio/src/components/tableinfo/TableTriggers.vue
@@ -66,17 +66,17 @@ export default {
     },
     sqliteTableColumns() {
       return [
-        { field: 'name', title: 'Name', tooltip: true},
-        { field: 'sql', title: 'SQL', tooltip: true}
+        { field: 'name', title: 'Name', tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'sql', title: 'SQL', tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
       ]
     },
     normalTableColumns() {
       return [
-        { field: 'name', title: "Name", tooltip: true},
-        { field: 'timing', title: "Timing"},
-        { field: 'manipulation', title: "Manipulation"},
-        { field: 'action', title: "Action", tooltip: true, widthGrow: 2.5},
-        { field: 'condition', title: "Condition", formatter: this.cellFormatter}
+        { field: 'name', title: "Name", tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'timing', title: "Timing", cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'manipulation', title: "Manipulation", cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'action', title: "Action", tooltip: true, widthGrow: 2.5, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'condition', title: "Condition", formatter: this.cellFormatter, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
       ]
     },
     tableData() {
@@ -86,6 +86,32 @@ export default {
   watch : {
     tableData() {
       if (this.tabulator) this.tabulator.replaceData(this.tableData)
+    }
+  },
+  methods: {
+    handleCellDoubleClick(cell) {
+
+      const element = cell.getElement();
+
+      // If already editable, remove contenteditable and stop execution
+      if (element.hasAttribute("contenteditable")) {
+        element.removeAttribute("contenteditable");
+        return;
+      }
+
+      // Enable text selection
+      element.setAttribute("contenteditable", "true");
+      element.focus();
+      document.execCommand("selectAll"); // Automatically select text
+
+      // Function to remove contenteditable when clicking anywhere
+      const removeEditable = (event) => {
+        element.removeAttribute("contenteditable");
+        document.removeEventListener("click", removeEditable);
+      };
+
+      // Attach a global event listener
+      document.addEventListener("click", removeEditable);
     }
   },
   mounted() {

--- a/apps/studio/src/components/tableinfo/TableTriggers.vue
+++ b/apps/studio/src/components/tableinfo/TableTriggers.vue
@@ -42,12 +42,14 @@ import data_mutators from '../../mixins/data_mutators'
 import globals from '../../common/globals'
 import StatusBar from '../common/StatusBar.vue'
 import { mapGetters, mapState } from 'vuex'
+import { SelectableCellMixin } from '@/mixins/selectableCell';
+
 
 export default {
   components: {
     StatusBar,
   },
-  mixins: [data_mutators],
+  mixins: [data_mutators, SelectableCellMixin],
   props: ["table", "tabId", "active", "properties"],
   data() {
     return {
@@ -86,32 +88,6 @@ export default {
   watch : {
     tableData() {
       if (this.tabulator) this.tabulator.replaceData(this.tableData)
-    }
-  },
-  methods: {
-    handleCellDoubleClick(cell) {
-
-      const element = cell.getElement();
-
-      // If already editable, remove contenteditable and stop execution
-      if (element.hasAttribute("contenteditable")) {
-        element.removeAttribute("contenteditable");
-        return;
-      }
-
-      // Enable text selection
-      element.setAttribute("contenteditable", "true");
-      element.focus();
-      document.execCommand("selectAll"); // Automatically select text
-
-      // Function to remove contenteditable when clicking anywhere
-      const removeEditable = (event) => {
-        element.removeAttribute("contenteditable");
-        document.removeEventListener("click", removeEditable);
-      };
-
-      // Attach a global event listener
-      document.addEventListener("click", removeEditable);
     }
   },
   mounted() {

--- a/apps/studio/src/mixins/selectableCell.ts
+++ b/apps/studio/src/mixins/selectableCell.ts
@@ -1,0 +1,29 @@
+export const SelectableCellMixin = {
+    methods: {
+      handleCellDoubleClick(cell) {
+        const element = cell.getElement();
+  
+        // If already editable, remove contenteditable and stop execution
+        if (element.hasAttribute("contenteditable")) {
+          element.removeAttribute("contenteditable");
+          window.getSelection().removeAllRanges();
+          return;
+        }
+  
+        // Enable text selection
+        element.setAttribute("contenteditable", "true");
+        element.focus();
+        document.execCommand("selectAll");
+  
+        const removeEditable = () => {
+          element.removeAttribute("contenteditable");
+          window.getSelection().removeAllRanges();
+          document.removeEventListener("click", removeEditable);
+        };
+  
+        setTimeout(() => {
+          document.addEventListener("click", removeEditable);
+        }, 0);
+      }
+    }
+}


### PR DESCRIPTION
In the table structure page > Indexes, Relations and Triggers, we cannot select the relation name to copy it.
I created a method (handleCellDoubleClick(cell)) in the Vue files TableRelations, TableIndexes, and TableTriggers to handle double-click selection. I added this method to the respective columns (only those that made sense to me, avoiding fields such as checkboxes).
Close #2489 