### PR TITLE
sometimes plugin requests are not responded after updates

### DIFF
--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -66,6 +66,7 @@ export default class WebPluginManager {
       throw new Error("Plugin not found: " + id);
     }
     await loader.unload();
+    loader.dispose();
     this.loaders.delete(id);
   }
 


### PR DESCRIPTION
I honestly can't replicate the issue but it seems like I know why that happens, when the app updates a plugin:

1. It calls `unload` which removes the message listener of the plugin
2. and then calls `load` to re-add the listener.

I think the issue happens because the iframe runs in between those two calls.

And I don't think re-adding the listener makes any changes at all too, so this is fine.