### PR TITLE
fix #2765: Import from URL bad special character handling bug

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -317,7 +317,26 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
         }
       }
 
-      const parsed = new ConnectionString(url.replaceAll(/\s/g, "%20"))
+      let cleanedUrl = url
+      let extractedUser = undefined
+      let extractedPassword = undefined
+  
+      if (url.includes('@')) {
+        const lastAtIndex = url.lastIndexOf('@')
+        const firstDoubleSlash = url.indexOf('//') + 1
+  
+        const credentials = url.substring(firstDoubleSlash, lastAtIndex)
+  
+        const [user, ...passwordParts] = credentials.split(':')
+        extractedUser = user
+        extractedPassword = passwordParts.join(':')
+  
+        cleanedUrl = url.substring(0, firstDoubleSlash) + url.substring(lastAtIndex + 1)
+      }
+
+      const encodedUrl = encodeURI(cleanedUrl)
+      const parsed = new ConnectionString(encodedUrl)
+  
       this.connectionType = parsed.protocol as ConnectionType || this.connectionType || 'postgresql'
       if (parsed.hostname && parsed.hostname.includes('redshift.amazonaws.com')) {
         this.connectionType = 'redshift'
@@ -338,8 +357,8 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
       }
       this.host = parsed.hostname || this.host
       this.port = parsed.port || this.port
-      this.username = parsed.user || this.username
-      this.password = parsed.password || this.password
+      this.username = extractedUser ?? parsed.user
+      this.password = extractedPassword ?? parsed.password
       this.defaultDatabase = parsed.path?.join('/') ?? this.defaultDatabase
       return true
     } catch (ex) {


### PR DESCRIPTION
When importing from a URL, if the user or password field contained a + or @ symbol, the parsing would be incorrect. I solved this by first locating the last @, which indicates where the password field ends and the host field begins. After that, I extracted the user and password fields and then cleaned the URL. This ensured that the parser methods wouldn’t mistakenly use the @ symbol in the password field to split the URL.