### PR TITLE
fix: reset read-only mode to false for existing connection when premium expires

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -345,10 +345,21 @@ export default Vue.extend({
         this.config = conn;
       })
     },
-    edit(config) {
+    async edit(config) {
       this.config = _.clone(config)
       this.errors = null
       this.connectionError = null
+
+       // If user didn't renew ultimate subscription, default read-only mode to false
+      if (this.config.readOnlyMode && !this.isUltimate) {
+        this.config.readOnlyMode = false;
+
+        try {
+          await this.$store.dispatch("data/connections/save", this.config);
+        } catch (error) {
+          console.error("failed to update readOnlyMode:", error);
+        }
+      }
     },
     async remove(config) {
       if (this.config === config) {


### PR DESCRIPTION
When a user's ultimate subscription expires, they lose access to the read-only toggle input (it becomes disabled). However, if read-only mode was enabled before expiration, it remained active, preventing them from making any changes to their connection.

This commit automatically resets read-only mode to false when it detects that subscription is not active, but read-only mode is enabled for selected connection, ensuring users which don't renew subscriptions can still use their existing connections normally.

I'm not sure how often such situations happen, but it was pretty annoying for me, so I've decided to contribute :)). 

![2025-10-25 19-27-06](https://github.com/user-attachments/assets/8a25b48c-25a1-496f-b4ff-6cc623c43a1e)