### PR TITLE
fix-3024: Process JSON View records using JSON.stringify and JsonSourceMap since JsonSourceMap does not support replacer

### DIFF
--- a/apps/studio/src/components/sidebar/JsonViewer.vue
+++ b/apps/studio/src/components/sidebar/JsonViewer.vue
@@ -160,7 +160,14 @@ export default Vue.extend({
       }, 500),
     },
     sourceMap() {
-      return JsonSourceMap.stringify(this.filteredValue, null, 2);
+      let replacedFilteredValue = this.filteredValue;
+      try {
+        // run the replacer on the filteredValue
+        replacedFilteredValue = JSON.parse(JSON.stringify(this.filteredValue, this.replacer));
+      } catch (error) {
+        log.warn("Failed to replace filtered value", error);
+      }
+      return JsonSourceMap.stringify(replacedFilteredValue, null, 2);
     },
     filteredValue() {
       if (this.empty) {


### PR DESCRIPTION
Convert JSON objects to a JSON save object using JSON.stringify and the existing replacer method