### PR TITLE
Support dynamic menu bar

### DIFF
--- a/apps/studio/src/background/NativeMenuActionHandlers.ts
+++ b/apps/studio/src/background/NativeMenuActionHandlers.ts
@@ -9,6 +9,7 @@ import { IMenuActionHandler } from '@/common/interfaces/IMenuActionHandler'
 import { autoUpdater } from "electron-updater"
 import { DevLicenseState } from '@/lib/license';
 import { setAllowBeta } from './update_manager'
+import { CustomMenuAction } from '@/types'
 
 type ElectronWindow = Electron.BrowserWindow | undefined
 
@@ -208,5 +209,9 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
 
   updatePin = (_1: Electron.MenuItem, win: ElectronWindow) => {
     if (win) win.webContents.send(AppEvent.updatePin)
+  }
+
+  handleAction = (action: Electron.MenuItem | CustomMenuAction, win: ElectronWindow) => {
+    if (win && action && 'event' in action) win.webContents.send(action.event, action.args)
   }
 }

--- a/apps/studio/src/common/interfaces/IMenuActionHandler.ts
+++ b/apps/studio/src/common/interfaces/IMenuActionHandler.ts
@@ -1,6 +1,7 @@
 // import { OpenOptions } from "@/background/WindowBuilder"
 
 import { DevLicenseState } from "@/lib/license";
+import { CustomMenuAction } from "@/types";
 
 type ElectronWindow = Electron.BrowserWindow | undefined
 
