### PR TITLE
fix draggable cell color

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -618,9 +618,10 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
 
 // * Applied when not dragging rows so frozen cells can be transparent
 // * Applied to draggable cells or cells that do not have a tabulator-field attribute
+// * Honestly, i forget what this is all about :D
 .tabulator:not(.tabulator-block-select) .tabulator-row .tabulator-frozen:not([tabulator-field]) {
   position: relative;
-  &:not(.edited) {
+  &:not(.edited):not(:has(.tabulator-row-handle-box)) {
     background-color: $query-editor-bg;
   }
   &::before {


### PR DESCRIPTION
The draggable cells (in table creation) use wrong color.

<img width="154" height="128" alt="2025-07-17-201357_154x128_scrot" src="https://github.com/user-attachments/assets/d9ebefef-ac55-4f29-9a60-b35b63e387ba" />
