### PR TITLE
some used configs are not passed to the `buildCompletionLevels`

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -638,7 +638,7 @@
         if (this.dialectData.textEditorMode === 'text/x-redis') {
           return 'redis';
         }
-        return 'sql'; // default for all SQL databases
+        return this.dialectData.textEditorMode;
       },
       replaceExtensions() {
         return (extensions) => {

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
@@ -9,11 +9,20 @@ import {
   SQLExtensionsConfig,
 } from "./extensions";
 import { ExtensionConfiguration } from "../text-editor/types";
+import { Cassandra, MySQL, PostgreSQL, SQLite, StandardSQL } from "@codemirror/lang-sql";
 
 export interface CompletionSource {
   defaultSchema?: string;
   entities: Entity[];
 }
+
+const langIdToDialect = {
+  "text/x-sql": StandardSQL,
+  "text/x-pgsql": PostgreSQL,
+  "text/x-mysql": MySQL,
+  "text/x-cassandra": Cassandra,
+  "text/x-sqlite": SQLite,
+};
 
 export class SqlTextEditor extends TextEditor {
   private extensionsConfig: SQLExtensionsConfig;
@@ -55,7 +64,10 @@ export class SqlTextEditor extends TextEditor {
     const baseExtensions = super.getExtensions(config);
     return [
       baseExtensions,
-      sqlExtensions(this.extensionsConfig),
+      sqlExtensions({
+        ...this.extensionsConfig,
+        dialect: langIdToDialect[config.languageId] || StandardSQL,
+      }),
     ];
   }
 }

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
@@ -306,8 +306,16 @@ export const completionLevels = StateField.define<{use: boolean; top: Completion
   update(value, tr) {
     for (let e of tr.effects) {
       if (e.is(setSchema)) {
+        const config = tr.state.facet(completeConfig);
         return {
-          ...buildCompletionLevels(e.value),
+          ...buildCompletionLevels(
+            e.value,
+            undefined,
+            undefined,
+            config.defaultTableName,
+            config.defaultSchemaName,
+            config.dialect
+          ),
           // HACK: Use when setSchema is triggered
           use: true,
         }
@@ -315,6 +323,19 @@ export const completionLevels = StateField.define<{use: boolean; top: Completion
     }
     return value;
   },
+});
+
+type SupportedCompleteConfig = {
+  defaultTableName?: string;
+  defaultSchemaName?: string;
+  dialect?: SQLDialect;
+}
+
+export const completeConfig = Facet.define<
+  SupportedCompleteConfig,
+  SupportedCompleteConfig
+>({
+  combine: (values) => values.reduce((a, b) => ({ ...a, ...b }), {}),
 });
 
 // Some of this is more gnarly than it has to be because we're also

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/sql.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/sql.ts
@@ -1,5 +1,5 @@
 import { keywordCompletionSource, SQLConfig, StandardSQL } from "@codemirror/lang-sql"
-import { completeFromSchema, completionLevels } from "./complete"
+import { completeFromSchema, completionLevels, completeConfig } from "./complete"
 import { Extension } from "@codemirror/state"
 import { CompletionSource } from "@codemirror/autocomplete"
 import { LanguageSupport } from "@codemirror/language"
@@ -14,7 +14,11 @@ export function schemaCompletionSource(config: SQLConfig): CompletionSource {
 }
 
 function schemaCompletion(config: SQLConfig): Extension {
-  return config.schema ? [completionLevels, (config.dialect || StandardSQL).language.data.of({
+  return config.schema ? [completionLevels, completeConfig.of({
+    defaultTableName: config.defaultTable,
+    defaultSchemaName: config.defaultSchema,
+    dialect: config.dialect || StandardSQL,
+  }), (config.dialect || StandardSQL).language.data.of({
     autocomplete: schemaCompletionSource(config)
   })] : []
 }


### PR DESCRIPTION
This issue causes MySQL to use `"` (double quotes) instead of  `` ` `` (backticks).