### PR TITLE
Fix composite keys and colliding table name keys

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
@@ -604,6 +604,7 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
       constraintName: row.constraint_name as string,
       onUpdate: row.update_rule as string,
       onDelete: row.delete_rule as string,
+      isComposite: false
     }));
   }
 

--- a/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
@@ -978,41 +978,70 @@ export class FirebirdClient extends BasicDatabaseClient<FirebirdResult> {
   ): Promise<TableKey[]> {
     const result = await this.driverExecuteSingle(
       `
-      SELECT
-        TRIM(PK.RDB$RELATION_NAME) AS TO_TABLE,
-        TRIM(ISP.RDB$FIELD_NAME) AS TO_COLUMN,
-        TRIM(FK.RDB$RELATION_NAME) AS FROM_TABLE,
-        TRIM(ISF.RDB$FIELD_NAME) AS FROM_COLUMN,
-        TRIM(FK.RDB$CONSTRAINT_NAME) AS CONSTRAINT_NAME,
-        TRIM(RC.RDB$UPDATE_RULE) AS ON_UPDATE,
-        TRIM(RC.RDB$DELETE_RULE) AS ON_DELETE
-      FROM
-        RDB$RELATION_CONSTRAINTS PK,
-        RDB$RELATION_CONSTRAINTS FK,
-        RDB$INDEX_SEGMENTS ISP,
-        RDB$INDEX_SEGMENTS ISF,
-        RDB$REF_CONSTRAINTS RC
-      WHERE FK.RDB$RELATION_NAME = ?
-        AND FK.RDB$CONSTRAINT_NAME = RC.RDB$CONSTRAINT_NAME
-        AND PK.RDB$CONSTRAINT_NAME = RC.RDB$CONST_NAME_UQ
-        AND ISP.RDB$INDEX_NAME = PK.RDB$INDEX_NAME
-        AND ISF.RDB$INDEX_NAME = FK.RDB$INDEX_NAME
-        AND ISP.RDB$FIELD_POSITION = ISF.RDB$FIELD_POSITION
+        SELECT
+          TRIM(PK.RDB$RELATION_NAME) AS TO_TABLE,
+          TRIM(ISP.RDB$FIELD_NAME) AS TO_COLUMN,
+          TRIM(FK.RDB$RELATION_NAME) AS FROM_TABLE,
+          TRIM(ISF.RDB$FIELD_NAME) AS FROM_COLUMN,
+          TRIM(FK.RDB$CONSTRAINT_NAME) AS CONSTRAINT_NAME,
+          TRIM(RC.RDB$UPDATE_RULE) AS ON_UPDATE,
+          TRIM(RC.RDB$DELETE_RULE) AS ON_DELETE,
+          ISF.RDB$FIELD_POSITION AS FIELD_POSITION
+        FROM
+          RDB$RELATION_CONSTRAINTS PK
+          JOIN RDB$REF_CONSTRAINTS RC ON PK.RDB$CONSTRAINT_NAME = RC.RDB$CONST_NAME_UQ
+          JOIN RDB$RELATION_CONSTRAINTS FK ON FK.RDB$CONSTRAINT_NAME = RC.RDB$CONSTRAINT_NAME
+          JOIN RDB$INDEX_SEGMENTS ISF ON ISF.RDB$INDEX_NAME = FK.RDB$INDEX_NAME
+          JOIN RDB$INDEX_SEGMENTS ISP ON ISP.RDB$INDEX_NAME = PK.RDB$INDEX_NAME AND ISP.RDB$FIELD_POSITION = ISF.RDB$FIELD_POSITION
+        WHERE
+          FK.RDB$RELATION_NAME = ?
+          AND FK.RDB$CONSTRAINT_TYPE = 'FOREIGN KEY'
+          AND PK.RDB$CONSTRAINT_TYPE IN ('PRIMARY KEY', 'UNIQUE')
+        ORDER BY
+          CONSTRAINT_NAME,
+          ISF.RDB$FIELD_POSITION
     `,
-      { params: [table] }
+      { params: [table.toUpperCase()] }
     );
 
-    return result.rows.map((row) => ({
-      fromTable: row["FROM_TABLE"],
-      fromColumn: row["FROM_COLUMN"],
-      fromSchema: "",
-      toTable: row["TO_TABLE"],
-      toColumn: row["TO_COLUMN"],
-      toSchema: "",
-      constraintName: row["CONSTRAINT_NAME"],
-      onUpdate: row["ON_UPDATE"],
-      onDelete: row["ON_DELETE"],
-    }));
+    // Group by constraint name to identify composite keys
+    const groupedKeys = _.groupBy(result.rows, "CONSTRAINT_NAME");
+    
+    return Object.keys(groupedKeys).map(constraintName => {
+      const keyParts = groupedKeys[constraintName];
+      
+      // If there's only one part, return a simple key (backward compatibility)
+      if (keyParts.length === 1) {
+        const row = keyParts[0];
+        return {
+          fromTable: row["FROM_TABLE"],
+          fromColumn: row["FROM_COLUMN"],
+          fromSchema: "",
+          toTable: row["TO_TABLE"],
+          toColumn: row["TO_COLUMN"],
+          toSchema: "",
+          constraintName: row["CONSTRAINT_NAME"],
+          onUpdate: row["ON_UPDATE"],
+          onDelete: row["ON_DELETE"],
+          isComposite: false
+        };
+      } 
+      
+      // If there are multiple parts, it's a composite key
+      const firstPart = keyParts[0];
+      return {
+        fromTable: firstPart["FROM_TABLE"],
+        fromColumn: keyParts.map(p => p["FROM_COLUMN"]),
+        fromSchema: "",
+        toTable: firstPart["TO_TABLE"],
+        toColumn: keyParts.map(p => p["TO_COLUMN"]),
+        toSchema: "",
+        constraintName: firstPart["CONSTRAINT_NAME"],
+        onUpdate: firstPart["ON_UPDATE"],
+        onDelete: firstPart["ON_DELETE"],
+        isComposite: true
+      };
+    });
   }
 
   async executeQuery(

--- a/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
@@ -536,6 +536,7 @@ export class OracleClient extends BasicDatabaseClient<DriverResult> {
       a.table_name,
       a.column_name,
       a.constraint_name,
+      a.position,
       c.owner,
       c.delete_rule,
        -- referenced
@@ -543,7 +544,8 @@ export class OracleClient extends BasicDatabaseClient<DriverResult> {
       c_pk.table_name as R_TABLE_NAME,
       c_pk.constraint_name as R_PK,
       c_pk.owner as R_OWNER,
-      r_a.COLUMN_NAME as R_COLUMN
+      r_a.COLUMN_NAME as R_COLUMN,
+      r_a.position as R_POSITION
   -- constraint columns
   FROM all_cons_columns a
   -- constraint info for those columns
@@ -559,39 +561,50 @@ export class OracleClient extends BasicDatabaseClient<DriverResult> {
   AND c_pk.constraint_type = 'P'
    AND a.table_name = ${D.escapeString(table.toUpperCase(), true)}
    ${schema ? `AND a.owner = ${D.escapeString(schema.toUpperCase(), true)}` : ''}
+  ORDER BY 
+    a.constraint_name,
+    a.position
     `
     const response = await this.driverExecuteSimple(sql)
-
+    
+    // Group by constraint name to identify composite keys
     const groupedKeys = _.groupBy(response, 'CONSTRAINT_NAME');
-
+    
     return Object.keys(groupedKeys).map(constraintName => {
       const keyParts = groupedKeys[constraintName];
-
-      if (keyParts.length === 1) {
-        const row = keyParts[0];
+      
+      // Sort key parts by position to ensure correct column order
+      const sortedKeyParts = _.sortBy(keyParts, 'POSITION');
+      
+      // If there's only one part, return a simple key (backward compatibility)
+      if (sortedKeyParts.length === 1) {
+        const row = sortedKeyParts[0];
         return {
-          constraintName: `${row.CONSTRAINT_NAME}`,
+          constraintName: row.CONSTRAINT_NAME,
           toTable: row.R_TABLE_NAME,
-          toColumn: row.R_COLUMN,
           toSchema: row.R_OWNER,
+          toColumn: row.R_COLUMN,
           fromTable: row.TABLE_NAME,
           fromSchema: row.OWNER,
           fromColumn: row.COLUMN_NAME,
+          onDelete: row.DELETE_RULE,
           isComposite: false
-        }
-      }
-
-      const firstPart = keyParts[0];
+        };
+      } 
+      
+      // If there are multiple parts, it's a composite key
+      const firstPart = sortedKeyParts[0];
       return {
-        constraintName: `${firstPart.CONSTRAINT_NAME}`,
+        constraintName: firstPart.CONSTRAINT_NAME,
         toTable: firstPart.R_TABLE_NAME,
-        toColumn: keyParts.map(p => p.R_COLUMN),
         toSchema: firstPart.R_OWNER,
+        toColumn: _.uniq(sortedKeyParts.map(p => p.R_COLUMN)),
         fromTable: firstPart.TABLE_NAME,
         fromSchema: firstPart.OWNER,
-        fromColumn: keyParts.map(p => p.COLUMN_NAME),
+        fromColumn: _.uniq(sortedKeyParts.map(p => p.COLUMN_NAME)),
+        onDelete: firstPart.DELETE_RULE,
         isComposite: true
-      }
+      };
     })
   }
 

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -815,7 +815,7 @@ export default Vue.extend({
               // Format regular key
               return `${item.toTable}(${item.toColumn})`;
             }
-          }).join(', ').replace(/, (?![\s\S]*, )/, ', or ')}`)
+          }).join(', ').replace(/\), (?![\s\S]*\), )/, '), or ')}`)
         }
       } else if (isPK) {
         headerTooltip += ' [Primary Key]'

--- a/apps/studio/src/lib/db/clients/bigquery.ts
+++ b/apps/studio/src/lib/db/clients/bigquery.ts
@@ -186,7 +186,8 @@ export class BigQueryClient extends BasicDatabaseClient<BigQueryResult> {
       fromColumn: row.from_column,
       constraintName: row.constraint_name,
       onUpdate: row.update_rule,
-      onDelete: row.delete_rule
+      onDelete: row.delete_rule,
+      isComposite: false
     }));
   }  
 

--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -711,7 +711,9 @@ export class MysqlClient extends BasicDatabaseClient<ResultType> {
       cu.REFERENCED_TABLE_NAME as referenced_table,
       cu.REFERENCED_COLUMN_NAME as referenced_column,
       rc.UPDATE_RULE as on_update,
-      rc.DELETE_RULE as on_delete
+      rc.DELETE_RULE as on_delete,
+      rc.CONSTRAINT_NAME as rc_constraint_name,
+      cu.ORDINAL_POSITION as ordinal_position
     FROM information_schema.key_column_usage cu
     JOIN information_schema.referential_constraints rc
       on cu.constraint_name = rc.constraint_name
@@ -719,25 +721,55 @@ export class MysqlClient extends BasicDatabaseClient<ResultType> {
     WHERE table_schema = database()
     AND cu.table_name = ?
     AND cu.referenced_table_name IS NOT NULL
+    ORDER BY rc.CONSTRAINT_NAME, cu.ORDINAL_POSITION
   `;
 
     const params = [table];
 
     const { rows } = await this.driverExecuteSingle(sql, { params });
