### PR TITLE
add open tab methods for plugins

### DIFF
--- a/apps/studio/src/services/plugin/web/WebPluginLoader.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginLoader.ts
@@ -195,6 +195,9 @@ export default class WebPluginLoader {
           // FIXME maybe we should ask user permission first before opening?
           window.main.openExternally(request.args.link);
           break;
+        case "openTab":
+          this.pluginStore.openTab(request.args);
+          break;
 
         default:
           throw new Error(`Unknown request: ${request.name}`);


### PR DESCRIPTION
closes #3455 - Open Query Tab
closes #3456 - Open Table Structure 
closes #3457 - Open TableTable

The APIs are released on `@beekeeperstudio/plugin` v1.4.0-beta.1. Here are how they look like:
```js
import { openTab } from "@beekeeperstudio/plugin";

await openTab("query");
await openTab("query", {
  query: "SELECT * FROM users;"
});
await openTab("tableStructure", {
  table: "users",
  schema: "public", // optional
});
await openTab("tableTable", {
  table: "users",
  schema: "public", // optional
  filters: [ // optional
    { field: "id", type: "=", value: "1" },
    { op: "OR", field: "id", type: "=", value: "2" },
  ],
});
```