### PR TITLE
fix clipboard in query editor

### DIFF
--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -21,9 +21,8 @@ import "codemirror/addon/merge/merge";
 import 'codemirror/keymap/vim.js'
 import CodeMirror, { TextMarker } from "codemirror";
 import _ from "lodash";
-import { setKeybindings, Config, extendVimOnCodeMirror } from "./vim";
+import { setKeybindings, Config, extendVimOnCodeMirror, Clipboard } from "./vim";
 import { divider, InternalContextItem, openMenu } from "../context-menu/menu";
-import { writeClipboard, readClipboard } from "../../utils/clipboard";
 import { cmCtrlOrCmd } from "../../utils/platform"
 import { PropType } from "vue";
 import { CustomMenuItems, useCustomMenuItems } from "../context-menu/menu";
@@ -500,10 +499,10 @@ export default {
           {
             label: "Cut",
             id: "text-cut",
-            handler: () => {
+            handler: async () => {
               const selection = this.editor.getSelection();
               this.editor.replaceSelection("");
-              writeClipboard(selection);
+              await this.clipboard?.writeText(selection);
             },
             class: selectionDepClass,
             shortcut: "Control+X",
@@ -514,7 +513,7 @@ export default {
             id: "text-copy",
             handler: async () => {
               const selection = this.editor.getSelection();
-              await writeClipboard(selection);
+              await this.clipboard?.writeText(selection);
             },
             class: selectionDepClass,
             shortcut: "Control+C",
@@ -523,7 +522,7 @@ export default {
             label: "Paste",
             id: "text-paste",
             handler: async () => {
-              const clipboard = await readClipboard();
+              const clipboard = this.clipboard?.readText()
               if (this.editor.getSelection()) {
                 this.editor.replaceSelection(clipboard, "around");
               } else {

--- a/apps/ui-kit/lib/components/text-editor/vim.ts
+++ b/apps/ui-kit/lib/components/text-editor/vim.ts
@@ -30,7 +30,7 @@ export function setKeybindings(codeMirrorVimInstance: any, mappings: IMapping[])
   }
 }
 
-type Clipboard = {
+export type Clipboard = {
   writeText(text: string, notify?: boolean): void
   readText(): string
 }


### PR DESCRIPTION
fix #3119 

I don't know exactly why this is the case, but the ui-kit uses navigator for clipboard capabilities. This works in most cases, except for the texteditor mixin for some reason. So I switched this to use the clipboard we pass in for vim.