### PR TITLE
feat: toggle devtools hotkey

### DIFF
--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -136,17 +136,9 @@ class BeekeeperWindow {
 
     await this.win.loadURL(this.appUrl)
     if ((platformInfo.env.development && !platformInfo.env.test) || platformInfo.debugEnabled) {
-      globalShortcut.register('F12', this.toggleDevTools.bind(this))
-      globalShortcut.register('CommandOrControl+Shift+I', this.toggleDevTools.bind(this))
+      globalShortcut.register('F12', this.win.webContents.toggleDevTools.bind(this.win.webContents))
+      globalShortcut.register('CommandOrControl+Shift+I', this.win.webContents.toggleDevTools.bind(this.win.webContents))
 
-      this.win.webContents.openDevTools()
-    }
-  }
-
-  private toggleDevTools() {
-    if (this.win.webContents.isDevToolsOpened()) {
-      this.win.webContents.closeDevTools()
-    } else {
       this.win.webContents.openDevTools()
     }
   }


### PR DESCRIPTION
Add devtools toggle hotkeys:
- F12
- CTRL+SHIFT+I

Enabled only in dev mode.

Why? Sometimes it's useful to close DevTools to check styles or smtn without restarting the application to reopen them, which is annoying.

Demonstration: https://www.youtube.com/watch?v=tX51JS7EU0k