### PR TITLE
add clipboard APIs for plugins, fix plugin cache, right clicking tab

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/shared-ini-file-loader": "^3.374.0",
     "@azure/msal-node": "^2.12.0",
     "@babel/plugin-transform-class-static-block": "^7.26.0",
-    "@beekeeperstudio/plugin": "^1.2.2",
+    "@beekeeperstudio/plugin": "^1.3.0-beta",
     "@cleverbrush/async": "^1.1.10",
     "@cleverbrush/deep": "^1.1.10",
     "@clickhouse/client": "^1.8.1",

--- a/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
+++ b/apps/studio/src/background/lib/electron/ProtocolBuilder.ts
@@ -96,11 +96,9 @@ export const ProtocolBuilder = {
         }
 
         const headers = {}
-        if (platformInfo.isDevelopment) {
-          headers['Cache-Control'] = 'no-cache'
-          headers['Pragma'] = 'no-cache'
-          headers['Expires'] = '0'
-        }
+        headers['Cache-Control'] = 'no-cache'
+        headers['Pragma'] = 'no-cache'
+        headers['Expires'] = '0'
 
         const response: any = {
           mimeType: mimeTypeOf(pathName),

--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -157,7 +157,7 @@ import { mapState } from 'vuex'
           { name: "Close Tabs to Right", slug: 'close-to-right', handler: ({item}) => this.$emit('closeToRight', item)},
           { name: "Duplicate", slug: 'duplicate', handler: ({item}) => this.$emit('duplicate', item) },
           { name: "Copy Entity Name", slug: 'copy-name', handler: ({item}) => this.$emit('copyName', item), class: copyNameClass },
-          ...(window.platformInfo.isDevelopment && devOptions),
+          ...(window.platformInfo.isDevelopment ? devOptions : []),
         ];
       },
       modalName() {

--- a/apps/studio/src/services/plugin/web/WebPluginLoader.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginLoader.ts
@@ -149,6 +149,9 @@ export default class WebPluginLoader {
           response.result = value;
           break;
         }
+        case "clipboard.readText":
+          response.result = window.main.readTextFromClipboard()
+          break;
 
         // ======== WRITE ACTIONS ===========
         case "runQuery":
@@ -164,6 +167,9 @@ export default class WebPluginLoader {
           )
           break;
         }
+        case "clipboard.writeText":
+          window.main.writeTextToClipboard(request.args.text)
+          break;
 
         // ======== UI ACTIONS ===========
         case "expandTableResult":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,10 +2071,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@beekeeperstudio/plugin@^1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@beekeeperstudio/plugin/-/plugin-1.2.2.tgz#aec18f3c02d35493a8a1a566dec779906145faee"
-  integrity sha512-JWUCjfS2POwLeO7hQfEdeuokGTfVg6ArEC6AQIqUZ87/JZgnQu3BJUUKsg2Qk73SBppm4lBdXSLa24tVVw8m0w==
+"@beekeeperstudio/plugin@^1.3.0-beta":
+  version "1.3.0-beta"
+  resolved "https://registry.yarnpkg.com/@beekeeperstudio/plugin/-/plugin-1.3.0-beta.tgz#87da0b7cbe65a653ab980775e33bbb232861de94"
+  integrity sha512-HYofwVa9YZWBJ9jb6JyJtYMqq7ULBXfD9nNKe70BbsFtphw8uK5z2H+jZKmu+i0IgPT65cofc+nP98eNDqad3g==
 
 "@bufbuild/protobuf@^2.0.0":
   version "2.2.3"
@@ -5973,11 +5973,6 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
-buildcheck@~0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
-  integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
-
 builder-util-runtime@9.2.10, builder-util-runtime@^9.1.1:
   version "9.2.10"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz#a0f7d9e214158402e78b74a745c8d9f870c604bc"
@@ -6597,13 +6592,8 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cpu-features@~0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.10.tgz#9aae536db2710c7254d7ed67cb3cbc7d29ad79c5"
-  integrity sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==
-  dependencies:
-    buildcheck "~0.0.6"
-    nan "^2.19.0"
+"cpu-features@file:./.yarn/packages/empty-package", cpu-features@~0.0.10:
+  version "1.0.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -10522,15 +10512,15 @@ named-placeholders@^1.1.3:
   dependencies:
     lru-cache "^7.14.1"
 
-nan@^2.19.0, nan@^2.22.2:
-  version "2.22.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
-  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
-
 nan@^2.20.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
   integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
+
+nan@^2.22.2:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
+  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
 nanoid@^3.3.8:
   version "3.3.8"


### PR DESCRIPTION
Clicking `copy` in AI shell does not work due to browser restriction (see https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). The easiest workaround is by adding clipboard APIs from electron.

Next, the plugin will run `clipboard.writeText` similar to the [Clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) interface from browser:

```js
import { clipboard } from "@beekeeperstudio/plugin";

await clipboard.writeText("this is copied from plugin");
```

The `clipboard` object is available in `v1.3.0-beta` of `@beekeeperstudio/plugin`. (It's beta because the clipboard APIs don't exist in bks yet until this PR is merged.)

AI Shell uses the new clipboard API in the draft release => https://github.com/beekeeper-studio/bks-ai-shell/releases/tag/untagged-51aa39a229e527754bed . (we just need to click "mark as latest" to actually release it)