### PR TITLE
remove deprecated height prop

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -33,7 +33,6 @@
       </div>
       <sql-text-editor
         :value="unsavedText"
-        :height="editor.height"
         :read-only="editor.readOnly"
         :focus="focusingElement === 'text-editor'"
         :markers="editorMarkers"


### PR DESCRIPTION
`height` is controlled directly by CSS after cm6 upgrade.