### PR TITLE
add plugin data table

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/shared-ini-file-loader": "^3.374.0",
     "@azure/msal-node": "^2.12.0",
     "@babel/plugin-transform-class-static-block": "^7.26.0",
-    "@beekeeperstudio/plugin": "^1.0.10",
+    "@beekeeperstudio/plugin": "^1.0.11",
     "@cleverbrush/async": "^1.1.10",
     "@cleverbrush/deep": "^1.1.10",
     "@clickhouse/client": "^1.8.1",

--- a/apps/studio/src/common/appdb/Connection.ts
+++ b/apps/studio/src/common/appdb/Connection.ts
@@ -15,6 +15,7 @@ import { PinnedConnection } from "./models/PinnedConnection"
 import { TokenCache } from "./models/token_cache"
 import { InstallationId } from "./models/installation_id"
 import { UserPin } from "./models/UserPin"
+import { PluginData } from "./models/PluginData";
 
 const models = [
   SavedConnection,
@@ -32,6 +33,7 @@ const models = [
   TokenCache,
   InstallationId,
   UserPin,
+  PluginData,
 ]
 
 interface IConnectionState {

--- a/apps/studio/src/common/appdb/models/PluginData.ts
+++ b/apps/studio/src/common/appdb/models/PluginData.ts
@@ -1,0 +1,24 @@
+import { Column, Entity } from "typeorm";
+import { ApplicationEntity } from "./application_entity";
+import { EncryptTransformer } from "../transformers/Transformers";
+import { loadEncryptionKey } from "../../encryption_key";
+import _ from "lodash";
+
+const encrypt = new EncryptTransformer(loadEncryptionKey());
+
+@Entity({ name: "plugin_data" })
+export class PluginData extends ApplicationEntity {
+  withProps(props: any) {
+    if (props) PluginData.merge(this, props);
+    return this;
+  }
+
+  @Column({ type: "varchar", nullable: false })
+  pluginId: string;
+
+  @Column({ type: "varchar", nullable: true })
+  data: string;
+
+  @Column({ type: "varchar", nullable: true, transformer: [encrypt] })
+  encryptedData: string;
+}

--- a/apps/studio/src/common/transport/index.ts
+++ b/apps/studio/src/common/transport/index.ts
@@ -30,6 +30,12 @@ export interface TransportLicenseKey extends Transport {
   maxAllowedAppRelease: { tagName: string } | null
 }
 
+export interface TransportPluginData extends Transport {
+  pluginId: string;
+  data: string | null;
+  encryptedData: string | null;
+}
+
 export interface TransportPinnedConn extends Transport {
   position: number;
   connectionId: number;

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -2,7 +2,7 @@ import { PinnedConnection } from "@/common/appdb/models/PinnedConnection";
 import { SavedConnection } from "@/common/appdb/models/saved_connection"
 import { UsedConnection } from "@/common/appdb/models/used_connection"
 import { IConnection } from "@/common/interfaces/IConnection"
-import { Transport, TransportCloudCredential, TransportFavoriteQuery, TransportLicenseKey, TransportPinnedConn, TransportUsedQuery } from "@/common/transport";
+import { Transport, TransportCloudCredential, TransportFavoriteQuery, TransportLicenseKey, TransportPinnedConn, TransportPluginData, TransportUsedQuery } from "@/common/transport";
 import { FindManyOptions, FindOneOptions, In, SaveOptions } from "typeorm";
 import _ from 'lodash';
 import { FavoriteQuery } from "@/common/appdb/models/favorite_query";
@@ -20,6 +20,7 @@ import { TokenCache } from "@/common/appdb/models/token_cache";
 import { CloudCredential } from "@/common/appdb/models/CloudCredential";
 import { LicenseKey } from "@/common/appdb/models/LicenseKey";
 import rawLog from "@bksLogger"
+import { PluginData } from "@/common/appdb/models/PluginData";
 
 const log = rawLog.scope('Appdb handlers');
 
@@ -122,6 +123,7 @@ export const AppDbHandlers = {
   ...handlersFor<TransportUserSetting>('setting', UserSetting, transformSetting),
   ...handlersFor<TransportCloudCredential>('credential', CloudCredential),
   ...handlersFor<TransportLicenseKey>('license', LicenseKey, transformLicense),
+  ...handlersFor<TransportPluginData>('pluginData', PluginData),
   'appdb/saved/parseUrl': async function({ url }: { url: string }) {
     const conn = new SavedConnection();
     if (!conn.parse(url)) {

--- a/apps/studio/src/migration/20250628_create_plugin_data.js
+++ b/apps/studio/src/migration/20250628_create_plugin_data.js
@@ -1,0 +1,23 @@
+export default {
+  name: '20250628_create_plugin_data',
+  async run(runner) {
+    // Create the plugin_data table
+    await runner.query(`
+      CREATE TABLE IF NOT EXISTS plugin_data (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        pluginId TEXT NOT NULL UNIQUE,
+        data TEXT,
+        encryptedData TEXT,
+        createdAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        updatedAt DATETIME NOT NULL DEFAULT (datetime('now')),
+        version INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+
+    // Create index on pluginId for better query performance
+    await runner.query(`
+      CREATE INDEX IF NOT EXISTS idx_plugin_data_plugin_id
+      ON plugin_data (pluginId)
+    `);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -62,6 +62,7 @@ import addContextToTabs from "./20250527_add_context_to_tabs"
 import addPluginSettings from "./20250529_add_plugin_settings"
 import addPrivacyModeSetting from "./20250618_add_privacy_mode_setting"
 import createUserPins from './20250604_create_user_pins'
+import createPluginData from './20250628_create_plugin_data'
 
 import ultimate from './ultimate/index'
 
@@ -98,6 +99,7 @@ const realMigrations = [
   addInstallationId,
   sqlAnywhereOptions,
   disabledPluginAutoUpdates, preinstalledPlugins, addContextToTabs, addPluginSettings, createUserPins, addPrivacyModeSetting,
+  createPluginData,
 ]
 
 // fixtures require the models

--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -143,7 +143,7 @@ export default class WebPluginManager {
       return this.loaders.get(manifest.id);
     }
 
-    const loader = new WebPluginLoader(manifest, this.pluginStore);
+    const loader = new WebPluginLoader(manifest, this.pluginStore, this.utilityConnection);
     await loader.load();
     this.loaders.set(manifest.id, loader);
     return loader;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,10 +2071,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@beekeeperstudio/plugin@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@beekeeperstudio/plugin/-/plugin-1.0.10.tgz#9885a66ec7ad49e6af541eb1ac360213c6ba4e8f"
-  integrity sha512-fKpKYvBUb6uZbPgmz1V+M2eZrL9pvK3oJ3K+b+xN9Wl/BJp8AsQsNePyL5fSX7FgvHn0ic0+5oY13y+pKwEj0Q==
+"@beekeeperstudio/plugin@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@beekeeperstudio/plugin/-/plugin-1.0.11.tgz#55b7252481a2849f77717d5aa090b6118954b222"
+  integrity sha512-FnqynrxPy0JC1InBfsBkbZQ84H+g+M/Frvmx6+CBD4LH3gCRXi5OsiY+2gLtCWfhNCEP5UsKKrS4KKkR7/dCkw==
 
 "@bufbuild/protobuf@^2.0.0":
   version "2.2.3"


### PR DESCRIPTION
## New Plugin's APIs

## setData / setEncryptedData

If you wish to save your plugin's data persistently in the app, you can use `setData` or `setEncryptedData` to save sensitive data.

```js
const provider = window.prompt("What's your provider?");
await request("setData", provider);
const apiKey = window.prompt("Please input your API key:");
await request("setEncryptedData", apiKey);
```

The data can be any type that is valid in JSON. We use `JSON.stringify` before storing it in the database.

```js
await request("setData", null);
await request("setData", false);
await request("setData", 123);
await request("setData", "abc");
await request("setData", {
  propA: 123
});
```

## getData / getEncryptedData

Use these to obtain the data. If you haven't stored any data before, they will return `undefined`:

```js
const provider = await request("getData");
const apiKey = await request"getEncryptedData")
```

## What about the existing getViewState / setViewState ?

`getViewState` and `setViewState` are used when you want to get or save data that's isolated for each individual view instance.

For example, AI Shell uses `getViewState` to get the saved conversation:

```js
const state = getViewState();
console.log("previous conversation", state.conversation);
```

If you create a new AI Shell tab, getViewState returns completely different data. Each view instance maintains its own isolated state and cannot access the state of other instances.