### PR TITLE
fix cm6 vim keymap

### DIFF
--- a/apps/ui-kit/lib/components/text-editor/v2/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/v2/extensions/index.ts
@@ -88,8 +88,8 @@ function language(languageId: string) {
 
 export function extensions(config: ExtensionConfiguration) {
   return [
-    extraKeymap({ keybindings: config.keybindings }),
     specialKeymap({ keymap: config.keymap, vimOptions: config.vimOptions }),
+    extraKeymap({ keybindings: config.keybindings }),
     lineNumbers({ enabled: config.lineNumbers }),
     highlightActiveLineGutter(),
     highlightSpecialChars(),


### PR DESCRIPTION
vim keymap is acting weirdge. It turns out that the extension order matters. Vim extension should be at the very top.