### PR TITLE
[docs] Use sudo for dnf/yum

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -63,9 +63,9 @@ sudo rpm --import https://rpm.beekeeperstudio.io/beekeeper.key
 dnf repolist
 
 # Then
-yum install beekeeper-studio
-# or
-dnf install beekeeper-studio
+sudo dnf install beekeeper-studio
+# or, on legacy systems
+sudo yum install beekeeper-studio
 ```
 
 ## AUR


### PR DESCRIPTION
Adds `sudo` to the `dnf` and `yum` commands (since the other commands use it), and move `dnf` above `yum` since it's the recommended RPM package manager these days.