### PR TITLE
use views instead of tabType

### DIFF
--- a/apps/studio/src/components/TabPluginShell.vue
+++ b/apps/studio/src/components/TabPluginShell.vue
@@ -130,9 +130,12 @@ export default Vue.extend({
     ...mapGetters(["isCommunity"]),
     url() {
       const manifest = this.$plugin.manifestOf(this.tab.context.pluginId);
-      const tabType = manifest.capabilities.views.tabTypes.find(
-        (t) => t.id === this.tab.context.pluginTabTypeId
-      );
+      const tabType =
+        manifest.capabilities.views.find?.(
+          (v) => v.id === this.tab.context.pluginTabTypeId
+        ) || manifest.capabilities.views.tabTypes?.find?.(
+            (t) => t.id === this.tab.context.pluginTabTypeId
+          );
       return this.$plugin.buildUrlFor(this.tab.context.pluginId, tabType.entry);
     },
     shouldInitialize() {

--- a/apps/studio/src/services/plugin/types.ts
+++ b/apps/studio/src/services/plugin/types.ts
@@ -10,8 +10,7 @@ import { PluginRequestData, PluginResponseData } from "@beekeeperstudio/plugin";
 export type TabKind = "shell";
 
 export type View = {
-  /** The id of the view.
-   *  NOTE: Don't worry about collisions. Beekeeper Studio prefix this with plugin id internally. */
+  /** The id of the view. */
   id: string;
   /** The name of the view that will be displayed in the UI */
   name: string;

--- a/apps/studio/src/services/plugin/web/WebPluginLoader.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginLoader.ts
@@ -50,23 +50,32 @@ export default class WebPluginLoader {
     // Add event listener for messages from iframe
     window.addEventListener("message", this.handleMessage);
 
-    this.manifest.capabilities.views?.sidebars?.forEach((sidebar) => {
-      this.pluginStore.addSidebarTab({
-        id: sidebar.id,
-        label: sidebar.name,
-        url: `plugin://${this.manifest.id}/${this.getEntry(sidebar.entry)}`,
+    if (_.isArray(this.manifest.capabilities.views)) {
+      this.manifest.capabilities.views.forEach((view) => {
+        // Only allow shell tabs
+        if (view.type !== "shell-tab") {
+          return;
+        }
+        this.pluginStore.addTabTypeConfig({
+          pluginId: this.manifest.id,
+          pluginTabTypeId: view.id,
+          name: view.name,
+          kind: "shell",
+          icon: this.manifest.icon,
+        });
       });
-    });
-
-    this.manifest.capabilities.views?.tabTypes?.forEach((tabType) => {
-      this.pluginStore.addTabTypeConfig({
-        pluginId: this.manifest.id,
-        pluginTabTypeId: tabType.id,
-        name: tabType.name,
-        kind: tabType.kind,
-        icon: this.manifest.icon,
+    } else {
+      // FOR BACKWARD COMPATIBILITY
+      this.manifest.capabilities.views.tabTypes?.forEach((tabType) => {
+        this.pluginStore.addTabTypeConfig({
+          pluginId: this.manifest.id,
+          pluginTabTypeId: tabType.id,
+          name: tabType.name,
+          kind: tabType.kind,
+          icon: this.manifest.icon,
+        });
       });
-    });
+    }
   }
 
   private handleMessage(event: MessageEvent) {


### PR DESCRIPTION
Make defining views in manifest.json a little simpler. The old structure is preserved for backward compat.

**Before:**

```json
{
  "views": {
    "tabType": [
      {
        "id": "tab-1",
        "kind": "shell"
      }
    ],
    "sidebar": [
      {
        "id": "sidebar-1",
        "kind": "primary"
      }
    ]
  }
}
```

**After:**

```json
{
  "views": [
    {
      "id": "tab-1",
      "type": "shell-tab"
    },
    {
      "id": "sidebar-1",
      "type": "primary-sidebar"
    }
  ]
}
```