### PR TITLE
try catch deparameterize

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -566,6 +566,9 @@
 
         try {
           const placeholders = this.individualQueries.flatMap((qs) => qs.parameters);
+          if (_.isEmpty(placeholders)) {
+            return query;
+          }
           const values = Object.values(this.queryParameterValues) as string[];
           const convertedParams = convertParamsForReplacement(placeholders, values);
           query = deparameterizeQuery(query, this.dialect, convertedParams, this.$bksConfig.db[this.dialect]?.paramTypes);


### PR DESCRIPTION
fixes #3654 

The error was thrown by `sql-formatter`. Simply adding try-catch solves the linked issue but I'm not sure if there are parts that depend on deparameterized query. Two things that we probably want ask ourselves IMO:

1. Can we fix this from `sql-formatter`?
2. If deparameterizing fails, do we have a way to anticipate it? does it still work normally?