### PR TITLE
use query editor status bar in plugin tab

### DIFF
--- a/apps/studio/src/assets/styles/app/plugin/plugin-shell.scss
+++ b/apps/studio/src/assets/styles/app/plugin/plugin-shell.scss
@@ -26,6 +26,8 @@
 
   .bottom-panel {
     overflow: auto;
+    display: flex;
+    flex-direction: column;
   }
 
   .hidden-panel {

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -3,6 +3,7 @@
     :active="active"
     :class="{ 'empty': results.length === 0, 'query-meta': true }"
   >
+    <slot name="left-actions"></slot>
     <template v-if="results.length > 0">
       <div
         class="truncate statusbar-info"

--- a/apps/studio/src/services/plugin/types.ts
+++ b/apps/studio/src/services/plugin/types.ts
@@ -65,12 +65,14 @@ export interface PluginRepository {
   readme: string;
 }
 
-export type OnViewRequestListener = (params: {
+export type OnViewRequestListener = (params: OnViewRequestListenerParams) => void | Promise<void>;
+
+export type OnViewRequestListenerParams = {
   source: HTMLIFrameElement;
   request: PluginRequestData;
   after: (callback: (response: PluginResponseData) => void) => void;
   modifyResult: (callback: (result: PluginResponseData['result']) => PluginResponseData['result'] | Promise<PluginResponseData['result']>) => void;
-}) => void | Promise<void>;
+}
 
 export type PluginSettings = {
   [pluginId: string]: {

--- a/apps/studio/src/services/plugin/web/PluginStoreService.ts
+++ b/apps/studio/src/services/plugin/web/PluginStoreService.ts
@@ -290,6 +290,8 @@ export default class PluginStoreService {
         dataType: field.dataType,
       })),
       rows: result.rows,
+      rowCount: result.rowCount,
+      affectedRows: result.affectedRows,
     };
   }
 


### PR DESCRIPTION
Just like Mongo shell tab, we could also use the same status bar in plugin shell tab!

The status bar contains result count, a dropdown to select result, time estimation, row affection count, and download dropdown.

![image](https://github.com/user-attachments/assets/89098440-b074-4f91-abf8-31d51c9a0758)



- NOTE: By default plugin system auto updates plugins. If you want to be sure, the version of the ai tab is `v1.0.21` for this PR.

Closes: beekeeper-studio/bks-ai-shell#8