### PR TITLE
feat: suggest foreign key names based on table names (#2939)

### DIFF
--- a/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
+++ b/apps/studio/src/components/common/texteditor/SQLTextEditor.vue
@@ -1,22 +1,68 @@
 <template>
-  <text-editor
-    v-bind="$attrs"
-    :value="value"
-    @input="$emit('input', $event)"
-    :hint="hint"
-    :mode="dialectData.textEditorMode"
-    :extra-keybindings="keybindings"
-    :hint-options="hintOptions"
-    :columns-getter="columnsGetter"
-    :context-menu-options="handleContextMenuOptions"
-    :plugins="plugins"
-    :auto-focus="true"
-    @update:focus="$emit('update:focus', $event)"
-    @update:selection="$emit('update:selection', $event)"
-    @update:cursorIndex="$emit('update:cursorIndex', $event)"
-    @update:cursorIndexAnchor="$emit('update:cursorIndexAnchor', $event)"
-    @update:initialized="$emit('update:initialized', $event)"
-  />
+  <div>
+    <text-editor
+      v-bind="$attrs"
+      :value="value"
+      @input="handleInput"
+      :hint="hint"
+      :mode="dialectData.textEditorMode"
+      :extra-keybindings="keybindings"
+      :hint-options="hintOptions"
+      :columns-getter="columnsGetter"
+      :context-menu-options="handleContextMenuOptions"
+      :plugins="plugins"
+      :auto-focus="true"
+      @update:focus="$emit('update:focus', $event)"
+      @update:selection="$emit('update:selection', $event)"
+      @update:cursorIndex="$emit('update:cursorIndex', $event)"
+      @update:cursorIndexAnchor="$emit('update:cursorIndexAnchor', $event)"
+      @update:initialized="$emit('update:initialized', $event)"
+    />
+
+    <modal
+    :name="fkSuggestionModalName"
+    class="vue-dialog beekeeper-modal fk-name-suggestion-modal"
+    width="400"
+    height="auto"
+    :scrollable="false"
+    :adaptive="true"
+    :pivot-y="0.3"
+  >
+    <div class="beekeeper-popup">
+      <div class="popup-content">
+        <div class="popup-header">
+          <span class="popup-title">Suggested foreign key name:</span>
+        </div>
+
+        <div class="current-vs-suggested" v-if="currentFkName">
+          <div class="current-name">
+            <label>Current:</label>
+            <div class="name-display current">{{ currentFkName }}</div>
+          </div>
+        </div>
+
+        <div class="suggested-name-container">
+          <label v-if="currentFkName">Suggested:</label>
+          <div class="suggested-name-display">
+            {{ suggestedFkName }}
+          </div>
+        </div>
+
+        <div class="popup-actions">
+          <button @click="applyFkNameAndClose" class="btn btn-primary">
+            {{ currentFkName ? "Rename" : "Apply" }}
+          </button>
+          <button
+            @click="dismissSuggestionAndClose"
+            class="btn btn-secondary"
+          >
+            Ignore
+          </button>
+        </div>
+      </div>
+    </div>
+  </modal>
+  </div>
 </template>
 
 <script lang="ts">
@@ -28,12 +74,39 @@ import { format } from "sql-formatter";
 import { FormatterDialect, dialectFor } from "@shared/lib/dialects/models";
 import CodeMirror from "codemirror";
 
+interface ForeignKeyInfo {
+  id: string;
+  fromTable: string;
+  toTable: string;
+  fromColumn: string;
+  toColumn: string;
+  currentName: string | null;
+  suggestedName: string;
+  position: number;
+  lineNumber: number;
+}
+
 export default Vue.extend({
   components: { TextEditor },
   props: ["value", "connectionType", "extraKeybindings", "contextMenuOptions"],
+  data() {
+    return {
+      suggestedFkName: "",
+      currentFkName: "",
+      currentTableName: "",
+      referencedTableName: "",
+      currentFkInfo: null as ForeignKeyInfo | null,
+      dismissedSuggestions: new Set<string>(),
+      detectedForeignKeys: [] as ForeignKeyInfo[],
+      suggestionQueue: [] as ForeignKeyInfo[],
+    };
+  },
   computed: {
     ...mapGetters(['defaultSchema', 'dialectData', 'isUltimate']),
     ...mapState(["tables"]),
+    fkSuggestionModalName() {
+      return "fk-name-suggestion-modal";
+    },
     hint() {
       // @ts-expect-error not fully typed
       return CodeMirror.hint.sql;
@@ -92,6 +165,250 @@ export default Vue.extend({
     }
   },
   methods: {
+    handleInput(newValue) {
+      this.$emit("input", newValue);
+      // Check for FK patterns
+      this.checkForForeignKeyPatterns(newValue);
+    },
+    checkForForeignKeyPatterns(sqlText) {
+      const foreignKeys = this.extractAllForeignKeys(sqlText);
+
+      // Find suggestions that should be appear
+      const suggestionsToShow = foreignKeys.filter((fk) => {
+        // Don't show if this suggestion was already ignored
+        if (this.dismissedSuggestions.has(fk.id)) {
+          return false;
+        }
+
+        // Show if no constraint name exists or if current name is different from suggested
+        return !fk.currentName || fk.currentName !== fk.suggestedName;
+      });
+
+      this.suggestionQueue = suggestionsToShow;
+
+      // Show next suggestion if modal is not already open
+      if (suggestionsToShow.length > 0 && !this.currentFkInfo) {
+        this.showNextSuggestion();
+      }
+    },
+    extractAllForeignKeys(sqlText): ForeignKeyInfo[] {
+      const foreignKeys: ForeignKeyInfo[] = [];
+      const lines = sqlText.split("\n");
+
+      // Regex patterns
+      const fkWithConstraintPattern =
+        /CONSTRAINT\s+(\w+)\s+FOREIGN\s+KEY\s*\((\w+)\)\s+REFERENCES\s+(\w+)(?:\s*\((\w+)\))?/gi;
+      const fkWithoutConstraintPattern =
+        /(?<!CONSTRAINT\s+\w+\s+)FOREIGN\s+KEY\s*\((\w+)\)\s+REFERENCES\s+(\w+)(?:\s*\((\w+)\))?/gi;
+
+      // Find all CREATE TABLE statements to get table contexts
+      const tableContexts = this.extractTableContexts(sqlText);
+
+      // Find FKs with constraint names
+      let match;
+      while ((match = fkWithConstraintPattern.exec(sqlText)) !== null) {
+        const constraintName = match[1];
+        const fromColumn = match[2];
+        const toTable = match[3];
+        const toColumn = match[4] || "id";
+
+        const lineNumber = this.getLineNumber(sqlText, match.index);
+        const fromTable = this.findTableForLine(tableContexts, lineNumber);
+        const suggestedName = this.generateFkName(fromTable, toTable);
+
+        const fkInfo: ForeignKeyInfo = {
+          id: this.generateFkId(fromTable, toTable, fromColumn, toColumn),
+          fromTable,
+          toTable,
+          fromColumn,
+          toColumn,
+          currentName: constraintName,
+          suggestedName,
+          position: match.index,
+          lineNumber,
+        };
+
+        foreignKeys.push(fkInfo);
+      }
+
+      // Reset regex state
+      fkWithoutConstraintPattern.lastIndex = 0;
+
+      // Find FKs without constraint names
+      while ((match = fkWithoutConstraintPattern.exec(sqlText)) !== null) {
+        const fromColumn = match[1];
+        const toTable = match[2];
+        const toColumn = match[3] || "id";
+
+        const lineNumber = this.getLineNumber(sqlText, match.index);
+        const fromTable = this.findTableForLine(tableContexts, lineNumber);
+        const suggestedName = this.generateFkName(fromTable, toTable);
+
+        const fkInfo: ForeignKeyInfo = {
+          id: this.generateFkId(fromTable, toTable, fromColumn, toColumn),
+          fromTable,
+          toTable,
+          fromColumn,
+          toColumn,
+          currentName: null,
+          suggestedName,
+          position: match.index,
+          lineNumber,
+        };
+
+        foreignKeys.push(fkInfo);
+      }
+
+      return foreignKeys;
+    },
+    extractTableContexts(sqlText) {
+      const contexts = [];
+      const lines = sqlText.split("\n");
+      let currentTable = null;
+      let tableStartLine = 0;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const createTableMatch = line.match(
+          /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)/i
+        );
+
+        if (createTableMatch) {
+          // Save previous table context if exists
+          if (currentTable) {
+            contexts.push({
+              tableName: currentTable,
+              startLine: tableStartLine,
+              endLine: i - 1,
+            });
+          }
+
+          currentTable = createTableMatch[1];
+          tableStartLine = i;
+        }
+      }
+
+      // Add the last table
+      if (currentTable) {
+        contexts.push({
+          tableName: currentTable,
+          startLine: tableStartLine,
+          endLine: lines.length - 1,
+        });
+      }
+
+      return contexts;
+    },
+    findTableForLine(tableContexts, lineNumber) {
+      for (const context of tableContexts) {
+        if (lineNumber >= context.startLine && lineNumber <= context.endLine) {
+          return context.tableName;
+        }
+      }
+      return "table";
+    },
+    getLineNumber(text, position) {
+      return text.substring(0, position).split("\n").length - 1;
+    },
+    generateFkId(fromTable, toTable, fromColumn, toColumn) {
+      return `${fromTable}.${fromColumn}->${toTable}.${toColumn}`;
+    },
+    showNextSuggestion() {
+      if (this.suggestionQueue.length === 0) {
+        return;
+      }
+
+      const nextSuggestion = this.suggestionQueue[0];
+      this.currentFkInfo = nextSuggestion;
+      this.suggestedFkName = nextSuggestion.suggestedName;
+      this.currentFkName = nextSuggestion.currentName || "";
+      this.currentTableName = nextSuggestion.fromTable;
+      this.referencedTableName = nextSuggestion.toTable;
+
+      // Show the modal
+      this.$modal.show(this.fkSuggestionModalName);
+    },
+    generateFkName(fromTable, toTable) {
+      // Clean table names
+      const cleanFromTable = fromTable.split(".").pop() || fromTable;
+      const cleanToTable = toTable.split(".").pop() || toTable;
+
+      return `FK_${cleanFromTable}_${cleanToTable}`;
+    },
+    applyFkNameAndClose() {
+      if (this.currentFkInfo) {
+        this.applyFkName(this.currentFkInfo);
+        this.moveToNextSuggestion();
+      }
+    },
+    applyFkName(fkInfo: ForeignKeyInfo) {
+      const nameToUse = fkInfo.suggestedName;
+      const currentValue = this.value;
+      const lines = currentValue.split("\n");
+
+      // Find the specific line for this FK
+      const targetLine = fkInfo.lineNumber;
+
+      if (targetLine >= 0 && targetLine < lines.length) {
+        let line = lines[targetLine];
+
+        if (fkInfo.currentName) {
+          // Replace existing constraint name
+          const constraintPattern = new RegExp(
+            `CONSTRAINT\\s+${fkInfo.currentName}\\s+`,
+            "i"
+          );
+          line = line.replace(constraintPattern, `CONSTRAINT ${nameToUse} `);
+        } else {
+          // Add constraint name before FOREIGN KEY
+          const fkIndex = line.search(/FOREIGN\s+KEY/i);
+          if (fkIndex >= 0) {
+            const beforeFK = line.substring(0, fkIndex);
+            const afterFK = line.substring(fkIndex);
+            line = `${beforeFK}CONSTRAINT ${nameToUse} ${afterFK}`;
+          }
+        }
+
+        lines[targetLine] = line;
+        const newValue = lines.join("\n");
+        this.$emit("input", newValue);
+      }
+    },
+    dismissSuggestionAndClose() {
+      if (this.currentFkInfo) {
+        // Mark this suggestion as dismissed
+        this.dismissedSuggestions.add(this.currentFkInfo.id);
+        this.moveToNextSuggestion();
+      }
+    },
+    moveToNextSuggestion() {
+      // Remove current suggestion from queue
+      this.suggestionQueue = this.suggestionQueue.slice(1);
+      this.currentFkInfo = null;
+
+      this.closeFkSuggestionModalImmediately();
+
+      this.$nextTick(() => {
+        setTimeout(() => {
+          if (this.suggestionQueue.length > 0) {
+            this.showNextSuggestion();
+          }
+        }, 100);
+      });
+    },
+    closeFkSuggestionModalImmediately() {
+      // Force immediate close
+      this.$modal.hide(this.fkSuggestionModalName);
+      this.$nextTick(() => {
+        this.resetSuggestionData();
+      });
+    },
+    resetSuggestionData() {
+      this.suggestedFkName = "";
+      this.currentFkName = "";
+      this.currentTableName = "";
+      this.referencedTableName = "";
+    },
     formatSql() {
       const formatted = format(this.value, {
         language: FormatterDialect(dialectFor(this.queryDialect)),
@@ -138,3 +455,121 @@ export default Vue.extend({
   },
 });
 </script>
+
+<style scoped>
+.fk-name-suggestion-modal .beekeeper-popup {
+  background: #1d1d1d;
+  border-radius: 6px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  border: 1px solid #404040;
+  overflow: hidden;
+}
+
+.popup-content {
+  padding: 24px;
+  color: #ffffff;
+}
+
+.popup-header {
+  margin-bottom: 20px;
+}
+
+.popup-title {
+  font-size: 15px;
+  color: #ffffff;
+  font-weight: 500;
+}
+
+.current-vs-suggested {
+  margin-bottom: 24px;
+}
+
+.current-name {
+  margin-bottom: 12px;
+}
+
+.current-name label {
+  font-size: 12px;
+  color: #999999;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.name-display {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 13px;
+  color: #cccccc;
+  padding: 0;
+  background: transparent;
+  border: none;
+  word-break: break-all;
+}
+
+.name-display.current {
+  color: #ffffff;
+}
+
+.suggested-name-container {
+  margin-bottom: 24px;
+}
+
+.suggested-name-container label {
+  font-size: 12px;
+  color: #999999;
+  margin-bottom: 6px;
+  display: block;
+  font-weight: bold;
+}
+
+.suggested-name-display {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 14px;
+  color: #eef1f3;
+  font-weight: bold;
+  background: transparent;
+  border: none;
+  padding: 0;
+  word-break: break-all;
+}
+
+.popup-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid #404040;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: #cccccc;
+  border: 1px solid #555555;
+}
+
+.btn-secondary:hover {
+  background: #404040;
+  border-color: #666666;
+}
+
+.fk-name-suggestion-modal .vue-dialog {
+  background: transparent !important;
+}
+
+.fk-name-suggestion-modal .dialog-content {
+  background: transparent !important;
+  box-shadow: none !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+@media (max-width: 480px) {
+  .popup-actions {
+    flex-direction: column;
+  }
+  
+  .btn {
+    width: 100%;
+  }
+}
+</style>

--- a/apps/studio/src/components/tableinfo/TableRelations.vue
+++ b/apps/studio/src/components/tableinfo/TableRelations.vue
@@ -19,12 +19,31 @@
           </div>
         </div>
 
+        <!-- FK Suggestions Notice -->
+        <div class="notices" v-if="showFkSuggestionNotice">
+          <div class="alert alert-warning alert-flex">
+            <div class="alert-left">
+              <i class="material-icons-outlined">lightbulb</i>
+              <span class="alert-message">{{ fkSuggestionMessage }}</span>
+            </div>
+            <button @click="openFkSuggestions" class="btn btn-suggestion">
+              View Suggestions
+            </button>
+          </div>
+        </div>
+
         <div class="table-subheader">
           <div class="table-title">
             <h2>Relations</h2>
           </div>
           <div class="expand" />
           <div class="actions">
+            <a
+              v-if="enabled && suggestedFks.length > 0"
+              @click.prevent="openFkSuggestions"
+              v-tooltip="'View Foreign Key naming suggestions'"
+              class="btn btn-link btn-fab"
+            ><i class="material-icons">auto_fix_high</i></a>
             <a
               @click.prevent="$emit('refresh')"
               v-tooltip="`${ctrlOrCmd('r')} or F5`"
@@ -44,6 +63,56 @@
         />
       </div>
     </div>
+
+    <!-- FK Suggestions Modal -->
+    <modal
+      :name="fkSuggestionsModalName"
+      class="vue-dialog beekeeper-modal fk-suggestions-modal"
+      @opened="onModalOpened"
+      @closed="onModalClosed"
+      width="600"
+      height="500"
+      :scrollable="true"
+    >
+      <div class="dialog-content">
+        <div class="suggestion-header">
+          <h4>Foreign Key Naming Suggestions</h4>
+          <p class="suggestion-subtitle">{{ suggestedFks.length }} foreign key{{ suggestedFks.length !== 1 ? 's' : '' }} with non-standard naming detected</p>
+        </div>
+        
+        <div class="suggestion-body">
+          <div 
+            v-for="(suggestion, index) in suggestedFks" 
+            :key="index"
+            class="suggestion-item"
+            :class="{ 'not-last': index < suggestedFks.length - 1 }"
+          >
+            <div class="suggestion-details">
+              <div class="fk-info">
+                <span class="fk-relationship">{{ suggestion.fromColumn }} → {{ suggestion.toTable }}.{{ suggestion.toColumn }}</span>
+              </div>
+              <div class="current-name-display">
+                Current name:
+                <span class="name-value current">{{ suggestion.currentName || '(no name)' }}</span>
+              </div>
+              <div class="suggested-name-display">
+                Suggested name:
+                <span class="name-value suggested">{{ suggestion.suggestedName }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+        
+        <div class="suggestion-actions">
+          <button 
+            @click="closeFkSuggestions"
+            class="btn btn-secondary"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </modal>
 
     <div class="expand" />
 
@@ -117,6 +186,14 @@ const log = rawLog.scope('TableRelations');
 import { escapeHtml } from '@shared/lib/tabulator'
 import { SelectableCellMixin } from '@/mixins/selectableCell';
 
+interface FkSuggestion {
+  currentName: string
+  suggestedName: string
+  fromColumn: string
+  toTable: string
+  toColumn: string
+}
+
 export default Vue.extend({
   mixins: [SelectableCellMixin],
   props: ["table", "tabId", "active", "properties", 'tabState'],
@@ -130,7 +207,10 @@ export default Vue.extend({
       newRows: [],
       removedRows: [],
       error: null,
-      loading: false
+      loading: false,
+      // FK Suggestions
+      suggestedFks: [] as FkSuggestion[],
+      showFkSuggestionNotice: false
     }
   },
   computed: {
@@ -175,6 +255,19 @@ export default Vue.extend({
     },
     editCount() {
       return this.newRows.length + this.removedRows.length
+    },
+    fkSuggestionMessage() {
+      const count = this.suggestedFks.length
+      if (count === 0) {
+        return 'No Foreign Keys with non-standard naming detected.'
+      }
+      if (count === 1) {
+        return '1 Foreign Key with non-standard naming detected.'
+      }
+      return `${count} Foreign Keys with non-standard naming detected.`
+    },
+    fkSuggestionsModalName() {
+      return `fk-suggestions-${this.tabId}`
     },
     tableColumns(): ColumnDefinition[] {
       const withSchemas: Dialect[] = ['postgresql', 'sqlserver']
@@ -268,6 +361,9 @@ export default Vue.extend({
     ...TabulatorStateWatchers,
     tableData() {
       if (this.tabulator) this.tabulator.replaceData(this.tableData)
+      this.$nextTick(() => {
+        this.detectNonStandardForeignKeys()
+      })
     },
     hasEdits() {
       this.tabState.dirty = this.hasEdits
@@ -306,6 +402,61 @@ export default Vue.extend({
       const result = await tableData.columns.map((c: TableColumn) => escapeHtml(c.columnName)) || []
       console.log("getcolumns", result)
       return result
+    },
+    // FK Suggestions methods
+    openFkSuggestions() {
+      this.$modal.show(this.fkSuggestionsModalName)
+    },
+    closeFkSuggestions() {
+      this.$modal.hide(this.fkSuggestionsModalName)
+    },
+    onModalOpened() {
+      // Modal opened callback
+    },
+    onModalClosed() {
+      // Modal closed callback
+    },
+    detectNonStandardForeignKeys() {
+      if (!this.enabled || !this.tableData?.length) {
+        this.suggestedFks = []
+        this.showFkSuggestionNotice = false
+        return
+      }
+
+      const suggestions: FkSuggestion[] = []
+
+      this.tableData.forEach((relation: any) => {
+        if (!relation.fromColumn || !relation.toTable || !relation.toColumn) {
+          return
+        }
+
+        const suggestedName = this.suggestForeignKeyName(
+          this.table.name,
+          relation.toTable
+        )
+
+        const currentName = relation.constraintName
+        if (currentName !== suggestedName) {
+          const suggestion = {
+            currentName: currentName,
+            suggestedName,
+            fromColumn: relation.fromColumn,
+            toTable: relation.toTable,
+            toColumn: relation.toColumn
+          }
+          
+          suggestions.push(suggestion)
+        }
+      })
+
+      this.suggestedFks = suggestions
+      this.showFkSuggestionNotice = suggestions.length > 0
+    },
+    suggestForeignKeyName(fromTable: string, toTable: string): string {
+      const cleanFromTable = fromTable.split('.').pop() || fromTable
+      const cleanToTable = toTable.split('.').pop() || toTable
+      
+      return `FK_${cleanFromTable}_${cleanToTable}`
     },
     getPayload(): RelationAlterations {
       const additions: CreateRelationSpec[] = this.newRows.map((row: RowComponent) => {
@@ -403,9 +554,197 @@ export default Vue.extend({
   mounted() {
     this.tabState.dirty = false
     this.initializeTabulator()
+    this.$nextTick(() => {
+      this.detectNonStandardForeignKeys()
+    })
   },
   beforeDestroy() {
     this.tabulator?.destroy()
   }
 })
 </script>
+
+<style scoped>
+.fk-suggestions-modal .dialog-content {
+  background: #2d2d2d;
+  color: #ffffff;
+  border-radius: 8px;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-secondary {
+  background: #ffffff;
+  color: #000000;
+  border: 1px solid #555555;
+}
+
+.btn-secondary:hover {
+  background: #d1d0d0;
+  border-color: #666666;
+}
+
+.suggestion-header {
+  padding: 20px 24px 16px 24px;
+  border-bottom: 1px solid #404040;
+  flex-shrink: 0;
+}
+
+.suggestion-header h4 {
+  margin: 0 0 8px 0;
+  font-size: 16px;
+  font-weight: 500;
+  color: #ffffff;
+}
+
+.suggestion-subtitle {
+  margin: 0;
+  font-size: 14px;
+  color: #cccccc;
+}
+
+.suggestion-body {
+  padding: 16px 24px;
+  flex: 1;
+  overflow-y: auto;
+  max-height: 350px;
+}
+
+.suggestion-item {
+  padding: 16px 0;
+}
+
+.suggestion-item.not-last {
+  border-bottom: 1px solid #404040;
+  margin-bottom: 16px;
+  padding-bottom: 24px;
+}
+
+.suggestion-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fk-info {
+  margin-bottom: 8px;
+}
+
+.fk-relationship {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 14px;
+  color: #81a1c1;
+  background: #3c3c3c;
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}
+
+.current-name-display {
+  font-size: 14px;
+  color: #cccccc;
+}
+
+.suggested-name-display {
+  font-size: 14px;
+  color: #cccccc;
+}
+
+.name-value {
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+  font-size: 15px;
+  font-weight: 500;
+  display: block;
+  margin-top: 4px;
+  margin-left: 4px;
+  padding: 6px 8px;
+  border-radius: 4px;
+
+}
+
+.name-value.current {
+  color: #ffa500;
+
+}
+
+.name-value.suggested {
+  color: #88c999;
+
+}
+
+.suggestion-actions {
+  display: flex;
+  gap: 12px;
+  padding: 20px 24px;
+  border-top: 1px solid #404040;
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+/* Notice styles */
+.alert-flex {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.alert-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.alert-message {
+  font-size: 15px;
+  color: #000;
+  font-weight: 500;
+}
+
+.btn-suggestion {
+  background: #f1f1f1;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 16px;
+  font-weight: bold;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.btn-suggestion:hover {
+  background-color: #e0e0e0;
+}
+
+.notices .alert {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 6px;
+}
+
+.notices .alert-warning {
+  background-color: #fad83c;
+  border: none;
+  color: #000000;
+}
+
+.notices .alert i {
+  flex-shrink: 0;
+  font-size: 1.25rem;
+}
+</style>

--- a/apps/studio/tests/unit/components/SQLTextEditor.spec.ts
+++ b/apps/studio/tests/unit/components/SQLTextEditor.spec.ts
@@ -1,0 +1,530 @@
+import { mount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuex from "vuex";
+import SQLTextEditor from "@/components/common/texteditor/SQLTextEditor.vue";
+
+Vue.use(Vuex);
+
+const MockTextEditor = {
+  name: "MockTextEditor",
+  props: [
+    "value",
+    "hint",
+    "mode",
+    "extra-keybindings",
+    "hint-options",
+    "columns-getter",
+    "context-menu-options",
+    "plugins",
+    "auto-focus",
+  ],
+  render(h) {
+    return h("div", {
+      class: "mock-text-editor",
+      attrs: {
+        "data-testid": "text-editor",
+      },
+    });
+  },
+  mounted() {
+    // Emit events that the SQLTextEditor expects
+    this.$emit("update:focus", true);
+    this.$emit("update:selection", {});
+    this.$emit("update:cursorIndex", 0);
+    this.$emit("update:cursorIndexAnchor", 0);
+    this.$emit("update:initialized", true);
+  },
+  methods: {
+    // Simulate input changes
+    simulateInput(value) {
+      this.$emit("input", value);
+    },
+  },
+};
+
+const MockModal = {
+  name: "MockModal",
+  props: [
+    "name",
+    "modalClass",
+    "width",
+    "height",
+    "scrollable",
+    "adaptive",
+    "pivot-y",
+  ],
+  render(h) {
+    return h(
+      "div",
+      {
+        class: ["mock-modal", this.modalClass],
+        attrs: {
+          "data-testid": "modal",
+        },
+      },
+      this.$slots.default
+    );
+  },
+};
+
+describe("SQLTextEditor.vue", () => {
+  let wrapper;
+  let store;
+  let mockDispatch;
+  let mockCommit;
+
+  beforeEach(() => {
+    // Mock functions
+    mockDispatch = jest.fn();
+    mockCommit = jest.fn();
+
+    store = new Vuex.Store({
+      state: {
+        tables: [
+          { name: "users", schema: "public", columns: [] },
+          { name: "orders", schema: "public", columns: [] },
+          { name: "products", schema: null, columns: [] },
+        ],
+      },
+      getters: {
+        defaultSchema: () => "public",
+        dialectData: () => ({ textEditorMode: "sql" }),
+        isUltimate: () => true,
+      },
+      actions: {
+        updateTableColumns: mockDispatch,
+      },
+    });
+
+    const modalMock = {
+      hide: jest.fn(),
+      show: jest.fn(),
+    };
+
+    wrapper = mount(SQLTextEditor, {
+      store,
+      components: {
+        TextEditor: MockTextEditor,
+        modal: MockModal,
+      },
+      mocks: {
+        $modal: modalMock,
+      },
+      propsData: {
+        value: "",
+        connectionType: "postgresql",
+        extraKeybindings: {},
+        contextMenuOptions: null,
+      },
+    });
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.destroy();
+    }
+  });
+
+  // Test FK suggestion modal name generation
+  it("generates correct FK suggestion modal name", () => {
+    expect(wrapper.vm.fkSuggestionModalName).toBe("fk-name-suggestion-modal");
+  });
+
+  // Test FK pattern detection with constraint names
+  it("detects foreign keys with constraint names correctly", () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id)
+      );
+    `;
+
+    const foreignKeys = wrapper.vm.extractAllForeignKeys(sqlText);
+
+    expect(foreignKeys).toHaveLength(1);
+    expect(foreignKeys[0].currentName).toBe("fk_user");
+    expect(foreignKeys[0].suggestedName).toBe("FK_orders_users");
+    expect(foreignKeys[0].fromTable).toBe("orders");
+    expect(foreignKeys[0].toTable).toBe("users");
+    expect(foreignKeys[0].fromColumn).toBe("user_id");
+    expect(foreignKeys[0].toColumn).toBe("id");
+  });
+
+  // Test FK pattern detection without constraint names
+  it("detects foreign keys without constraint names correctly", () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+      );
+    `;
+
+    const foreignKeys = wrapper.vm.extractAllForeignKeys(sqlText);
+
+    expect(foreignKeys).toHaveLength(1);
+    expect(foreignKeys[0].currentName).toBe(null);
+    expect(foreignKeys[0].suggestedName).toBe("FK_orders_users");
+    expect(foreignKeys[0].fromTable).toBe("orders");
+    expect(foreignKeys[0].toTable).toBe("users");
+  });
+
+  // Test FK pattern detection with multiple tables
+  it("detects foreign keys across multiple tables correctly", () => {
+    const sqlText = `
+      CREATE TABLE users (
+        id INT PRIMARY KEY,
+        name VARCHAR(100)
+      );
+      
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        product_id INT,
+        CONSTRAINT fk_order_user FOREIGN KEY (user_id) REFERENCES users(id),
+        FOREIGN KEY (product_id) REFERENCES products(id)
+      );
+    `;
+
+    const foreignKeys = wrapper.vm.extractAllForeignKeys(sqlText);
+
+    expect(foreignKeys).toHaveLength(2);
+    expect(foreignKeys[0].currentName).toBe("fk_order_user");
+    expect(foreignKeys[0].suggestedName).toBe("FK_orders_users");
+    expect(foreignKeys[1].currentName).toBe(null);
+    expect(foreignKeys[1].suggestedName).toBe("FK_orders_products");
+  });
+
+  // Test FK ID generation
+  it("generates unique FK IDs correctly", () => {
+    const id1 = wrapper.vm.generateFkId("orders", "users", "user_id", "id");
+    const id2 = wrapper.vm.generateFkId(
+      "orders",
+      "products",
+      "product_id",
+      "id"
+    );
+
+    expect(id1).toBe("orders.user_id->users.id");
+    expect(id2).toBe("orders.product_id->products.id");
+    expect(id1).not.toBe(id2);
+  });
+
+  // Test FK name generation
+  it("generates FK names correctly", () => {
+    expect(wrapper.vm.generateFkName("orders", "users")).toBe(
+      "FK_orders_users"
+    );
+    expect(wrapper.vm.generateFkName("public.orders", "public.users")).toBe(
+      "FK_orders_users"
+    );
+    expect(wrapper.vm.generateFkName("order_items", "products")).toBe(
+      "FK_order_items_products"
+    );
+  });
+
+  // Test table context extraction
+  it("extracts table contexts correctly", () => {
+    const sqlText = `
+      CREATE TABLE users (
+        id INT PRIMARY KEY
+      );
+      
+      CREATE TABLE IF NOT EXISTS orders (
+        id INT PRIMARY KEY
+      );
+    `;
+
+    const contexts = wrapper.vm.extractTableContexts(sqlText);
+
+    expect(contexts).toHaveLength(2);
+    expect(contexts[0].tableName).toBe("users");
+    expect(contexts[1].tableName).toBe("orders");
+  });
+
+  // Test line number calculation
+  it("calculates line numbers correctly", () => {
+    const text = "line1\nline2\nline3\nline4";
+    expect(wrapper.vm.getLineNumber(text, 0)).toBe(0);
+    expect(wrapper.vm.getLineNumber(text, 6)).toBe(1);
+    expect(wrapper.vm.getLineNumber(text, 12)).toBe(2);
+  });
+
+  // Test FK suggestion filtering
+  it("filters suggestions correctly based on dismissed items", () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+      );
+    `;
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+    expect(wrapper.vm.suggestionQueue).toHaveLength(1);
+
+    // Dismiss the suggestion
+    const fkId = wrapper.vm.suggestionQueue[0].id;
+    wrapper.vm.dismissedSuggestions.add(fkId);
+
+    // Should not show the same suggestion
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+    expect(wrapper.vm.suggestionQueue).toHaveLength(0);
+  });
+
+  // Test suggestion queue
+  it("manages suggestion queue correctly", () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        product_id INT,
+        FOREIGN KEY (user_id) REFERENCES users(id),
+        FOREIGN KEY (product_id) REFERENCES products(id)
+      );
+    `;
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+    expect(wrapper.vm.suggestionQueue).toHaveLength(2);
+
+    wrapper.vm.showNextSuggestion();
+    expect(wrapper.vm.currentFkInfo).toBeTruthy();
+    expect(wrapper.vm.suggestedFkName).toBe("FK_orders_users");
+  });
+
+  // Test FK name application for existing constraints
+  it("applies FK names to existing constraints correctly", async () => {
+    const sqlText = `CREATE TABLE orders (
+  id INT PRIMARY KEY,
+  user_id INT,
+  CONSTRAINT old_name FOREIGN KEY (user_id) REFERENCES users(id)
+);`;
+
+    await wrapper.setProps({ value: sqlText });
+    await Vue.nextTick();
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+
+    // Get the detected FK
+    const detectedFks = wrapper.vm.extractAllForeignKeys(sqlText);
+    expect(detectedFks).toHaveLength(1);
+
+    const fkInfo = detectedFks[0];
+    // Verify if the detected FK has the correct current name
+    expect(fkInfo.currentName).toBe("old_name");
+    expect(fkInfo.suggestedName).toBe("FK_orders_users");
+
+    const emitSpy = jest.spyOn(wrapper.vm, "$emit");
+
+    // Apply the FK name using the actual detected FK
+    wrapper.vm.applyFkName(fkInfo);
+    await Vue.nextTick();
+
+
+    expect(emitSpy).toHaveBeenCalledWith("input", expect.any(String));
+
+
+    const inputCalls = emitSpy.mock.calls.filter((call) => call[0] === "input");
+    expect(inputCalls.length).toBeGreaterThan(0);
+
+    const emittedValue = inputCalls[inputCalls.length - 1][1];
+    expect(emittedValue).toContain("CONSTRAINT FK_orders_users");
+    expect(emittedValue).not.toContain("CONSTRAINT old_name");
+  });
+
+  it("applies FK names to unnamed constraints correctly", async () => {
+    const sqlText = `CREATE TABLE orders (
+  id INT PRIMARY KEY,
+  user_id INT,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);`;
+
+    await wrapper.setProps({ value: sqlText });
+    await Vue.nextTick();
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+
+    const detectedFks = wrapper.vm.extractAllForeignKeys(sqlText);
+    expect(detectedFks).toHaveLength(1);
+
+    const fkInfo = detectedFks[0];
+
+    const emitSpy = jest.spyOn(wrapper.vm, "$emit");
+
+    wrapper.vm.applyFkName(fkInfo);
+    await Vue.nextTick();
+
+    expect(emitSpy).toHaveBeenCalledWith("input", expect.any(String));
+
+    // Get the emitted value
+    const inputCalls = emitSpy.mock.calls.filter((call) => call[0] === "input");
+    expect(inputCalls.length).toBeGreaterThan(0);
+
+    const emittedValue = inputCalls[inputCalls.length - 1][1];
+    expect(emittedValue).toContain("CONSTRAINT FK_orders_users FOREIGN KEY");
+
+    expect(emittedValue).toContain(
+      "FOREIGN KEY (user_id) REFERENCES users(id)"
+    );
+  });
+
+  it("applies FK names to unnamed constraints correctly - full simulation", async () => {
+    const sqlText = `CREATE TABLE orders (
+  id INT PRIMARY KEY,
+  user_id INT,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);`;
+
+    await wrapper.setProps({ value: sqlText });
+    await Vue.nextTick();
+
+    const emitSpy = jest.spyOn(wrapper.vm, "$emit");
+
+    // Simulate the user typing/inputting the SQL which triggers FK detection
+    wrapper.vm.handleInput(sqlText);
+    await Vue.nextTick();
+
+    // Check if suggestions were created
+    expect(wrapper.vm.suggestionQueue.length).toBeGreaterThan(0);
+
+    // Simulate clicking "Apply" in the modal
+    await wrapper.vm.applyFkNameAndClose();
+    await Vue.nextTick();
+
+    // Verify the result
+    const inputCalls = emitSpy.mock.calls.filter((call) => call[0] === "input");
+    if (inputCalls.length > 0) {
+      const emittedValue = inputCalls[inputCalls.length - 1][1];
+      expect(emittedValue).toContain("CONSTRAINT FK_orders_users FOREIGN KEY");
+    }
+  });
+
+  // Test modal interaction - apply FK name
+  it("handles apply FK name and close correctly", async () => {
+    const mockFkInfo = {
+      id: "orders.user_id->users.id",
+      fromTable: "orders",
+      toTable: "users",
+      fromColumn: "user_id",
+      toColumn: "id",
+      currentName: null,
+      suggestedName: "FK_orders_users",
+      position: 50,
+      lineNumber: 2,
+    };
+
+    wrapper.vm.currentFkInfo = mockFkInfo;
+    wrapper.vm.suggestionQueue = [mockFkInfo];
+
+    // Mock applyFkName method
+    const applyFkNameSpy = jest
+      .spyOn(wrapper.vm, "applyFkName")
+      .mockImplementation(() => {});
+
+    await wrapper.vm.applyFkNameAndClose();
+
+    expect(applyFkNameSpy).toHaveBeenCalledWith(mockFkInfo);
+    expect(wrapper.vm.$modal.hide).toHaveBeenCalledWith(
+      "fk-name-suggestion-modal"
+    );
+
+    applyFkNameSpy.mockRestore();
+  });
+
+  // Test modal interaction - dismiss suggestion
+  it("handles dismiss suggestion correctly", async () => {
+    const mockFkInfo = {
+      id: "orders.user_id->users.id",
+      fromTable: "orders",
+      toTable: "users",
+      fromColumn: "user_id",
+      toColumn: "id",
+      currentName: null,
+      suggestedName: "FK_orders_users",
+      position: 50,
+      lineNumber: 2,
+    };
+
+    wrapper.vm.currentFkInfo = mockFkInfo;
+    wrapper.vm.suggestionQueue = [mockFkInfo];
+
+    await wrapper.vm.dismissSuggestionAndClose();
+
+    expect(wrapper.vm.dismissedSuggestions.has(mockFkInfo.id)).toBe(true);
+    expect(wrapper.vm.$modal.hide).toHaveBeenCalledWith(
+      "fk-name-suggestion-modal"
+    );
+  });
+
+  // Test input handling with FK detection
+  it("handles input and triggers FK pattern checking", () => {
+    const spy = jest.spyOn(wrapper.vm, "checkForForeignKeyPatterns");
+    const newValue = "CREATE TABLE test (id INT);";
+
+    wrapper.vm.handleInput(newValue);
+
+    expect(wrapper.emitted("input")).toBeTruthy();
+    expect(wrapper.emitted("input")[0][0]).toBe(newValue);
+    expect(spy).toHaveBeenCalledWith(newValue);
+
+    spy.mockRestore();
+  });
+
+  // Test modal display logic
+  it("shows modal when suggestions are available", () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        FOREIGN KEY (user_id) REFERENCES users(id)
+      );
+    `;
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+
+    expect(wrapper.vm.$modal.show).toHaveBeenCalledWith(
+      "fk-name-suggestion-modal"
+    );
+    expect(wrapper.vm.currentFkInfo).toBeTruthy();
+  });
+
+  it("resets suggestion data correctly", () => {
+    wrapper.vm.suggestedFkName = "test";
+    wrapper.vm.currentFkName = "test";
+    wrapper.vm.currentTableName = "test";
+    wrapper.vm.referencedTableName = "test";
+
+    wrapper.vm.resetSuggestionData();
+
+    expect(wrapper.vm.suggestedFkName).toBe("");
+    expect(wrapper.vm.currentFkName).toBe("");
+    expect(wrapper.vm.currentTableName).toBe("");
+    expect(wrapper.vm.referencedTableName).toBe("");
+  });
+
+  // Test multiple suggestions queue processing
+  it("processes multiple suggestions in sequence", async () => {
+    const sqlText = `
+      CREATE TABLE orders (
+        id INT PRIMARY KEY,
+        user_id INT,
+        product_id INT,
+        FOREIGN KEY (user_id) REFERENCES users(id),
+        FOREIGN KEY (product_id) REFERENCES products(id)
+      );
+    `;
+
+    wrapper.vm.checkForForeignKeyPatterns(sqlText);
+    expect(wrapper.vm.suggestionQueue).toHaveLength(2);
+
+    // Process first suggestion
+    const firstSuggestion = wrapper.vm.currentFkInfo;
+    expect(firstSuggestion.suggestedName).toBe("FK_orders_users");
+
+    // MoveToNextSuggestion 
+    wrapper.vm.moveToNextSuggestion();
+
+    expect(wrapper.vm.suggestionQueue).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
This adds foreign key name suggestions using the format FK_fromTable_toTable. The feature is implemented in two parts:

SQL Text Editor: When the user writes or pastes a CREATE TABLE statement that includes a foreign key with no name or a non-standard name, a suggestion popup appears with the recommended name. If the user dismisses the suggestion, it won’t appear again for that specific foreign key.

Table Relations View: After a table is created, suggestions are shown for existing foreign keys that don’t follow the expected naming format. The user can apply or ignore the suggestion.

The goal is to improve consistency in foreign key naming. Suggestions are based on the names of the two tables involved in the relationship and follow the naming convention described in issue #2939.

Example:
<img width="1086" alt="Screenshot 2025-06-06 at 16 38 25" src="https://github.com/user-attachments/assets/1cbb677d-fbe9-4ecd-967c-6a9c8261e0dd" />
<img width="1079" alt="Screenshot 2025-06-06 at 16 38 52" src="https://github.com/user-attachments/assets/afb51dc5-d5a6-45e9-8f0b-c784a9d75dfa" />

If the table is "orders" and it references "users", the suggestion will be "FK_orders_users".

Co-authored-by: Henrique José Cavaco Ramalho [henrique.j.cavaco@tecnico.ulisboa.pt]