### PR TITLE
fix trapped keyboard

### DIFF
--- a/apps/studio/src/components/menu/NewAppMenu.vue
+++ b/apps/studio/src/components/menu/NewAppMenu.vue
@@ -5,6 +5,9 @@
     v-hotkey="allHotkeys"
     :class="{active: menuActive}"
     ref="nav"
+    tabindex="-1"
+    role="menubar"
+    @keydown="maybeCaptureKeydown"
   >
     <!-- TOP MENU, eg File, Edit -->
     <ul class="menu-bar">
@@ -36,8 +39,8 @@
               :class="hoverClass(item)"
             >
               <span class="label">
-                <span 
-                  class="material-icons" 
+                <span
+                  class="material-icons"
                   v-if="item.checked"
                 >done</span>
                 <span>{{ item.label }}</span>
@@ -228,6 +231,7 @@ export default {
     setActive(item) {
       this.menuActive = !this.menuActive
       this.selected = item
+      this.$nextTick(() => this.$refs.nav?.focus())
     },
     setSelected(item) {
       this.selected = item
@@ -259,11 +263,9 @@ export default {
   },
   async mounted() {
     document.addEventListener('click', this.maybeHideMenu)
-    window.addEventListener('keydown', this.maybeCaptureKeydown, false)
   },
   beforeDestroy() {
     document.removeEventListener('click', this.maybeHideMenu)
-    window.removeEventListener('keydown', this.maybeCaptureKeydown, false)
   }
 
 


### PR DESCRIPTION
Input fields stop accepting text after a certain condition. These are the steps to reproduce:

1. Connect to a database
2. Disconnect by clicking `File > Disconnect` (not with the shortcut or other buttons)
3. Type the filter input or click a connection and try to edit it

Notice that you can select inputs, buttons, and other elements but you can't type in.

This happens on my Linux and Windows machines.

The workarounds:
a. When it's unresponsive, just connect to a database and then re-disconnect.
b. Restart the app.