### PR TITLE
fix: handle read-only permission errors gracefully in PostgreSQL table properties

### DIFF
--- a/apps/studio/src/components/TabTableProperties.vue
+++ b/apps/studio/src/components/TabTableProperties.vue
@@ -86,6 +86,14 @@
                 >
                   <i class="material-icons-outlined">report_problem</i> Read Only
                 </span>
+                <span
+                  class="statusbar-item permission-warning"
+                  v-if="properties && properties.permissionWarnings && properties.permissionWarnings.length > 0"
+                  :title="permissionWarningsTooltip"
+                  @click="showPermissionWarnings"
+                >
+                  <i class="material-icons-outlined">warning</i> Limited Info
+                </span>
               </template>
             </div>
           </template>
@@ -288,6 +296,10 @@ export default {
     humanIndexSize() {
       return humanBytes(this.properties.indexSize)
     },
+    permissionWarningsTooltip() {
+      if (!this.properties?.permissionWarnings?.length) return ''
+      return `Some information couldn't be displayed:\n${this.properties.permissionWarnings.join('\n')}`
+    },
   },
   methods: {
     close() {
@@ -338,6 +350,19 @@ export default {
         this.loading = false
       }
     },
+    showPermissionWarnings() {
+      if (!this.properties?.permissionWarnings?.length) return
+      
+      const warnings = this.properties.permissionWarnings
+      const message = `Some table information couldn't be displayed due to insufficient permissions:\n\n• ${warnings.join('\n• ')}`
+      
+      this.$noty.warning(message, { 
+        timeout: 8000,
+        modal: false,
+        layout: 'center',
+        theme: 'mint'
+      })
+    },
     async openTable() {
       this.$root.$emit("loadTable", { table: this.table })
     }
@@ -347,3 +372,18 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.permission-warning {
+  cursor: pointer;
+  color: #f39c12;
+}
+
+.permission-warning:hover {
+  color: #e67e22;
+}
+
+.permission-warning i {
+  color: inherit !important;
+}
+</style>

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -748,6 +748,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
 
   async getTableProperties(table: string, schema: string = this._defaultSchema): Promise<TableProperties> {
     const identifier = this.wrapTable(table, schema)
+    const permissionWarnings: string[] = []
 
     const statements = [
       `pg_indexes_size('${identifier}') as index_size`,
@@ -764,31 +765,37 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
     // Execute each query independently with error handling for read-only connections
     const detailsPromise = this.driverExecuteSingle(sql).catch(err => {
       log.warn('Unable to fetch table size/description (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table size and description due to insufficient permissions')
       return { rows: [{ index_size: 0, table_size: 0, description: null }] }
     });
 
     const indexesPromise = this.listTableIndexes(table, schema).catch(err => {
       log.warn('Unable to fetch table indexes (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table indexes due to insufficient permissions')
       return []
     });
 
     const relationsPromise = this.getTableKeys(table, schema).catch(err => {
       log.warn('Unable to fetch table relations (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table relations due to insufficient permissions')
       return []
     });
 
     const triggersPromise = this.listTableTriggers(table, schema).catch(err => {
       log.warn('Unable to fetch table triggers (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table triggers due to insufficient permissions')
       return []
     });
 
     const partitionsPromise = this.listTablePartitions(table, schema).catch(err => {
       log.warn('Unable to fetch table partitions (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table partitions due to insufficient permissions')
       return []
     });
 
     const ownerPromise = this.getTableOwner(table, schema).catch(err => {
       log.warn('Unable to fetch table owner (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table owner due to insufficient permissions')
       return null
     });
 
@@ -817,7 +824,8 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult> {
       relations,
       triggers,
       partitions,
-      owner
+      owner,
+      permissionWarnings: permissionWarnings.length > 0 ? permissionWarnings : undefined
     }
   }
 

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -84,6 +84,7 @@ export interface TableProperties {
   partitions?: TablePartition[]
   owner?: string,
   createdAt?: string
+  permissionWarnings?: string[]
 }
 
 export interface TableColumn {

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -159,6 +159,16 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(result.indexSize).toBe(0);
     expect(result.size).toBe(0);
     expect(result.description).toBeNull();
+    
+    // Verify that permission warnings are included
+    expect(result.permissionWarnings).toBeDefined();
+    expect(result.permissionWarnings).toContain('Unable to retrieve table size and description due to insufficient permissions');
+    expect(result.permissionWarnings).toContain('Unable to retrieve table indexes due to insufficient permissions');
+    expect(result.permissionWarnings).toContain('Unable to retrieve table triggers due to insufficient permissions');
+    expect(result.permissionWarnings).toContain('Unable to retrieve table partitions due to insufficient permissions');
+    expect(result.permissionWarnings).toContain('Unable to retrieve table owner due to insufficient permissions');
+    // Relations should succeed, so it should not have a warning for relations
+    expect(result.permissionWarnings).not.toContain('Unable to retrieve table relations due to insufficient permissions');
 
     // Verify that all methods were called despite some failing
     expect(client.getTableKeys).toHaveBeenCalledWith('test_table', 'public');

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -133,6 +133,11 @@ describe("Postgres UNIT tests (no connection required)", () => {
       }
     ];
 
+    // Set up the client properly for testing
+    client._defaultSchema = 'public';
+    client.version = { number: 100000 }; // Mock a modern PostgreSQL version
+    client.wrapTable = jest.fn().mockReturnValue('"public"."test_table"');
+
     // Mock methods that may fail with permission errors
     client.driverExecuteSingle = jest.fn().mockRejectedValue(new Error('permission denied for function pg_relation_size'));
     client.listTableIndexes = jest.fn().mockRejectedValue(new Error('permission denied'));


### PR DESCRIPTION
Fixes issue where Relations tab shows empty for read-only PostgreSQL connections.

## Changes
- Modified getTableProperties method to handle permission errors gracefully
- Added individual error handlers for each query to prevent total failure
- Ensures relations are still displayed even when permission-sensitive queries fail
- Added comprehensive unit test to prevent regression

Resolves #3262

Generated with [Claude Code](https://claude.ai/code)