### PR TITLE
fix text editor font

### DIFF
--- a/apps/ui-kit/lib/components/text-editor/v2/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/v2/text-editor.scss
@@ -116,6 +116,10 @@
     color: var(--bks-text-editor-fg-color);
   }
 
+  .cm-scroller {
+    font-family: $font-family-mono;
+  }
+
   // Semantic token styles for v2 - using distinct colors in 6-digit hex format
   .cm-semanticToken-namespace { color: var(--bks-text-editor-namespace-fg-color); }
   .cm-semanticToken-type { color: var(--bks-text-editor-type-fg-color); }


### PR DESCRIPTION
The text editor font in beta is not the same as before.

v5.3.0 (monospace = wrong font)
![2025-07-09-190711_220x120_scrot](https://github.com/user-attachments/assets/79a10d33-e8c1-479c-b6bc-3b0c3f9f1b4c)
![2025-07-09-191050_217x127_scrot](https://github.com/user-attachments/assets/0b8a83c4-812a-4dca-8563-773848010512)

before v5.3.0 (Source Code Pro) ✔
![2025-07-09-190838_220x123_scrot](https://github.com/user-attachments/assets/e14bc407-38e8-4615-980a-3391a7667436)
![2025-07-09-190925_217x121_scrot](https://github.com/user-attachments/assets/58cc8f0f-b6bd-43d9-b128-001888153523)

On higher resolution, the light theme looks slightly less readable.
