### PR TITLE
Fix #2882: BUG: "Add row" button raises an error on a table with a JSON column #2882

### DIFF
--- a/apps/studio/src/lib/data/tools.ts
+++ b/apps/studio/src/lib/data/tools.ts
@@ -99,9 +99,9 @@ export const Mutators = {
 
   },
 
-  /** Stringify json data for MySQL column */
-  jsonMutator(value: any): JsonFriendly {
-    if (_.isString(value) || _.isNull(value)) return value
+   /** Stringify json data for MySQL & Postgres column */
+   jsonMutator(value: any): JsonFriendly {    
+    if (_.isString(value) || _.isNull(value) || _.isUndefined(value)) return value
     return friendlyJsonObject(value)
   },
 }


### PR DESCRIPTION
Added an undefined check before calling `friendlyJsonObject`