@@ -45,4 +46,7 @@ export interface IMenuActionHandler {
   toggleBeta: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   managePlugins: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   updatePin: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
+  /** `handleAction` is used by menus that are defined at runtime (unlike other
+   * actions) so the signature is a little bit different than the rest. */
+  handleAction: (action: Electron.MenuItem | CustomMenuAction, win: ElectronWindow) => void
 }

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -29,6 +29,7 @@ export default class extends DefaultMenu {
 
   devMenu() {
     return {
+      id: 'dev',
       label: 'Dev',
       submenu: [
         this.menuItems.reload,
@@ -39,6 +40,7 @@ export default class extends DefaultMenu {
 
   helpMenu() {
     const helpMenu = {
+      id: "help",
       label: "Help",
       submenu: [
         this.menuItems.enterLicense,
@@ -76,6 +78,7 @@ export default class extends DefaultMenu {
     }
 
     const fileMenu = {
+      id: 'file',
       label: 'File',
       submenu: [
         this.menuItems.newWindow,
@@ -100,6 +103,7 @@ export default class extends DefaultMenu {
       ...appMenu,
       fileMenu,
       {
+        id: 'edit',
         label: 'Edit',
         submenu: [
           this.menuItems.undo,

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -112,6 +112,7 @@ export default class extends DefaultMenu {
       },
       this.viewMenu(),
       {
+        id: "tools",
         label: "Tools",
         submenu: [
           this.menuItems.backupDatabase,

--- a/apps/studio/src/components/menu/NewAppMenu.vue
+++ b/apps/studio/src/components/menu/NewAppMenu.vue
@@ -88,7 +88,6 @@ export default {
     return {
       menuBuilder: null,
       actionHandler: new ClientMenuActionHandler(),
-      menus: [],
       menuActive: false,
       selected: null,
       hovered: null,
@@ -101,18 +100,6 @@ export default {
         "Escape": this.closeMenu,
         "Enter": this.clickHovered
       },
-      connectionMenuItems:[
-          "new-query-menu", 
-          "go-to", 
-          "disconnect", 
-          "import-sql-files", 
-          "close-tab", 
-          "menu-toggle-sidebar", 
-          "menu-secondary-sidebar",
-          "backup-database", 
-          "restore-database", 
-          "export-tables"
-      ]
     }
   },
   computed: {
@@ -132,17 +119,10 @@ export default {
     menuElements() {
       return Array.from(this.$refs.nav.getElementsByTagName("*"))
     },
-    ...mapGetters({'settings': 'settings/settings'}),
+    ...mapGetters('menu', ['menus', 'connectionMenuItems']),
     ...mapState(['connected'])
   },
   watch: {
-    settings: {
-      deep: true,
-      handler() {
-        this.menuBuilder = new MenuBuilder(this.settings, this.actionHandler, this.$config, this.$bksConfig)
-        this.menus = this.menuBuilder.buildTemplate()
-      }
-    },
     menuActive() {
       if (!this.menuActive) {
         this.selected = null
@@ -278,8 +258,6 @@ export default {
     }
   },
   async mounted() {
-    this.menuBuilder = new MenuBuilder(this.settings, this.actionHandler, this.$config, this.$bksConfig)
-    this.menus = this.menuBuilder.buildTemplate()
     document.addEventListener('click', this.maybeHideMenu)
     window.addEventListener('keydown', this.maybeCaptureKeydown, false)
   },

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -2,6 +2,7 @@ import { IMenuActionHandler } from '@/common/interfaces/IMenuActionHandler'
 import _ from 'lodash'
 import {AppEvent} from '../../common/AppEvent'
 import rawLog from '@bksLogger'
+import { CustomMenuAction } from '@/types'
 
 const log = rawLog.scope("ClientMenuActionHandler")
 
@@ -61,6 +62,5 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   }
   updatePin = () => send('updatePin')
   managePlugins = () => send("managePlugins")
-
-  send = send
+  handleAction = (action: CustomMenuAction) => send('handleAction', action)
 }

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -61,4 +61,6 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   }
   updatePin = () => send('updatePin')
   managePlugins = () => send("managePlugins")
+
+  send = send
 }

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -36,6 +36,7 @@ import { CloudClient } from '@/lib/cloud/CloudClient'
 import { ConnectionTypes, SurrealAuthType } from '@/lib/db/types'
 import { SidebarModule } from './modules/SidebarModule'
 import { isVersionLessThanOrEqual, parseVersion } from '@/common/version'
+import { MenuBarModule } from './modules/MenuBarModule'
 
 
 const log = RawLog.scope('store/index')
@@ -98,6 +99,7 @@ const store = new Vuex.Store<State>({
     imports: ImportStoreModule,
     backups: BackupModule,
     sidebar: SidebarModule,
+    menu: MenuBarModule,
   },
   state: {
     connection: new ElectronUtilityConnectionClient(),

--- a/apps/studio/src/store/modules/MenuBarModule.ts
+++ b/apps/studio/src/store/modules/MenuBarModule.ts
@@ -5,25 +5,13 @@ import MenuBuilder from "@/common/menus/MenuBuilder";
 import ClientMenuActionHandler from "@/lib/menu/ClientMenuActionHandler";
 import config from "@/config";
 import RawLog from "@bksLogger";
-import { AppEvent } from "@/common/AppEvent";
-import { JsonValue } from "@/types";
+import { ExternalMenuItem } from "@/types";
 
 interface State {
   externalMenu: { [menuItemId: string]: ExternalMenuItem };
 }
 
 const log = RawLog.scope("MenuBarModule");
-
-export type ExternalMenuItem = {
-  id: string;
-  parentId: string;
-  label: string;
-  enableWhenConnected?: boolean;
-  action: {
-    event: AppEvent;
-    args?: JsonValue;
-  };
-};
 
 const actionHandler = new ClientMenuActionHandler();
 
@@ -58,9 +46,7 @@ export const MenuBarModule: Module<State, RootState> = {
       const menus = builder.buildTemplate();
 
       for (const externalItem of Object.values(state.externalMenu)) {
-        const parent = menus.find(
-          (item) => item.id === externalItem.parentId
-        );
+        const parent = menus.find((item) => item.id === externalItem.parentId);
 
         if (!parent) {
           log.warn(`Parent menu not found: "${externalItem.parentId}"`);
@@ -70,10 +56,7 @@ export const MenuBarModule: Module<State, RootState> = {
         (parent.submenu as Electron.MenuItemConstructorOptions[]).push({
           label: externalItem.label,
           click: () => {
-            actionHandler.send(
-              externalItem.action.event,
-              externalItem.action.args
-            );
+            actionHandler.handleAction(externalItem.action);
           },
         });
       }

--- a/apps/studio/src/store/modules/MenuBarModule.ts
+++ b/apps/studio/src/store/modules/MenuBarModule.ts
@@ -1,0 +1,107 @@
+import { Module } from "vuex";
+import { State as RootState } from "../index";
+import _ from "lodash";
+import MenuBuilder from "@/common/menus/MenuBuilder";
+import ClientMenuActionHandler from "@/lib/menu/ClientMenuActionHandler";
+import config from "@/config";
+import RawLog from "@bksLogger";
+import { AppEvent } from "@/common/AppEvent";
+import { JsonValue } from "@/types";
+
+interface State {
+  externalMenu: { [menuItemId: string]: ExternalMenuItem };
+}
+
+const log = RawLog.scope("MenuBarModule");
+
+export type ExternalMenuItem = {
+  id: string;
+  parentId: string;
+  label: string;
+  enableWhenConnected?: boolean;
+  action: {
+    event: AppEvent;
+    args?: JsonValue;
+  };
+};
+
+const actionHandler = new ClientMenuActionHandler();
+
+export const MenuBarModule: Module<State, RootState> = {
+  namespaced: true,
+  state: () => ({
+    externalMenu: {},
+  }),
+  getters: {
+    connectionMenuItems() {
+      return [
+        "new-query-menu",
+        "go-to",
+        "disconnect",
+        "import-sql-files",
+        "close-tab",
+        "menu-toggle-sidebar",
+        "menu-secondary-sidebar",
+        "backup-database",
+        "restore-database",
+        "export-tables",
+      ];
+    },
+    menus(state, _getters, rootState) {
+      const builder = new MenuBuilder(
+        rootState["settings/settings"],
+        actionHandler,
+        config,
+        window.bksConfig
+      );
+
+      const menus = builder.buildTemplate();
+
+      for (const externalItem of Object.values(state.externalMenu)) {
+        const parent = menus.find(
+          (item) => item.id === externalItem.parentId
+        );
+
+        if (!parent) {
+          log.warn(`Parent menu not found: "${externalItem.parentId}"`);
+          continue;
+        }
+
+        (parent.submenu as Electron.MenuItemConstructorOptions[]).push({
+          label: externalItem.label,
+          click: () => {
+            actionHandler.send(
+              externalItem.action.event,
+              externalItem.action.args
+            );
+          },
+        });
+      }
+
+      return menus;
+    },
+  },
+  mutations: {
+    externalMenu(state, menu: State["externalMenu"]) {
+      state.externalMenu = menu;
+    },
+  },
+  actions: {
+    add(context, menuItem: ExternalMenuItem): string {
+      if (context.state.externalMenu[menuItem.id]) {
+        throw new Error(`Menu item ${menuItem.id} already exists`);
+      }
+      context.commit("externalMenu", {
+        ...context.state.externalMenu,
+        [menuItem.id]: menuItem,
+      });
+      return menuItem.id;
+    },
+    remove(context, id: string) {
+      if (!context.state.externalMenu[id]) {
+        throw new Error(`Menu item ${id} does not exist`);
+      }
+      context.commit("externalMenu", _.omit(context.state.externalMenu, id));
+    },
+  },
+};

--- a/apps/studio/src/types.ts
+++ b/apps/studio/src/types.ts
@@ -1,3 +1,5 @@
+import { AppEvent } from "./common/AppEvent";
+
 interface UtilProcReadyMessage {
   type: "ready";
 }
@@ -12,3 +14,17 @@ export type UtilProcMessage =
   | UtilProcOpenExternalMessage;
 
 export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export type CustomMenuAction = {
+  event: AppEvent;
+  args?: JsonValue;
+}
+
+export type ExternalMenuItem = {
+  id: string;
+  parentId: string;
+  label: string;
+  enableWhenConnected?: boolean;
+  action: CustomMenuAction;
+};
+

--- a/apps/studio/src/types.ts
+++ b/apps/studio/src/types.ts
@@ -10,3 +10,5 @@ interface UtilProcOpenExternalMessage {
 export type UtilProcMessage =
   | UtilProcReadyMessage
   | UtilProcOpenExternalMessage;
+
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };


### PR DESCRIPTION
This PR aims to make the **client** menu bar to be a little bit extensible. After this, we should be able to add menu items from plugins. This is an example to add/remove a custom item to the "Tools" menu:

```js
export default {
  methods: {
    ...mapActions('menu', ['add', 'remove']),
  },
  mounted() {
    this.add({
      id: 'test-item', parentId: 'tools',
      label: 'Open a new query',
      action: {
        event: AppEvent.newTab,
        args: "SELECT * FROM test" // optional, depending on the event
      },
      enableWhenConnected: true, // optional
    })

    await new Promise(resolve => setTimeout(resolve, 3000))

    this.remove('test-item') // use the id
  },
}
```

NOTE: Make sure that the `AppEvent` is forwarded in AppEventHandler.js: https://github.com/beekeeper-studio/beekeeper-studio/blob/0a27f1ba56e5a6c58df63036949751aea1a00f73/apps/studio/src/lib/events/AppEventHandler.js#L19-L32