### PR TITLE
fix: update macos fullscreen shortcut to commandcontrolf

### DIFF
--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -82,7 +82,7 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
     fullscreen: {
       id: 'fullscreen',
       label: "Toggle Full Screen",
-      accelerator: platformInfo.isMac ? 'Shift+CommandOrControl+F' : 'F11',
+      accelerator: platformInfo.isMac ? 'Command+Control+F' : 'F11',
       click: actionHandler.fullscreen
     },
     // help


### PR DESCRIPTION
closes: #3381, #3401 

seems like control + command + f is common in most macOS apps. 
so I think it make sense to update the fullscreen shortcut to that.