### PR TITLE
fix vim system clipboard

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -48,6 +48,7 @@
         :columns-getter="columnsGetter"
         :default-schema="defaultSchema"
         :mode="dialectData.textEditorMode"
+        :clipboard="$native.clipboard"
         @bks-initialized="handleEditorInitialized"
         @bks-value-change="unsavedText = $event.value"
         @bks-blur="onTextEditorBlur?.()"

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -96,6 +96,7 @@ export default {
      * In vim, that would be `:map ; :`.
      */
     vimKeymaps: Array,
+    clipboard: Object as PropType<Clipboard>
   },
   data() {
     return {
@@ -157,7 +158,7 @@ export default {
 
       if (this.keymap === "vim") {
         const cmEl = this.$refs.editor.parentNode.querySelector(".CodeMirror");
-        extendVimOnCodeMirror(cmEl, this.vimConfig, this.vimKeymaps);
+        extendVimOnCodeMirror(cmEl, this.vimConfig, this.vimKeymaps, this.clipboard);
       }
     },
     vimKeymaps() {
@@ -380,7 +381,7 @@ export default {
       cmEl.addEventListener("contextmenu", this.showContextMenu);
 
       if (this.keymap === "vim") {
-        extendVimOnCodeMirror(cmEl, this.vimConfig, this.vimKeymaps);
+        extendVimOnCodeMirror(cmEl, this.vimConfig, this.vimKeymaps, this.clipboard);
       }
 
       if (this.plugins) {

--- a/apps/ui-kit/lib/components/text-editor/vim.ts
+++ b/apps/ui-kit/lib/components/text-editor/vim.ts
@@ -104,7 +104,7 @@ export class Register {
   }
 }
 
-export function extendVimOnCodeMirror(cmEl: any, vimConfig?: Config, vimKeymaps: IMapping[] = []) {
+export function extendVimOnCodeMirror(cmEl: any, vimConfig?: Config, vimKeymaps: IMapping[] = [], clipboard: Clipboard) {
   const codeMirrorVimInstance = cmEl.CodeMirror.constructor.Vim;
 
   if (!codeMirrorVimInstance) {
@@ -124,7 +124,7 @@ export function extendVimOnCodeMirror(cmEl: any, vimConfig?: Config, vimKeymaps:
     try {
       codeMirrorVimInstance.defineRegister(
         "*",
-        new Register(navigator)
+        new Register(clipboard)
       );
     } catch (e) {
       // nothing


### PR DESCRIPTION
System clipboard was attempting to use navigator rather than our native plugin (which has to go through preload). I made it so the user of ui-kit has to provide a clipboard if they want the system clipboard to work, much like how codemirror does it.