### PR TITLE
Feat #2963: Implemented Query Variables Support

### DIFF
--- a/apps/studio/tests/unit/common/inLineVars.spec.js
+++ b/apps/studio/tests/unit/common/inLineVars.spec.js
@@ -1,0 +1,144 @@
+import { extractVariablesAndCleanQuery, substituteVariables } from "@/common/utils";
+
+describe("Inline Variables - extractVariablesAndCleanQuery", () => {
+  it("extracts variables defined with line comments", () => {
+    const query = `
+      -- %limit% = 10
+      -- %status% = 'active'
+      SELECT * FROM users WHERE status = %status% LIMIT %limit%;
+    `;
+
+    const { variables, cleanedQuery } = extractVariablesAndCleanQuery(query);
+
+    expect(variables).toEqual({
+      limit: '10',
+      status: "'active'",
+    });
+
+    expect(cleanedQuery).toContain("SELECT * FROM users");
+    expect(cleanedQuery).not.toContain("-- %limit%");
+  });
+
+  it("extracts variables from VARS block", () => {
+    const query = `
+      /* VARS:
+      %limit% = 20
+      %status% = 'pending'
+      */
+      SELECT * FROM orders WHERE status = %status% LIMIT %limit%;
+    `;
+
+    const { variables } = extractVariablesAndCleanQuery(query);
+
+    expect(variables).toEqual({
+      limit: '20',
+      status: "'pending'",
+    });
+  });
+
+  it("throws error if line comment variable is malformed", () => {
+    const query = `
+      -- %limit% =
+      SELECT * FROM users;
+    `;
+
+    expect(() => extractVariablesAndCleanQuery(query)).toThrow("Malformed variable");
+  });
+
+  it("throws error if block variable is malformed", () => {
+    const query = `
+      /* VARS:
+      %limit% =
+      */
+      SELECT * FROM users;
+    `;
+
+    expect(() => extractVariablesAndCleanQuery(query)).toThrow("Malformed variable");
+  });
+});
+
+describe("Inline Variables - substituteVariables", () => {
+  it("substitutes variables correctly", () => {
+    const query = "SELECT * FROM users WHERE status = %status% LIMIT %limit%;";
+    const variables = {
+      status: "'active'",
+      limit: "10",
+    };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM users WHERE status = 'active' LIMIT 10;");
+  });
+
+  it("adds quotes if missing", () => {
+    const query = "SELECT * FROM products WHERE category = %category%;";
+    const variables = { category: "books" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM products WHERE category = 'books';");
+  });
+
+  it("keeps valid JSON values as-is", () => {
+    const query = "SELECT * FROM data WHERE payload = %payload%;";
+    const variables = { payload: '{"key": "value"}' };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe(`SELECT * FROM data WHERE payload = {"key": "value"};`);
+  });
+
+  it("does not add quotes to valid SQL lists", () => {
+    const query = "SELECT * FROM users WHERE id IN %ids%;";
+    const variables = { ids: "(1, 2, 3)" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM users WHERE id IN (1, 2, 3);");
+  });
+
+  it("substitutes multiple occurrences of the same variable", () => {
+    const query = "SELECT * FROM logs WHERE user_id = %id% OR actor_id = %id%;";
+    const variables = { id: "42" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM logs WHERE user_id = 42 OR actor_id = 42;");
+  });
+
+  it("keeps null without quotes", () => {
+    const query = "SELECT * FROM users WHERE deleted_at IS %deleted%;";
+    const variables = { deleted: "null" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM users WHERE deleted_at IS null;");
+  });
+
+  it("adds quotes to strings with spaces", () => {
+    const query = "SELECT * FROM books WHERE title = %title%;";
+    const variables = { title: "Harry Potter" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM books WHERE title = 'Harry Potter';");
+  });
+
+  it("does not add quotes to floats and negative numbers", () => {
+    const query = "SELECT * FROM readings WHERE value > %min% AND value < %max%;";
+    const variables = { min: "-5.5", max: "42.0" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM readings WHERE value > -5.5 AND value < 42.0;");
+  });
+
+  it("ignores variables that are not used in the query", () => {
+    const query = "SELECT * FROM products;";
+    const variables = { price: "100" };
+
+    const result = substituteVariables(query, variables);
+
+    expect(result).toBe("SELECT * FROM products;");
+  });
+});

--- a/docs/user_guide/sql_editor/editor.md
+++ b/docs/user_guide/sql_editor/editor.md
@@ -51,7 +51,37 @@ select * from table where foo = $1 and bar = $2
 ```
 ![Image Alt Tag](../../assets/images/using-the-sql-editor-13.gif)
 
+## Inline Variables
 
+If you're writing queries that you want to test and tweak frequently, Beekeeper Studio supports *inline variables* that make your queries more flexible and readable.
+
+Inline variables allow you to define temporary values that are substituted before the query is run, without using SQL engine-specific parameter syntax.
+
+### Defining Inline Variables
+
+You can define inline variables in two ways:
+
+#### 1. Line Comments (`--`)
+
+```sql
+-- %limit% = 10
+-- %status% = 'active'
+
+SELECT * FROM users WHERE status = %status% LIMIT %limit%;
+```
+#### 2. Block Comment (`/* VARS: */`)
+
+Alternatively, you can define multiple variables using a single block comment. This helps reduce clutter when working with many variables:
+
+```sql
+/* VARS:
+%limit% = 10
+%status% = 'active'
+%sort% = 'name'
+*/
+
+SELECT * FROM users WHERE status = %status% ORDER BY %sort% LIMIT %limit%;
+```
 ## Downloading Results
 
 When you run a query, the results will appear right underneath the SQL editor, simple!


### PR DESCRIPTION
Resolves #2963

This PR adds support for inline variables in SQL queries, allowing users to define 
and use variables directly within the query text using special comment syntax. Variables can be 
declared using single-line comments like -- %var% = value or block comments such as /* VARS: ... */.

During parsing, these variables are extracted and removed from the original query,
 then substituted with the appropriate value based on their type. The substitution logic handles 
 quoting for strings, preserves numeric and null values, supports JSON objects, and formats lists 
 in a SQL-compatible way — all without introducing syntax errors.

The implementation includes robust error handling for malformed declarations and a
 comprehensive test suite that covers a wide range of use cases: valid and invalid inputs,
  repeated variables, optional substitutions, strings with spaces, floats, nulls, JSON, and lists.
  (We also added examples and information in editor.md)


https://github.com/user-attachments/assets/c14ac31b-c84d-4786-88b7-7fcdf88ce61e


