### PR TITLE
fix bracket color, and remove redundant variable

### DIFF
--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -130,7 +130,7 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   --bks-text-editor-number-fg-color: #{$brand-primary};
   --bks-text-editor-string-fg-color: #{$brand-primary};
   --bks-text-editor-cursor-bg-color: #{$text-dark};
-  --bks-text-editor-selected-bg-color: #{rgba($theme-base, 0.25)};
+  --bks-text-editor-bracket-fg-color: #{$text};
 }
 
 .BksTextEditor-hints {


### PR DESCRIPTION
This is a fix to the query editor bracket color in dark theme