### PR TITLE
Less distracting JSON Viewer error lines

### DIFF
--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -268,7 +268,7 @@
   // Marker styles
   .cm-error {
     background-color: var(--bks-text-editor-error-bg-color);
-    border-bottom: 2px dashed var(--bks-text-editor-error-fg-color);
+    border-bottom: 1px solid var(--bks-text-editor-error-fg-color);
     border-radius: 2px;
   }
 


### PR DESCRIPTION
**Before**
<img width="226" height="162" alt="2025-09-18-162020_226x162_scrot" src="https://github.com/user-attachments/assets/659d1662-3295-4547-9f54-72886cec7521" />

**After**
<img width="231" height="165" alt="2025-09-18-161532_231x165_scrot" src="https://github.com/user-attachments/assets/526cd57e-e5a5-407d-908e-dfabe0f08d10" />
