### PR TITLE
Fix/load tabs

### DIFF
--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -17,7 +17,7 @@
           :key="tab.id"
           :tab="tab"
           :tabs-count="tabItems.length"
-          :selected="activeTab.id === tab.id"
+          :selected="activeTab?.id === tab.id"
           @click="click"
           @close="close"
           @closeAll="closeAll"
@@ -71,18 +71,18 @@
         class="tab-pane"
         :id="'tab-' + idx"
         :key="tab.id"
-        :class="{active: (activeTab.id === tab.id)}"
-        v-show="activeTab.id === tab.id"
+        :class="{active: (activeTab?.id === tab.id)}"
+        v-show="activeTab?.id === tab.id"
       >
         <QueryEditor
           v-if="tab.tabType === 'query'"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :tab="tab"
           :tab-id="tab.id"
         />
         <Shell
           v-if="tab.tabType === 'shell'"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :tab="tab"
           :tab-id="tab.id"
         />
@@ -94,7 +94,7 @@
           <template v-slot:default="slotProps">
             <TableTable
               :tab="tab"
-              :active="activeTab.id === tab.id"
+              :active="activeTab?.id === tab.id"
               :table="slotProps.table"
             />
           </template>
@@ -106,7 +106,7 @@
         >
           <template v-slot:default="slotProps">
             <TableProperties
-              :active="activeTab.id === tab.id"
+              :active="activeTab?.id === tab.id"
               :tab="tab"
               :tab-id="tab.id"
               :table="slotProps.table"
@@ -115,7 +115,7 @@
         </tab-with-table>
         <TableBuilder
           v-if="tab.tabType === 'table-builder'"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :tab="tab"
           :tab-id="tab.id"
         />
@@ -123,14 +123,14 @@
           v-if="tab.tabType === 'import-export-database'"
           :schema="tab.schemaName"
           :tab="tab"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           @close="close"
         />
         <DatabaseBackup
           v-if="tab.tabType === 'backup'"
           :connection="connection"
           :is-restore="false"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :tab="tab"
           @close="close"
         />
@@ -138,7 +138,7 @@
           v-if="tab.tabType === 'restore'"
           :connection="connection"
           :is-restore="true"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :tab="tab"
           @close="close"
         />
@@ -147,7 +147,7 @@
           :tab="tab"
           :schema="tab.schemaName"
           :table="tab.tableName"
-          :active="activeTab.id === tab.id"
+          :active="activeTab?.id === tab.id"
           :connection="connection"
           @close="close"
         />
@@ -308,51 +308,53 @@ import Shell from './TabShell.vue'
 import { safeSqlFormat as safeFormat } from '@/common/utils';
 import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/transport/TransportOpenTab'
 
-  export default Vue.extend({
-    props: [],
-    components: {
-      Statusbar,
-      QueryEditor,
-      CoreTabHeader,
-      TableTable,
-      TableProperties,
-      ImportExportDatabase,
-      ImportTable,
-      Draggable,
-      ShortcutHints,
-      TableBuilder,
-      TabWithTable,
-      TabIcon,
-      DatabaseBackup,
-      PendingChangesButton,
-      ConfirmationModal,
-      SqlFilesImportModal,
-      CreateCollectionModal,
-      Shell
-    },
-    data() {
-      return {
-        showExportModal: false,
-        tableExportOptions: null,
-        dragOptions: {
-          handle: '.nav-item'
-        },
-        // below are connected to the modal for delete/truncate
-        sureOpen: false,
-        lastFocused: null,
-        dbAction: null,
-        dbElement: null,
-        dbEntityType: null,
-        dbDeleteElementParams: null,
-        // below are connected to the modal for duplicate
-        dbDuplicateTableParams: null,
-        duplicateTableName: null,
-        closingTab: null,
-        confirmModalId: 'core-tabs-close-confirmation',
-      }
-    },
-    watch: {
-
+export default Vue.extend({
+  props: [],
+  components: {
+    Statusbar,
+    QueryEditor,
+    CoreTabHeader,
+    TableTable,
+    TableProperties,
+    ImportExportDatabase,
+    ImportTable,
+    Draggable,
+    ShortcutHints,
+    TableBuilder,
+    TabWithTable,
+    TabIcon,
+    DatabaseBackup,
+    PendingChangesButton,
+    ConfirmationModal,
+    SqlFilesImportModal,
+    CreateCollectionModal,
+    Shell
+  },
+  data() {
+    return {
+      showExportModal: false,
+      tableExportOptions: null,
+      dragOptions: {
+        handle: '.nav-item'
+      },
+      // below are connected to the modal for delete/truncate
+      sureOpen: false,
+      lastFocused: null,
+      dbAction: null,
+      dbElement: null,
+      dbEntityType: null,
+      dbDeleteElementParams: null,
+      // below are connected to the modal for duplicate
+      dbDuplicateTableParams: null,
+      duplicateTableName: null,
+      closingTab: null,
+      confirmModalId: 'core-tabs-close-confirmation',
+    }
+  },
+  watch: {
+    async usedConfig() {
+      await this.$store.dispatch('tabs/load')
+    }
   },
   filters: {
     titleCase: function (value) {
@@ -364,7 +366,7 @@ import { TransportOpenTab, setFilters, matches, duplicate } from '@/common/trans
   computed: {
     ...mapState(['selectedSidebarItem']),
     ...mapState('tabs', { 'activeTab': 'active', 'tabs': 'tabs' }),
-    ...mapState(['connection', 'connectionType']),
+    ...mapState(['connection', 'connectionType', 'usedConfig']),
     ...mapGetters({ 'dialect': 'dialect', 'dialectData': 'dialectData', 'dialectTitle': 'dialectTitle' }),
     tabIcon() {
       return {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -499,7 +499,7 @@
         return !isEmpty(this.unsavedText)
       },
       hasTitle() {
-        return this.query.title && this.query.title.replace(/\s+/, '').length > 0
+        return this.query?.title && this.query.title.replace(/\s+/, '').length > 0
       },
       splitElements() {
         return [
@@ -695,7 +695,7 @@
       initialize() {
         this.initialized = true
         // TODO (matthew): Add hint options for all tables and columns\
-        this.query.title = this.activeTab.title
+        this.query.title = this.activeTab?.title
 
         if (this.split) {
           this.split.destroy();


### PR DESCRIPTION
Seems there's a race condition between CoreTabs being mounted and the store connect function finishing, so the usedConfig is sometimes null when CoreTabs is mounted and the tabs are loaded (thus no tabs are loaded). I made sure there wasn't a possibility of us trying to access fields on the undefined activeTab and also added a watcher for usedConfig, so if setting usedConfig is after CoreTabs has been mounted, we can still load the tabs.