### PR TITLE
disable reordering column position in mysql temporarily

### DIFF
--- a/apps/studio/src/shared/lib/dialects/mysql.ts
+++ b/apps/studio/src/shared/lib/dialects/mysql.ts
@@ -55,6 +55,7 @@ export const MysqlData: DialectData = {
     alter: {
       multiStatement: true,
       renameSchema: true,
+      reorderColumn: true, // FIXME remove this once it's fixed
     },
     schema: true,
   },


### PR DESCRIPTION
There is an ongoing issue with reordering column in table builder for mysql. Will re-enable reordering column once it's fixed soon!