### PR TITLE
Fix: start Electron properly on dev mode using vite-plugin-electron (#2974)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -23,6 +23,7 @@
     "postinstall": "electron-builder install-app-deps",
     "internal:integration": "cross-env TEST_MODE=1 ELECTRON_RUN_AS_NODE=1 yarn electron ../../node_modules/jest/bin/jest.js --config ./jest.integration.config.js",
     "test:integration": "../../bin/integration-tests.sh",
+    "dev:electron": "vite dev -c vite.electron.config.mjs",
     "dev:esbuild": "./esbuild.mjs watch",
     "dev:vite": "vite dev"
   },
@@ -188,6 +189,8 @@
     "typescript": "~4.3.0",
     "vite": "~5.4.15",
     "vite-plugin-commonjs": "^0.10.1",
+    "vite-plugin-electron": "^0.29.0",
+    "vite-plugin-electron-renderer": "^0.14.6",
     "vue-template-compiler": "^2.7.16",
     "xvfb-maybe": "^0.2.1"
   },

--- a/apps/studio/vite.electron.config.mjs
+++ b/apps/studio/vite.electron.config.mjs
@@ -1,0 +1,50 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue2';
+import path from 'path'
+import commonjs from 'vite-plugin-commonjs'
+import electron from 'vite-plugin-electron/simple'
+
+export default defineConfig({
+  plugins: [
+    vue(), 
+    commonjs(),
+    electron({
+      main: {
+        entry: 'src-commercial/entrypoints/main.ts',
+      },
+      preload: {
+        input: path.join(__dirname, 'src-commercial/entrypoints/preload.ts'),
+      },
+      renderer: {},
+    })
+  ],
+  base: '/', // Set the base URL for the app
+  optimizeDeps: {
+    exclude: []
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      "@commercial": path.resolve(__dirname, "./src-commercial"),
+      "@shared": path.resolve(__dirname, "./src/shared"),
+      "assets": path.resolve(__dirname, './src/assets'),
+      "@bksLogger": path.resolve(__dirname, './src/lib/log/rendererLogger'),
+      buffer: 'buffer/' // avoid uncaught error on dynamic require
+    },
+  },
+  build: {
+    outDir: 'dist/renderer', // Output directory for the renderer process
+    emptyOutDir: true, // Clears the directory before building
+    rollupOptions: {
+      external: [],
+      input: './index.html', // Entry point for the renderer process
+      output: {
+        format: 'cjs'
+      },
+    }
+  },
+  server: {
+    port: 3003, // Development server port
+    // open: './src/index.html'
+  }
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "apps/*"
   ],
   "scripts": {
+    "bks:electron": "yarn lib:build && yarn workspace beekeeper-studio dev:electron",
     "bks:build": "yarn lib:build && yarn workspace beekeeper-studio electron:build",
     "bks:dev": "yarn lib:build && yarn workspace beekeeper-studio electron:serve",
     "bks:config:build": "yarn workspace beekeeper-studio config:build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13203,6 +13203,16 @@ vite-plugin-dynamic-import@^1.6.0:
     fast-glob "^3.3.2"
     magic-string "^0.30.11"
 
+vite-plugin-electron-renderer@^0.14.6:
+  version "0.14.6"
+  resolved "https://registry.yarnpkg.com/vite-plugin-electron-renderer/-/vite-plugin-electron-renderer-0.14.6.tgz#45fa5072d2ad39bcaa6d3eedf09f5bb9e04ac0a4"
+  integrity sha512-oqkWFa7kQIkvHXG7+Mnl1RTroA4sP0yesKatmAy0gjZC4VwUqlvF9IvOpHd1fpLWsqYX/eZlVxlhULNtaQ78Jw==
+
+vite-plugin-electron@^0.29.0:
+  version "0.29.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-electron/-/vite-plugin-electron-0.29.0.tgz#a30e0288c46f55848d23ed49582fb574e8573fc6"
+  integrity sha512-HP0DI9Shg41hzt55IKYVnbrChWXHX95QtsEQfM+szQBpWjVhVGMlqRjVco6ebfQjWNr+Ga+PeoBjMIl8zMaufw==
+
 vite-plugin-vue2@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vite-plugin-vue2/-/vite-plugin-vue2-2.0.3.tgz#19aab2720e13a969b9d9272f85e899c671930ef2"


### PR DESCRIPTION
This PR addresses [#2974](https://github.com/beekeeper-studio/beekeeper-studio/issues/2974), where the Electron app fails to launch in dev mode when executing `yarn bks:dev`.

### ❗ The problem
The existing `esbuild.mjs` script builds the app but fails to spawn the Electron process, exiting silently after the build step.

### ✅ The solution
This PR introduces a new Vite configuration file, `vite.electron.config.mjs` on the apps/studio folder, which integrates [`vite-plugin-electron`](https://github.com/electron-vite/vite-plugin-electron) and [`vite-plugin-electron-renderer`](https://github.com/electron-vite/vite-plugin-electron-renderer).  

To maintain compatibility with existing Vite scripts and configurations, a separate script is added to launch Vite with this additional configuration.

With this change:
- Electron launches automatically after build.
- Live reload works for both the main and renderer processes.
- The existing main Vite configuration remains untouched.

### 🔄 New scripts  
A new script is added to `package.json` on the apps/studio dir to run Vite with the Electron configuration:  
```json
"scripts": {
  "dev:electron": "vite dev -c vite.electron.config.mjs"
}
```

and a new script on the root `package.json` to call the previous script:
```json
"scripts": {
  "bks:electron": "yarn lib:build && yarn workspace beekeeper-studio dev:electron"
}
```

### 🛠 Fix for "Dynamic require of 'buffer' is not supported"

While testing, an error was observed in the renderer process console:

- Which keeps the UI on the **loading state** without showing the app content on the renderer

![beekeeper-issue-4](https://github.com/user-attachments/assets/b244c05c-15b2-42ea-befe-3af7b9ac600d)

To fix this, the following alias was added to the **resolve.alias** section in the new **vite.electron.config.js**:

- The rest of the content of this vite config is equal the the main vite.config.js besides the new electron plugin

```js
resolve: {
    alias: {
      buffer: 'buffer/',
      // other alias
    },
  }
```

### 🧪 Steps to test
1. Run `yarn bks:electron` on the root directory.
3. Confirm that:
   - The Vite dev server starts for the renderer.
   - Electron launches and opens the application window.
   - Making changes in the `apps/studio` folder triggers rebuild and restarts Electron as expected.

### 🛠 Notes
- This solution is cross-platform and tested on Windows 10 with Node.js `v20.17.0`.
- Existing behavior is preserved while improving the dev experience.

---

Closes #2974
