### PR TITLE
Feat/streamer mode

### DIFF
--- a/apps/studio/src/components/MaskedInput.vue
+++ b/apps/studio/src/components/MaskedInput.vue
@@ -1,0 +1,48 @@
+<template>
+    <input
+      :type="computedType"
+      :value="displayedValue"
+      @input="handleInput"
+      :readonly="privacyMode"
+      class="form-control"
+    >
+  </template>
+  
+  <script>
+  export default {
+    name: 'MaskedInput',
+    props: {
+      value: {
+        type: [String, Number],
+        default: ''
+      },
+      privacyMode: {
+        type: Boolean,
+        default: false
+      },
+      type: {
+        type: String,
+        default: 'text'
+      },
+      mask: {
+        type: String,
+        default: '******'
+      }
+    },
+    computed: {
+      computedType() {
+        return this.privacyMode ? 'text' : this.type;
+      },
+      displayedValue() {
+        return this.privacyMode ? this.mask : this.value;
+      }
+    },
+    methods: {
+      handleInput(event) {
+        if (!this.privacyMode) {
+          this.$emit('input', event.target.value);
+        }
+      }
+    }
+  }
+  </script>

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -38,10 +38,12 @@
       <div class="col s3 form-group" v-if="supportsSocketPathWithCustomPort">
         <label for="port">Port</label>
         <input
-          type="number"
+          :type="streamerMode ? 'text' : 'number'"
           class="form-control"
           name="port"
-          v-model.number="config.port"
+          :value="streamerMode ? '******' : config.port"
+          @input="!streamerMode && (config.port = $event.target.value)"
+          :readonly="streamerMode"
         >
       </div>
     </div>
@@ -56,16 +58,20 @@
           class="form-control"
           @paste="onPaste"
           name="host"
-          v-model="config.host"
+          :value="streamerMode ? '******' : config.host"
+          @input="!streamerMode && (config.host = $event.target.value)"
+          :readonly="streamerMode"
         >
       </div>
       <div class="col s3 form-group">
         <label for="port">Port</label>
         <input
-          type="number"
+          :type="streamerMode ? 'text' : 'number'"
           class="form-control"
           name="port"
-          v-model.number="config.port"
+          :value="streamerMode ? '******' : config.port"
+          @input="!streamerMode && (config.port = $event.target.value)"
+          :readonly="streamerMode"
         >
       </div>
     </div>
@@ -173,8 +179,10 @@
         <input
           type="text"
           name="user"
-          v-model="config.username"
+          :value="streamerMode ? '******' : config.username"
+          @input="!streamerMode && (config.username = $event.target.value)"
           class="form-control"
+          :readonly="streamerMode"
         >
       </div>
       <div class="col s6 form-group">
@@ -214,6 +222,7 @@ import FilePicker from '@/components/common/form/FilePicker.vue'
 import ExternalLink from '@/components/common/ExternalLink.vue'
 import { findClient } from '@/lib/db/clients'
 import ToggleFormArea from '../common/ToggleFormArea.vue'
