### PR TITLE
Fix plugins can lose their states when switching tabs

### DIFF
--- a/apps/studio/src/components/plugins/IsolatedPluginView.vue
+++ b/apps/studio/src/components/plugins/IsolatedPluginView.vue
@@ -31,6 +31,7 @@ export default Vue.extend({
   data() {
     return {
       loaded: false,
+      mounted: false,
       // Use a timestamp parameter to force iframe refresh
       timestamp: Date.now(),
       unsubscribe: null,
@@ -44,7 +45,11 @@ export default Vue.extend({
       // FIXME move this somewhere
       return `${this.url}?timestamp=${this.timestamp}`;
     },
-    showIframe() {
+    shouldMountIframe() {
+      // If it's already mounted, do not unmount it unless it's not loaded
+      if (this.mounted) {
+        return this.loaded;
+      }
       return this.visible && this.loaded;
     },
   },
@@ -52,10 +57,10 @@ export default Vue.extend({
     reload() {
       this.timestamp = Date.now();
     },
-    showIframe: {
+    shouldMountIframe: {
       async handler() {
         await this.$nextTick();
-        if (this.showIframe) {
+        if (this.shouldMountIframe) {
           this.mountIframe();
         } else {
           this.unmountIframe();
@@ -83,6 +88,7 @@ export default Vue.extend({
       });
       this.$refs.container.appendChild(iframe);
       this.iframe = iframe;
+      this.mounted = true;
     },
     unmountIframe() {
       if (!this.iframe) {
@@ -93,6 +99,7 @@ export default Vue.extend({
       this.unsubscribe?.();
       this.iframe.remove();
       this.iframe = null;
+      this.mounted = false;
     },
     handleError(e) {
       console.error(`${this.pluginId} iframe error`, e);


### PR DESCRIPTION
This PR prevents plugin iframes to be destroyed when users switch tab.

NOTE: The behavior of iframes not mounted when it hasn't been focused (for the first time) is kept.