### PR TITLE
fix NixOS extraResources

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -55,10 +55,17 @@ module.exports = {
       to: 'public'
     },
     {
-      from: ".",
-      to: ".",
-      filter: ["user.config.ini", "system.config.ini", "default.config.ini"],
+      from: "./user.config.ini",
+      to: "user.config.ini"
     },
+    {
+      from: "./system.config.ini",
+      to: "system.config.ini"
+    },
+    {
+      from: "./default.config.ini",
+      to: "default.config.ini"
+    }
   ],
   fileAssociations: [
     {


### PR DESCRIPTION
Other extra resources seem to work without issues. Don't know why config.ini fails the copy permission on NixOS. One obvious difference between config files and the other extra resources is the way we define them in the electron builder config, so I guess matching it with the other configs would work?