### PR TITLE
fix: JSON viewer not showing columns which are not there in left sidebar inside collection in MongoDB

### DIFF
--- a/apps/studio/src/mixins/data_converter.js
+++ b/apps/studio/src/mixins/data_converter.js
@@ -13,9 +13,14 @@ export default {
               ];
             */
           const columnNamesOnly = columns.map((c) => c.field)
-          return data.rows.map((row, idx) => {
-            return _.pick(row, columnNamesOnly)
-          })
+          // For MongoDB, do not filter fields at all, return full document
+          if (this.connectionType === 'mongodb') {
+            return data.rows
+          } else {
+            return data.rows.map((row, idx) => {
+              return _.pick(row, columnNamesOnly)
+            })
+          }
         },
         extractColumns(data) {
             // columns here

--- a/apps/studio/src/mixins/data_converter.js
+++ b/apps/studio/src/mixins/data_converter.js
@@ -13,8 +13,9 @@ export default {
               ];
             */
           const columnNamesOnly = columns.map((c) => c.field)
-          // For MongoDB, do not filter fields at all, return full document
-          if (this.connectionType === 'mongodb') {
+          // Set of connectionTypes that should bypass column filtering
+          const bypassColumnFilterConnectionTypes = new Set(['mongodb'])
+          if (bypassColumnFilterConnectionTypes.has(this.connectionType)) {
             return data.rows
           } else {
             return data.rows.map((row, idx) => {


### PR DESCRIPTION
Description:
This PR makes column filtering configurable by connection type. For types like MongoDB, the full document is shown (no filtering). 