-
-    return rows.map((row) => ({
-      constraintName: `${row.constraint_name}`,
-      toTable: row.referenced_table,
-      toColumn: row.referenced_column,
-      fromTable: table,
-      fromColumn: row.column_name,
-      referencedTable: row.referenced_table_name,
-      keyType: `${row.key_type} KEY`,
-      onDelete: row.on_delete,
-      onUpdate: row.on_update,
-      toSchema: "",
-      fromSchema: "",
-    }));
+    
+    // Group by constraint name to identify composite keys
+    const groupedKeys = _.groupBy(rows, 'constraint_name');
+    
+    return Object.keys(groupedKeys).map(constraintName => {
+      const keyParts = groupedKeys[constraintName];
+      
+      // If there's only one part, return a simple key (backward compatibility)
+      if (keyParts.length === 1) {
+        const row = keyParts[0];
+        return {
+          constraintName: `${row.constraint_name}`,
+          toTable: row.referenced_table,
+          toColumn: row.referenced_column,
+          fromTable: table,
+          fromColumn: row.column_name,
+          referencedTable: row.referenced_table_name,
+          keyType: `${row.key_type} KEY`,
+          onDelete: row.on_delete,
+          onUpdate: row.on_update,
+          toSchema: "",
+          fromSchema: "",
+          isComposite: false,
+        };
+      } 
+      
+      // If there are multiple parts, it's a composite key
+      const firstPart = keyParts[0];
+      return {
+        constraintName: `${firstPart.constraint_name}`,
+        toTable: firstPart.referenced_table,
+        toColumn: keyParts.map(p => p.referenced_column),
+        fromTable: table,
+        fromColumn: keyParts.map(p => p.column_name),
+        referencedTable: firstPart.referenced_table_name,
+        keyType: `${firstPart.key_type} KEY`,
+        onDelete: firstPart.on_delete,
+        onUpdate: firstPart.on_update,
+        toSchema: "",
+        fromSchema: "",
+        isComposite: true
+      };
+    });
   }
 
   async getTableProperties(

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -556,47 +556,83 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   async getTableKeys(table: string, schema: string = this._defaultSchema): Promise<TableKey[]> {
     const sql = `
+      WITH fk_constraints AS (
+        SELECT DISTINCT
+          tc.constraint_name,
+          kcu.constraint_schema AS from_schema,
+          kcu.table_name AS from_table,
+          rc.unique_constraint_schema AS to_schema,
+          rc.unique_constraint_name,
+          rc.update_rule,
+          rc.delete_rule
+        FROM
+          information_schema.table_constraints AS tc
+          JOIN information_schema.key_column_usage AS kcu
+            ON tc.constraint_name = kcu.constraint_name
+          JOIN information_schema.referential_constraints AS rc
+            ON rc.constraint_name = tc.constraint_name
+        WHERE
+          tc.constraint_type = 'FOREIGN KEY' AND
+          kcu.table_schema NOT LIKE 'pg_%' AND
+          kcu.table_schema = $2 AND
+          kcu.table_name = $1
+      ),
+      fk_columns AS (
+        SELECT
+          tc.constraint_name,
+          STRING_AGG(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS from_column,
+          ARRAY_AGG(kcu.column_name ORDER BY kcu.ordinal_position) AS from_columns_array,
+          COUNT(kcu.column_name) as column_count
+        FROM
+          information_schema.table_constraints AS tc
+          JOIN information_schema.key_column_usage AS kcu
+            ON tc.constraint_name = kcu.constraint_name
+        WHERE
+          tc.constraint_type = 'FOREIGN KEY' AND
+          kcu.table_schema = $2 AND
+          kcu.table_name = $1
+        GROUP BY
+          tc.constraint_name
+      ),
+      pk_table AS (
+        SELECT DISTINCT
+          fk.unique_constraint_name,
+          kcu.table_name AS to_table
+        FROM
+          fk_constraints AS fk
+          JOIN information_schema.key_column_usage AS kcu
+            ON kcu.constraint_name = fk.unique_constraint_name
+      ),
+      pk_columns AS (
+        SELECT
+          fk.unique_constraint_name,
+          STRING_AGG(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS to_column,
+          ARRAY_AGG(kcu.column_name ORDER BY kcu.ordinal_position) AS to_columns_array
+        FROM
+          fk_constraints AS fk
+          JOIN information_schema.key_column_usage AS kcu
+            ON kcu.constraint_name = fk.unique_constraint_name
+        GROUP BY
+          fk.unique_constraint_name
+      )
       SELECT
-        kcu.constraint_schema AS from_schema,
-        kcu.table_name AS from_table,
-        STRING_AGG(kcu.column_name, ',' ORDER BY kcu.ordinal_position) AS from_column,
-        rc.unique_constraint_schema AS to_schema,
-        tc.constraint_name,
-        rc.update_rule,
-        rc.delete_rule,
-        (
-          SELECT STRING_AGG(kcu2.column_name, ',' ORDER BY kcu2.ordinal_position)
-          FROM information_schema.key_column_usage AS kcu2
-          WHERE kcu2.constraint_name = rc.unique_constraint_name
-        ) AS to_column,
-        (
-          SELECT kcu2.table_name
-          FROM information_schema.key_column_usage AS kcu2
-          WHERE kcu2.constraint_name = rc.unique_constraint_name LIMIT 1
-        ) AS to_table
+        fk.constraint_name,
+        fk.from_schema,
+        fk.from_table,
+        fk.to_schema,
+        fk.update_rule,
+        fk.delete_rule,
+        fc.from_column,
+        fc.from_columns_array,
+        fc.column_count,
+        pt.to_table,
+        pc.to_column,
+        pc.to_columns_array
       FROM
-        information_schema.key_column_usage AS kcu
-        JOIN
-        information_schema.table_constraints AS tc
-      ON
-        tc.constraint_name = kcu.constraint_name
-        JOIN
-        information_schema.referential_constraints AS rc
-        ON
-        rc.constraint_name = kcu.constraint_name
-      WHERE
-        tc.constraint_type = 'FOREIGN KEY' AND
-        kcu.table_schema NOT LIKE 'pg_%' AND
-        kcu.table_schema = $2 AND
-        kcu.table_name = $1
-      GROUP BY
-        kcu.constraint_schema,
-        kcu.table_name,
-        rc.unique_constraint_schema,
-        rc.unique_constraint_name,
-        tc.constraint_name,
-        rc.update_rule,
-        rc.delete_rule;
+        fk_constraints AS fk
+        JOIN fk_columns AS fc ON fk.constraint_name = fc.constraint_name
+        JOIN pk_table AS pt ON fk.unique_constraint_name = pt.unique_constraint_name
+        JOIN pk_columns AS pc ON fk.unique_constraint_name = pc.unique_constraint_name;
     `;
 
     const params = [
@@ -606,17 +642,23 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
     const data = await this.driverExecuteSingle(sql, { params });
 
-    return data.rows.map((row) => ({
-      toTable: row.to_table,
-      toSchema: row.to_schema,
-      toColumn: row.to_column,
-      fromTable: row.from_table,
-      fromSchema: row.from_schema,
-      fromColumn: row.from_column,
-      constraintName: row.constraint_name,
-      onUpdate: row.update_rule,
-      onDelete: row.delete_rule
-    }));
+    return data.rows.map((row) => {
+      // Determine if this is a composite key (more than one column)
+      const isComposite = row.column_count > 1;
+      
+      return {
+        toTable: row.to_table,
+        toSchema: row.to_schema,
+        toColumn: isComposite ? row.to_columns_array : row.to_column,
+        fromTable: row.from_table,
+        fromSchema: row.from_schema,
+        fromColumn: isComposite ? row.from_columns_array : row.from_column,
+        constraintName: row.constraint_name,
+        onUpdate: row.update_rule,
+        onDelete: row.delete_rule,
+        isComposite: isComposite
+      };
+    });
   }
 
   async query(queryText: string): Promise<CancelableQuery> {

--- a/apps/studio/src/lib/db/clients/redshift.ts
+++ b/apps/studio/src/lib/db/clients/redshift.ts
@@ -166,6 +166,8 @@ export class RedshiftClient extends PostgresClient {
 
     const data = await this.driverExecuteSingle(sql, { params });
 
+    // For now, treat all keys as non-composite until we can properly test with Redshift
+    // TODO: Implement proper composite key detection for Redshift
     return data.rows.map((row) => ({
       toTable: row.to_table,
       toSchema: row.to_schema,
@@ -175,7 +177,8 @@ export class RedshiftClient extends PostgresClient {
       fromColumn: row.from_column,
       constraintName: row.constraint_name,
       onUpdate: row.update_rule,
-      onDelete: row.delete_rule
+      onDelete: row.delete_rule,
+      isComposite: false
     }));
   }
   async getTableCreateScript(table: string, schema: string = this._defaultSchema): Promise<string> {

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -234,7 +234,8 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
       fromColumn: row.from,
       toColumn: row.to,
       onUpdate: row.on_update,
-      onDelete: row.on_delete
+      onDelete: row.on_delete,
+      isComposite: false
     }))
   }
 

--- a/apps/studio/src/shared/lib/dialects/bigquery.ts
+++ b/apps/studio/src/shared/lib/dialects/bigquery.ts
@@ -33,6 +33,7 @@ export const BigQueryData: DialectData = {
     sqlCreate: true,
     dropTable: true,
     indexes: true,
+    compositeKeys: true,
     constraints: {
       onUpdate: true,
       onDelete: true

--- a/apps/studio/src/shared/lib/dialects/cassandra.ts
+++ b/apps/studio/src/shared/lib/dialects/cassandra.ts
@@ -64,6 +64,7 @@ export const CassandraData: DialectData = {
   disabledFeatures: {
     shell: true,
     defaultValue: true,
+    compositeKeys: true,
     alter: {
       alterColumn: true,
       multiStatement: true,

--- a/apps/studio/src/shared/lib/dialects/clickhouse.ts
+++ b/apps/studio/src/shared/lib/dialects/clickhouse.ts
@@ -78,6 +78,7 @@ export const ClickHouseData: DialectData = {
   disabledFeatures: {
     shell: true,
     triggers: true,
+    compositeKeys: true,
     createIndex: true,
     generatedColumns: true,
     alter: {

--- a/apps/studio/src/shared/lib/dialects/duckdb.ts
+++ b/apps/studio/src/shared/lib/dialects/duckdb.ts
@@ -39,6 +39,7 @@ export const DuckDBData: DialectData = {
   disabledFeatures: {
     shell: true,
     triggers: true,
+    compositeKeys: true,
     multipleDatabases: true,
     alter: {
       multiStatement: true,

--- a/apps/studio/src/shared/lib/dialects/models.ts
+++ b/apps/studio/src/shared/lib/dialects/models.ts
@@ -165,6 +165,7 @@ export interface DialectData {
     initialSort?: boolean
     multipleDatabase?: boolean
     sqlCreate?: boolean
+    compositeKeys?: boolean    // Whether composite keys are supported
     schemaValidation?: boolean  // Whether schema validation features are disabled
   },
   notices?: {

--- a/apps/studio/src/shared/lib/dialects/models.ts
+++ b/apps/studio/src/shared/lib/dialects/models.ts
@@ -316,12 +316,13 @@ export type DialectConfig = {
 
 
 export interface TableKey {
+  isComposite: boolean;
   toTable: string;
   toSchema: string;
-  toColumn: string;
+  toColumn: string | string[];
   fromTable: string;
   fromSchema: string;
-  fromColumn: string;
+  fromColumn: string | string[];
   constraintName?: string;
   onUpdate?: string;
   onDelete?: string;

--- a/apps/studio/src/shared/lib/dialects/mongodb.ts
+++ b/apps/studio/src/shared/lib/dialects/mongodb.ts
@@ -18,6 +18,7 @@ export const MongoDBData: DialectData = {
     nullable: true,
     defaultValue: true,
     primary: true,
+    compositeKeys: true,
     comments: true,
     index: {
       id: true,

--- a/apps/studio/src/shared/lib/dialects/sqlite.ts
+++ b/apps/studio/src/shared/lib/dialects/sqlite.ts
@@ -40,6 +40,7 @@ export const SqliteData: DialectData = {
     shell: true,
     schema: true,
     comments: true,
+    compositeKeys: true,
     alter: {
       alterColumn: true,
       multiStatement: true,

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -136,7 +136,7 @@ export function runCommonTests(getUtil, opts = {}) {
       await getUtil().primaryKeyTests()
     })
     
-    test.only("composite key tests", async () => {
+    test("composite key tests", async () => {
       await getUtil().compositeKeyTests()
     })
 

--- a/apps/studio/tests/integration/lib/db/clients/all.js
+++ b/apps/studio/tests/integration/lib/db/clients/all.js
@@ -135,6 +135,10 @@ export function runCommonTests(getUtil, opts = {}) {
     test("primary key tests", async () => {
       await getUtil().primaryKeyTests()
     })
+    
+    test.only("composite key tests", async () => {
+      await getUtil().compositeKeyTests()
+    })
 
     describe("Table Structure", () => {
       test("should fetch table properties", async () => {

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -105,6 +105,67 @@ function testWith(dockerTag: string, readonly: boolean) {
         expect(result.result.length).toBe(1)
         expect(result.fields.length).toBe(2)
       })
+      
+      it("should properly filter foreign keys by schema", async () => {
+        // Skip in read-only mode
+        if (readonly) return;
+        
+        // Create test schemas and tables with separate statements
+        await util.knex.raw(`CREATE SCHEMA schema_test_1`);
+        await util.knex.raw(`CREATE SCHEMA schema_test_2`);
+        
+        await util.knex.raw(`
+          CREATE TABLE schema_test_1.parent (
+            id INT PRIMARY KEY
+          )
+        `);
+        
+        await util.knex.raw(`
+          CREATE TABLE schema_test_2.parent (
+            id INT PRIMARY KEY
+          )
+        `);
+        
+        await util.knex.raw(`
+          CREATE TABLE schema_test_1.child (
+            id INT PRIMARY KEY,
+            parent_id INT,
+            CONSTRAINT FK_Child_Parent_1 FOREIGN KEY (parent_id) REFERENCES schema_test_1.parent(id)
+          )
+        `);
+        
+        await util.knex.raw(`
+          CREATE TABLE schema_test_2.child (
+            id INT PRIMARY KEY,
+            parent_id INT,
+            CONSTRAINT FK_Child_Parent_2 FOREIGN KEY (parent_id) REFERENCES schema_test_2.parent(id)
+          )
+        `);
+        
+        // Get foreign keys from schema_test_1
+        const keys1 = await util.connection.getTableKeys('child', 'schema_test_1');
+        
+        // Get foreign keys from schema_test_2
+        const keys2 = await util.connection.getTableKeys('child', 'schema_test_2');
+        
+        // Verify foreign keys from schema_test_1 refer to the correct parent table
+        expect(keys1.length).toBe(1);
+        expect(keys1[0].fromSchema).toBe('schema_test_1');
+        expect(keys1[0].fromTable).toBe('child');
+        expect(keys1[0].toSchema).toBe('schema_test_1');
+        expect(keys1[0].toTable).toBe('parent');
+        
+        // Verify foreign keys from schema_test_2 refer to the correct parent table
+        expect(keys2.length).toBe(1);
+        expect(keys2[0].fromSchema).toBe('schema_test_2');
+        expect(keys2[0].fromTable).toBe('child');
+        expect(keys2[0].toSchema).toBe('schema_test_2');
+        expect(keys2[0].toTable).toBe('parent');
+        
+        // Verify no cross-schema references
+        expect(keys1.some(k => k.toSchema === 'schema_test_2')).toBe(false);
+        expect(keys2.some(k => k.toSchema === 'schema_test_1')).toBe(false);
+      })
     })
 
     // Regression test for #1945 -> cloning with bit fields doesn't work

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -165,6 +165,18 @@ function testWith(dockerTag: string, readonly: boolean) {
         // Verify no cross-schema references
         expect(keys1.some(k => k.toSchema === 'schema_test_2')).toBe(false);
         expect(keys2.some(k => k.toSchema === 'schema_test_1')).toBe(false);
+        
+        // Clean up created schemas and tables (in reverse order of creation)
+        try {
+          await util.knex.raw(`DROP TABLE schema_test_1.child`);
+          await util.knex.raw(`DROP TABLE schema_test_2.child`);
+          await util.knex.raw(`DROP TABLE schema_test_1.parent`);
+          await util.knex.raw(`DROP TABLE schema_test_2.parent`);
+          await util.knex.raw(`DROP SCHEMA schema_test_1`);
+          await util.knex.raw(`DROP SCHEMA schema_test_2`);
+        } catch (e) {
+          console.warn('Failed to clean up schema test objects:', e);
+        }
       })
     })
 

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -270,20 +270,36 @@ export class DBTestUtil {
       ])
     }
 
+    // idk why oracle decided it doesn't like knex for this specific task
     if (!this.data.disabledFeatures.compositeKeys) {
       // Insert some test data
-      await this.knex("composite_parent").insert({
-        parent_id1: 1,
-        parent_id2: 2,
-        name: "Parent Test"
-      });
+      if (this.dbType !== 'oracle') {
+        await this.knex("composite_parent").insert({
+          parent_id1: 1,
+          parent_id2: 2,
+          name: "parent test"
+        });
 
-      await this.knex("composite_child").insert({
-        child_id: 1, 
-        ref_id1: 1, 
-        ref_id2: 2, 
-        description: "Child Test"
-      });
+        await this.knex("composite_child").insert({
+          child_id: 1, 
+          ref_id1: 1, 
+          ref_id2: 2, 
+          description: "child test"
+        });
+      } else {
+        await this.knex("COMPOSITE_PARENT").insert({
+          PARENT_ID1: 1,
+          PARENT_ID2: 2,
+          NAME: "Parent Test"
+        });
+
+        await this.knex("COMPOSITE_CHILD").insert({
+          CHILD_ID: 1, 
+          REF_ID1: 1, 
+          REF_ID2: 2, 
+          DESCRIPTION: "Child Test"
+        });
+      }
 
     }
   }
@@ -1738,7 +1754,7 @@ export class DBTestUtil {
     })
 
     if (!this.data.disabledFeatures.generatedColumns && !this.options.skipGeneratedColumns) {
-      const generatedDefs: Omit<Queries, 'redshift' | 'cassandra' | 'bigquery' | 'firebird' | 'clickhouse'> = {
+      const generatedDefs: Omit<Queries, 'redshift' | 'cassandra' | 'bigquery' | 'firebird' | 'clickhouse' | 'mongodb' | 'sqlanywhere'> = {
         sqlite: "TEXT GENERATED ALWAYS AS (first_name || ' ' || last_name) STORED",
         mysql: "VARCHAR(255) AS (CONCAT(first_name, ' ', last_name)) STORED",
         tidb: "VARCHAR(255) AS (CONCAT(first_name, ' ', last_name)) STORED",
@@ -1758,24 +1774,46 @@ export class DBTestUtil {
       })
     }
     if (!this.data.disabledFeatures.compositeKeys) {
-      // Create a parent table with composite primary key
-      await this.knex.schema.dropTableIfExists("composite_parent");
-      await this.knex.schema.createTable("composite_parent", (table) => {
-        table.integer("parent_id1").notNullable();
-        table.integer("parent_id2").notNullable();
-        table.string("name").notNullable();
-        table.primary(["parent_id1", "parent_id2"]);
-      });
+      if (this.dbType !== 'oracle') {
+        // Create a parent table with composite primary key
+        await this.knex.schema.createTable("composite_parent", (table) => {
+          table.integer("parent_id1").notNullable();
+          table.integer("parent_id2").notNullable();
+          table.string("name").notNullable();
+          table.primary(["parent_id1", "parent_id2"]);
+        });
 
-      // Create a child table with composite foreign key
-      await this.knex.schema.dropTableIfExists("composite_child");
-      await this.knex.schema.createTable("composite_child", (table) => {
-        table.integer("child_id").notNullable().primary();
-        table.integer("ref_id1").notNullable();
-        table.integer("ref_id2").notNullable();
-        table.string("description");
-        table.foreign(['ref_id1', 'ref_id2']).references(['parent_id1', 'parent_id2']).inTable("composite_parent");
-      });
+        // Create a child table with composite foreign key
+        await this.knex.schema.createTable("composite_child", (table) => {
+          table.integer("child_id").notNullable().primary();
+          table.integer("ref_id1").notNullable();
+          table.integer("ref_id2").notNullable();
+          table.string("description");
+          table.foreign(['ref_id1', 'ref_id2']).references(['parent_id1', 'parent_id2']).inTable("composite_parent");
+        });
+      } else {
+        // the knex driver from oracle doesn't seem to create the fks properly
+        await this.knex.schema.raw(`
+          CREATE TABLE composite_parent (
+            parent_id1 NUMBER(10) NOT NULL,
+            parent_id2 NUMBER(10) NOT NULL,
+            name VARCHAR2(255) NOT NULL,
+            CONSTRAINT pk_comp_parent PRIMARY KEY (parent_id1, parent_id2)
+          )
+        `);
+
+        await this.knex.schema.raw(`
+          CREATE TABLE composite_child (
+            child_id NUMBER(10) NOT NULL,
+            ref_id1 NUMBER(10) NOT NULL,
+            ref_id2 NUMBER(10) NOT NULL,
+            description VARCHAR2(255),
+            CONSTRAINT comp_child_fk FOREIGN KEY (ref_id1, ref_id2)
+              REFERENCES composite_parent(parent_id1, parent_id2)
+          )
+        `)
+      }
+
     }
   }
 
@@ -1798,7 +1836,7 @@ export class DBTestUtil {
 
     // Test composite foreign keys functionality
     const tableKeys = await this.connection.getTableKeys('composite_child');
-    
+
     // Check that we have composite keys
     const compositeKey = tableKeys.find(key => key.isComposite === true);
     // If we have a composite key, assert its structure

--- a/apps/studio/tests/lib/db.ts
+++ b/apps/studio/tests/lib/db.ts
@@ -1835,7 +1835,7 @@ export class DBTestUtil {
     }
 
     // Test composite foreign keys functionality
-    const tableKeys = await this.connection.getTableKeys('composite_child');
+    const tableKeys = await this.connection.getTableKeys('composite_child', this.defaultSchema);
 
     // Check that we have composite keys
     const compositeKey = tableKeys.find(key => key.isComposite === true);


### PR DESCRIPTION
fix #3021 
fix #3018 

Some of our queries weren't taking schema into account, so we ended up with more keys being pulled in if there was a collision of table names.

For composite keys, looks like we just never adjusted the query to actually handle them at all.