### PR TITLE
Fix clickhouse query export

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -1038,8 +1038,21 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
     return { totalRows, columns, cursor };
   }
 
-  queryStream(_query: string, _chunkSize: number): Promise<StreamResults> {
-    throw new Error("Method not implemented.");
+  async queryStream(query: string, chunkSize: number): Promise<StreamResults> {
+    const cursorOpts = {
+      query,
+      params: [],
+      client: this.client,
+      chunkSize
+    }
+
+    const { columns, totalRows } = await this.getColumnsAndTotalRows(query);
+
+    return {
+      totalRows,
+      columns,
+      cursor: new ClickHouseCursor(cursorOpts)
+    }
   }
 
   wrapIdentifier(value: string): string {


### PR DESCRIPTION
Implemented missing function in the clickhouse client to allow for exporting full result sets.