### PR TITLE
fix: avoid history duplication if current and last query are same

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -955,7 +955,13 @@
           console.log("non empty result", nonEmptyResult)
           this.selectedResult = nonEmptyResult === -1 ? results.length - 1 : nonEmptyResult
 
-          this.$store.dispatch('data/usedQueries/save', { text: query, numberOfRecords: totalRows, queryId: this.query?.id, connectionId: this.usedConfig.id })
+          const lastQueryText = this.$store.state['data/usedQueries']?.items[0]?.text
+          const isDuplicate = lastQueryText === query
+          
+          if(!isDuplicate){
+            this.$store.dispatch('data/usedQueries/save', { text: query, numberOfRecords: totalRows, queryId: this.query?.id, connectionId: this.usedConfig.id })
+          }
+          
           log.debug('identification', identification)
           const found = identification.find(i => {
             return i.type === 'CREATE_TABLE' || i.type === 'DROP_TABLE' || i.type === 'ALTER_TABLE'


### PR DESCRIPTION
fixes: #2804 

before:

https://github.com/user-attachments/assets/835ac422-8008-4bbd-9a05-f4e9bf22aaae


after:

https://github.com/user-attachments/assets/973cb260-6abf-495a-8a74-cb9eaf6e8898

