### PR TITLE
Fix switching tabs with used connections

### DIFF
--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -435,12 +435,12 @@ const store = new Vuex.Store<State>({
         context.commit('connected', true);
         context.commit('supportedFeatures', supportedFeatures);
         context.commit('versionString', versionString);
+        config = await context.dispatch('data/usedconnections/recordUsed', config)
         context.commit('newConnection', config)
 
         await context.dispatch('updateDatabaseList')
         await context.dispatch('updateTables')
         await context.dispatch('updateRoutines')
-        await context.dispatch('data/usedconnections/recordUsed', config)
         context.dispatch('updateWindowTitle', config)
 
         await Vue.prototype.$util.send('appdb/tabhistory/clearDeletedTabs', { workspaceId: context.state.usedConfig.workspaceId, connectionId: context.state.usedConfig.id }) 

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -34,8 +34,10 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
         lastUsedConnection.updatedAt = new Date();
         await context.dispatch('save', lastUsedConnection);
       } else {
-        await context.dispatch('save', config);
+        const id = await context.dispatch('save', config);
+        config = context.state.items.find((item) => item.id === id);
       }
+      return config;
     },
     async load(context) {
       context.commit("error", null);


### PR DESCRIPTION
This probably affect a whole lot of other features (hiding entities and pinning for sure).

When connecting to a connection that was never saved, we were saving the connection, but not updating the config in the store after saving it, so it didn't have an id. This means that a lot of actions ( which checked for an id on the used config), just silently did nothing. In the case of switching tabs, we wouldn't save the tabs when there was no id, so it ended up with every tab being set as active, with a bunch of cascading bugs coming from that.