### PR TITLE
fix: call updateJsonViewer instead of the defunct updateDefaultView

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1296,7 +1296,7 @@ export default Vue.extend({
         let pendingUpdates = _.reject(this.pendingChanges.updates, { 'key': payload.key })
         pendingUpdates.push(payload)
         this.$set(this.pendingChanges, 'updates', pendingUpdates)
-        this.updateDetailView()
+        this.updateJsonViewer()
       }
     },
     cloneSelection(range?: RangeComponent) {


### PR DESCRIPTION
I noticed in apps/studio/src/components/tableview/TableTable.vue, there's an error in the devtools when updating a cell where this.updateDetailView() isn't a function (line 1299). It happens at the end of the code block so doesn't do anything, but it's not anywhere in the file. Looking back, it appears that function was replaced with the updateJsonView()