### PR TITLE
fix: truncate quick search text

### DIFF
--- a/apps/studio/src/components/quicksearch/QuickSearch.vue
+++ b/apps/studio/src/components/quicksearch/QuickSearch.vue
@@ -57,7 +57,7 @@
             class="material-icons item-icon database"
             v-else
           >code</i>
-          <span v-html="highlightHistory(blob)" />
+          <span class="truncate" v-html="highlightHistory(blob)" />
         </li>
       </ul>
       <div


### PR DESCRIPTION
fixes: #2993 

before:
<img width="712" alt="Screenshot 2025-04-11 at 10 22 34" src="https://github.com/user-attachments/assets/cfa07d58-0537-4b63-a134-00e7ad5b93d1" />


after:
<img width="712" alt="Screenshot 2025-04-11 at 10 22 10" src="https://github.com/user-attachments/assets/01a2ce45-df27-41f3-811e-b4c24ea8d72c" />
