### PR TITLE
fix: macos disable connection menu items when all windows are closed

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -164,6 +164,8 @@ async function initBasics() {
 app.on('window-all-closed', () => {
   // On macOS it is common for applications and their menu bar
   // to stay active until the user quits explicitly with Cmd + Q
+  ipcMain.emit("disable-connection-menu-items");
+
   if (process.platform !== 'darwin') {
     app.quit()
   }


### PR DESCRIPTION
with #3040, in macOs I noticed that when user closes window when the app was connected with db, the connection menu items stays enabled. so this PR fixes that issue by disabling connection menu items when all windows are closed.

also I noticed, there is another issue in macOS in case there are multiple windows, since  same menu are shared across all of the windows. Enabling or disabling menu items in one window affects all the other windows too. I'll check on that too if I can find any solution to that.

before:

https://github.com/user-attachments/assets/27d2e33f-f6bf-4e3f-b3d7-82c07b9e1876


after:

https://github.com/user-attachments/assets/21aaf7ac-8c85-4d5e-96af-7d7f4ac66701

