### PR TITLE
Fix: Preserve cursor position when switching tabs

### DIFF
--- a/apps/studio/src/common/appdb/models/OpenTab.ts
+++ b/apps/studio/src/common/appdb/models/OpenTab.ts
@@ -8,7 +8,7 @@ import { TransportOpenTab } from "@/common/transport/TransportOpenTab";
 
 type TabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
 
-const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName', 'entityType', 'titleScope', 'connectionId', 'workspaceId', 'position']
+const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'cursorIndex', 'cursorIndexAnchor', 'tableName', 'schemaName', 'entityType', 'titleScope', 'connectionId', 'workspaceId', 'position']
 
 interface ConnectionIds {
   connectionId: number,
@@ -57,6 +57,12 @@ export class OpenTab extends ApplicationEntity {
 
   @Column({type: 'text', nullable: true})
   unsavedQueryText?: string
+
+  @Column({type: 'integer', nullable: true})
+  cursorIndex?: number
+
+  @Column({type: 'integer', nullable: true})
+  cursorIndexAnchor?: number
 
   // TABLE TAB
   @Column({type: 'varchar', length: 255, nullable: true})

--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -5,7 +5,7 @@ import ISavedQuery from "../interfaces/ISavedQuery";
 
 type TabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
 
-const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName']
+const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'cursorIndex', 'cursorIndexAnchor', 'tableName', 'schemaName']
 
 export interface TransportOpenTab extends Transport {
   tabType: TabType,
@@ -17,6 +17,8 @@ export interface TransportOpenTab extends Transport {
   active: boolean,
   queryId?: number,
   unsavedQueryText?: string,
+  cursorIndex?: number, // Add cursor position index
+  cursorIndexAnchor?: number, // Add cursor anchor position index
   tableName?: string,
   schemaName?: string,
   entityType?: string,

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -628,6 +628,20 @@
         this.tab.unsavedQueryText = this.unsavedText
         this.saveTab()
       },
+      'editor.cursorIndex'() {
+        if (this.editor.initialized) {
+          this.tab.cursorIndex = this.editor.cursorIndex
+          this.tab.cursorIndexAnchor = this.editor.cursorIndexAnchor
+          this.saveTab()
+        }
+      },
+      'editor.cursorIndexAnchor'() {
+        if (this.editor.initialized) {
+          this.tab.cursorIndex = this.editor.cursorIndex
+          this.tab.cursorIndexAnchor = this.editor.cursorIndexAnchor
+          this.saveTab()
+        }
+      },
       remoteDeleted() {
         if (this.remoteDeleted) {
           this.editor.readOnly = 'nocursor'
@@ -753,6 +767,15 @@
         this.$nextTick(() => {
           this.tableHeight = this.$refs.bottomPanel.clientHeight
           this.updateEditorHeight()
+          
+          // Set cursor position if saved in tab
+          if (this.editor.initialized && this.tab.cursorIndex !== undefined) {
+            const doc = this.editor.initialized.getDoc();
+            const pos = doc.posFromIndex(this.tab.cursorIndex);
+            const anchorPos = this.tab.cursorIndexAnchor !== undefined ? 
+              doc.posFromIndex(this.tab.cursorIndexAnchor) : pos;
+            doc.setSelection(anchorPos, pos);
+          }
         })
       },
       saveTab: _.debounce(function() {
@@ -982,6 +1005,14 @@
         if (originalText) {
           this.originalText = originalText
           this.unsavedText = originalText
+        }
+        
+        // Restore cursor position if available
+        if (this.tab.cursorIndex !== undefined) {
+          this.editor.cursorIndex = this.tab.cursorIndex
+        }
+        if (this.tab.cursorIndexAnchor !== undefined) {
+          this.editor.cursorIndexAnchor = this.tab.cursorIndexAnchor
         }
       },
       fakeRemoteChange() {

--- a/apps/studio/src/migration/20250401_add_cursor_position_to_tabs.js
+++ b/apps/studio/src/migration/20250401_add_cursor_position_to_tabs.js
@@ -1,0 +1,9 @@
+// add cursor position columns to tabs table
+
+module.exports = async function(connection) {
+  console.log("[20250401] Add cursor position to tabs");
+  await connection.schema.alterTable('tabs', function(t) {
+    t.integer('cursorIndex').nullable();
+    t.integer('cursorIndexAnchor').nullable();
+  });
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -53,6 +53,7 @@ import deleteDuplicateConnections from './20241115_delete_duplicate_connections'
 import addNewUrlField from './20250128_add_new_url_field'
 import tabHistoryIndex from './20250211_add_tab_history_index'
 import fixOracleData from './20250225_oracle_default_connection_method'
+import addCursorPositionToTabs from './20250401_add_cursor_position_to_tabs'
 
 import ultimate from './ultimate/index'
 
@@ -85,6 +86,7 @@ const realMigrations = [
   addNewUrlField,
   tabHistoryIndex,
   fixOracleData,
+  addCursorPositionToTabs,
 ]
 
 // fixtures require the models


### PR DESCRIPTION
## Summary
- Added cursor position tracking in the tab state with two new fields:  and 
- Added watchers to save cursor position changes to the tab state
- Restore cursor position when switching back to a tab
- Created migration script to add necessary database columns

## Test plan
1. Open a query editor tab with multiple pages of SQL
2. Scroll to middle of page and position cursor at that position
3. Click on a table view tab
4. Click back to the query tab
5. Verify that the cursor position and viewport position is maintained

Fixes #2711

🤖 Generated with [Claude Code](https://claude.ai/code)