### PR TITLE
add GITHUB_TOKEN env

### DIFF
--- a/apps/studio/src/services/plugin/PluginRepositoryService.ts
+++ b/apps/studio/src/services/plugin/PluginRepositoryService.ts
@@ -7,6 +7,7 @@ export default class PluginRepositoryService {
   constructor() {
     this.octokit = new Octokit({
       userAgent: "Beekeeper Studio",
+      auth: process.env.GITHUB_TOKEN,
     });
   }
 


### PR DESCRIPTION
It can get a little annoying when getting limit errors when testing plugins on build version :laughing: . The best we can do for now is letting users to use their github token via env variable.