### PR TITLE
feat #2431: Connection Quick Switcher

### DIFF
--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -618,3 +618,77 @@
   }
 
 }
+.quick-switcher-panel {
+  position: fixed;
+  bottom: $statusbar-height;
+  left: $sidebar-min-w * 0.77;
+  width: $sidebar-min-w;
+  padding: $gutter-w * 0.5;
+  margin-bottom: $gutter-w * 0.3;
+  background: $theme-bg;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  border-radius: 4px;
+  z-index: 1000;
+  max-height: 50vh;
+  display: flex;
+  flex-direction: column;
+  border-radius: 8px;
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba($theme-base, 0.1);
+}
+
+.quick-switcher-content {
+  padding: $gutter-w;
+  overflow-y: auto;
+  color: $theme-base;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.quick-switcher-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 6px;
+}
+
+.quick-switcher-item {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 4px 4px;
+  cursor: pointer;
+  border-radius: 4px;
+  color: $theme-base;
+  white-space: nowrap;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  overflow: hidden;
+  transition: background 0.15s ease-in-out;
+
+  &:hover {
+    background: rgba($theme-base, 0.05);
+  }
+}
+
+.quick-switcher-header {
+  color: $text-dark;
+  background-color: $theme-bg;
+  padding: 4px 6px;
+  flex-shrink: 0;
+}
+
+.quick-switcher-footer {
+  background-color: $theme-bg;
+  padding: 0px 6px;
+  flex-shrink: 0;
+}
+
+.quick-switcher-list-wrapper {
+  overflow-y: auto;
+  flex-grow: 1;
+  max-height: calc(50vh - 70px);
+}

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -2,8 +2,8 @@
   <div
     class="connection-button"
     v-if="config"
-    :title="privacyMode ? 
-      'Connection details hidden by Privacy Mode' : 
+    :title="privacyMode ?
+      'Connection details hidden by Privacy Mode' :
       $bks.buildConnectionString(config)"
     :class="classes"
   >
@@ -19,7 +19,7 @@
         class="connection-type badge truncate"
         v-tooltip="databaseVersion"
       >{{ connectionType }}</span>
-      <x-menu>
+      <x-menu @close="isQuickSwitcherVisible = false">
         <x-menuitem
           @click.prevent="disconnect(false)"
           class="red"
@@ -42,6 +42,17 @@
           <x-label>
             <i class="material-icons">sync</i>Sync Database
           </x-label>
+        </x-menuitem>
+        <x-menuitem @click.stop.prevent="showQuickSwitcher">
+            <x-label class="flex items-center justify-between">
+              <span class="flex items-center">
+                <i class="material-icons">swap_horiz</i>
+                Switch Connection
+              </span>
+              <span style="font-size: 22px;">
+                {{ isQuickSwitcherVisible ? '‹' : '›' }}
+              </span>
+            </x-label>
         </x-menuitem>
       </x-menu>
     </x-button>
@@ -120,6 +131,40 @@
         </form>
       </modal>
     </portal>
+    <portal to="menus">
+      <div
+        class="quick-switcher-panel"
+        ref="quickSwitcherPanel"
+        v-if="isQuickSwitcherVisible"
+        @click.stop
+      >
+        <div class="quick-switcher-header">
+          {{ showingMore ? 'saved connections:' : 'recent connections:' }}
+        </div>
+        <div class="quick-switcher-list-wrapper">
+          <div class="quick-switcher-list">
+            <button
+              v-for="conn in displayedConnections"
+              :key="conn.id"
+              :config="conn"
+              :show-duplicate="false"
+              class="quick-switcher-item"
+              @click="selectConnection(conn)"
+            >
+              {{ conn.name }}
+            </button>
+          </div>
+        </div>
+        <div class="quick-switcher-footer">
+          <button class="quick-switcher-item more" @click.stop="toggleMore">
+            <span class="label">{{ showingMore ? 'less' : 'more' }}</span>
+            <span style="font-size: 22px;">
+              {{ showingMore ? '‹' : '›' }}
+            </span>
+          </button>
+        </div>
+      </div>
+    </portal>
   </div>
 </template>
 <script>
@@ -135,7 +180,10 @@ export default {
   },
   data() {
     return {
-      errors: null
+      errors: null,
+      isQuickSwitcherVisible: false,
+      showingMore: false,
+      recentConnections: [],
     }
   },
   computed: {
@@ -145,10 +193,12 @@ export default {
       versionString: state => state.versionString
     }),
     ...mapState('settings', ['privacyMode']),
+    ...mapState('data/connections', {'connectionConfigs': 'items'}),
     ...mapGetters({
       hasRunningExports: 'exports/hasRunningExports',
       workspace: 'workspace',
-      connectionColor: 'connectionColor'
+      connectionColor: 'connectionColor',
+      savedConnections: 'data/connections/filteredConnections',
     }),
     connectionName() {
       return this.config ? this.$bks.buildConnectionName(this.config) : 'Connection'
@@ -158,6 +208,16 @@ export default {
     },
     databaseVersion() {
       return this.versionString
+    },
+    recentConnectionsConfigs() {
+      return this.$store.getters['data/usedconnections/orderedUsedConfigs'] || []
+    },
+    displayedConnections() {
+      const connections = this.showingMore ? this.savedConnections : this.recentConnections;
+
+      return connections.filter(conn =>
+        conn.id !== this.config.id || conn.workspaceId !== this.config.workspaceId
+      );
     },
     classes() {
       const result = {
@@ -198,7 +258,44 @@ export default {
         log.error(error)
         this.$noty.error(error.message)
       }
-    }
+    },
+    showQuickSwitcher() {
+      this.isQuickSwitcherVisible = !this.isQuickSwitcherVisible;
+      if (this.isQuickSwitcherVisible) {
+        this.populateRecentConnections();
+      }
+    },
+    async selectConnection(config) {
+      await this.$store.dispatch('disconnect')
+      try {
+        await this.$store.dispatch('connect', config)
+      } catch (ex) {
+        log.error(ex)
+        this.$noty.error("Error establishing a connection")
+      }
+      this.isQuickSwitcherVisible = false
+    },
+    toggleMore() {
+      this.showingMore = !this.showingMore;
+    },
+    populateRecentConnections() {
+      if (!this.config.id || !this.config.workspaceId) {
+        console.log('Missing id or workspaceId:', {
+          id: this.config.id,
+          workspaceId: this.config.workspaceId
+        });
+        return
+      }
+
+      const filteredRecent = this.recentConnectionsConfigs
+        .map(rc => this.connectionConfigs.find(c =>
+          c.id === rc.connectionId &&
+          c.workspaceId === rc.workspaceId &&
+          (c.id !== this.config.id || c.workspaceId !== this.config.workspaceId)
+        ))
+        .filter(Boolean);
+      this.recentConnections = filteredRecent.slice(0, 5)
+    },
   }
 }
 </script>


### PR DESCRIPTION
Closes: #2431
Introduced a Connection Quick Switcher accessible via the connection menu, allowing users to quickly switch between recent or saved connections.

- Added "Switch Connection" button to the status bar menu
- Added quick-switcher-panel with recent and saved connections toggle
- Populates recent connections (max 5) and recent connections excluding the active one