### PR TITLE
fix: optional chaining error on magiccolumnbuilder

### DIFF
--- a/apps/studio/src/lib/magic/MagicColumnBuilder.ts
+++ b/apps/studio/src/lib/magic/MagicColumnBuilder.ts
@@ -19,7 +19,7 @@ const MagicColumnBuilder = {
     log.debug("finding magics for", parts)
     if (parts.length < 2) return null
     const topLevel = magicFor(parts[1], magics)
-    if (parts[2] && topLevel.subMagics?.length) {
+    if (parts[2] && topLevel?.subMagics?.length) {
       const result = magicFor(parts[2], topLevel.subMagics) || topLevel
       return result
     } else {


### PR DESCRIPTION
fixes: #3422 
seems like another optional chaining error 😅


before:
<img width="1198" height="766" alt="Screenshot 2025-08-06 at 13 19 31" src="https://github.com/user-attachments/assets/fd774b32-8fe7-442b-ae4d-c1303d29d0e9" />


after:
<img width="1198" height="766" alt="Screenshot 2025-08-06 at 13 19 42" src="https://github.com/user-attachments/assets/0b1956fa-1bef-44bb-9a70-37ed70112abc" />

