### PR TITLE
disable plugins from config files

### DIFF
--- a/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
+++ b/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs'
 import { URL } from 'url'
 import rawLog from '@bksLogger'
 import platformInfo from '@/common/platform_info'
+import bksConfig from "@/common/bksConfig";
 
 const log = rawLog.scope('ProtocolBuilder')
 
@@ -78,6 +79,11 @@ export const ProtocolBuilder = {
       const normalized = path.normalize(pathName)
       const fullPath = path.join(platformInfo.userDirectory, "plugins", normalized)
       log.debug("resolving", pathName, 'to', fullPath)
+      console.log("plugin", pathName, fullPath, {host:url.host})
+      if (bksConfig.get(`plugins.${url.host}.enabled`) === false) {
+        respond({ error: -20 }) // blocked by client
+        return;
+      }
       readFile(fullPath, (error, data) => {
         if (error) {
           log.error("error loading plugin file", pathName, error)

--- a/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
+++ b/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
@@ -75,12 +75,12 @@ export const ProtocolBuilder = {
     protocol.registerBufferProtocol("plugin", (request, respond) => {
       // Removes the leading "plugin://" and the query string
       const url = new URL(request.url);
-      const pathName = path.join(url.host, url.pathname);
+      const pluginId = url.host;
+      const pathName = path.join(pluginId, url.pathname);
       const normalized = path.normalize(pathName)
       const fullPath = path.join(platformInfo.userDirectory, "plugins", normalized)
       log.debug("resolving", pathName, 'to', fullPath)
-      console.log("plugin", pathName, fullPath, {host:url.host})
-      if (bksConfig.get(`plugins.${url.host}.enabled`) === false) {
+      if (bksConfig.get(`plugins.${pluginId}.enabled`) === false) {
         respond({ error: -20 }) // blocked by client
         return;
       }

--- a/apps/studio/src/common/bksConfig/BksConfigProvider.ts
+++ b/apps/studio/src/common/bksConfig/BksConfigProvider.ts
@@ -22,7 +22,9 @@ export interface ConfigEntryDetailWarning {
   path: string;
 }
 
-type ConfigValue = string | number | IniArray | undefined;
+type IniValue = string | number | boolean | IniArray | undefined;
+
+type ConfigValue = IniValue | Record<string, IniValue>;
 
 export type KeybindingPath = DeepKeyOf<IBksConfig["keybindings"]>;
 

--- a/apps/studio/src/common/bksConfig/mainBksConfig.ts
+++ b/apps/studio/src/common/bksConfig/mainBksConfig.ts
@@ -33,6 +33,12 @@ export function checkUnrecognized(
   function traverse(obj: Record<string, any>, parentPath = "") {
     for (const key of Object.keys(obj)) {
       const path = parentPath ? `${parentPath}.${key}` : key;
+      
+      // Skip validation for plugin configurations (plugins and plugins.[plugin-id])
+      if (path === 'plugins' || /^plugins\.[^.]+/.test(path)) {
+        continue;
+      }
+      
       const unrecognized = !_.has(defaultConfig, path);
       const value = obj[key];
 

--- a/apps/studio/src/components/plugins/IsolatedPluginView.vue
+++ b/apps/studio/src/components/plugins/IsolatedPluginView.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="isolated-plugin-view">
+    <div v-if="$bksConfig.plugins?.[pluginId].enabled === false" class="alert">
+      <i class="material-icons-outlined">info</i>
+      <div>This plugin ({{ pluginId }}) has been disabled via configuration</div>
+    </div>
     <iframe
-      v-if="visible || loaded"
+      v-else-if="visible || loaded"
       :src="baseUrl"
       sandbox="allow-scripts allow-same-origin allow-forms"
       allow="clipboard-read; clipboard-write;"

--- a/apps/studio/src/components/plugins/PluginList.vue
+++ b/apps/studio/src/components/plugins/PluginList.vue
@@ -10,6 +10,7 @@
       <div class="info">
         <div class="title">
           {{ plugin.name }}
+          <span class="badge" v-if="$bksConfig.plugins?.[plugin.id]?.enabled === false">disabled</span>
         </div>
         <div class="description">
           {{ plugin.description }}

--- a/apps/studio/src/components/plugins/PluginManagerModal.vue
+++ b/apps/studio/src/components/plugins/PluginManagerModal.vue
@@ -169,7 +169,6 @@ export default Vue.extend({
           ...manifest,
           installed: true,
           installing: false,
-          enabled: true,
           checkingForUpdates: null,
         };
 
@@ -198,7 +197,6 @@ export default Vue.extend({
             ...entry,
             installed: false,
             installing: false,
-            enabled: false,
             checkingForUpdates: null,
           };
 

--- a/apps/studio/src/components/plugins/PluginPage.vue
+++ b/apps/studio/src/components/plugins/PluginPage.vue
@@ -63,14 +63,17 @@
           }}</x-label>
         </x-button>
       </div>
-      <div class="update-indicator">
-        <template
-          v-if="
-            !plugin.checkingForUpdates && plugin.checkingForUpdates !== null
-          "
-        >
-          {{ plugin.updateAvailable ? "Update Available!" : "Up to date!" }}
-        </template>
+      <div
+        v-if="
+          !plugin.checkingForUpdates && plugin.checkingForUpdates !== null
+        "
+        class="update-indicator"
+      >
+        {{ plugin.updateAvailable ? "Update Available!" : "Up to date!" }}
+      </div>
+      <div class="alert" v-if="$bksConfig.plugins?.[plugin.id]?.enabled === false">
+        <i class="material-icons-outlined">info</i>
+        <div>This plugin has been disabled via configuration</div>
       </div>
     </div>
     <div class="markdown-content">

--- a/apps/studio/src/services/plugin/PluginManager.ts
+++ b/apps/studio/src/services/plugin/PluginManager.ts
@@ -203,6 +203,7 @@ export default class PluginManager {
 
   /**
    * Loads the list of disabled auto-update plugins from the database
+   * @todo all plugin settings should be loaded and saved from the config files
    */
   private async loadPluginSettings() {
     const setting = await UserSetting.get(PluginManager.PLUGIN_SETTINGS);

--- a/apps/studio/src/store/modules/TabModule.ts
+++ b/apps/studio/src/store/modules/TabModule.ts
@@ -41,6 +41,9 @@ export const TabModule: Module<State, RootState> = {
         if (tab.type === "shell" && rootGetters.dialectData?.disabledFeatures?.shell) {
           return false;
         }
+        if (tab.type === "plugin-shell") {
+          return window.bksConfig.get(`plugins.${tab.pluginId}.enabled`) === true;
+        }
         return true;
       })
     },

--- a/apps/studio/tests/unit/config.spec.js
+++ b/apps/studio/tests/unit/config.spec.js
@@ -108,6 +108,17 @@ minRes = 10
     expect(warnings).toEqual(expectedWarnings);
   });
 
+  it("should recognize plugin configurations", () => {
+    const defaultConfig = parseIni(``);
+    const userConfig = parseIni(`
+[plugins.bks-ai-shell]
+enabled = true
+    `);
+
+    const warnings = checkUnrecognized(defaultConfig, userConfig, "user");
+    expect(warnings).toEqual([]);
+  })
+
   it("should detect conflicts between user and system keys", () => {
     const systemConfig = parseIni(`
 [general]


### PR DESCRIPTION
This allows users to disable plugins from config files (not from UI. we're not able to write/replace config files in a way that preserve comments yet!)

![image](https://github.com/user-attachments/assets/198abee0-c4d7-41db-92fe-68e30f044574)
![image](https://github.com/user-attachments/assets/ce31c00e-0be0-470a-b70e-d7646810ff01)
![image](https://github.com/user-attachments/assets/02c32b52-aa5c-40ab-b47e-fbd190df08aa)
