### PR TITLE
fix: do not convert empty arrays to (NULL) for display

### DIFF
--- a/apps/studio/src/mixins/data_mutators.ts
+++ b/apps/studio/src/mixins/data_mutators.ts
@@ -17,9 +17,6 @@ export function emptyResult(value: any) {
   if (_.isString(value) && _.isEmpty(value)) {
     return buildNullValue('EMPTY')
   }
-  if (_.isArray(value) && value.length === 0) {
-    return buildNullValue('NULL')
-  }
 
   return null
 }


### PR DESCRIPTION
Fix #2665 
Before
<img width="1192" alt="beekeeper-not-showing-empty-array" src="https://github.com/user-attachments/assets/0c7c88ee-8ca1-4daf-9ca4-f4155fa60013" />

After
<img width="1314" alt="beekeeper-show-empty-array" src="https://github.com/user-attachments/assets/43df8a1b-55bb-47b5-8e6a-982bf89bfa6d" />

Empty arrays were previously converted to `(NULL)` for display, which was misleading.