### PR TITLE
Fix plugin postMessage and add broadcast API

### DIFF
--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -104,13 +104,13 @@ export default class WebPluginManager {
     if (!loader) {
       throw new Error("Plugin not found: " + pluginId);
     }
-    loader.postMessage(data);
+    loader.broadcast(data);
   }
 
   /** Send a notification to all plugins */
   async notifyAll(data: PluginNotificationData) {
     this.loaders.forEach((loader) => {
-      loader.postMessage(data);
+      loader.broadcast(data);
     })
   }
 


### PR DESCRIPTION
This PR fixes the API responses and notifications that are always sent to all views. So if there is one view that does a request, the response will be sent to all views instead of that one view specifically. 

In addition to that, this PR also adds a new `broadcast` API that lets Views to communicate with other Views of the same plugin, sort of like event bus and [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) (but it doesn't use the BroadcastChannel API).

```js
// View A

import { notify } from "@beekeeperstudio/plugin";

notify("broadcast", {
  message: "Can you hear me?", // message can be any json value
})
```

```js
// View B

import { addNotificationListener } from "@beekeeperstudio/plugin";

addNotificationListener("broadcast", ({ message }) => {
  console.log(message); // Can you hear me?
})
```

NOTE: `View A` notifications are sent to other views and not to itself.