### PR TITLE
fix editor focus

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -34,7 +34,7 @@
       <sql-text-editor
         :value="unsavedText"
         :read-only="editor.readOnly"
-        :focus="focusingElement === 'text-editor'"
+        :is-focused="focusingElement === 'text-editor'"
         :markers="editorMarkers"
         :formatter-dialect="formatterDialect"
         :identifier-dialect="identifierDialect"

--- a/apps/studio/src/components/TabShell.vue
+++ b/apps/studio/src/components/TabShell.vue
@@ -14,7 +14,7 @@
         :vim-keymaps="vimKeymaps"
         :keymap="userKeymap"
         :output="mongoOutputResult"
-        :focus="focusingElement === 'text-editor'"
+        :is-focused="focusingElement === 'text-editor'"
         :auto-focus="true"
         :extensions="extensions"
         :promptSymbol="promptSymbol"

--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -82,7 +82,7 @@
               :value="content"
               :language-id="language.languageId"
               :line-wrapping="wrapText"
-              :focus="editorFocus"
+              :is-focused="editorFocus"
               :readOnly="isReadOnly"
               :replace-extensions="replaceExtensions"
               @focus="editorFocus = $event"

--- a/apps/ui-kit/lib/components/mongo-shell/MongoShell.vue
+++ b/apps/ui-kit/lib/components/mongo-shell/MongoShell.vue
@@ -41,6 +41,10 @@ export default {
       if (!this.textEditor) return;
       this.applyLineWrapping();
     },
+    isFocused() {
+      if (!this.textEditor) return;
+      this.applyFocus();
+    },
     promptSymbol(value) {
       if (this.textEditor) {
         this.textEditor.dispatchChange({
@@ -188,6 +192,11 @@ export default {
     },
     applyKeymap() {
       this.textEditor.setKeymap(this.keymap, this.vimOptions);
+    },
+    applyFocus() {
+      if (this.isFocused) {
+        this.textEditor.focus();
+      }
     },
     getPromptText(promptSymbol) {
       if (promptSymbol.length <= this.maxPromptSymbolLength) return promptSymbol;

--- a/apps/ui-kit/lib/components/text-editor/v2/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/v2/mixin.ts
@@ -38,7 +38,7 @@ export default {
       if (!this.textEditor) return;
       this.applyReadOnly();
     },
-    focus() {
+    isFocused() {
       if (!this.textEditor) return;
       this.applyFocus();
     },
@@ -103,7 +103,7 @@ export default {
       this.textEditor.setReadOnly(this.readOnly);
     },
     applyFocus() {
-      if (this.focus) {
+      if (this.isFocused) {
         this.textEditor.focus();
       }
     },
@@ -167,7 +167,7 @@ export default {
         replaceExtensions: this.replaceExtensions,
         lsConfig: this.lsConfig,
         initialValue: this.value,
-        focus: this.focus,
+        focus: this.isFocused,
         readOnly: this.readOnly,
         keymap: this.keymap,
         vimOptions: this.vimOptions,


### PR DESCRIPTION
Had to use a different prop name (`isFocused`) because it was conflicting with the HTML `focus()` method.