### PR TITLE
sometimes a race condition happens when plugin is initializing

### DIFF
--- a/apps/studio/src/services/plugin/web/WebPluginLoader.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginLoader.ts
@@ -39,10 +39,13 @@ export default class WebPluginLoader {
 
   /** Starts the plugin */
   async load(manifest?: Manifest) {
+    // FIXME dont load manifest this way. probably make a new method `setManifest`
     if (manifest) {
       // @ts-ignore
       this.manifest = manifest;
     }
+
+    this.log.info("Loading plugin", this.manifest);
 
     // Add event listener for messages from iframe
     window.addEventListener("message", this.handleMessage);
@@ -246,10 +249,12 @@ export default class WebPluginLoader {
 
   registerIframe(iframe: HTMLIFrameElement) {
     this.iframes.push(iframe);
-    this.postMessage({
-      name: "themeChanged",
-      args: this.pluginStore.getTheme(),
-    });
+    iframe.onload = () => {
+      this.postMessage({
+        name: "themeChanged",
+        args: this.pluginStore.getTheme(),
+      });
+    };
   }
 
   unregisterIframe(iframe: HTMLIFrameElement) {

--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -78,8 +78,9 @@ export default class WebPluginManager {
     await loader.load(manifest);
   }
 
-  /** If the plugin uses iframes, please register the iframe so we can send
-   * and receive messages. Make sure to register after the iframe is fully loaded. */
+  /** For plugins that use iframes, they need to be registered so that we can
+   * communicate. Please call this BEFORE the iframe is loaded.
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/load_event} */
   registerIframe(pluginId: string, iframe: HTMLIFrameElement) {
     const loader = this.loaders.get(pluginId);
     if (!loader) {
@@ -134,7 +135,7 @@ export default class WebPluginManager {
     if (!loader) {
       throw new Error("Plugin not found: " + pluginId);
     }
-    loader.addListener(listener);
+    return loader.addListener(listener);
   }
 
   private async loadPlugin(manifest: Manifest) {


### PR DESCRIPTION
When opening AI Shell, sometimes it renders loading screen infinitely and never gets to the chat screen. (You'll need to open a new AI tab, or restart the app to escape)

This happens because the plugin runs before beekeeper studio is ready to accept messages.

In this case, the main issue is the `@load` event which can be triggered after the plugin is executed. The iframe registration happens on `@load` event, so if the event is triggered after the plugin, some messages from the plugin are not captured.