+import { mapGetters } from 'vuex'
 
   export default {
     props: {
@@ -236,6 +245,12 @@ import ToggleFormArea from '../common/ToggleFormArea.vue'
       }
     },
     computed: {
+      ...mapGetters({
+        settings: 'settings/settings'
+      }),
+      streamerMode() {
+        return this.settings?.streamerMode || false
+      },
       hasAdvancedSsl() {
         return this.config.sslCaFile || this.config.sslCertFile || this.config.sslKeyFile
       },

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -37,14 +37,12 @@
       </div>
       <div class="col s3 form-group" v-if="supportsSocketPathWithCustomPort">
         <label for="port">Port</label>
-        <input
-          :type="privacyMode ? 'text' : 'number'"
-          class="form-control"
-          name="port"
-          :value="privacyMode ? '******' : config.port"
-          @input="!privacyMode && (config.port = $event.target.value)"
-          :readonly="privacyMode"
-        >
+        <masked-input
+          :value="config.port"
+          :privacyMode="privacyMode"
+          :type="'number'"
+          @input="val => config.port = val"
+        />
       </div>
     </div>
     <div
@@ -53,26 +51,20 @@
     >
       <div class="col s9 form-group">
         <label for="Host">Host</label>
-        <input
-          type="text"
-          class="form-control"
-          @paste="onPaste"
-          name="host"
-          :value="privacyMode ? '******' : config.host"
-          @input="!privacyMode && (config.host = $event.target.value)"
-          :readonly="privacyMode"
-        >
+        <masked-input
+          :value="config.host"
+          :privacyMode="privacyMode"
+          @input="val => config.host = val"
+        />
       </div>
       <div class="col s3 form-group">
         <label for="port">Port</label>
-        <input
-          :type="privacyMode ? 'text' : 'number'"
-          class="form-control"
-          name="port"
-          :value="privacyMode ? '******' : config.port"
-          @input="!privacyMode && (config.port = $event.target.value)"
-          :readonly="privacyMode"
-        >
+        <masked-input
+          :value="config.port"
+          :privacyMode="privacyMode"
+          :type="'number'"
+          @input="val => config.port = val"
+        />
       </div>
     </div>
 
@@ -176,14 +168,11 @@
     <div class="row gutter">
       <div class="col s6 form-group">
         <label for="user">User</label>
-        <input
-          type="text"
-          name="user"
-          :value="privacyMode ? '******' : config.username"
-          @input="!privacyMode && (config.username = $event.target.value)"
-          class="form-control"
-          :readonly="privacyMode"
-        >
+        <masked-input
+          :value="config.username"
+          :privacyMode="privacyMode"
+          @input="val => config.username = val"
+        />
       </div>
       <div class="col s6 form-group">
         <label for="password">Password</label>
@@ -222,6 +211,7 @@ import FilePicker from '@/components/common/form/FilePicker.vue'
 import ExternalLink from '@/components/common/ExternalLink.vue'
 import { findClient } from '@/lib/db/clients'
 import ToggleFormArea from '../common/ToggleFormArea.vue'
+import MaskedInput from '@/components/MaskedInput.vue'
 import { mapState } from 'vuex'
 
 export default {
@@ -236,7 +226,8 @@ export default {
   components: {
     FilePicker,
     ExternalLink,
-    ToggleFormArea
+    ToggleFormArea,
+    MaskedInput
   },
   data() {
     return {

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -38,12 +38,12 @@
       <div class="col s3 form-group" v-if="supportsSocketPathWithCustomPort">
         <label for="port">Port</label>
         <input
-          :type="streamerMode ? 'text' : 'number'"
+          :type="privacyMode ? 'text' : 'number'"
           class="form-control"
           name="port"
-          :value="streamerMode ? '******' : config.port"
-          @input="!streamerMode && (config.port = $event.target.value)"
-          :readonly="streamerMode"
+          :value="privacyMode ? '******' : config.port"
+          @input="!privacyMode && (config.port = $event.target.value)"
+          :readonly="privacyMode"
         >
       </div>
     </div>
@@ -58,20 +58,20 @@
           class="form-control"
           @paste="onPaste"
           name="host"
-          :value="streamerMode ? '******' : config.host"
-          @input="!streamerMode && (config.host = $event.target.value)"
-          :readonly="streamerMode"
+          :value="privacyMode ? '******' : config.host"
+          @input="!privacyMode && (config.host = $event.target.value)"
+          :readonly="privacyMode"
         >
       </div>
       <div class="col s3 form-group">
         <label for="port">Port</label>
         <input
-          :type="streamerMode ? 'text' : 'number'"
+          :type="privacyMode ? 'text' : 'number'"
           class="form-control"
           name="port"
-          :value="streamerMode ? '******' : config.port"
-          @input="!streamerMode && (config.port = $event.target.value)"
-          :readonly="streamerMode"
+          :value="privacyMode ? '******' : config.port"
+          @input="!privacyMode && (config.port = $event.target.value)"
+          :readonly="privacyMode"
         >
       </div>
     </div>
@@ -179,10 +179,10 @@
         <input
           type="text"
           name="user"
-          :value="streamerMode ? '******' : config.username"
-          @input="!streamerMode && (config.username = $event.target.value)"
+          :value="privacyMode ? '******' : config.username"
+          @input="!privacyMode && (config.username = $event.target.value)"
           class="form-control"
-          :readonly="streamerMode"
+          :readonly="privacyMode"
         >
       </div>
       <div class="col s6 form-group">
@@ -222,90 +222,85 @@ import FilePicker from '@/components/common/form/FilePicker.vue'
 import ExternalLink from '@/components/common/ExternalLink.vue'
 import { findClient } from '@/lib/db/clients'
 import ToggleFormArea from '../common/ToggleFormArea.vue'
-import { mapGetters } from 'vuex'
+import { mapState } from 'vuex'
 
-  export default {
-    props: {
-      config: Object,
-      sslHelp: String,
-      supportComplexSSL: {
-        type: Boolean,
-        default: true
-      }
-    },
-    components: {
-      FilePicker,
-      ExternalLink,
-      ToggleFormArea
-    },
-    data() {
-      return {
-        sslToggled: false,
-        showPassword: false,
-      }
-    },
-    computed: {
-      ...mapGetters({
-        settings: 'settings/settings'
-      }),
-      streamerMode() {
-        return this.settings?.streamerMode || false
-      },
-      hasAdvancedSsl() {
-        return this.config.sslCaFile || this.config.sslCertFile || this.config.sslKeyFile
-      },
-      toggleIcon() {
-        return this.sslToggled ? 'keyboard_arrow_down' : 'keyboard_arrow_right'
-      },
-      togglePasswordIcon() {
-        return this.showPassword ? "visibility_off" : "visibility"
-      },
-      togglePasswordInputType() {
-        return this.showPassword ? "text" : "password"
-      },
-      supportsSocketPath() {
-        return findClient(this.config.connectionType).supportsSocketPath
-      },
-      supportsSocketPathWithCustomPort() {
-        return findClient(this.config.connectionType).supportsSocketPathWithCustomPort
-      },
-    },
-    methods: {
-      async onPaste(event) {
-        const data = event.clipboardData.getData('text')
-        try {
-          await this.$util.send('appdb/saved/parseUrl', { url: data });
-          event.preventDefault();
-        } catch {
-          return;
-        }
-      },
-      toggleSsl() {
-        this.config.ssl = !this.config.ssl
-
-        // Remove CA file when disabling ssl
-        if (!this.config.ssl) {
-          this.config.sslCaFile = null
-          this.config.sslCertFile = null
-          this.config.sslKeyFile = null
-        }
-      },
-      toggleSslAdvanced() {
-        this.sslToggled = !this.sslToggled;
-      },
-      togglePassword() {
-        this.showPassword = !this.showPassword
-      }
-    },
-    mounted() {
-      this.sslToggled = this.hasAdvancedSsl
+export default {
+  props: {
+    config: Object,
+    sslHelp: String,
+    supportComplexSSL: {
+      type: Boolean,
+      default: true
     }
+  },
+  components: {
+    FilePicker,
+    ExternalLink,
+    ToggleFormArea
+  },
+  data() {
+    return {
+      sslToggled: false,
+      showPassword: false,
+    }
+  },
+  computed: {
+    ...mapState('settings', ['privacyMode']),
+    hasAdvancedSsl() {
+      return this.config.sslCaFile || this.config.sslCertFile || this.config.sslKeyFile
+    },
+    toggleIcon() {
+      return this.sslToggled ? 'keyboard_arrow_down' : 'keyboard_arrow_right'
+    },
+    togglePasswordIcon() {
+      return this.showPassword ? "visibility_off" : "visibility"
+    },
+    togglePasswordInputType() {
+      return this.showPassword ? "text" : "password"
+    },
+    supportsSocketPath() {
+      return findClient(this.config.connectionType).supportsSocketPath
+    },
+    supportsSocketPathWithCustomPort() {
+      return findClient(this.config.connectionType).supportsSocketPathWithCustomPort
+    },
+  },
+  methods: {
+    async onPaste(event) {
+      const data = event.clipboardData.getData('text')
+      try {
+        await this.$util.send('appdb/saved/parseUrl', { url: data });
+        event.preventDefault();
+      } catch {
+        return;
+      }
+    },
+    toggleSsl() {
+      this.config.ssl = !this.config.ssl
+
+      // Remove CA file when disabling ssl
+      if (!this.config.ssl) {
+        this.config.sslCaFile = null
+        this.config.sslCertFile = null
+        this.config.sslKeyFile = null
+      }
+    },
+    toggleSslAdvanced() {
+      this.sslToggled = !this.sslToggled;
+    },
+    togglePassword() {
+      this.showPassword = !this.showPassword
+    }
+  },
+  mounted() {
+    this.sslToggled = this.hasAdvancedSsl
   }
+}
 </script>
 
 <style lang="scss" scoped>
-  .optional-text {
-    font-style: italic;
-    padding-left: .2rem;
-  }
+.optional-text {
+  font-style: italic;
+  padding-left: .2rem;
+}
 </style>

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -292,7 +292,6 @@ export default {
       foldersError: 'error',
       foldersUnsupported: 'unsupported'
     }),
-    // Map the privacyMode from the Vuex 'settings' module so that the component always reflects it
     ...mapState('settings', ['privacyMode']),
     ...mapGetters({
       usedConfigs: 'data/usedconnections/orderedUsedConfigs',

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -53,6 +53,9 @@
               </div>
               <span class="expand" />
               <div class="actions">
+                <a @click.prevent="streamerMode = !streamerMode" :title="streamerMode ? 'Disable streamer mode' : 'Enable streamer mode'">
+                  <i class="material-icons">{{ streamerMode ? 'visibility_off' : 'visibility' }}</i>
+                </a>
                 <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
               </div>
             </div>
@@ -75,6 +78,7 @@
                 :selected-config="selectedConfig"
                 :show-duplicate="true"
                 :pinned="true"
+                :streamer-mode="streamerMode"
                 @edit="edit"
                 @remove="remove"
                 @duplicate="duplicate"
@@ -104,6 +108,9 @@
                     @click.prevent="importFromLocal"
                     title="Import connections from local workspace"
                   ><i class="material-icons">save_alt</i></a>
+                  <a @click.prevent="streamerMode = !streamerMode" :title="streamerMode ? 'Disable streamer mode' : 'Enable streamer mode'">
+                    <i class="material-icons">{{ streamerMode ? 'visibility_off' : 'visibility' }}</i>
+                  </a>
                   <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
                   <sidebar-sort-buttons
                     v-model="sort"
@@ -170,6 +177,7 @@
                   :selected-config="selectedConfig"
                   :show-duplicate="true"
                   :pinned="pinnedConnections.includes(c)"
+                  :streamer-mode="streamerMode"
                   @edit="edit"
                   @remove="remove"
                   @duplicate="duplicate"
@@ -183,6 +191,7 @@
                 :selected-config="selectedConfig"
                 :show-duplicate="true"
                 :pinned="pinnedConnections.includes(c)"
+                :streamer-mode="streamerMode"
                 @edit="edit"
                 @remove="remove"
                 @duplicate="duplicate"
@@ -214,6 +223,7 @@
                 :selected-config="selectedConfig"
                 :is-recent-list="true"
                 :show-duplicate="false"
+                :streamer-mode="streamerMode"
                 @edit="edit"
                 @remove="removeUsedConfig"
                 @doubleClick="connect"
@@ -245,6 +255,7 @@ export default {
   components: { ConnectionListItem, SidebarLoading, ErrorAlert, SidebarFolder, SidebarSortButtons, WorkspaceSidebar },
   props: ['selectedConfig'],
   data: () => ({
+    streamerMode : false,
     split: null,
     sortables: {
       labelColor: "Color",
@@ -260,6 +271,9 @@ export default {
       await this.$settings.set('connectionsSortOrder', this.sort.order)
       await this.$settings.set('connectionsSortBy', this.sort.field)
     },
+    async streamerMode(newVal) {
+      await this.$settings.set('streamerMode', newVal)
+    }
   },
   computed: {
     ...mapState('data/connections', {'connectionsLoading': 'loading', 'connectionsError': 'error', 'connectionFilter': 'filter'}),
@@ -349,7 +363,10 @@ export default {
     this.buildSplit()
     const [field, order] = await Promise.all([
       this.$settings.get('connectionsSortBy', 'name'),
-      this.$settings.get('connectionsSortOrder', 'asc')
+      this.$settings.get('connectionsSortOrder', 'asc'),
+      this.$settings.get('streamerMode', false).then(mode => {
+        this.streamerMode = mode
+      })
     ])
     this.sort.field = field
     this.sort.order = order

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -43,7 +43,7 @@
           class="list saved-connection-list expand"
           ref="pinnedConnectionList"
           v-show="!noPins && !connFilter"
-          >
+        >
           <div class="list-group">
             <div class="list-heading">
               <div class="flex">
@@ -53,8 +53,8 @@
               </div>
               <span class="expand" />
               <div class="actions">
-                <a @click.prevent="streamerMode = !streamerMode" :title="streamerMode ? 'Disable streamer mode' : 'Enable streamer mode'">
-                  <i class="material-icons">{{ streamerMode ? 'visibility_off' : 'visibility' }}</i>
+                <a @click="togglePrivacyMode" :title="privacyMode ? 'Disable Privacy Mode' : 'Enable Privacy Mode'">
+                  <i class="material-icons">{{ privacyMode ? 'visibility_off' : 'visibility' }}</i>
                 </a>
                 <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
               </div>
@@ -78,7 +78,7 @@
                 :selected-config="selectedConfig"
                 :show-duplicate="true"
                 :pinned="true"
-                :streamer-mode="streamerMode"
+                :privacy-mode="privacyMode"
                 @edit="edit"
                 @remove="remove"
                 @duplicate="duplicate"
@@ -107,9 +107,11 @@
                     v-if="isCloud"
                     @click.prevent="importFromLocal"
                     title="Import connections from local workspace"
-                  ><i class="material-icons">save_alt</i></a>
-                  <a @click.prevent="streamerMode = !streamerMode" :title="streamerMode ? 'Disable streamer mode' : 'Enable streamer mode'">
-                    <i class="material-icons">{{ streamerMode ? 'visibility_off' : 'visibility' }}</i>
+                  >
+                    <i class="material-icons">save_alt</i>
+                  </a>
+                  <a @click="togglePrivacyMode" :title="privacyMode ? 'Disable Privacy Mode' : 'Enable Privacy Mode'">
+                    <i class="material-icons">{{ privacyMode ? 'visibility_off' : 'visibility' }}</i>
                   </a>
                   <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
                   <sidebar-sort-buttons
@@ -177,7 +179,7 @@
                   :selected-config="selectedConfig"
                   :show-duplicate="true"
                   :pinned="pinnedConnections.includes(c)"
-                  :streamer-mode="streamerMode"
+                  :privacy-mode="privacyMode"
                   @edit="edit"
                   @remove="remove"
                   @duplicate="duplicate"
@@ -191,7 +193,7 @@
                 :selected-config="selectedConfig"
                 :show-duplicate="true"
                 :pinned="pinnedConnections.includes(c)"
-                :streamer-mode="streamerMode"
+                :privacy-mode="privacyMode"
                 @edit="edit"
                 @remove="remove"
                 @duplicate="duplicate"
@@ -223,7 +225,7 @@
                 :selected-config="selectedConfig"
                 :is-recent-list="true"
                 :show-duplicate="false"
-                :streamer-mode="streamerMode"
+                :privacy-mode="privacyMode"
                 @edit="edit"
                 @remove="removeUsedConfig"
                 @doubleClick="connect"
@@ -239,7 +241,7 @@
 <script>
 import _ from 'lodash'
 import WorkspaceSidebar from './WorkspaceSidebar.vue'
-import { mapState, mapGetters } from 'vuex'
+import { mapState, mapGetters, mapActions } from 'vuex'
 import ConnectionListItem from './connection/ConnectionListItem.vue'
 import SidebarLoading from '@/components/common/SidebarLoading.vue'
 import ErrorAlert from '@/components/common/ErrorAlert.vue'
@@ -252,10 +254,16 @@ import SidebarSortButtons from '../common/SidebarSortButtons.vue'
 const log = rawLog.scope('connection-sidebar');
 
 export default {
-  components: { ConnectionListItem, SidebarLoading, ErrorAlert, SidebarFolder, SidebarSortButtons, WorkspaceSidebar },
+  components: {
+    ConnectionListItem,
+    SidebarLoading,
+    ErrorAlert,
+    SidebarFolder,
+    SidebarSortButtons,
+    WorkspaceSidebar
+  },
   props: ['selectedConfig'],
   data: () => ({
-    streamerMode : false,
     split: null,
     sortables: {
       labelColor: "Color",
@@ -271,20 +279,28 @@ export default {
       await this.$settings.set('connectionsSortOrder', this.sort.order)
       await this.$settings.set('connectionsSortBy', this.sort.field)
     },
-    async streamerMode(newVal) {
-      await this.$settings.set('streamerMode', newVal)
-    }
   },
   computed: {
-    ...mapState('data/connections', {'connectionsLoading': 'loading', 'connectionsError': 'error', 'connectionFilter': 'filter'}),
-    ...mapState('data/connectionFolders', {'folders': 'items', 'foldersLoading': 'loading', 'foldersError': 'error', 'foldersUnsupported': 'unsupported'}),
+    ...mapState('data/connections', {
+      connectionsLoading: 'loading',
+      connectionsError: 'error',
+      connectionFilter: 'filter'
+    }),
+    ...mapState('data/connectionFolders', {
+      folders: 'items',
+      foldersLoading: 'loading',
+      foldersError: 'error',
+      foldersUnsupported: 'unsupported'
+    }),
+    // Map the privacyMode from the Vuex 'settings' module so that the component always reflects it
+    ...mapState('settings', ['privacyMode']),
     ...mapGetters({
-      'usedConfigs': 'data/usedconnections/orderedUsedConfigs',
-      'settings': 'settings/settings',
-      'isCloud': 'isCloud',
-      'activeWorkspaces': 'credentials/activeWorkspaces',
-      'pinnedConnections': 'pinnedConnections/pinnedConnections',
-      'filteredConnections': 'data/connections/filteredConnections'
+      usedConfigs: 'data/usedconnections/orderedUsedConfigs',
+      settings: 'settings/settings',
+      isCloud: 'isCloud',
+      activeWorkspaces: 'credentials/activeWorkspaces',
+      pinnedConnections: 'pinnedConnections/pinnedConnections',
+      filteredConnections: 'data/connections/filteredConnections'
     }),
     connFilter: {
       get() {
@@ -312,14 +328,10 @@ export default {
     foldersWithConnections() {
       if (this.loading) return []
 
-      const result = this.folders.map((folder) => {
-        return {
-          folder,
-          connections: this.sortedConnections.filter((c) => c.connectionFolderId === folder.id)
-        }
-      })
-
-      return result
+      return this.folders.map((folder) => ({
+        folder,
+        connections: this.sortedConnections.filter((c) => c.connectionFolderId === folder.id)
+      }));
     },
     loading() {
       return this.connectionsLoading || this.foldersLoading
@@ -354,8 +366,7 @@ export default {
       } else {
         result = _.orderBy(this.filteredConnections, this.sort.field)
       }
-
-      if (this.sort.order == 'desc') result = result.reverse()
+      if (this.sort.order === 'desc') result = result.reverse()
       return result;
     },
   },
@@ -363,15 +374,15 @@ export default {
     this.buildSplit()
     const [field, order] = await Promise.all([
       this.$settings.get('connectionsSortBy', 'name'),
-      this.$settings.get('connectionsSortOrder', 'asc'),
-      this.$settings.get('streamerMode', false).then(mode => {
-        this.streamerMode = mode
-      })
-    ])
+      this.$settings.get('connectionsSortOrder', 'asc')
+    ]);
     this.sort.field = field
     this.sort.order = order
   },
   methods: {
+    ...mapActions({
+      togglePrivacyMode: 'settings/togglePrivacyMode',
+    }),
     clearFilter() {
       this.connFilter = null;
     },

--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -19,19 +19,19 @@
         <div class="subtitle">
           <span
             class="bastion"
-            v-if="this.config.sshBastionHost && !streamerMode"
+            v-if="this.config.sshBastionHost && !privacyMode"
           >
             <span class="truncate">{{ this.config.sshBastionHost }}</span>&nbsp;>&nbsp;
           </span>
           <span
             class="ssh"
-            v-if="this.config.sshHost && !streamerMode"
+            v-if="this.config.sshHost && !privacyMode"
           >
             <span class="truncate">{{ this.config.sshHost }}</span>&nbsp;>&nbsp;
           </span>
           <span class="connection">
             <span>
-              {{ streamerMode ? '******' : subtitleSimple }}
+              {{ privacyMode ? '******' : subtitleSimple }}
             </span>
           </span>
         </div>
@@ -84,7 +84,7 @@ export default {
     'selectedConfig',
     'showDuplicate',
     'pinned',
-    'streamerMode'
+    'privacyMode'
   ],
   data: () => ({
     timeAgo: new TimeAgo('en-US'),
@@ -138,8 +138,8 @@ export default {
       }
     },
     title() {
-      return this.streamerMode ? 
-        'Connection details hidden by Streamer Mode' : 
+      return this.privacyMode ? 
+        'Connection details hidden by Privacy Mode' : 
         this.$bks.buildConnectionString(this.config)
     },
     savedConnection() {

--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -13,22 +13,26 @@
     >
       <span :class="`connection-label connection-label-color-${labelColor}`" />
       <div class="connection-title flex-col expand">
-        <div class="title">{{ label }}</div>
+        <div class="title">
+          {{ label }}
+        </div>
         <div class="subtitle">
           <span
             class="bastion"
-            v-if="this.config.sshBastionHost"
+            v-if="this.config.sshBastionHost && !streamerMode"
           >
             <span class="truncate">{{ this.config.sshBastionHost }}</span>&nbsp;>&nbsp;
           </span>
           <span
             class="ssh"
-            v-if="this.config.sshHost"
+            v-if="this.config.sshHost && !streamerMode"
           >
             <span class="truncate">{{ this.config.sshHost }}</span>&nbsp;>&nbsp;
           </span>
           <span class="connection">
-            <span>{{ subtitleSimple }}</span>
+            <span>
+              {{ streamerMode ? '******' : subtitleSimple }}
+            </span>
           </span>
         </div>
       </div>
@@ -74,7 +78,14 @@ import { isUltimateType } from '@/common/interfaces/IConnection'
 export default {
   // recent list is 'recent connections'
   // if that is true, we need to find the companion saved connection
-  props: ['config', 'isRecentList', 'selectedConfig', 'showDuplicate', 'pinned'],
+  props: [
+    'config',
+    'isRecentList',
+    'selectedConfig',
+    'showDuplicate',
+    'pinned',
+    'streamerMode'
+  ],
   data: () => ({
     timeAgo: new TimeAgo('en-US'),
     split: null
@@ -127,7 +138,9 @@ export default {
       }
     },
     title() {
-      return this.$bks.buildConnectionString(this.config)
+      return this.streamerMode ? 
+        'Connection details hidden by Streamer Mode' : 
+        this.$bks.buildConnectionString(this.config)
     },
     savedConnection() {
 

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -2,8 +2,8 @@
   <div
     class="connection-button flex flex-middle"
     v-if="config"
-    :title="streamerMode ? 
-      'Connection details hidden by Streamer Mode' : 
+    :title="privacyMode ? 
+      'Connection details hidden by Privacy Mode' : 
       $bks.buildConnectionString(config)"
   >
     <x-button
@@ -139,24 +139,25 @@ export default {
     }
   },
   computed: {
-      ...mapState({'config': 'usedConfig', 'connection': 'connection', 'versionString': 'versionString'}),
-      ...mapGetters({
-        'hasRunningExports': 'exports/hasRunningExports', 
-        'workspace': 'workspace',
-        settings: 'settings/settings',
-      }),
-      streamerMode() {
-        return this.settings?.streamerMode || false
-      },
-      connectionName() {
-        return this.config ? this.$bks.buildConnectionName(this.config) : 'Connection'
-      },
-      connectionType() {
-        return `${this.config.connectionType}`
-      },
-      databaseVersion() {
-        return this.versionString
-      }
+    ...mapState({
+      config: state => state.usedConfig,
+      connection: state => state.connection,
+      versionString: state => state.versionString
+    }),
+    ...mapState('settings', ['privacyMode']),
+    ...mapGetters({
+      hasRunningExports: 'exports/hasRunningExports',
+      workspace: 'workspace'
+    }),
+    connectionName() {
+      return this.config ? this.$bks.buildConnectionName(this.config) : 'Connection'
+    },
+    connectionType() {
+      return `${this.config.connectionType}`
+    },
+    databaseVersion() {
+      return this.versionString
+    }
   },
   methods: {
 

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -2,14 +2,18 @@
   <div
     class="connection-button flex flex-middle"
     v-if="config"
-    :title="$bks.buildConnectionString(config)"
+    :title="streamerMode ? 
+      'Connection details hidden by Streamer Mode' : 
+      $bks.buildConnectionString(config)"
   >
     <x-button
       class="btn btn-link btn-icon"
       menu
     >
       <i class="material-icons">link</i>
-      <span class="connection-name truncate expand">{{ connectionName }}</span>
+      <span class="connection-name truncate expand">
+        {{ connectionName }}
+      </span>
       <span
         class="connection-type badge truncate"
         v-tooltip="databaseVersion"
@@ -136,7 +140,14 @@ export default {
   },
   computed: {
       ...mapState({'config': 'usedConfig', 'connection': 'connection', 'versionString': 'versionString'}),
-      ...mapGetters({'hasRunningExports': 'exports/hasRunningExports', 'workspace': 'workspace'}),
+      ...mapGetters({
+        'hasRunningExports': 'exports/hasRunningExports', 
+        'workspace': 'workspace',
+        settings: 'settings/settings',
+      }),
+      streamerMode() {
+        return this.settings?.streamerMode || false
+      },
       connectionName() {
         return this.config ? this.$bks.buildConnectionName(this.config) : 'Connection'
       },

--- a/docs/user_guide/privacy-mode.md
+++ b/docs/user_guide/privacy-mode.md
@@ -1,0 +1,36 @@
+---
+title: Privacy Mode
+summary: "Hide sensitive data."
+old_url: "https://docs.beekeeperstudio.io/docs/privacy-mode"
+---
+
+Beekeeper Studio provides a Privacy Mode that hides sensitive data when you're sharing your screen, so you can keep private information private.
+
+
+## Interaction
+
+While hovering the Sidebar, you can see the "Toggle Privacy Mode" button, represented with an eye.
+Clicking this button will toggle the Privacy Mode On/Off.
+
+| Privacy Mode Off | Privacy Mode On |
+| - | - |
+|![image](https://github.com/user-attachments/assets/0dfbeeba-7bfb-456f-9a03-6489689989e9)|![image](https://github.com/user-attachments/assets/0b15018c-d10d-4217-b3b4-b4fdaec6b619) |
+| Fig.1 Button Off | Fig.2 Button On |
+
+## What Gets Hidden?
+
+Privacy Mode hides some fields that might be considered as sensitive:
+- Host / Port / DB in Saved Connections
+- Pop-up with the full URL on Hover
+- Host / Port / DB in Connection Settings
+- URL when hovering over the DB name after connecting
+
+| Hidden Host / Port / DB in Saved Connections | The pop-up with the full URL on Hover |
+|-|-|
+|![image](https://github.com/user-attachments/assets/d6be5cb4-9d4c-4414-a088-48b65fefe9a4) | ![image](https://github.com/user-attachments/assets/b005b9d7-f3f8-424d-843b-a520b3a015cd)|
+| Fig.3 - Hidden Feature 1 | Fig.4 - Hidden Feature 2 |
+
+| Host / Port / DB in Connection Settings |  URL when hovering over the DB name after connecting |
+| - | - |
+|![image](https://github.com/user-attachments/assets/873c0646-028e-4907-a9e5-33e27cf1b4a2) | ![image](https://github.com/user-attachments/assets/0617a437-71a7-4562-9057-025413c16eb1) |
+| Fig.5 - Hidden Feature 3 | Fig.6 - Hidden Feature 4 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
     - user_guide/editing-data.md
     - user_guide/data-export.md
     - user_guide/modify-tables.md
+    - user_guide/privacy-mode.md
     - user_guide/entity-relationship-diagrams-erd.md
     - user_guide/backup-restore.md
     - user_guide/cloud-storage-team-workspaces.md


### PR DESCRIPTION
Closes #2856 

The motivation for contributing to an open source project came from a faculty course unit, and in the scope of that I have detailed all the findings and the fix solution [here](https://github.com/thePeras/beekeeper-studio/wiki/Issue-%232856).
On the details section I layed out our Wiki documentation on this specific Issue.

Fell free to suggest improvements.
I think I implemented all that the issuer wanted, but something could have slipped.

<details>

# Issue and Requirements

Issue [#2856](https://github.com/beekeeper-studio/beekeeper-studio/issues/2856) describes a feature known as "Streamer Mode", but we'll name it **"Privacy Mode"**, because it isn't just made for streamers.

This is a common feature in multiple applications, more in particular, applications that contain sensitive data. This feature aims to hide information for when the user is streaming/screensharing.

The reporter suggested that a toggle icon for enabling/disabling the Privacy Mode would also be an ergonomic way of using this feature.

| Privacy Mode Toggle Button |
| - |
| ![420608304-4ba7d49d-f49a-4863-b267-9217a5f98898](https://github.com/user-attachments/assets/fc93528e-be60-462b-805b-432dfe5e114e)|
| Fig.1 User Print 1 |

The reporter also shared the specific fields that they wanted hidden, namely:

| Host / Port / DB in Saved Connections | The pop-up with the full URL on Hover |
| - | - |
| ![421115860-eb9ab99a-c50e-41d1-8a8b-a24295171219](https://github.com/user-attachments/assets/616b02db-9aab-4475-8c85-0a30f6537d69) | ![421115885-5b5ae907-6f51-4193-a668-c14be7cf7a9c](https://github.com/user-attachments/assets/ca16a418-6c2f-4548-8431-d64e82de7de8) |
| Fig.2 User Print 2 | Fig.3 User Print 3 |

| Host / Port / DB in Connection Settings |  URL when hovering over the DB name after connecting |
| - | - |
| ![421115905-1838c709-ff2c-4a99-bb3a-15c7c1cde6d4](https://github.com/user-attachments/assets/776c48ff-5ba6-497c-9dfb-1e45b696e1d6) | ![421115915-1875bcee-971c-4245-a4b1-6f0a0c23b6af](https://github.com/user-attachments/assets/9b1f458c-9fb0-4633-9012-1feb3ca47622) |
| Fig.4 User Print 4 | Fig.5 User Print 5 |

Expected behavior: When activating Privacy Mode, the above specified fields should become hidden.

This issue probably won't depend on the operating system, but it could be important to specify that I am using Windows 10.


# Source Code Files

The files related to the issue are:

| File | Description |
| ---- | ----------- |
| ConnectionSidebar.vue | A Vue.js component that renders a sidebar interface for managing database connections. |
| ConnectionListItem.vue | A Vue.js component that renders a clickable list item for a database connection, displaying connection details. |
| CommonServerInputs.vue | A Vue.js component that provides a form for configuring database connection details. |
| ConnectionButton.vue | A Vue.js component that displays a connection button in the UI that shows the current database connection details. |
| MaskedInput.vue | A Vue.js component that was created in order to simplify the censored fields in the CommonServerInputs. |
| SettingsStoreModule.ts | A Vuex store module that manages user settings. |

# Design of the Fix

While trying to find a solution for this feature, I just needed to use the selecion tool provided by the 'Inspect'-like feature on the right side of the BeekeeperStudio app. This allowed me to find where were the components that needed to be hidden by the Privacy Mode somewhat quickly.

Note: The Inspect is really useful from a maintenance POV, well done.


The Privacy Mode feature is expected to work like described in the following Sequence Diagram from Figure 6: 

The user clicks the Privacy Mode Icon that is located on the Sidebar, which will update the privacyMode variable to the new value (true/false). Then, the SettingsStore notifies all components and the UI re-renders the affected fields.

| Expected Sequence Diagram |
|-|
| ![Privacy Mode Sequence Diagram](https://github.com/user-attachments/assets/1c9fb588-8dfe-4641-966e-b358a26a194f) |
| Fig.6 Privacy Mode Sequence Diagram |

The following State Diagram show sthe binary toggle between modes. The notes in the diagram show an example of what the final result of the Privacy Mode should look like.

| Expected State Diagram |
|-|
| ![Privacy Mode State Diagram](https://github.com/user-attachments/assets/84bf571a-c104-451e-be03-e0d49e07f17a) |
| Fig.7 Privacy Mode State Diagram |

As I am not 100% familiar with Vue, in the beggining I was trying to propagate the privacyMode variable value from the ConnectionSidebar.vue file to the other components. However, I ended up realizing that using the Store feature from Vue would make it way simpler.

# Update Source Code

## ConnectionSidebar.vue

```jsx
<div class="actions">
    <a 
        @click="togglePrivacyMode" 
        :title="privacyMode ? 'Disable Privacy Mode' : 'Enable Privacy Mode'"
    >
        <i class="material-icons">{{ privacyMode ? 'visibility_off' : 'visibility' }}</i>
    </a>
    <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
</div>
```

This adds the new button for toggling the Privacy Mode.


```jsx
<connection-list-item
  // ...
  :pinned="true"
  :privacy-mode="privacyMode"
  @edit="edit"
  // ...
/>
```

This sends the value of privacy-mode to the ConnectionListItem.

```jsx
  computed: {
    ...mapState('settings', ['privacyMode']),
  }
```
This maps the privacyMode from the Vuex 'settings' module so that the component always reflects it

```jsx
  methods: {
    ...mapActions({
      togglePrivacyMode: 'settings/togglePrivacyMode',
    }),
```
This makes sure that when we're calling the `togglePrivacyMode` function, it's the one from the settings, which changes the original privacyMode variable.


## ConnectionListItem.vue

```jsx
<div class="subtitle">
  <span
    class="bastion"
    v-if="this.config.sshBastionHost && !privacyMode"
```
This will show the subtitle if sshBastionHost exists and if the Privacy Mode is deactivated.

```jsx
    v-if="this.config.sshHost && !privacyMode"
```
The same as the sshBastionHost but with the sshHost.

```jsx
<span class="connection">
  <span>
    {{ privacyMode ? '******' : subtitleSimple }}
```
If the Privacy Mode is On, the subtitle will only show '******', otherwise it will show the subtitle normally.

```jsx
  title() {
    return this.privacyMode ? 
      'Connection details hidden by Privacy Mode' : 
      this.$bks.buildConnectionString(this.config)
  },
```
When Privacy Mode is On, hovering a Connection will show 'Connection details hidden by Privacy Mode, otherwise it will show the Connection String normally.


## CommonServerInputs.vue

```jsx
  <label for="port">Port</label>
  <masked-input
    :value="config.port"
    :privacyMode="privacyMode"
    :type="'number'"
    @input="val => config.port = val"
  />
```
This hides the Port value as '******' when Privacy Mode is On, otherwise it will show normally.


```jsx
  <label for="Host">Host</label>
  <masked-input
    :value="config.host"
    :privacyMode="privacyMode"
    @input="val => config.host = val"
  />
```
This hides the Host value as '******' when Privacy Mode is On, otherwise it will show normally.


```jsx
  <label for="user">User</label>
  <masked-input
    :value="config.username"
    :privacyMode="privacyMode"
    @input="val => config.username = val"
  />
```
This hides the Username value as '******' when Privacy Mode is On, otherwise it will show normally.

## ConnectionButton.vue

```jsx
  <div
    class="connection-button flex flex-middle"
    v-if="config"
    :title="privacyMode ? 
      'Connection details hidden by Privacy Mode' : 
      $bks.buildConnectionString(config)"
  >
```
This hides the connection details while hovering when Privacy Mode is on.

## MaskedInput.vue

This is a new file that handles the repetitive logic of the censored inputs in the CommonServerInputs.

```jsx
<template>
  <input
    :type="computedType"
    :value="displayedValue"
    @input="handleInput"
    :readonly="privacyMode"
    class="form-control"
  >
</template>
```
Defines an input element that binds its type, value, and readonly state to dynamic component properties and handles input events.

```jsx
props: {
    value: {
      type: [String, Number],
      default: ''
    },
    privacyMode: {
      type: Boolean,
      default: false
    },
    type: {
      type: String,
      default: 'text'
    },
    mask: {
      type: String,
      default: '******'
    }
  },
```
Props for value, privacy mode, input type, and mask string.

```jsx
  computed: {
    computedType() {
      return this.privacyMode ? 'text' : this.type;
    },
    displayedValue() {
      return this.privacyMode ? this.mask : this.value;
    }
  },
```
Calculates the actual input type and displayed value based on the privacy mode, switching between provided values and defaults.


```jsx
  methods: {
    handleInput(event) {
      if (!this.privacyMode) {
        this.$emit('input', event.target.value);
      }
    }
  }
```
Implements a handler that emits user input only when privacy mode is disabled, ensuring proper input management.

## SettingStoreModule.ts

```ts
interface State {
  privacyMode: boolean
}
```
Adds the the privacyMode variable (which is a boolean) to the State interface.

```ts
const M = {
  state: () => ({
    privacyMode: false
  }),
```
Adds the variable privacyMode to the context.


```ts
    SET_PRIVACY_MODE(state, value: boolean) {
      state.privacyMode = value;
    }
```
Function that changes the value of privacyMode.

```ts
    if (key === 'privacyMode') {
        const setting = context.state.settings[key] || await Vue.prototype.$util.send('appdb/setting/new');
        setting.key = key;

        if (_.isBoolean(value)) setting.valueType = UserSettingValueType.boolean;
        setValue(setting, value);
        const newSetting = await Vue.prototype.$util.send('appdb/setting/save', { obj: setting });
        _.merge(setting, newSetting);
        context.commit(M.ADD, setting);
    }
```
Checks if the setting key is 'privacyMode', prepares or creates a new setting object, assigns a boolean type if applicable, updates its value, saves it via an API call, merges the result, and commits it to the store.

```ts
    togglePrivacyMode({ commit, state }) {
      const newPrivacyMode = !state.privacyMode;
      commit('SET_PRIVACY_MODE', newPrivacyMode);
    },
```
Toggles the privacyMode state by inverting its current value and committing the updated value to the store.

# Final Result

| Privacy Mode Off | Privacy Mode On |
| - | - |
|![image](https://github.com/user-attachments/assets/0dfbeeba-7bfb-456f-9a03-6489689989e9)|![image](https://github.com/user-attachments/assets/0b15018c-d10d-4217-b3b4-b4fdaec6b619) |
| Fig.8 Button Off | Fig.9 Button On |

| Hidden Host / Port / DB in Saved Connections | The pop-up with the full URL on Hover |
|-|-|
|![image](https://github.com/user-attachments/assets/d6be5cb4-9d4c-4414-a088-48b65fefe9a4) | ![image](https://github.com/user-attachments/assets/ac3af386-c220-4392-b3bf-a582f87c1632)|
| Fig.10 - Hidden Feature 1 | Fig.11 - Hidden Feature 2 |

| Host / Port / DB in Connection Settings |  URL when hovering over the DB name after connecting |
| - | - |
|![image](https://github.com/user-attachments/assets/873c0646-028e-4907-a9e5-33e27cf1b4a2) | ![image](https://github.com/user-attachments/assets/1a458ad3-0270-4b0e-bbd3-9b818b748b6f) |
| Fig.12 - Hidden Feature 3 | Fig.13 - Hidden Feature 4 |

# Pull Request

Proposed fix submitted in the [#2934](https://github.com/beekeeper-studio/beekeeper-studio/pull/2934) PR
</details>