### PR TITLE
Feat #2826: Improve pagination/navigation

### DIFF
--- a/apps/studio/default.config.ini
+++ b/apps/studio/default.config.ini
@@ -139,3 +139,5 @@ nextPage = ctrlOrCmd+right
 previousPage = ctrlOrCmd+left
 focusOnFilterInput = ctrlOrCmd+f
 openEditorModal = shift+enter
+firstPage = ctrlOrCmd+h
+lastPage = ctrlOrCmd+l

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -86,6 +86,13 @@
         <div class="flex-center flex-middle flex">
           <a
             v-if="(this.page > 1)"
+            @click="page = 1"
+            v-tooltip="$bksConfig.keybindings.tableTable.firstPage"
+          ><i
+            class="material-icons"
+          >first_page</i></a>
+          <a
+            v-if="(this.page > 1)"
             @click="page = page - 1"
             v-tooltip="$bksConfig.keybindings.tableTable.previousPage"
           ><i
@@ -96,9 +103,17 @@
             v-model="page"
           >
           <a
+            v-if="hasNextPage"
             @click="page = page + 1"
             v-tooltip="$bksConfig.keybindings.tableTable.nextPage"
           ><i class="material-icons">navigate_next</i></a>
+          <a
+            v-if="hasNextPage"
+            @click="jumpToLastPage"
+            v-tooltip="$bksConfig.keybindings.tableTable.lastPage"
+          >
+            <i class="material-icons">last_page</i>
+          </a>
         </div>
       </div>
 
@@ -340,6 +355,7 @@ export default Vue.extend({
       columnsSet: false,
       tabulator: null,
       loading: false,
+      hasNextPage: false,
 
       // table data
       data: null, // array of data
@@ -442,7 +458,9 @@ export default Vue.extend({
         'general.cloneSelection': this.cloneSelection.bind(this),
         'general.deleteSelection': this.deleteTableSelection.bind(this),
         'tableTable.nextPage': this.navigatePage.bind(this, 'next'),
+        'tableTable.lastPage': this.navigatePage.bind(this, 'last'),
         'tableTable.previousPage': this.navigatePage.bind(this, 'prev'),
+        'tableTable.firstPage': this.navigatePage.bind(this, 'first'),
         'tableTable.openEditorModal': this.openEditorMenuByShortcut.bind(this),
       })
     },
@@ -904,11 +922,18 @@ export default Vue.extend({
       log.debug('tab pressed')
 
     },
-    navigatePage (dir: 'next' | 'prev') {
+    navigatePage (dir: 'next' | 'prev' | 'first' | 'last') {
       const focusingTable = this.tabulator.element.contains(document.activeElement)
       if (!focusingTable) {
-        if (dir === 'next') this.page++
-        else this.page--
+        if (dir === 'next') {
+          this.page++
+        } else if (dir === 'prev') {
+          this.page--
+        } else if (dir === 'first') {
+          this.page = 1
+        } else if (dir === 'last') {
+          this.page = this.jumpToLastPage()
+        }
       }
     },
     copySelection() {
@@ -1662,7 +1687,7 @@ export default Vue.extend({
             const response = await this.connection.selectTop(
               this.table.name,
               offset,
-              this.limit,
+              this.limit + 1, // +1 to check if there is a next page
               orderBy,
               filters,
               this.table.schema,
@@ -1682,6 +1707,13 @@ export default Vue.extend({
             //  // FIXME: This should be added to all clients, not just cassandra (cassandra needs ALLOW FILTERING to do filtering because of performance)
             //  { allowFilter: this.isCassandra }
             //);
+
+            this.hasNextPage = response.result.length > this.limit
+
+            if (this.hasNextPage) {
+              response.result.pop()
+            }
+            this.data = response.result
 
             if (_.xor(response.fields, this.table.columns.map(c => c.columnName)).length > 0) {
               log.debug('table has changed, updating')
@@ -1747,6 +1779,19 @@ export default Vue.extend({
     },
     clearQueryError() {
       this.queryError = null
+    },
+    async jumpToLastPage() {
+      try {
+        const totalRows = await this.connection.getTableLength(this.table.name, this.table.schema); // -> SELECT (*) FROM table
+
+        const lastPage = Math.ceil(totalRows / this.limit);
+
+        this.page = lastPage;
+
+        this.tabulator.setPage(lastPage);
+      } catch (error) {
+        console.error("Error jumping to the last page:", error);
+      }
     },
     async getTableKeys() {
       this.rawTableKeys = await this.connection.getTableKeys(this.table.name, this.table.schema);


### PR DESCRIPTION
Improves pagination by adding navigation buttons that allow users to jump directly to the first and last pages. This enhancement provides quicker access to the beginning and end of the content, improving overall user experience.

To support this functionality, a new function, jumpToLastPage(), was implemented. Alongside this, keyboard shortcuts were introduced to enable faster navigation through the table pages.

Finally, the commit includes conditional logic that hides the jump, next, and previous buttons whenever navigation is not possible. 

We tried to do everything as per discussed in the issue, but please feel free to request any changes. 


https://github.com/user-attachments/assets/d08645ef-fd25-490b-a81a-aceecbaaa8b8

