### PR TITLE
fix: remove unnecessary outline on query editor

### DIFF
--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -123,6 +123,7 @@
   }
 
   .cm-scroller {
+    outline: none;
     font-family: $font-family-mono;
   }
 


### PR DESCRIPTION
fixes: #3388 