### PR TITLE
Fix stupid buffer issues

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1447,11 +1447,9 @@ export default Vue.extend({
           let value = cell.getValue();
           if (isBinary) {
             try {
-              // I don't know if sending arraybuffer to tabulator is correct
-              // lol. We used Buffer.from before.
               value = stringToTypedArray(value, "hex")
             } catch (e) {
-              log.debug("failed to convert to hex", pk, value)
+              log.error(`Error converting ${value} to typed array. Skipping...`, e)
             }
           }
           primaryKeys.push({

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1444,9 +1444,19 @@ export default Vue.extend({
         this.primaryKeys.forEach((pk: string) => {
           const cell = row.getCell(pk)
           const isBinary = cell.getColumn().getDefinition().dataType.toUpperCase().includes('BINARY')
+          let value = cell.getValue();
+          if (isBinary) {
+            try {
+              // I don't know if sending arraybuffer to tabulator is correct
+              // lol. We used Buffer.from before.
+              value = stringToTypedArray(value, "hex")
+            } catch (e) {
+              log.debug("failed to convert to hex", pk, value)
+            }
+          }
           primaryKeys.push({
             column: cell.getField(),
-            value: isBinary ? Buffer.from(cell.getValue(), 'hex') : cell.getValue()
+            value,
           })
         })
 

--- a/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
+++ b/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
@@ -40,13 +40,9 @@ export class LicenseKeyController {
       // Base64 encode the installation info for the header
       const encoder = new TextEncoder();
       const data = encoder.encode(JSON.stringify(installationInfo))
-      let binaryString = '';
 
-      for (const char of data) {
-        binaryString += String.fromCharCode(char)
-      }
-
-      const encodedInstallationInfo = btoa(binaryString)
+      // @ts-expect-error polyfill
+      const encodedInstallationInfo = data.toBase64()
 
       // Add the installation info header to the request
       headers['X-Installation-Id'] = encodedInstallationInfo;

--- a/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
+++ b/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
@@ -38,7 +38,15 @@ export class LicenseKeyController {
 
 
       // Base64 encode the installation info for the header
-      const encodedInstallationInfo = Buffer.from(JSON.stringify(installationInfo)).toString('base64');
+      const encoder = new TextEncoder();
+      const data = encoder.encode(JSON.stringify(installationInfo))
+      let binaryString = '';
+
+      for (const char of data) {
+        binaryString += String.fromCharCode(char)
+      }
+
+      const encodedInstallationInfo = btoa(binaryString)
 
       // Add the installation info header to the request
       headers['X-Installation-Id'] = encodedInstallationInfo;


### PR DESCRIPTION
We were somehow still using Buffer in the frontend, and it finally decided to break in v5.3.5. This removes it from the frontend entirely 