### PR TITLE
fix(#2677): copy tab names

### DIFF
--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -138,8 +138,11 @@ import TabIcon from './tab/TabIcon.vue'
           { name: "Close Others", slug: 'close-others', handler: ({item}) => this.$emit('closeOther', item)},
           { name: 'Close All', slug: 'close-all', handler: ({item}) => this.$emit('closeAll', item)},
           { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({item}) => this.$emit('closeToRight', item)},
-          { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.$emit('duplicate', item) }
-        ]
+          { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.$emit('duplicate', item) },
+          { name: "Copy Name", slug: 'copy-name', handler: ({item}) => this.$emit('copyName', item), disabled: !(this.tab.tabType === "table" || this.tab.tabType === "table-properties") }
+        ].map((option) => ({
+      ...option,
+      class: option.disabled ? "disabled" : "",}));
       },
       modalName() {
         return `sure-${this.tab.id}`

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -25,6 +25,7 @@
           @closeToRight="closeToRight"
           @forceClose="forceClose"
           @duplicate="duplicate"
+          @copyName="copyName"
         />
       </Draggable>
       <!-- </div> -->
@@ -1044,6 +1045,9 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
     },
     createQueryFromItem(item) {
       this.createQuery(item.text ?? item.unsavedQueryText, item.title ?? null)
+    },
+    copyName(item) {
+      (item.tabType !== 'table' || item.tabType !== "table-properties") ? '' : this.$copyText(item.tableName)
     }
   },
   beforeDestroy() {


### PR DESCRIPTION
Solution for issue #2677 is ready to merge.

The users are now able to copy table names by right clicking on the opened tabs.