### PR TITLE
fix initial query tab that wasn't showing up

### DIFF
--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -367,6 +367,9 @@ export default Vue.extend({
   watch: {
     async usedConfig() {
       await this.$store.dispatch('tabs/load')
+      if (!this.tabItems?.length) {
+        this.createQuery()
+      }
     }
   },
   filters: {
@@ -1156,10 +1159,6 @@ export default Vue.extend({
   },
 
   async mounted() {
-    await this.$store.dispatch('tabs/load')
-    if (!this.tabItems?.length) {
-      this.createQuery()
-    }
     this.registerHandlers(this.rootBindings)
   }
 })


### PR DESCRIPTION
The bug was introduced by this PR https://github.com/beekeeper-studio/beekeeper-studio/pull/3158

1. Open a connection
2. Close all tabs
3. disconnect
4. reopen the same connection
5. The new query tab is closed by itself.

It's closed by itself because we call `tabs/load` which removes the query tab that we created.

Not sure if this PR addresses the issue correctly.

@not-night-but need you to confirm since this was related to your PR.