### PR TITLE
Fix #2627: Foreign key button not visible if column content is truncated

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -336,6 +336,9 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%);
 
   i.fk-link {
     display:none;
+    position: absolute;
+    right: 5px;
+    background-color: $theme-bg;
     cursor: pointer;
     color: $text-light;
     font-size: 14px;


### PR DESCRIPTION
Added `position: absolute` and `right: 5px` to position the button correctly.
Set `background-color: $theme-bg` to improve visibility when overlapping text.

Close #2627