### PR TITLE
fix hardcoded tab type

### DIFF
--- a/apps/studio/src/services/plugin/web/PluginStoreService.ts
+++ b/apps/studio/src/services/plugin/web/PluginStoreService.ts
@@ -453,8 +453,14 @@ export default class PluginStoreService {
       title = `${options.manifest.name} #${tNum}`;
     } while (tabItems.filter((t) => t.title === title).length > 0);
 
+    const views = options.manifest.capabilities.views as PluginView[];
+    const view = views.find((v) => v.id === options.viewId);
+    const tabType: PluginTabType = view.type.includes("shell")
+      ? "plugin-shell"
+      : "plugin-base";
+
     return {
-      tabType: "plugin-shell", // FIXME(azmi): We only support shell for now
+      tabType,
       title: options.manifest.name,
       unsavedChanges: false,
       context: {


### PR DESCRIPTION
We can't hardcode this because we now support two types:
- plain tab
- shell tab

This also fixes tab icon for plugins that are not registered correctly:

<img width="204" height="67" alt="2025-09-18-193728_204x67_scrot" src="https://github.com/user-attachments/assets/5f17d5f8-bfd6-430a-bc75-ee8917bf77a1" />
