### PR TITLE
fix: submit raw query filter only on form submit

### DIFF
--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -321,13 +321,6 @@ export default Vue.extend({
     filterMode() {
       this.submit();
     },
-    filterRaw() {
-      const focusIsOnInput = document.activeElement.isSameNode(this.$refs.valueInput)
-      if (!focusIsOnInput) {
-        this.updateMinimalModeByFilterRaw()
-      }
-      this.submit();
-    },
     externalFilters() {
       this.hideInMinimalMode = checkEmptyFilters(this.externalFilters)
       if (this.isCommunity) {


### PR DESCRIPTION
fixes: #2485 

removing watch method for raw filter and only search when user clicks enter or clicks search icon, 
same behavior as query filter builders.