### PR TITLE
add plain tab type for non shell plugins

### DIFF
--- a/apps/studio/src/assets/styles/app/_all.scss
+++ b/apps/studio/src/assets/styles/app/_all.scss
@@ -18,4 +18,4 @@
 @import './tooltips.scss';
 @import './ultimate-only.scss';
 @import './modals/plugin-manager-modal.scss';
-@import './plugin/plugin-shell.scss';
+@import './plugin/all';

--- a/apps/studio/src/assets/styles/app/plugin/_all.scss
+++ b/apps/studio/src/assets/styles/app/plugin/_all.scss
@@ -1,0 +1,2 @@
+@use './plugin-base.scss';
+@use './plugin-shell.scss';

--- a/apps/studio/src/assets/styles/app/plugin/plugin-base.scss
+++ b/apps/studio/src/assets/styles/app/plugin/plugin-base.scss
@@ -1,0 +1,17 @@
+.plugin-base {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 100%;
+
+  .isolated-plugin-view {
+    width: 100%;
+    height: 100%;
+
+    >iframe {
+      width: 100%;
+      height: 100%;
+      border: none;
+    }
+  }
+}

--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -3,7 +3,9 @@ import { Transport } from ".";
 import _ from "lodash";
 import ISavedQuery from "../interfaces/ISavedQuery";
 
-export type TabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell' | 'plugin-shell'
+export type PluginTabType = 'plugin-base' | 'plugin-shell';
+export type CoreTabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
+export type TabType = CoreTabType | PluginTabType
 
 const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName']
 
@@ -29,16 +31,18 @@ export interface TransportOpenTab<Context = {}> extends Transport {
   context: Context
 }
 
