### PR TITLE
Fix add database

### DIFF
--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -24,6 +24,9 @@ import rawLog from "@bksLogger"
 const log = rawLog.scope('Appdb handlers');
 
 function defaultTransform<T extends Transport>(obj: T, cls: any) {
+  if (_.isNil(obj)) {
+    return null
+  }
   const newObj = {} as unknown as T;
   return cls.merge(newObj, obj);
 }


### PR DESCRIPTION
fix #3067 

The default transform function wasn't checking if the received object was null/undefined, so it was constructing an empty object, which then caused things in the frontend to think results were being returned when they weren't.