### PR TITLE
fix: autoclose export table status alert

### DIFF
--- a/apps/studio/src/components/export/ExportNotification.vue
+++ b/apps/studio/src/components/export/ExportNotification.vue
@@ -59,6 +59,11 @@ export default {
     }
   },
   watch: {
+    percentComplete() {
+      if(this.percentComplete === 100) {
+        setTimeout(()=> this.notification.close(), 2000);
+      }
+    },
     notificationText: {
       handler() {
         if (this.notification) {


### PR DESCRIPTION
fixes: #3346 

quick fix to autoclose export table status alert.

before:

https://github.com/user-attachments/assets/078cff21-de79-46cf-b0b9-ecbf6950cb4c



after:

https://github.com/user-attachments/assets/3941274b-6908-4358-8a44-11f95e559328

