### PR TITLE
fix: add grouped-tables-base to bottom of dark theme variables

### DIFF
--- a/apps/studio/src/assets/styles/themes/dark/variables.scss
+++ b/apps/studio/src/assets/styles/themes/dark/variables.scss
@@ -50,3 +50,6 @@ $statusbar-text:            black;
 $statusbar-text-default:    white;
 
 $row-handle: rgb(22 22 22);
+
+$grouped-tables-base: color.adjust($theme-bg, $lightness: 2%);
+$grouped-tables-light: color.adjust($grouped-tables-base, $lightness: 2%);


### PR DESCRIPTION
resolves #3081 
(bouncing between themes, so just warning your eyes now)
![bug-3081](https://github.com/user-attachments/assets/8250e432-a0b8-40d7-8669-9de0041ddf8d)
