### PR TITLE
Fix importing from local workspace

### DIFF
--- a/apps/studio/src/components/data/ImportQueriesModal.vue
+++ b/apps/studio/src/components/data/ImportQueriesModal.vue
@@ -66,8 +66,8 @@
   </modal>
 </template>
 <script lang="ts">
-import { FavoriteQuery } from '@/common/appdb/models/favorite_query'
 import { AppEvent } from '@/common/AppEvent'
+import { TransportFavoriteQuery } from '@/common/transport'
 import ErrorAlert from '@/components/common/ErrorAlert.vue'
 import Vue from 'vue'
 export default Vue.extend({
@@ -97,7 +97,7 @@ export default Vue.extend({
       this.error = null
     },
     async openModal() {
-      this.queries = (await FavoriteQuery.find()).map((q) => {
+      this.queries = (await this.$util.send('appdb/query/find')).map((q: TransportFavoriteQuery) => {
         return {
           ...q,
           checked: false

--- a/apps/studio/src/components/tab/TabIcon.vue
+++ b/apps/studio/src/components/tab/TabIcon.vue
@@ -55,14 +55,14 @@
 import Vue, { PropType } from 'vue'
 import TableIcon from '../common/TableIcon.vue'
 import LoadingSpinner from '../common/loading/LoadingSpinner.vue'
-import { OpenTab } from '@/common/appdb/models/OpenTab'
 import { mapGetters } from 'vuex'
+import { TransportOpenTab } from '@/common/transport/TransportOpenTab'
 
 export default Vue.extend({
   components: { TableIcon, LoadingSpinner },
   props: {
     tab: {
-      type: Object as PropType<OpenTab>
+      type: Object as PropType<TransportOpenTab>
     },
     forceIcon: {
       type: Boolean,


### PR DESCRIPTION
It appears the import queries modal was still using the typeorm model directly (which obviously didn't work).