### PR TITLE
Fix copy as sql

### DIFF
--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -174,9 +174,10 @@ export async function copyRanges(options: {
           data: rangeData,
         },
       });
+      break;
     case "columnName":
       const columnNames = Object.keys(extractedData.data[0]);
-      text = columnNames.join(" "); 
+      text = columnNames.join(" ");
       break;
   }
   ElectronPlugin.clipboard.writeText(text);
@@ -193,7 +194,7 @@ function extractRanges(ranges: RangeComponent[]): ExtractedData {
     // Replace column identifiers with column titles
     const columns = ranges[0].getColumns();
     const mappedData = mapColumnIdsToTitles(rangeData, columns);
-    
+
     return {
       data: mappedData,
       sources: [ranges[0]],
@@ -222,7 +223,7 @@ function extractRanges(ranges: RangeComponent[]): ExtractedData {
     // Replace column identifiers with column titles
     const columns = ranges[0].getColumns();
     const mappedData = mapColumnIdsToTitles(allData, columns);
-    
+
     return {
       data: mappedData,
       sources: ranges,
@@ -240,12 +241,12 @@ function extractRanges(ranges: RangeComponent[]): ExtractedData {
         });
       }
     }
-    
+
     // Replace column identifiers with column titles
     const allColumns = sorted.reduce((cols, range) => cols.concat(range.getColumns()), []);
     const uniqueColumns = _.uniqBy(allColumns, col => col.getField());
     const mappedData = mapColumnIdsToTitles(rows, uniqueColumns);
-    
+
     return {
       data: mappedData,
       sources: ranges,
@@ -254,11 +255,11 @@ function extractRanges(ranges: RangeComponent[]): ExtractedData {
 
   const source = _.first(ranges);
   const rangeData = source.getData() as RangeData;
-  
+
   // Replace column identifiers with column titles
   const columns = source.getColumns();
   const mappedData = mapColumnIdsToTitles(rangeData, columns);
-  
+
   return {
     data: mappedData,
     sources: [source],
@@ -318,7 +319,7 @@ export function setCellValue(cell: CellComponent, value: string) {
 // Helper function to map column IDs to column titles
 function mapColumnIdsToTitles(data: RangeData, columns: ColumnComponent[]): RangeData {
   if (!data || !data.length || !columns || !columns.length) return data;
-  
+
   const colIdToTitleMap = new Map();
   columns.forEach(col => {
     const field = col.getField();
@@ -326,7 +327,7 @@ function mapColumnIdsToTitles(data: RangeData, columns: ColumnComponent[]): Rang
     const title = col.getDefinition().title;
     if (title) colIdToTitleMap.set(field, title);
   });
-  
+
   return data.map(row => {
     const newRow = {};
     Object.entries(row).forEach(([key, value]) => {


### PR DESCRIPTION
fix #3404

We were missing a break in the switch case, causing sql copyRanges to fall through to copy columnNames