### PR TITLE
feat: Unified search bar for JSON 🔥🔥🔥🔥

### DIFF
--- a/apps/studio/src-commercial/entrypoints/renderer.ts
+++ b/apps/studio/src-commercial/entrypoints/renderer.ts
@@ -40,6 +40,8 @@ import { ForeignCacheTabulatorModule } from '@/plugins/ForeignCacheTabulatorModu
 import { WebPluginManager } from '@/services/plugin/web'
 import PluginStoreService from '@/services/plugin/web/PluginStoreService'
 import * as UIKit from '@beekeeperstudio/ui-kit'
+// Import for side effects: enhances CodeMirror search panel UI (hides replace row, injects 3-dots menu, auto-opens search/focuses find box in JSON viewer)
+import '@/search-panel-ui-toggle'
 
 (async () => {
 

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -1,5 +1,73 @@
 @import "./text-editor-plugins/partial-read-only.scss";
 
+// Shared search panel UI variables and mixins
+$bks-toggle-size: 20px !default;
+$bks-toggle-radius: 4px !default;
+$bks-toggle-gap-x: 2px !default;
+
+@mixin bks-toggle-label() {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0;
+  margin: 0 $bks-toggle-gap-x 0 0;
+  color: transparent;
+  font-size: 0; // prevent hidden text from occupying space
+  white-space: nowrap;
+  user-select: none;
+}
+@mixin bks-toggle-input() {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+@mixin bks-toggle-box-base() {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $bks-toggle-size;
+  height: $bks-toggle-size;
+  border-radius: $bks-toggle-radius;
+  border: 1px solid rgba($theme-base, 0.32);
+  background: transparent;
+  color: rgba($theme-base, 0.9);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+// Tooltip helper for icon-only controls
+@mixin bks-hover-tooltip($text) {
+  &::before {
+    content: $text;
+    position: absolute;
+    left: 50%;
+    top: calc(100% + 8px);
+    transform: translateX(-50%) translateY(-2px);
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 3px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    z-index: 10;
+    transition: opacity 120ms ease, transform 120ms ease, visibility 120ms linear;
+  }
+  &:hover::before {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 .BksTextEditor {
   padding: 0.75rem 0;
   &.remove-json-root-brackets .CodeMirror-code {
@@ -29,5 +97,345 @@
     text-decoration-line: underline;
     text-decoration-style: wavy;
     text-decoration-color: rgba($brand-danger, 0.6);
+  }
+
+  // Hide specific CodeMirror search panel controls
+  // Keep search/replace working via shortcuts, just remove these UI buttons
+  .cm-panel.cm-search {
+    // Lay out controls responsively
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px;
+    overflow: visible; // allow tooltips to render outside
+
+    // Make text fields (find/replace) flex to fill available space
+    > input[type="text"],
+    > input.cm-textfield,
+    > .cm-textfield {
+      flex: 1 1 280px;
+      min-width: 140px;
+      max-width: none;
+    }
+    // Remove default left spacing on checkbox labels inside search panel
+    label:has(> input[type="checkbox"]) {
+      margin-left: 0 !important;
+      padding-left: 0 !important;
+    }
+
+    button[name="next"],
+    button[name="prev"],
+    button[name="replaceAll"],
+    button[name="all"],
+    button[name="select"],
+    button[name="selectMatches"],
+    button[name="selectAll"],
+    button[name="close"],
+    .cm-button[name="next"],
+    .cm-button[name="prev"],
+    .cm-button[name="replaceAll"],
+    .cm-button[name="all"],
+    .cm-button[name="select"],
+    .cm-button[name="selectMatches"],
+    .cm-button[name="selectAll"],
+    .cm-button[name="close"],
+    button[aria-label*="all" i],
+    .cm-button[aria-label*="all" i],
+    button[title*="all" i],
+    .cm-button[title*="all" i],
+    button[aria-label*="select" i],
+    .cm-button[aria-label*="select" i],
+    button[title*="select" i],
+    .cm-button[title*="select" i],
+    button[aria-label*="close" i],
+    .cm-button[aria-label*="close" i],
+    button[title*="close" i],
+    .cm-button[title*="close" i] {
+      display: none !important;
+    }
+
+    // Push replace icons to rightmost, and keep them last in flow
+    button[name="replace"],
+    .cm-button[name="replace"],
+    button[aria-label="replace" i],
+    .cm-button[aria-label="replace" i] {
+      order: 100;
+      margin-left: auto; // consumes remaining space to push to right
+    }
+    button[name="replaceAll"],
+    .cm-button[name="replaceAll"],
+    button[aria-label*="replace all" i],
+    .cm-button[aria-label*="replace all" i] {
+      order: 101; // ensure it sits just after Replace
+    }
+
+    // Kebab menu button on the far right
+    .bks-json-menu {
+      order: 102;
+      margin-left: 2px;
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: auto;
+      height: auto;
+      min-width: 0;
+      min-height: 0;
+      border: 0;
+      background: transparent;
+      cursor: pointer;
+      line-height: 1;
+      padding: 0;
+      @include bks-hover-tooltip("More options");
+    }
+    .bks-json-menu::after {
+      content: "⋮"; // Unicode vertical ellipsis
+      font-size: 12px;
+      line-height: 1;
+      color: rgba($theme-base, 0.9);
+    }
+    .bks-json-menu:hover { background: rgba($theme-base, 0.06); }
+    .bks-json-menu:focus-visible { outline: 2px solid rgba($theme-base, 0.5); outline-offset: 2px; }
+    .bks-json-menu.open { background: rgba($theme-base, 0.08); }
+    .bks-json-menu-popover {
+      position: absolute;
+      top: calc(100% + 6px);
+      right: 0;
+      min-width: 200px;
+      background: #1f1f1f;
+      color: #fff;
+      border: 1px solid rgba($theme-base, 0.25);
+      border-radius: 6px;
+      padding: 4px;
+      display: none;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+      z-index: 100;
+    }
+    .bks-json-menu.open > .bks-json-menu-popover { display: block; }
+    .bks-json-menu-item {
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      color: inherit;
+      border: 0;
+      border-radius: 4px;
+      padding: 6px 8px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .bks-json-menu-item:hover { background: rgba(255,255,255,0.08); }
+
+    // When toggled off, hide replace controls (UI only)
+    &.bks-hide-replace {
+      // Hide the second text field and replace buttons
+      > input[type="text"]:nth-of-type(2),
+      > input.cm-textfield:nth-of-type(2),
+      > .cm-textfield:nth-of-type(2),
+      button[name="replace"],
+      .cm-button[name="replace"],
+      button[name="replaceAll"],
+      .cm-button[name="replaceAll"] {
+        display: none !important;
+      }
+    }
+
+    // (tooltip mixin defined globally)
+
+    // Show Replace and Replace All using the same box style as toggles
+    // Replace
+    button[name="replace"],
+    .cm-button[name="replace"],
+    button[aria-label="replace" i],
+    .cm-button[aria-label="replace" i] {
+      display: inline-flex !important;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 $bks-toggle-size;
+      width: $bks-toggle-size;
+      height: $bks-toggle-size;
+      min-width: $bks-toggle-size;
+      max-width: $bks-toggle-size;
+      min-height: $bks-toggle-size;
+      max-height: $bks-toggle-size;
+      box-sizing: border-box;
+      margin: 0 $bks-toggle-gap-x 0 0;
+      padding: 0;
+      border-radius: $bks-toggle-radius;
+      border: 1px solid rgba($theme-base, 0.32);
+      background: transparent;
+      font-size: 0; // hide text label
+      line-height: 0; // prevent baseline from adding height
+      overflow: hidden; // prevent hidden text from reserving space
+      white-space: nowrap;
+      cursor: pointer;
+      transition: background-color 120ms ease, border-color 120ms ease;
+      position: relative;
+      @include bks-hover-tooltip("Replace");
+    }
+    button[name="replace"]::after,
+    .cm-button[name="replace"]::after,
+    button[aria-label="replace" i]::after,
+    .cm-button[aria-label="replace" i]::after {
+      content: "redo";
+      font-family: "Material Icons";
+      font-weight: normal;
+      font-style: normal;
+      font-size: 12px; // match toggle glyph size
+      line-height: 1;
+      letter-spacing: normal;
+      text-transform: none;
+      display: inline-block;
+      white-space: nowrap;
+      word-wrap: normal;
+      direction: ltr;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      font-feature-settings: "liga";
+      color: rgba($theme-base, 0.9);
+    }
+    button[name="replace"]:hover,
+    .cm-button[name="replace"]:hover,
+    button[aria-label="replace" i]:hover,
+    .cm-button[aria-label="replace" i]:hover {
+      border-color: rgba($theme-base, 0.5);
+      background: rgba($theme-base, 0.06);
+    }
+    button[name="replace"]:focus-visible,
+    .cm-button[name="replace"]:focus-visible,
+    button[aria-label="replace" i]:focus-visible,
+    .cm-button[aria-label="replace" i]:focus-visible {
+      outline: 2px solid rgba($theme-base, 0.5);
+      outline-offset: 2px;
+    }
+
+    // Replace All
+    // Re-enable visibility if previously hidden by generic rules
+    button[name="replaceAll"],
+    .cm-button[name="replaceAll"],
+    button[aria-label*="replace all" i],
+    .cm-button[aria-label*="replace all" i] {
+      display: inline-flex !important;
+      align-items: center;
+      justify-content: center;
+      flex: 0 0 $bks-toggle-size;
+      width: $bks-toggle-size;
+      height: $bks-toggle-size;
+      min-width: $bks-toggle-size;
+      max-width: $bks-toggle-size;
+      min-height: $bks-toggle-size;
+      max-height: $bks-toggle-size;
+      box-sizing: border-box;
+      margin: 0 $bks-toggle-gap-x 0 0;
+      padding: 0;
+      border-radius: $bks-toggle-radius;
+      border: 1px solid rgba($theme-base, 0.32);
+      background: transparent;
+      font-size: 0; // hide text label
+      line-height: 0; // prevent baseline from adding height
+      overflow: hidden; // prevent hidden text from reserving space
+      white-space: nowrap;
+      cursor: pointer;
+      transition: background-color 120ms ease, border-color 120ms ease;
+      position: relative;
+      @include bks-hover-tooltip("Replace All");
+    }
+    button[name="replaceAll"]::after,
+    .cm-button[name="replaceAll"]::after,
+    button[aria-label*="replace all" i]::after,
+    .cm-button[aria-label*="replace all" i]::after {
+      content: "find_replace";
+      font-family: "Material Icons";
+      font-weight: normal;
+      font-style: normal;
+      font-size: 12px; // match toggle glyph size
+      line-height: 1;
+      letter-spacing: normal;
+      text-transform: none;
+      display: inline-block;
+      white-space: nowrap;
+      word-wrap: normal;
+      direction: ltr;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      font-feature-settings: "liga";
+      color: rgba($theme-base, 0.9);
+    }
+    button[name="replaceAll"]:hover,
+    .cm-button[name="replaceAll"]:hover,
+    button[aria-label*="replace all" i]:hover,
+    .cm-button[aria-label*="replace all" i]:hover {
+      border-color: rgba($theme-base, 0.5);
+      background: rgba($theme-base, 0.06);
+    }
+    button[name="replaceAll"]:focus-visible,
+    .cm-button[name="replaceAll"]:focus-visible,
+    button[aria-label*="replace all" i]:focus-visible,
+    .cm-button[aria-label*="replace all" i]:focus-visible {
+      outline: 2px solid rgba($theme-base, 0.5);
+      outline-offset: 2px;
+    }
+
+    // Common label styling
+    label:has(> input[name="case"]),
+    label:has(> input[name="regexp"]),
+    label:has(> input[name="re"]),
+    label:has(> input[name="word"]),
+    label:has(> input[name="whole"]) {
+      @include bks-toggle-label();
+    }
+    // Tooltips for the three search toggles
+    label:has(> input[name="case"]) { @include bks-hover-tooltip("Match Case"); }
+    label:has(> input[name="regexp"]),
+    label:has(> input[name="re"]) { @include bks-hover-tooltip("Use Regular Expression"); }
+    label:has(> input[name="word"]),
+    label:has(> input[name="whole"]) { @include bks-hover-tooltip("Match Whole Word"); }
+    // Hide native inputs (but keep interactive)
+    label:has(> input[name="case"]) > input[type="checkbox"],
+    label:has(> input[name="regexp"]) > input[type="checkbox"],
+    label:has(> input[name="re"]) > input[type="checkbox"],
+    label:has(> input[name="word"]) > input[type="checkbox"],
+    label:has(> input[name="whole"]) > input[type="checkbox"] {
+      @include bks-toggle-input();
+    }
+    // Common box base
+    label:has(> input[name="case"])::after,
+    label:has(> input[name="regexp"])::after,
+    label:has(> input[name="re"])::after,
+    label:has(> input[name="word"])::after,
+    label:has(> input[name="whole"])::after {
+      @include bks-toggle-box-base();
+    }
+    // Specific glyphs
+    label:has(> input[name="case"])::after { content: "Aa"; padding-bottom: 1px; }
+    label:has(> input[name="regexp"])::after,
+    label:has(> input[name="re"])::after { content: ".*"; }
+    label:has(> input[name="word"])::after,
+    label:has(> input[name="whole"])::after { content: "ab"; }
+
+    // States
+    label:has(> input[name="case"]):hover::after,
+    label:has(> input[name="regexp"]):hover::after,
+    label:has(> input[name="re"]):hover::after,
+    label:has(> input[name="word"]):hover::after,
+    label:has(> input[name="whole"]):hover::after {
+      border-color: rgba($theme-base, 0.5);
+      background: rgba($theme-base, 0.06);
+    }
+    label:has(> input[name="case"]:focus-visible)::after,
+    label:has(> input[name="regexp"]:focus-visible)::after,
+    label:has(> input[name="re"]:focus-visible)::after,
+    label:has(> input[name="word"]:focus-visible)::after,
+    label:has(> input[name="whole"]:focus-visible)::after {
+      outline: 2px solid rgba($theme-base, 0.5);
+      outline-offset: 2px;
+    }
+    label:has(> input[name="case"]:checked)::after,
+    label:has(> input[name="regexp"]:checked)::after,
+    label:has(> input[name="re"]:checked)::after,
+    label:has(> input[name="word"]:checked)::after,
+    label:has(> input[name="whole"]:checked)::after {
+      background: rgba($theme-base, 0.18);
+      border-color: rgba($theme-base, 0.55);
+    }
   }
 }

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -100,16 +100,12 @@ $bks-toggle-gap-x: 2px !default;
   }
 
   // Hide specific CodeMirror search panel controls
-  // Keep search/replace working via shortcuts, just remove these UI buttons
   .cm-panel.cm-search {
-    // Lay out controls responsively
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 4px;
-    overflow: visible; // allow tooltips to render outside
-
-    // Make text fields (find/replace) flex to fill available space
+    overflow: visible; 
     > input[type="text"],
     > input.cm-textfield,
     > .cm-textfield {
@@ -117,12 +113,10 @@ $bks-toggle-gap-x: 2px !default;
       min-width: 140px;
       max-width: none;
     }
-    // Remove default left spacing on checkbox labels inside search panel
     label:has(> input[type="checkbox"]) {
       margin-left: 0 !important;
       padding-left: 0 !important;
     }
-
     button[name="next"],
     button[name="prev"],
     button[name="replaceAll"],
@@ -154,22 +148,20 @@ $bks-toggle-gap-x: 2px !default;
       display: none !important;
     }
 
-    // Push replace icons to rightmost, and keep them last in flow
     button[name="replace"],
     .cm-button[name="replace"],
     button[aria-label="replace" i],
     .cm-button[aria-label="replace" i] {
       order: 100;
-      margin-left: auto; // consumes remaining space to push to right
+      margin-left: auto; 
     }
     button[name="replaceAll"],
     .cm-button[name="replaceAll"],
     button[aria-label*="replace all" i],
     .cm-button[aria-label*="replace all" i] {
-      order: 101; // ensure it sits just after Replace
+      order: 101; 
     }
 
-    // Kebab menu button on the far right
     .bks-json-menu {
       order: 102;
       margin-left: 2px;
@@ -189,7 +181,7 @@ $bks-toggle-gap-x: 2px !default;
       @include bks-hover-tooltip("More options");
     }
     .bks-json-menu::after {
-      content: "⋮"; // Unicode vertical ellipsis
+      content: "⋮"; 
       font-size: 12px;
       line-height: 1;
       color: rgba($theme-base, 0.9);
@@ -227,7 +219,6 @@ $bks-toggle-gap-x: 2px !default;
 
     // When toggled off, hide replace controls (UI only)
     &.bks-hide-replace {
-      // Hide the second text field and replace buttons
       > input[type="text"]:nth-of-type(2),
       > input.cm-textfield:nth-of-type(2),
       > .cm-textfield:nth-of-type(2),
@@ -264,8 +255,8 @@ $bks-toggle-gap-x: 2px !default;
       border: 1px solid rgba($theme-base, 0.32);
       background: transparent;
       font-size: 0; // hide text label
-      line-height: 0; // prevent baseline from adding height
-      overflow: hidden; // prevent hidden text from reserving space
+      line-height: 0; 
+      overflow: hidden; 
       white-space: nowrap;
       cursor: pointer;
       transition: background-color 120ms ease, border-color 120ms ease;
@@ -280,7 +271,7 @@ $bks-toggle-gap-x: 2px !default;
       font-family: "Material Icons";
       font-weight: normal;
       font-style: normal;
-      font-size: 12px; // match toggle glyph size
+      font-size: 12px; 
       line-height: 1;
       letter-spacing: normal;
       text-transform: none;
@@ -308,8 +299,6 @@ $bks-toggle-gap-x: 2px !default;
       outline-offset: 2px;
     }
 
-    // Replace All
-    // Re-enable visibility if previously hidden by generic rules
     button[name="replaceAll"],
     .cm-button[name="replaceAll"],
     button[aria-label*="replace all" i],
@@ -331,8 +320,8 @@ $bks-toggle-gap-x: 2px !default;
       border: 1px solid rgba($theme-base, 0.32);
       background: transparent;
       font-size: 0; // hide text label
-      line-height: 0; // prevent baseline from adding height
-      overflow: hidden; // prevent hidden text from reserving space
+      line-height: 0; 
+      overflow: hidden; 
       white-space: nowrap;
       cursor: pointer;
       transition: background-color 120ms ease, border-color 120ms ease;
@@ -347,7 +336,7 @@ $bks-toggle-gap-x: 2px !default;
       font-family: "Material Icons";
       font-weight: normal;
       font-style: normal;
-      font-size: 12px; // match toggle glyph size
+      font-size: 12px; 
       line-height: 1;
       letter-spacing: normal;
       text-transform: none;
@@ -375,7 +364,6 @@ $bks-toggle-gap-x: 2px !default;
       outline-offset: 2px;
     }
 
-    // Common label styling
     label:has(> input[name="case"]),
     label:has(> input[name="regexp"]),
     label:has(> input[name="re"]),
@@ -383,13 +371,13 @@ $bks-toggle-gap-x: 2px !default;
     label:has(> input[name="whole"]) {
       @include bks-toggle-label();
     }
-    // Tooltips for the three search toggles
+
     label:has(> input[name="case"]) { @include bks-hover-tooltip("Match Case"); }
     label:has(> input[name="regexp"]),
     label:has(> input[name="re"]) { @include bks-hover-tooltip("Use Regular Expression"); }
     label:has(> input[name="word"]),
     label:has(> input[name="whole"]) { @include bks-hover-tooltip("Match Whole Word"); }
-    // Hide native inputs (but keep interactive)
+
     label:has(> input[name="case"]) > input[type="checkbox"],
     label:has(> input[name="regexp"]) > input[type="checkbox"],
     label:has(> input[name="re"]) > input[type="checkbox"],

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -1,3 +1,40 @@
+// --- Common Button and Toggle Mixins ---
+@mixin bks-icon-btn($tooltip) {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 $bks-toggle-size;
+  width: $bks-toggle-size;
+  height: $bks-toggle-size;
+  min-width: $bks-toggle-size;
+  max-width: $bks-toggle-size;
+  min-height: $bks-toggle-size;
+  max-height: $bks-toggle-size;
+  box-sizing: border-box;
+  margin: 0 $bks-toggle-gap-x 0 0;
+  padding: 0;
+  border-radius: $bks-toggle-radius;
+  border: 1px solid rgba($theme-base, 0.32);
+  background: transparent;
+  font-size: 0; // hide text label
+  line-height: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms ease, border-color 120ms ease;
+  position: relative;
+  @include bks-hover-tooltip($tooltip);
+}
+
+@mixin bks-icon-btn-hover {
+  border-color: rgba($theme-base, 0.5);
+  background: rgba($theme-base, 0.06);
+}
+
+@mixin bks-icon-btn-focus {
+  outline: 2px solid rgba($theme-base, 0.5);
+  outline-offset: 2px;
+}
 @import "./text-editor-plugins/partial-read-only.scss";
 
 // Shared search panel UI variables and mixins
@@ -117,35 +154,16 @@ $bks-toggle-gap-x: 2px !default;
       margin-left: 0 !important;
       padding-left: 0 !important;
     }
-    button[name="next"],
-    button[name="prev"],
-    button[name="replaceAll"],
-    button[name="all"],
-    button[name="select"],
-    button[name="selectMatches"],
-    button[name="selectAll"],
-    button[name="close"],
-    .cm-button[name="next"],
-    .cm-button[name="prev"],
-    .cm-button[name="replaceAll"],
-    .cm-button[name="all"],
-    .cm-button[name="select"],
-    .cm-button[name="selectMatches"],
-    .cm-button[name="selectAll"],
-    .cm-button[name="close"],
-    button[aria-label*="all" i],
-    .cm-button[aria-label*="all" i],
-    button[title*="all" i],
-    .cm-button[title*="all" i],
-    button[aria-label*="select" i],
-    .cm-button[aria-label*="select" i],
-    button[title*="select" i],
-    .cm-button[title*="select" i],
-    button[aria-label*="close" i],
-    .cm-button[aria-label*="close" i],
-    button[title*="close" i],
-    .cm-button[title*="close" i] {
-      display: none !important;
+    $bks-hide-btns: ("next", "prev", "replaceAll", "all", "select", "selectMatches", "selectAll", "close");
+    @each $btn in $bks-hide-btns {
+      button[name="#{$btn}"],
+      .cm-button[name="#{$btn}"],
+      button[aria-label*="#{$btn}" i],
+      .cm-button[aria-label*="#{$btn}" i],
+      button[title*="#{$btn}" i],
+      .cm-button[title*="#{$btn}" i] {
+        display: none !important;
+      }
     }
 
     button[name="replace"],
@@ -234,196 +252,85 @@ $bks-toggle-gap-x: 2px !default;
 
     // Show Replace and Replace All using the same box style as toggles
     // Replace
-    button[name="replace"],
-    .cm-button[name="replace"],
-    button[aria-label="replace" i],
-    .cm-button[aria-label="replace" i] {
-      display: inline-flex !important;
-      align-items: center;
-      justify-content: center;
-      flex: 0 0 $bks-toggle-size;
-      width: $bks-toggle-size;
-      height: $bks-toggle-size;
-      min-width: $bks-toggle-size;
-      max-width: $bks-toggle-size;
-      min-height: $bks-toggle-size;
-      max-height: $bks-toggle-size;
-      box-sizing: border-box;
-      margin: 0 $bks-toggle-gap-x 0 0;
-      padding: 0;
-      border-radius: $bks-toggle-radius;
-      border: 1px solid rgba($theme-base, 0.32);
-      background: transparent;
-      font-size: 0; // hide text label
-      line-height: 0; 
-      overflow: hidden; 
-      white-space: nowrap;
-      cursor: pointer;
-      transition: background-color 120ms ease, border-color 120ms ease;
-      position: relative;
-      @include bks-hover-tooltip("Replace");
-    }
-    button[name="replace"]::after,
-    .cm-button[name="replace"]::after,
-    button[aria-label="replace" i]::after,
-    .cm-button[aria-label="replace" i]::after {
-      content: "redo";
-      font-family: "Material Icons";
-      font-weight: normal;
-      font-style: normal;
-      font-size: 12px; 
-      line-height: 1;
-      letter-spacing: normal;
-      text-transform: none;
-      display: inline-block;
-      white-space: nowrap;
-      word-wrap: normal;
-      direction: ltr;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      font-feature-settings: "liga";
-      color: rgba($theme-base, 0.9);
-    }
-    button[name="replace"]:hover,
-    .cm-button[name="replace"]:hover,
-    button[aria-label="replace" i]:hover,
-    .cm-button[aria-label="replace" i]:hover {
-      border-color: rgba($theme-base, 0.5);
-      background: rgba($theme-base, 0.06);
-    }
-    button[name="replace"]:focus-visible,
-    .cm-button[name="replace"]:focus-visible,
-    button[aria-label="replace" i]:focus-visible,
-    .cm-button[aria-label="replace" i]:focus-visible {
-      outline: 2px solid rgba($theme-base, 0.5);
-      outline-offset: 2px;
+    $bks-icon-btns: (
+      "replace": ("Replace", "redo"),
+      "replaceAll": ("Replace All", "find_replace")
+    );
+    @each $btn, $data in $bks-icon-btns {
+      $label: nth($data, 1);
+      $icon: nth($data, 2);
+      button[name="#{$btn}"],
+      .cm-button[name="#{$btn}"],
+      button[aria-label*="#{$btn}" i],
+      .cm-button[aria-label*="#{$btn}" i] {
+        @include bks-icon-btn($label);
+      }
+      button[name="#{$btn}"]::after,
+      .cm-button[name="#{$btn}"]::after,
+      button[aria-label*="#{$btn}" i]::after,
+      .cm-button[aria-label*="#{$btn}" i]::after {
+        content: $icon;
+        font-family: "Material Icons";
+        font-weight: normal;
+        font-style: normal;
+        font-size: 12px;
+        line-height: 1;
+        letter-spacing: normal;
+        text-transform: none;
+        display: inline-block;
+        white-space: nowrap;
+        word-wrap: normal;
+        direction: ltr;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        font-feature-settings: "liga";
+        color: rgba($theme-base, 0.9);
+      }
+      button[name="#{$btn}"]:hover,
+      .cm-button[name="#{$btn}"]:hover,
+      button[aria-label*="#{$btn}" i]:hover,
+      .cm-button[aria-label*="#{$btn}" i]:hover {
+        @include bks-icon-btn-hover;
+      }
+      button[name="#{$btn}"]:focus-visible,
+      .cm-button[name="#{$btn}"]:focus-visible,
+      button[aria-label*="#{$btn}" i]:focus-visible,
+      .cm-button[aria-label*="#{$btn}" i]:focus-visible {
+        @include bks-icon-btn-focus;
+      }
     }
 
-    button[name="replaceAll"],
-    .cm-button[name="replaceAll"],
-    button[aria-label*="replace all" i],
-    .cm-button[aria-label*="replace all" i] {
-      display: inline-flex !important;
-      align-items: center;
-      justify-content: center;
-      flex: 0 0 $bks-toggle-size;
-      width: $bks-toggle-size;
-      height: $bks-toggle-size;
-      min-width: $bks-toggle-size;
-      max-width: $bks-toggle-size;
-      min-height: $bks-toggle-size;
-      max-height: $bks-toggle-size;
-      box-sizing: border-box;
-      margin: 0 $bks-toggle-gap-x 0 0;
-      padding: 0;
-      border-radius: $bks-toggle-radius;
-      border: 1px solid rgba($theme-base, 0.32);
-      background: transparent;
-      font-size: 0; // hide text label
-      line-height: 0; 
-      overflow: hidden; 
-      white-space: nowrap;
-      cursor: pointer;
-      transition: background-color 120ms ease, border-color 120ms ease;
-      position: relative;
-      @include bks-hover-tooltip("Replace All");
+    // Toggle label/checkboxes (case, regexp, word, whole)
+    @mixin bks-toggle-label-group($name, $glyph, $tooltip) {
+      label:has(> input[name=#{$name}]) {
+        @include bks-toggle-label();
+        @include bks-hover-tooltip($tooltip);
+      }
+      label:has(> input[name=#{$name}]) > input[type="checkbox"] {
+        @include bks-toggle-input();
+      }
+      label:has(> input[name=#{$name}])::after {
+        @include bks-toggle-box-base();
+        content: $glyph;
+        @if $name == "case" { padding-bottom: 1px; }
+      }
+      label:has(> input[name=#{$name}]):hover::after {
+        border-color: rgba($theme-base, 0.5);
+        background: rgba($theme-base, 0.06);
+      }
+      label:has(> input[name=#{$name}]:focus-visible)::after {
+        outline: 2px solid rgba($theme-base, 0.5);
+        outline-offset: 2px;
+      }
+      label:has(> input[name=#{$name}]:checked)::after {
+        background: rgba($theme-base, 0.18);
+        border-color: rgba($theme-base, 0.55);
+      }
     }
-    button[name="replaceAll"]::after,
-    .cm-button[name="replaceAll"]::after,
-    button[aria-label*="replace all" i]::after,
-    .cm-button[aria-label*="replace all" i]::after {
-      content: "find_replace";
-      font-family: "Material Icons";
-      font-weight: normal;
-      font-style: normal;
-      font-size: 12px; 
-      line-height: 1;
-      letter-spacing: normal;
-      text-transform: none;
-      display: inline-block;
-      white-space: nowrap;
-      word-wrap: normal;
-      direction: ltr;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      font-feature-settings: "liga";
-      color: rgba($theme-base, 0.9);
-    }
-    button[name="replaceAll"]:hover,
-    .cm-button[name="replaceAll"]:hover,
-    button[aria-label*="replace all" i]:hover,
-    .cm-button[aria-label*="replace all" i]:hover {
-      border-color: rgba($theme-base, 0.5);
-      background: rgba($theme-base, 0.06);
-    }
-    button[name="replaceAll"]:focus-visible,
-    .cm-button[name="replaceAll"]:focus-visible,
-    button[aria-label*="replace all" i]:focus-visible,
-    .cm-button[aria-label*="replace all" i]:focus-visible {
-      outline: 2px solid rgba($theme-base, 0.5);
-      outline-offset: 2px;
-    }
-
-    label:has(> input[name="case"]),
-    label:has(> input[name="regexp"]),
-    label:has(> input[name="re"]),
-    label:has(> input[name="word"]),
-    label:has(> input[name="whole"]) {
-      @include bks-toggle-label();
-    }
-
-    label:has(> input[name="case"]) { @include bks-hover-tooltip("Match Case"); }
-    label:has(> input[name="regexp"]),
-    label:has(> input[name="re"]) { @include bks-hover-tooltip("Use Regular Expression"); }
-    label:has(> input[name="word"]),
-    label:has(> input[name="whole"]) { @include bks-hover-tooltip("Match Whole Word"); }
-
-    label:has(> input[name="case"]) > input[type="checkbox"],
-    label:has(> input[name="regexp"]) > input[type="checkbox"],
-    label:has(> input[name="re"]) > input[type="checkbox"],
-    label:has(> input[name="word"]) > input[type="checkbox"],
-    label:has(> input[name="whole"]) > input[type="checkbox"] {
-      @include bks-toggle-input();
-    }
-    // Common box base
-    label:has(> input[name="case"])::after,
-    label:has(> input[name="regexp"])::after,
-    label:has(> input[name="re"])::after,
-    label:has(> input[name="word"])::after,
-    label:has(> input[name="whole"])::after {
-      @include bks-toggle-box-base();
-    }
-    // Specific glyphs
-    label:has(> input[name="case"])::after { content: "Aa"; padding-bottom: 1px; }
-    label:has(> input[name="regexp"])::after,
-    label:has(> input[name="re"])::after { content: ".*"; }
-    label:has(> input[name="word"])::after,
-    label:has(> input[name="whole"])::after { content: "ab"; }
-
-    // States
-    label:has(> input[name="case"]):hover::after,
-    label:has(> input[name="regexp"]):hover::after,
-    label:has(> input[name="re"]):hover::after,
-    label:has(> input[name="word"]):hover::after,
-    label:has(> input[name="whole"]):hover::after {
-      border-color: rgba($theme-base, 0.5);
-      background: rgba($theme-base, 0.06);
-    }
-    label:has(> input[name="case"]:focus-visible)::after,
-    label:has(> input[name="regexp"]:focus-visible)::after,
-    label:has(> input[name="re"]:focus-visible)::after,
-    label:has(> input[name="word"]:focus-visible)::after,
-    label:has(> input[name="whole"]:focus-visible)::after {
-      outline: 2px solid rgba($theme-base, 0.5);
-      outline-offset: 2px;
-    }
-    label:has(> input[name="case"]:checked)::after,
-    label:has(> input[name="regexp"]:checked)::after,
-    label:has(> input[name="re"]:checked)::after,
-    label:has(> input[name="word"]:checked)::after,
-    label:has(> input[name="whole"]:checked)::after {
-      background: rgba($theme-base, 0.18);
-      border-color: rgba($theme-base, 0.55);
-    }
+    @include bks-toggle-label-group("case", "Aa", "Match Case");
+    @include bks-toggle-label-group("regexp", ".*", "Use Regular Expression");
+    @include bks-toggle-label-group("re", ".*", "Use Regular Expression");
+    @include bks-toggle-label-group("word", "ab", "Match Whole Word");
+    @include bks-toggle-label-group("whole", "ab", "Match Whole Word");
   }
 }

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -196,6 +196,7 @@ $bks-toggle-gap-x: 2px !default;
       cursor: pointer;
       line-height: 1;
       padding: 0;
+      @include bks-hover-tooltip("More options");
     }
     .bks-json-menu::after {
       content: "⋮"; 

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -196,7 +196,6 @@ $bks-toggle-gap-x: 2px !default;
       cursor: pointer;
       line-height: 1;
       padding: 0;
-      @include bks-hover-tooltip("More options");
     }
     .bks-json-menu::after {
       content: "⋮"; 

--- a/apps/studio/src/search-panel-ui-toggle.ts
+++ b/apps/studio/src/search-panel-ui-toggle.ts
@@ -13,9 +13,10 @@
     const toggleReplaceLabel = isHidden ? 'Show Replace Row' : 'Hide Replace Row';
 
     const menuBtn = document.createElement('button');
-  menuBtn.type = 'button';
-  menuBtn.className = 'bks-json-menu cm-button';
-  menuBtn.setAttribute('aria-label', 'More');
+    menuBtn.type = 'button';
+    menuBtn.className = 'bks-json-menu cm-button';
+    menuBtn.setAttribute('aria-label', 'More');
+    menuBtn.setAttribute('title', 'More');
 
     const menu = document.createElement('div');
     menu.className = 'bks-json-menu-popover';

--- a/apps/studio/src/search-panel-ui-toggle.ts
+++ b/apps/studio/src/search-panel-ui-toggle.ts
@@ -1,0 +1,163 @@
+// UI-only enhancer: adds a dot-menu inside the search panel and toggles the replace row from there
+(function () {
+  function enhancePanel(panel: HTMLElement) {
+    if (panel.classList.contains('bks-enhanced')) return;
+    panel.classList.add('bks-enhanced');
+
+    const container = panel.closest('.json-viewer') as HTMLElement | null;
+    if (!container) return;
+
+    // Default: hide replace row on initial enhance
+    panel.classList.add('bks-hide-replace');
+    const isHidden = panel.classList.contains('bks-hide-replace');
+    const toggleReplaceLabel = isHidden ? 'Show Replace Row' : 'Hide Replace Row';
+
+    const menuBtn = document.createElement('button');
+    menuBtn.type = 'button';
+    menuBtn.className = 'bks-json-menu cm-button';
+    menuBtn.setAttribute('aria-label', 'More');
+    menuBtn.setAttribute('title', 'More');
+
+    const menu = document.createElement('div');
+    menu.className = 'bks-json-menu-popover';
+    menu.innerHTML = `
+      <button class="bks-json-menu-item" data-action="toggle-replace-row">${toggleReplaceLabel}</button>
+      <button class="bks-json-menu-item" data-action="copy-visible">Copy Visible</button>
+      <button class="bks-json-menu-item" data-action="collapse-all">Collapse all</button>
+      <button class="bks-json-menu-item" data-action="expand-all">Expand all</button>
+      <button class="bks-json-menu-item" data-action="toggle-expand-fk">Always Expand Foreign Keys</button>
+      <button class="bks-json-menu-item" data-action="toggle-wrap-text">Wrap Text</button>
+    `;
+
+    const dispatch = (type: string) => {
+      const ev = new CustomEvent(type, { bubbles: true, cancelable: true });
+      container.dispatchEvent(ev);
+    };
+
+    menu.addEventListener('click', (e) => {
+      const target = e.target as HTMLElement;
+      if (!target || !target.matches('.bks-json-menu-item')) return;
+      const action = target.getAttribute('data-action');
+      switch (action) {
+        case 'toggle-replace-row': {
+          panel.classList.toggle('bks-hide-replace');
+          const hidden = panel.classList.contains('bks-hide-replace');
+          const item = menu.querySelector('.bks-json-menu-item[data-action="toggle-replace-row"]') as HTMLButtonElement | null;
+          if (item) item.textContent = hidden ? 'Show Replace Row' : 'Hide Replace Row';
+          break;
+        }
+        case 'copy-visible': dispatch('bks-json-menu:copy-visible'); break;
+        case 'collapse-all': dispatch('bks-json-menu:collapse-all'); break;
+        case 'expand-all': dispatch('bks-json-menu:expand-all'); break;
+        case 'toggle-expand-fk': dispatch('bks-json-menu:toggle-expand-fk'); break;
+        case 'toggle-wrap-text': dispatch('bks-json-menu:toggle-wrap-text'); break;
+      }
+      menuBtn.classList.remove('open');
+    });
+
+    menuBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      menuBtn.classList.toggle('open');
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!(e.target instanceof Node)) return;
+      if (menuBtn.contains(e.target) || menu.contains(e.target)) return;
+      menuBtn.classList.remove('open');
+    });
+
+    menuBtn.appendChild(menu);
+    panel.appendChild(menuBtn);
+  }
+
+  function scan() {
+    document.querySelectorAll<HTMLElement>('.cm-panel.cm-search').forEach(enhancePanel);
+    // For existing JSON viewers, open find only if they are currently visible
+    document.querySelectorAll<HTMLElement>('.json-viewer').forEach((el) => maybeOpenFindOnVisible(el));
+  }
+
+  function isVisible(el: HTMLElement): boolean {
+    const style = window.getComputedStyle(el);
+    return style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+  }
+
+  function dispatchModF(target: HTMLElement) {
+    const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+    const ev = new KeyboardEvent('keydown', {
+      key: 'f',
+      code: 'KeyF',
+      metaKey: isMac,
+      ctrlKey: !isMac,
+      altKey: false,
+      shiftKey: false,
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(ev);
+  }
+
+  function openFindWhenReady(container: HTMLElement, tries = 20) {
+    if (!isVisible(container)) return;
+    const editor = container.querySelector('.cm-editor');
+    const content = editor?.querySelector('.cm-content') as HTMLElement | null;
+    if (content) {
+      try {
+        content.focus();
+        dispatchModF(content);
+        container.dataset.bksFindOpenState = 'opened';
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    if (tries <= 0) return;
+    setTimeout(() => openFindWhenReady(container, tries - 1), 100);
+  }
+
+  function maybeOpenFindOnVisible(container: HTMLElement) {
+    // Only act on visibility transitions to visible
+    const visible = isVisible(container);
+    const state = container.dataset.bksFindOpenState; // 'opened' during current visible session
+    if (visible && state !== 'opened') {
+      container.dataset.bksFindOpenState = 'pending';
+      openFindWhenReady(container);
+    } else if (!visible && state) {
+      // reset when hidden so we open again on next show
+      delete container.dataset.bksFindOpenState;
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', scan);
+  } else {
+    scan();
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      m.addedNodes.forEach((node) => {
+        if (!(node instanceof HTMLElement)) return;
+        if (node.matches && node.matches('.cm-panel.cm-search')) {
+          enhancePanel(node as HTMLElement);
+        } else {
+          node.querySelectorAll && node.querySelectorAll('.cm-panel.cm-search').forEach((el) => enhancePanel(el as HTMLElement));
+        }
+        // Respond to JSON viewer additions (open find if visible)
+        if (node.matches && node.matches('.json-viewer')) {
+          maybeOpenFindOnVisible(node);
+        } else if (node.querySelector) {
+          node.querySelectorAll('.json-viewer').forEach((el) => maybeOpenFindOnVisible(el as HTMLElement));
+        }
+      });
+    }
+  });
+
+  observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['style', 'class'] });
+
+  // Watch for json-viewer visibility changes (v-show toggles display)
+  document.addEventListener('transitionend', (e) => {
+    if (!(e.target instanceof HTMLElement)) return;
+    const container = e.target.closest('.json-viewer') as HTMLElement | null;
+    if (container) maybeOpenFindOnVisible(container);
+  }, true);
+})();

--- a/apps/studio/src/search-panel-ui-toggle.ts
+++ b/apps/studio/src/search-panel-ui-toggle.ts
@@ -13,10 +13,9 @@
     const toggleReplaceLabel = isHidden ? 'Show Replace Row' : 'Hide Replace Row';
 
     const menuBtn = document.createElement('button');
-    menuBtn.type = 'button';
-    menuBtn.className = 'bks-json-menu cm-button';
-    menuBtn.setAttribute('aria-label', 'More');
-    menuBtn.setAttribute('title', 'More');
+  menuBtn.type = 'button';
+  menuBtn.className = 'bks-json-menu cm-button';
+  menuBtn.setAttribute('aria-label', 'More');
 
     const menu = document.createElement('div');
     menu.className = 'bks-json-menu-popover';


### PR DESCRIPTION
✨ Search, but simpler!
Earlier we had two different search boxes 🤯 –
🔎 One just for keys
🔎 Another (opened with Cmd+F) with way too many options cluttering the UI
😕 And too be very honest, the second one was so cluttered and confusing, that no one in our team wanted to use that.

Explored `Monaco editor` but its integration is too complicated at this stage to replace `CodeMirror` with that.

Inspiration:- VSCode search bar

Now 👉 replaced all that with a unified, super simple search bar 🪄
🚀 Cleaner, easier, and way more user-friendly
🚀 By default, only find will be visible to make the UI simpler, you can toggle to use replace functionality.
📸 Attaching screenshots for a quick look 👀


🛠️ Built on CodeMirror only, with UI-level improvements 🎨
🔥 A lot less confusion, a lot more speed!
🔥 Sleeker and more fun – ready to go!

<img width="1512" height="982" alt="Screenshot 2025-09-21 at 8 42 48 PM" src="https://github.com/user-attachments/assets/f65179c9-063c-45f8-80a2-1e408b1a704b" />
<img width="1512" height="982" alt="Screenshot 2025-09-21 at 8 42 43 PM" src="https://github.com/user-attachments/assets/5b3af349-a011-444d-b8be-3605aae81b3f" />
<img width="1512" height="982" alt="Screenshot 2025-09-21 at 8 42 35 PM" src="https://github.com/user-attachments/assets/a3400cdb-32af-410c-a63a-d43ff02fb22c" />



EASY BOX CONTAINS TOOLTIP FOR CLARITY:-

<img width="1512" height="982" alt="Screenshot 2025-09-21 at 10 05 53 PM" src="https://github.com/user-attachments/assets/aedcd240-d973-4236-aebc-38d5224a7a1d" />