-export type TransportPluginShellTab = TransportOpenTab<{
+export type TransportPluginTab = TransportOpenTab<PluginTabContext>;
+
+export type PluginTabContext = {
   pluginId: string;
   pluginTabTypeId: string;
   /** A plugin can save the state of the tab here. For example, an AI plugin
      * can save the chat conversation here */
   data: any;
-}>
+};
 
 export namespace TabTypeConfig {
-  interface BaseTabTypeConfig {
+  interface BaseConfig {
     type: TabType;
     name: string;
     /** Used for the dropdown menu next to the "new tab" icon. */
@@ -48,24 +52,25 @@ export namespace TabTypeConfig {
     };
   }
 
-  interface DefaultConfig extends BaseTabTypeConfig {
-    type: Exclude<TabType, "plugin-shell">;
+  interface CoreConfig extends BaseConfig {
+    type: CoreTabType;
   }
 
   /** `"plugin-shell"` consists of two parts; an iframe at the top and a table at
    * the bottom. This tab looks almost identical to the query tab. The only
    * difference is, in this tab, the result table can be collapsed completely. */
-  export interface PluginShellConfig extends BaseTabTypeConfig, PluginShellConfigIdentifiers {
-    type: "plugin-shell";
+  export interface PluginConfig extends BaseConfig, PluginRef {
+    type: PluginTabType;
     icon?: string; // from material-icons
   }
 
-  export interface PluginShellConfigIdentifiers {
+  export interface PluginRef {
+    /** Use plugin id from the manifest */
     pluginId: string;
     pluginTabTypeId: string;
   }
 
-  export type Config = DefaultConfig | PluginShellConfig;
+  export type Config = CoreConfig | PluginConfig;
 }
 
 export function setFilters(obj: TransportOpenTab, filters: Nullable<TableFilter[]>) {

--- a/apps/studio/src/components/CoreTabHeader.vue
+++ b/apps/studio/src/components/CoreTabHeader.vue
@@ -146,7 +146,7 @@ import { mapState } from 'vuex'
         const copyNameClass = (this.tab.tabType === "table" || this.tab.tabType === "table-properties") ? "" : "disabled";
 
         const devOptions = []
-        if (this.tab.tabType === "plugin-shell") {
+        if (this.tab.tabType === "plugin-shell" || this.tab.tabType === "plugin-base") {
           devOptions.push({ name: "[DEV] Reload plugin view", slug: 'dev-reload-plugin-view', handler: ({item}) => this.$emit('reloadPluginView', item) })
         }
 

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -88,6 +88,13 @@
           :tab="tab"
           :tab-id="tab.id"
         />
+        <PluginBase
+          v-if="tab.tabType === 'plugin-base'"
+          :tab="tab"
+          :active="activeTab.id === tab.id"
+          :reload="reloader[tab.id]"
+          @close="close"
+        />
         <PluginShell
           v-if="tab.tabType === 'plugin-shell'"
           :tab="tab"
@@ -296,6 +303,7 @@ import ImportExportDatabase from './importexportdatabase/ImportExportDatabase.vu
 import ImportTable from './TabImportTable.vue'
 import DatabaseBackup from './TabDatabaseBackup.vue'
 import PluginShell from './TabPluginShell.vue'
+import PluginBase from './TabPluginBase.vue'
 import { AppEvent } from '../common/AppEvent'
 import { mapGetters, mapState } from 'vuex'
 import Draggable from 'vuedraggable'
@@ -314,10 +322,9 @@ import ConfirmationModal from './common/modals/ConfirmationModal.vue'
 import CreateCollectionModal from './common/modals/CreateCollectionModal.vue'
 import SqlFilesImportModal from '@/components/common/modals/SqlFilesImportModal.vue'
 import Shell from './TabShell.vue'
-import { TabTypeConfig } from "@/store/modules/TabModule";
 
 import { safeSqlFormat as safeFormat } from '@/common/utils';
-import { TransportOpenTab, TransportPluginShellTab, setFilters, matches, duplicate, TabType } from '@/common/transport/TransportOpenTab'
+import { TabTypeConfig, TransportOpenTab, TransportPluginTab, setFilters, matches, duplicate, TabType } from '@/common/transport/TransportOpenTab'
 
 export default Vue.extend({
   props: [],
@@ -341,6 +348,7 @@ export default Vue.extend({
     CreateCollectionModal,
     Shell,
     PluginShell,
+    PluginBase,
   },
   data() {
     return {
@@ -651,12 +659,12 @@ export default Vue.extend({
     closeCurrentTab(_id?:number, options?: CloseTabOptions) {
       if (this.activeTab) this.close(this.activeTab, options)
     },
-    async createTab(config: TabTypeConfig) {
+    async createTab(config: TabTypeConfig.Config) {
       if (config.type === "query") {
         this.createQuery()
       } else if (config.type === "shell") {
         this.createShell()
-      } else if (config.type === "plugin-shell") {
+      } else if (config.type === "plugin-shell" || config.type === "plugin-base") {
         let tNum = 0;
         let title = config.name;
         do {
@@ -672,7 +680,7 @@ export default Vue.extend({
             pluginId: config.pluginId,
             pluginTabTypeId: config.pluginTabTypeId,
           },
-        } as TransportPluginShellTab;
+        } as TransportPluginTab;
         await this.addTab(tab)
       }
     },

--- a/apps/studio/src/components/TabPluginBase.vue
+++ b/apps/studio/src/components/TabPluginBase.vue
@@ -1,0 +1,80 @@
+<template>
+  <div v-if="isCommunity && tab.context.pluginId === 'bks-ai-shell'" class="tab-upsell-wrapper">
+    <upsell-content />
+  </div>
+  <div v-else class="plugin-base" ref="container">
+    <isolated-plugin-view
+      :visible="active"
+      :plugin-id="tab.context.pluginId"
+      :url="url"
+      :reload="reload"
+      :on-request="handleRequest"
+      :command="tab.context.command"
+      :args="tab.context.args"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { PropType } from "vue";
+import { TransportPluginTab } from "@/common/transport/TransportOpenTab";
+import IsolatedPluginView from "@/components/plugins/IsolatedPluginView.vue";
+import Vue from "vue";
+import { mapGetters } from "vuex";
+import UpsellContent from "@/components/upsell/UpsellContent.vue";
+import { OnViewRequestListenerParams } from "@/services/plugin/types";
+
+export default Vue.extend({
+  components: {
+    IsolatedPluginView,
+    UpsellContent,
+  },
+
+  props: {
+    tab: {
+      type: Object as PropType<TransportPluginTab>,
+      required: true,
+    },
+    active: Boolean,
+    reload: null,
+  },
+
+  computed: {
+    ...mapGetters(["isCommunity"]),
+    url() {
+      const manifest = this.$plugin.manifestOf(this.tab.context.pluginId);
+      const tabType = manifest.capabilities.views.find(
+        (v) => v.id === this.tab.context.pluginTabTypeId
+      );
+      return this.$plugin.buildUrlFor(this.tab.context.pluginId, tabType.entry);
+    },
+  },
+
+  methods: {
+    async handleRequest({
+      request,
+      modifyResult,
+    }: OnViewRequestListenerParams) {
+      switch (request.name) {
+        case "setTabTitle": {
+          if (!request.args.title) {
+            throw new Error("Tab title is required");
+          }
+          this.tab.title = request.args.title;
+          await this.$store.dispatch("tabs/save", this.tab);
+          break;
+        }
+        case "getViewState": {
+          modifyResult(() => this.tab.context.state);
+          break;
+        }
+        case "setViewState": {
+          this.tab.context.state = request.args.state;
+          await this.$store.dispatch("tabs/save", this.tab);
+          break;
+        }
+      }
+    },
+  },
+});
+</script>

--- a/apps/studio/src/components/TabPluginShell.vue
+++ b/apps/studio/src/components/TabPluginShell.vue
@@ -82,7 +82,7 @@ import ShortcutHints from "@/components/editor/ShortcutHints.vue";
 import QueryEditorStatusBar from "@/components/editor/QueryEditorStatusBar.vue";
 import ErrorAlert from "@/components/common/ErrorAlert.vue";
 import { PropType } from "vue";
-import { TransportPluginShellTab } from "@/common/transport/TransportOpenTab";
+import { TransportPluginTab } from "@/common/transport/TransportOpenTab";
 import IsolatedPluginView from "@/components/plugins/IsolatedPluginView.vue";
 import Vue from "vue";
 import { mapGetters } from "vuex";
@@ -102,7 +102,7 @@ export default Vue.extend({
   },
   props: {
     tab: {
-      type: Object as PropType<TransportPluginShellTab>,
+      type: Object as PropType<TransportPluginTab>,
       required: true,
     },
     active: Boolean,

--- a/apps/studio/src/services/plugin/types.ts
+++ b/apps/studio/src/services/plugin/types.ts
@@ -3,11 +3,12 @@ import { PluginRequestData, PluginResponseData } from "@beekeeperstudio/plugin";
 /**
  * The kind of the tab. There is only one kind currently:
  *
- * - `shell`: Like a query tab. This tab has two main parts; A plugin's
+ * - `base-tab`: A plain tab with no special UI.
+ * - `shell-tab`: Like a query tab. This tab has two main parts; A plugin's
  *   `<iframe>` (placed at the top), and a table component (placed at the
  *   bottom). The table can be collapsed completely.
  **/
-export type TabKind = "shell";
+export type TabType = "shell" | "base";
 
 export type View = {
   /** The id of the view.
@@ -16,7 +17,7 @@ export type View = {
   /** The name of the view that will be displayed in the UI */
   name: string;
   /** The type of the view. */
-  type: "primary-sidebar" | "secondary-sidebar" | "shell-tab" | "plain-tab";
+  type: `${TabType}-tab`;
     /** The html entry point of the view. For example, `index.html`. */
   entry: string;
 }
@@ -44,7 +45,7 @@ export interface Manifest {
       tabTypes?: {
         id: string;
         name: string;
-        kind: TabKind;
+        kind: TabType;
         /** Same as `entry` above. */
         entry: string;
       }[];

--- a/apps/studio/src/services/plugin/web/PluginStoreService.ts
+++ b/apps/studio/src/services/plugin/web/PluginStoreService.ts
@@ -15,12 +15,12 @@ import {
   TabResponse,
   ThemeChangedNotification,
 } from "@beekeeperstudio/plugin";
-import { findTable } from "@/common/transport/TransportOpenTab";
+import { findTable, PluginTabType } from "@/common/transport/TransportOpenTab";
 import { AppEvent } from "@/common/AppEvent";
 import { NgQueryResult } from "@/lib/db/models";
 import _ from "lodash";
 import { SidebarTab } from "@/store/modules/SidebarModule";
-import { TabKind } from "../types";
+import { TabType } from "../types";
 
 /**
  * Service that provides an interface to the plugin Vuex module
@@ -197,10 +197,10 @@ export default class PluginStoreService {
     pluginId: string;
     pluginTabTypeId: string;
     name: string;
-    kind: TabKind;
+    kind: TabType;
     icon?: string;
   }): void {
-    const config: TabTypeConfig.PluginShellConfig = {
+    const config: TabTypeConfig.PluginConfig = {
       type: `plugin-${params.kind}` as const,
       name: params.name,
       pluginId: params.pluginId,
@@ -211,7 +211,7 @@ export default class PluginStoreService {
     this.store.commit("tabs/addTabTypeConfig", config);
   }
 
-  removeTabTypeConfig(identifier: TabTypeConfig.PluginShellConfigIdentifiers): void {
+  removeTabTypeConfig(identifier: TabTypeConfig.PluginRef): void {
     this.store.commit("tabs/removeTabTypeConfig", identifier);
   }
 
@@ -246,12 +246,8 @@ export default class PluginStoreService {
   async getColumns(
     tableName: string,
     schema?: string
-  ): Promise<GetColumnsResponse> {
-    const table = this.findTable(tableName, schema);
-
-    if (!table) {
-      throw new Error(`Table ${tableName} not found`);
-    }
+  ): Promise<GetColumnsResponse['result']> {
+    const table = this.findTableOrThrow(tableName, schema);
 
     if (!table.columns || table.columns.length === 0) {
       await this.store.dispatch("updateTableColumns", table);

--- a/apps/studio/src/store/modules/TabModule.ts
+++ b/apps/studio/src/store/modules/TabModule.ts
@@ -41,7 +41,7 @@ export const TabModule: Module<State, RootState> = {
         if (tab.type === "shell" && rootGetters.dialectData?.disabledFeatures?.shell) {
           return false;
         }
-        if (tab.type === "plugin-shell") {
+        if (tab.type === "plugin-shell" || tab.type === "plugin-base") {
           return !window.bksConfig.get(`plugins.${tab.pluginId}.disabled`);
         }
         return true;
@@ -96,13 +96,13 @@ export const TabModule: Module<State, RootState> = {
       state.tabs = tabs
     },
 
-    addTabTypeConfig(state, newConfig: TabTypeConfig.PluginShellConfig) {
+    addTabTypeConfig(state, newConfig: TabTypeConfig.PluginConfig) {
       state.allTabTypeConfigs.push(newConfig)
     },
 
-    removeTabTypeConfig(state, config: TabTypeConfig.PluginShellConfig) {
-      state.allTabTypeConfigs = state.allTabTypeConfigs.filter((t: TabTypeConfig.PluginShellConfig) => {
-        if (t.type !== "plugin-shell") {
+    removeTabTypeConfig(state, config: TabTypeConfig.PluginConfig) {
+      state.allTabTypeConfigs = state.allTabTypeConfigs.filter((t: TabTypeConfig.PluginConfig) => {
+        if (t.type !== "plugin-shell" && t.type !== "plugin-base") {
           return true;
         }
         const matches = t.pluginId === config.pluginId && t.pluginTabTypeId === config.pluginTabTypeId

--- a/docs/plugin_development/manifest.md
+++ b/docs/plugin_development/manifest.md
@@ -85,7 +85,7 @@ The `manifest.json` file defines your plugin's metadata, capabilities, settings,
 | Value                 | Description                                                                            |
 | --------------------- | -------------------------------------------------------------------------------------- |
 | `"shell-tab"`         | Tab with your plugin's iframe at the top and a collapsible result table at the bottom. |
-| `"plain-tab"`         | Full-tab interface. _(Planned for future releases)_                                    |
+| `"base-tab"`          | Full-tab interface.                                                                    |
 | `"primary-sidebar"`   | Primary sidebar panel. _(Planned for future releases)_                                 |
 | `"secondary-sidebar"` | Secondary sidebar panel. _(Planned for future releases)_                               |
 


### PR DESCRIPTION
Plugins can now have two options of view:
- `shell`: used by AI Shell. It has result table at the bottom, and other elements at statusbar. The result table can be in sync with JSON sidebar.
- `base`: No other elements exist. Just the plugin.