### PR TITLE
Update ubuntu version used in CI

### DIFF
--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-14, ubuntu-20.04, windows-2019, ubuntu-arm64]
+        os: [macos-14, ubuntu-24.04, windows-2019, ubuntu-arm64]
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/studio-publish-test.yml
+++ b/.github/workflows/studio-publish-test.yml
@@ -15,7 +15,7 @@ jobs:
           - name: test
             owner: beekeeper-studio
             repo: test-releases
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       assets_url: ${{ steps.create_release.outputs.assets_url }}
@@ -41,7 +41,7 @@ jobs:
   # electron-builder comes built in with channels -- latest, beta, alpha.
   # To support these for deb, rpm, and snap, we need to extract the channel from the package version
   identify_channel:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       channel: ${{steps.extract_channel.outputs.channel}}
       deb_codename: ${{steps.extract_channel.outputs.codename}}
@@ -69,7 +69,7 @@ jobs:
             owner: beekeeper-studio
             repo: test-releases
         os:
-          - name: ubuntu-20.04
+          - name: ubuntu-24.04
             arch: x64
             type: linux
             setup_python: true

--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -8,7 +8,7 @@ on:
       - "apps/sqltools/**"
 jobs:
   create_draft_release:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       assets_url: ${{ steps.create_release.outputs.assets_url }}
@@ -36,7 +36,7 @@ jobs:
   # outputs: latest, beta, alpha
   # deb_codename: stable, beta
   identify_channel:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-24.04"
     outputs:
       channel: ${{steps.extract_channel.outputs.channel}}
       deb_codename: ${{steps.extract_channel.outputs.deb_codename}}
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - name: ubuntu-20.04
+          - name: ubuntu-24.04
             arch: x64
             type: linux
             setup_python: true


### PR DESCRIPTION
Recent PR CI checks have been marked as failures due to the fact that Ubuntu 20.04 is no longer a supported image for Github Actions (see https://github.com/actions/runner-images/issues/11101 )

This PR updates Ubuntu workflows to 24.04.

I have tested the Ubuntu 24.04 PR CI checks in my local fork (see https://github.com/bradynwalsh/beekeeper-studio/pull/1 - I canceled the arm64 check because it couldn't find a runner but that workflow isn't changed by this PR), and think the release workflows should work as well (they don't seem to depend on anything removed in the 24.04 image)