### PR TITLE
fix: close all not removing tabs from appdb

### DIFF
--- a/apps/studio/src/store/modules/TabModule.ts
+++ b/apps/studio/src/store/modules/TabModule.ts
@@ -92,7 +92,7 @@ export const TabModule: Module<State, RootState> = {
       }
     },
     async unload(context) {
-      context.commit('remove', context.state.tabs)
+      context.dispatch('remove', context.state.tabs)
       context.commit('setActive', null)
     },
     async reopenLastClosedTab(context) {


### PR DESCRIPTION
fixes: #3185

issue was with the `close all` option only.  other close options seems to be working fine!

before:

https://github.com/user-attachments/assets/f595cd7c-6875-4bc2-94a0-7ba32fc2e482

after:

https://github.com/user-attachments/assets/30418c46-0fa8-4baa-ae75-abaabfde819c

