### PR TITLE
fix: excel sheet naming errors

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -333,7 +333,14 @@
              const ws = XLSX.utils.aoa_to_sheet(values);
              const wb = XLSX.utils.book_new();
 
-             XLSX.utils.book_append_sheet(wb, ws, title);
+             // sheet title cannot be more than 31 characters and sheet title cannot be 'history'
+             // source: https://support.microsoft.com/en-us/office/rename-a-worksheet-3f1f7148-ee83-404d-8ef0-9ff99fbad1f9
+             let sheetTitle = title.slice(0,31);
+             if (title.toLowerCase() === "history") {
+              sheetTitle = "history-sheet";
+             }
+
+             XLSX.utils.book_append_sheet(wb, ws, sheetTitle);
              const excel = XLSX.write(wb, { type: 'buffer' });
              setFileContents(excel);
           }


### PR DESCRIPTION
fixes: #3127 

https://support.microsoft.com/en-us/office/rename-a-worksheet-3f1f7148-ee83-404d-8ef0-9ff99fbad1f9

errors:
<img width="324" alt="Screenshot 2025-05-08 at 19 51 55" src="https://github.com/user-attachments/assets/cd4f51ce-4cc7-4776-8229-1cdf8337fe6a" />
<img width="324" alt="Screenshot 2025-05-08 at 19 54 47" src="https://github.com/user-attachments/assets/9daec328-6463-496e-927e-731955ac1635" />
