### PR TITLE
feat: support regex filter in json viewer

### DIFF
--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -312,3 +312,13 @@ export function removeUnsortableColumnsFromSortBy(sortParms: { field: string; di
       return acc
     }, [])
 }
+
+export function toRegexSafe(input: string) {
+  const match = input.match(/^\/(.+)\/([a-z]*)$/);
+  if (!match) return null;
+  try {
+    return new RegExp(match[1], match[2]);
+  } catch (e) {
+    return null;
+  }
+}

--- a/apps/studio/src/lib/data/jsonViewer.ts
+++ b/apps/studio/src/lib/data/jsonViewer.ts
@@ -2,6 +2,7 @@ import { TableKey } from "@/shared/lib/dialects/models";
 import _ from "lodash";
 import globals from '@/common/globals'
 import { LineGutter } from "../editor/utils";
+import { toRegexSafe } from "@/common/utils";
 
 export interface UpdateOptions {
   dataId: number | string;
@@ -99,9 +100,11 @@ export function deepFilterObjectProps(
   filter: string,
   paths?: string[]
 ) {
+  const regex = toRegexSafe(filter);
+
   if (!paths) paths = getPaths(obj);
   const filteredPaths = paths.filter((path) =>
-    path.toLowerCase().includes(filter)
+    regex ? regex.test(path) : path.toLowerCase().includes(filter)
   );
   return _.pick(obj, filteredPaths);
 }


### PR DESCRIPTION
I wanted to filter some keys by a pattern in a json viewer, and it seemed logical to use regex for that, so I added support for it.

Here's an example of only showing keys with "smart" or "gam" in them:

![63370](https://github.com/user-attachments/assets/c129bed8-c715-4a8b-aa84-61a9e2e75cc5)
