### PR TITLE
fix config plugin to actually provide platformInfo

### DIFF
--- a/apps/studio/src/plugins/ConfigPlugin.ts
+++ b/apps/studio/src/plugins/ConfigPlugin.ts
@@ -1,4 +1,4 @@
-import config from "@/config";
+import { buildConfig } from "@/config";
 import _ from "lodash";
 import { BksConfigProvider, KeybindingPath } from "@/common/bksConfig/BksConfigProvider";
 import type { VueConstructor } from "vue/types/umd";
@@ -28,7 +28,7 @@ export default {
     const BksConfig = BksConfigProvider.create(window.bksConfigSource, window.platformInfo);
     window.bksConfig = BksConfig;
     Vue.prototype.$bksConfig = BksConfig;
-    Vue.prototype.$config = config;
+    Vue.prototype.$config = buildConfig(window.platformInfo);
     Vue.prototype.$vHotkeyKeymap = createVHotkeyKeymap;
   },
 };


### PR DESCRIPTION
Seems a change was lost in the ini config merge, so $config didn't actually have anything from platformInfo, which caused a bunch of issues (I only actually noticed the dev menu disappearing, but I know there were a bunch of other issues as we use $config like 50+ times in the app to get platformInfo.)