### PR TITLE
Fix the gpg referred to in our rpm postinstall script

### DIFF
--- a/apps/studio/build/rpm-postinstall
+++ b/apps/studio/build/rpm-postinstall
@@ -69,7 +69,7 @@ name=Beekeeper Studio Repository
 baseurl=https://rpm.beekeeperstudio.io/repo/
 enabled=1
 gpgcheck=1
-gpgkey=https://rpm.beekeeperstudio.io/repo/repodata/repomd.xml.asc
+gpgkey=https://rpm.beekeeperstudio.io/beekeeper.key
 EOF
 
 


### PR DESCRIPTION
fix #3175 

As mentioned in the issue above, looks like our repo file references the wrong url for our gpg key, which on some systems causes the install to fail. 