### PR TITLE
CHORE: Add load test container to Docker Compose

### DIFF
--- a/apps/studio/src/migration/dev-8.js
+++ b/apps/studio/src/migration/dev-8.js
@@ -1,0 +1,33 @@
+import _ from 'lodash'
+import { SavedConnection } from '../common/appdb/models/saved_connection'
+import platformInfo from '../common/platform_info'
+
+export default {
+  name: 'dev-8-fixtures',
+  env: 'development',
+  dbs: [
+    {
+      name: "[DEV] Docker Load Test PSQL",
+      connectionType: 'postgresql',
+      port: 5435,
+      username: 'postgres',
+      password: 'example',
+      defaultDatabase: 'load_test_db'
+    }
+  ],
+
+  async run() {
+
+    const connections = this.dbs.map(db => {
+      const connection = new SavedConnection()
+      _.merge(connection, db)
+      return connection
+    })
+
+    for (let i = 0; i < connections.length; i++) {
+      const connection = connections[i];
+      await connection.save()
+    }
+
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -12,6 +12,7 @@ import dev4 from './dev-4'
 import dev5 from './dev-5'
 import dev6 from './dev-6'
 import dev7 from './dev-7'
+import dev8 from './dev-8'
 import domains from './20200519'
 import encrypt from './20200917-encrypt-passwords'
 import sslFiles from './20201008-add-ssl-files'
@@ -93,7 +94,7 @@ const fixtures = [
 ]
 
 const devMigrations = [
-  dev1, dev2, dev3, dev4, dev5, dev6, dev7
+  dev1, dev2, dev3, dev4, dev5, dev6, dev7, dev8
 ]
 
 const migrations = [...realMigrations, ...fixtures, ...devMigrations]
@@ -137,10 +138,10 @@ export default class {
     const runner = this.connection.connection.createQueryRunner()
     try {
       await runner.query(setupSQL)
-      for(let i = 0; i < migrations.length; i++) {
+      for (let i = 0; i < migrations.length; i++) {
         const migration = migrations[i]
         logger.debug(`Checking migration ${migration.name}`)
-        if(migration.env && migration.env !== this.env) {
+        if (migration.env && migration.env !== this.env) {
           // env defined, and does not match
           logger.debug(`Skipping ${migration.name} in ${this.env}, required ${migration.env} `)
           continue

--- a/dev/docker_psql_load_test_init/1_schema.sql
+++ b/dev/docker_psql_load_test_init/1_schema.sql
@@ -1,0 +1,17 @@
+SELECT format('CREATE TABLE load_table_%s (
+    id SERIAL PRIMARY KEY,
+    char_name TEXT NOT NULL DEFAULT ''Cloud Strife'',
+    job TEXT NOT NULL DEFAULT ''Mercenary'',
+    level INT NOT NULL DEFAULT 1,
+    weapon TEXT NOT NULL DEFAULT ''Buster Sword'',
+    spell TEXT NOT NULL DEFAULT ''Firaga'',
+    hp INT NOT NULL DEFAULT 1000,
+    mp INT NOT NULL DEFAULT 500,
+    location TEXT NOT NULL DEFAULT ''Midgar'',
+    quest TEXT NOT NULL DEFAULT ''Save the Planet''
+);', i)
+FROM generate_series(1, 15000) AS s(i)
+\gexec
+
+-- We just need a very big amount of tables to make things funky in the UI so for now I am not worrying so much about their content
+

--- a/dev/docker_psql_load_test_init/2_data.sql
+++ b/dev/docker_psql_load_test_init/2_data.sql
@@ -1,0 +1,15 @@
+SELECT format('INSERT INTO load_table_%s (char_name, job, level, weapon, spell, hp, mp, location, quest)
+SELECT char_name, job, level, weapon, spell, hp, mp, location, quest FROM (
+    SELECT ''Cloud Strife'' AS char_name, 
+           ''Mercenary'' AS job, 
+           floor(random() * 99 + 1)::INT AS level, 
+           ''Buster Sword'' AS weapon, 
+           ''Firaga'' AS spell, 
+           floor(random() * 5000 + 1000)::INT AS hp, 
+           floor(random() * 500 + 100)::INT AS mp, 
+           ''Midgar'' AS location, 
+           ''Save the Planet'' AS quest
+    FROM generate_series(1, 100)
+) AS temp;', i)
+FROM generate_series(1, 15000) AS s(i)
+\gexec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   mysql4.1:
   psql96:
   psql13:
+  psql15_load_test_data:
   mariadb:
   cockroachdb:
   oracle18:
@@ -40,6 +41,18 @@ services:
       - ./dev/docker_oracle_init:/docker-entrypoint-initdb.d
     ports:
       - 1521:1521
+
+  psql15-load-test:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: example
+      POSTGRES_DB: load_test_db
+    volumes:
+      - psql15_load_test_data:/var/lib/postgresql/data
+      - ./dev/docker_psql_load_test_init:/docker-entrypoint-initdb.d
+    ports:
+      - 5435:5432
 
   psql15:
     image: postgres:15
@@ -131,8 +144,8 @@ services:
   sqlserverlatin:
     image: 'mcr.microsoft.com/mssql/server:2017-latest-ubuntu'
     volumes:
-    - mssqllatin:/var/opt/mssql/data
-    - ./dev/docker_sqlserver:/docker_init
+      - mssqllatin:/var/opt/mssql/data
+      - ./dev/docker_sqlserver:/docker_init
     environment:
       ACCEPT_EULA: "Y"
       SA_PASSWORD: Example@1"
@@ -150,16 +163,16 @@ services:
     command: start-single-node --insecure
   cassandra:
     image: cassandra:latest
-    entrypoint: ["/docker-entrypoint.initdb.d/entry.sh"]
+    entrypoint: [ "/docker-entrypoint.initdb.d/entry.sh" ]
     ports:
       - 9042:9042
     volumes:
       - cassandra:/var/lib/cassandra
       - ./dev/docker_cassandra_init:/docker-entrypoint.initdb.d
-# use keyspace; describe tables; # get all the tables for a specific keyspace
-# select * from system_schema.keyspaces; # gets all keyspaces
-# https://www.folkstalk.com/2022/09/get-all-keyspaces-in-cassandra-with-code-examples.html
-# Create keyspace https://www.tutorialspoint.com/cassandra/cassandra_create_keyspace.htm
+  # use keyspace; describe tables; # get all the tables for a specific keyspace
+  # select * from system_schema.keyspaces; # gets all keyspaces
+  # https://www.folkstalk.com/2022/09/get-all-keyspaces-in-cassandra-with-code-examples.html
+  # Create keyspace https://www.tutorialspoint.com/cassandra/cassandra_create_keyspace.htm
   bigquery:
     image: ghcr.io/goccy/bigquery-emulator:latest
     volumes:
@@ -186,9 +199,9 @@ services:
       - 8081:8080
       - 5001:5001
       # environment:
-    #   - SQLD_NODE=primary
-    # volumes:
-    #   - ./dev/docker_libsql:/var/lib/sqld
+      #   - SQLD_NODE=primary
+      # volumes:
+      #   - ./dev/docker_libsql:/var/lib/sqld
   clickhouse:
     image: clickhouse/clickhouse-server
     ports:


### PR DESCRIPTION
# Add Load Test Container to Docker Compose

## Overview

This PR introduces a new container service to the existing Docker Compose setup to facilitate stressing beekeeper. 

## Changes

- **New Container Service**: `psql15-load-test` added to the `docker-compose.yml`.
  - Configured with a separated volume.
  - Includes initialization scripts to create 15000 tables and populate them with 100 rows of data per table (we could go harder but it's good enough to make the app stressed.
  - Exposes the container on port `5435`.

## How to Use

1. `docker compose up psql15-load-test`   
