### PR TITLE
Fix objectid formatter

### DIFF
--- a/apps/studio/src/components/sidebar/JsonViewer.vue
+++ b/apps/studio/src/components/sidebar/JsonViewer.vue
@@ -160,7 +160,14 @@ export default Vue.extend({
       }, 500),
     },
     sourceMap() {
-      return JsonSourceMap.stringify(this.filteredValue, null, 2);
+      let replacedFilteredValue = this.filteredValue;
+      try {
+        // run the replacer on the filteredValue
+        replacedFilteredValue = JSON.parse(JSON.stringify(this.filteredValue, this.replacer));
+      } catch (error) {
+        log.warn("Failed to replace filtered value", error);
+      }
+      return JsonSourceMap.stringify(replacedFilteredValue, null, 2);
     },
     filteredValue() {
       if (this.empty) {

--- a/apps/studio/src/components/sidebar/JsonViewer.vue
+++ b/apps/studio/src/components/sidebar/JsonViewer.vue
@@ -343,6 +343,10 @@ export default Vue.extend({
   },
   methods: {
     replacer(_key: string, value: unknown) {
+      // HACK: this is the case in mongodb objectid
+      if (typeof value === "object" && _.isTypedArray((value as any).buffer)) {
+        return typedArrayToString((value as any).buffer, this.binaryEncoding)
+      }
       if (_.isTypedArray(value)) {
         return typedArrayToString(value as ArrayBufferView, this.binaryEncoding)
       }

--- a/apps/studio/src/shared/lib/tabulator.ts
+++ b/apps/studio/src/shared/lib/tabulator.ts
@@ -32,6 +32,8 @@ export default {
     let cellValue = value.toString();
     if (_.isTypedArray(value)) {
       cellValue = typedArrayToString(value, binaryEncoding)
+    } else if (_.isTypedArray(value?.buffer)) { // HACK: mongodb sends buffer this way
+      cellValue = typedArrayToString(value.buffer, binaryEncoding)
     } else if (_.isArray(value) || _.isObject(value)) {
       cellValue = JSON.stringify(value)
     }


### PR DESCRIPTION
This does not fix the serializer but fixes the format of ObjectID in table result and json viewer.

Before:
![image](https://github.com/user-attachments/assets/cf93567a-4df2-45be-95c5-f65a4f60fc58)

After:
![image](https://github.com/user-attachments/assets/643a34f6-a4c9-4848-b37a-e95fc4ab88f8)

One commit for json viewer was cherry picked from a PR that was merge in master. https://github.com/beekeeper-studio/beekeeper-studio/pull/3025

