### PR TITLE
fix sql text editor race condition

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -686,10 +686,7 @@
       initialize() {
         this.initialized = true
         // TODO (matthew): Add hint options for all tables and columns\
-        this.initializeQueries()
         this.query.title = this.activeTab.title
-
-        this.tab.unsavedChanges = this.unsavedChanges
 
         if (this.split) {
           this.split.destroy();
@@ -697,6 +694,9 @@
         }
 
         this.$nextTick(() => {
+          this.initializeQueries()
+          this.tab.unsavedChanges = this.unsavedChanges
+
           this.split = Split(this.splitElements, {
             elementStyle: (_dimension, size) => ({
                 'flex-basis': `calc(${size}%)`,


### PR DESCRIPTION
This should fix a race condition when we click `SQL: Create` and the sql does not show in the query editor.