### PR TITLE
Fix #2695: Unable to Export Queries from Saved Queries

### DIFF
--- a/apps/studio/src-commercial/entrypoints/preload.ts
+++ b/apps/studio/src-commercial/entrypoints/preload.ts
@@ -86,7 +86,7 @@ export const api = {
 
     return [];
   },
-  async getLastExportPath(filename?: string) {
+  async defaultExportPath(filename?: string) {
     return path.join(homedir(), filename);
   },
   showOpenDialogSync(args: any) {

--- a/apps/studio/src-commercial/entrypoints/preload.ts
+++ b/apps/studio/src-commercial/entrypoints/preload.ts
@@ -87,10 +87,7 @@ export const api = {
     return [];
   },
   async getLastExportPath(filename?: string) {
-    return await SettingsPlugin.get(
-      "lastExportPath",
-      path.join(homedir(), filename)
-    );
+    return path.join(homedir(), filename);
   },
   showOpenDialogSync(args: any) {
     return electron.dialog.showOpenDialogSync(args);

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -277,7 +277,6 @@ import { readWebFile } from '@/common/utils'
 import Noty from 'noty'
 import ConfirmationModal from './common/modals/ConfirmationModal.vue'
 import SqlFilesImportModal from '@/components/common/modals/SqlFilesImportModal.vue'
-import path from 'path';
 
 import { safeSqlFormat as safeFormat } from '@/common/utils';
 import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/transport/TransportOpenTab'

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -277,6 +277,7 @@ import { readWebFile } from '@/common/utils'
 import Noty from 'noty'
 import ConfirmationModal from './common/modals/ConfirmationModal.vue'
 import SqlFilesImportModal from '@/components/common/modals/SqlFilesImportModal.vue'
+import path from 'path';
 
 import { safeSqlFormat as safeFormat } from '@/common/utils';
 import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/transport/TransportOpenTab'
@@ -833,11 +834,14 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
       }
     },
     async handlePromptQueryExport(query) {
-      const safeFilename = query.title.replace(/[/\\?%*:|"<>]/g, '_')
+      const safeFilename = query.title.replace(/[/\\?%*:|"<>]/g, '_');
+      const fileName = `${safeFilename}.sql`;
+
+      const lastExportPath = await Vue.prototype.$settings.get("lastExportPath", await window.main.getLastExportPath(fileName));
 
       const filePath = this.$native.dialog.showSaveDialogSync({
         title: "Export Query",
-        defaultPath: await window.main.getLastExportPath(`${safeFilename}.sql`),
+        defaultPath: lastExportPath,
         filters: [
           { name: 'SQL (*.sql)', extensions: ['sql'] },
           { name: 'All Files (*.*)', extensions: ['*'] },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -837,7 +837,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
 
       const filePath = this.$native.dialog.showSaveDialogSync({
         title: "Export Query",
-        defaultPath: await window.main.getLastExportPath(`${safeFilename}.sql`),
+        defaultPath: `${safeFilename}.sql`,
         filters: [
           { name: 'SQL (*.sql)', extensions: ['sql'] },
           { name: 'All Files (*.*)', extensions: ['*'] },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -837,7 +837,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
 
       const filePath = this.$native.dialog.showSaveDialogSync({
         title: "Export Query",
-        defaultPath: `${safeFilename}.sql`,
+        defaultPath: await window.main.getLastExportPath(`${safeFilename}.sql`),
         filters: [
           { name: 'SQL (*.sql)', extensions: ['sql'] },
           { name: 'All Files (*.*)', extensions: ['*'] },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -837,11 +837,11 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
       const safeFilename = query.title.replace(/[/\\?%*:|"<>]/g, '_');
       const fileName = `${safeFilename}.sql`;
 
-      const lastExportPath = await Vue.prototype.$settings.get("lastExportPath", await window.main.getLastExportPath(fileName));
+      const defaultExportPath = await Vue.prototype.$settings.get("defaultExportPath", await window.main.defaultExportPath(fileName));
 
       const filePath = this.$native.dialog.showSaveDialogSync({
         title: "Export Query",
-        defaultPath: lastExportPath,
+        defaultPath: defaultExportPath,
         filters: [
           { name: 'SQL (*.sql)', extensions: ['sql'] },
           { name: 'All Files (*.*)', extensions: ['*'] },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -836,11 +836,11 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
       const safeFilename = query.title.replace(/[/\\?%*:|"<>]/g, '_');
       const fileName = `${safeFilename}.sql`;
 
-      const defaultExportPath = await Vue.prototype.$settings.get("defaultExportPath", await window.main.defaultExportPath(fileName));
+      const lastExportPath = await Vue.prototype.$settings.get("lastExportPath", await window.main.defaultExportPath(fileName));
 
       const filePath = this.$native.dialog.showSaveDialogSync({
         title: "Export Query",
-        defaultPath: defaultExportPath,
+        defaultPath: lastExportPath,
         filters: [
           { name: 'SQL (*.sql)', extensions: ['sql'] },
           { name: 'All Files (*.*)', extensions: ['*'] },

--- a/apps/studio/src/plugins/SettingsPlugin.ts
+++ b/apps/studio/src/plugins/SettingsPlugin.ts
@@ -7,9 +7,8 @@ export const SettingsPlugin = {
 
   async get(key, defaultValue) {
     const result = await Vue.prototype.$util.send('appdb/setting/get', { key });
-    result.value = defaultValue;
     log.info("get", JSON.stringify(result));
-    if (result) {
+    if (result && result.value !== undefined) {
       return result.value
     }
     return defaultValue;

--- a/apps/studio/src/plugins/SettingsPlugin.ts
+++ b/apps/studio/src/plugins/SettingsPlugin.ts
@@ -5,18 +5,22 @@ const log = rawLog.scope('settings-plugin')
 
 export const SettingsPlugin = {
 
-  async get(key: string, defaultValue?: any) {
+  async get(key, defaultValue) {
+    if (!Vue.prototype.$util) {
+      return defaultValue || null;
+    }
     const result = await Vue.prototype.$util.send('appdb/setting/get', { key });
-    log.info("get", JSON.stringify(result))
+    log.info("get", JSON.stringify(result));
     if (result) {
       return result.value
     }
-    return defaultValue || null
+    return defaultValue || null;
   },
 
-  async set(key: string, value: string) {
-    log.info("set", key, value)
-    await Vue.prototype.$util.send('appdb/setting/set', { key, value });
+  async set(key, value) {
+    const util = await this.waitForUtil();
+    log.info("set", key, value);
+    await util.send('appdb/setting/set', { key, value });
   }
 }
 

--- a/apps/studio/src/plugins/SettingsPlugin.ts
+++ b/apps/studio/src/plugins/SettingsPlugin.ts
@@ -6,15 +6,13 @@ const log = rawLog.scope('settings-plugin')
 export const SettingsPlugin = {
 
   async get(key, defaultValue) {
-    if (!Vue.prototype.$util) {
-      return defaultValue || null;
-    }
     const result = await Vue.prototype.$util.send('appdb/setting/get', { key });
+    result.value = defaultValue;
     log.info("get", JSON.stringify(result));
     if (result) {
       return result.value
     }
-    return defaultValue || null;
+    return defaultValue;
   },
 
   async set(key: string, value: string) {

--- a/apps/studio/src/plugins/SettingsPlugin.ts
+++ b/apps/studio/src/plugins/SettingsPlugin.ts
@@ -17,10 +17,9 @@ export const SettingsPlugin = {
     return defaultValue || null;
   },
 
-  async set(key, value) {
-    const util = await this.waitForUtil();
-    log.info("set", key, value);
-    await util.send('appdb/setting/set', { key, value });
+  async set(key: string, value: string) {
+    log.info("set", key, value)
+    await Vue.prototype.$util.send('appdb/setting/set', { key, value });
   }
 }
 

--- a/apps/studio/tests/unit/lib/export/formats/sql.spec.js
+++ b/apps/studio/tests/unit/lib/export/formats/sql.spec.js
@@ -22,4 +22,11 @@ describe('sql exporter', () => {
     const result = exporter.formatRow(input)
     expect(result).toBe(`insert into "table" ("col_1") values ('a''\nb')`)
   })
+
+  it("Should set defaultPath correctly after refactor", () => {
+    const safeFilename = "exported_data";
+    let exporter = new SqlExporter(`${safeFilename}.sql`, {connectionType: 'postgresql'}, { name: 'table'}, '', '', [], {}, {})
+
+    expect(exporter.getFileName()).toBe("exported_data.sql");
+  });
 });


### PR DESCRIPTION
Fix #2695: Changed the way defaultPath was given a name by removing a function that was not returning anything (getLastExportPath) and was breaking the code. Also added a test case. Now the saved queries can be exported correctly.