### PR TITLE
upgrade queryleaf to v0.2.3

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -45,7 +45,7 @@
     "@mongosh/browser-runtime-electron": "^3.8.0",
     "@mongosh/service-provider-node-driver": "^3.6.0",
     "@pdanpdan/vue-keyboard-trap": "^1.0.19",
-    "@queryleaf/lib": "^0.2.2",
+    "@queryleaf/lib": "^0.2.3",
     "@types/ini": "^4.1.0",
     "ansi-to-html": "^0.7.2",
     "axios": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3213,10 +3213,10 @@
   dependencies:
     playwright "1.50.1"
 
-"@queryleaf/lib@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@queryleaf/lib/-/lib-0.2.2.tgz#87200730afb8aa6a0ae785e7b739622372a89e94"
-  integrity sha512-HwIQ/2Zeyj+loXc0k8i7Js/PXyNHVseJdXCH6/d5EHoEqHnPHvqEMeYYCI1s7ocYe+1YIgKxg76LWpoLOPsK1g==
+"@queryleaf/lib@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@queryleaf/lib/-/lib-0.2.3.tgz#5c06c7cc9b98c91feff8f56c4fa900d265da0e5c"
+  integrity sha512-Ir3Ne9O/rZbsOd/nN0wQvcUmjA8JLYTI7zUz2tJlHVJZWVPTmLraDTdD7JgZMvxflIbyPORG7M4d88AR2lrtxg==
   dependencies:
     debug "^4.4.0"
     node-sql-parser "^4.11.0"


### PR DESCRIPTION
This will fixes issues with aliases in SQL queries, the _id always being present in select queries even when it shouldn't be,
and deep array access (so you can do stuff like `films[0].lead.firstName`