### PR TITLE
Fix #2907: Prevent "ß" from printing when toggling the sidebar

### DIFF
--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -165,7 +165,7 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
     primarySidebarToggle: {
       id: 'menu-toggle-sidebar',
       label: 'Toggle Primary Sidebar',
-      accelerator: "Alt+S",
+      accelerator: platformInfo.isMac? "CommandOrControl+B" : "Alt+S",
       click: actionHandler.togglePrimarySidebar,
     },
     secondarySidebarToggle: {

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -82,9 +82,16 @@
         "secondarySidebarSize",
       ]),
       keymap() {
-        return this.$vHotkeyKeymap({
+        const result = this.$vHotkeyKeymap({
           'general.openQuickSearch': this.showQuickSearch
-        })
+        });
+        if (this.$config.isMac) {
+          result['alt+s'] = (event) => {
+            event.preventDefault();
+            this.toggleSidebar();
+          };
+        }
+        return result;
       },
       splitElements() {
         return [

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -85,12 +85,6 @@
         const result = this.$vHotkeyKeymap({
           'general.openQuickSearch': this.showQuickSearch
         });
-        if (this.$config.isMac) {
-          result['alt+s'] = (event) => {
-            event.preventDefault();
-            this.toggleSidebar();
-          };
-        }
         return result;
       },
       splitElements() {


### PR DESCRIPTION
The issue occurs when the keybind is activated, causing the cursor in the text editor to trigger and print "ß". To resolve this, I modified the keymap() function to prevent the default behavior (printing) on Mac when the keybind is triggered, ensuring only the sidebar is toggled.

Close #2907 