### PR TITLE
Fix editing json columns in the json viewer

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1145,10 +1145,10 @@ export default Vue.extend({
             .filter(v => v !== null && v !== undefined);
           return selectedValues.length > 0 ? selectedValues : [clickedValue];
         }
-        
+
         case 'like':
           return `%${clickedValue}%`;
-        
+
         default:
           return clickedValue;
       }
@@ -1165,9 +1165,9 @@ export default Vue.extend({
             label: createMenuItem(`${cell.getField()} ${s} value`),
             disabled: this.$store.getters.isCommunity,
             action: async (_e, cell: CellComponent) => {
-              const newFilter = [{ 
-                field: cell.getField(), 
-                type: s, 
+              const newFilter = [{
+                field: cell.getField(),
+                type: s,
                 value: this.getActionValue(cell, s)
               }]
               this.tableFilters = newFilter
@@ -2037,6 +2037,14 @@ export default Vue.extend({
       ])
     },
     handleJsonValueChange({key, value}) {
+      const column = this.table.columns.find((c) => c.columnName === key);
+      if (column) {
+        const isJsonColumn = String(column.dataType).toUpperCase() === 'JSON' || String(column.dataType).toUpperCase() === 'JSONB'
+
+        if (isJsonColumn && _.isObject(value)) {
+          value = JSON.stringify(value)
+        }
+      }
       this.selectedRow?.getCell(key).setValue(value)
     },
     debouncedSaveTab: _.debounce(function(tab) {

--- a/apps/studio/src/lib/data/jsonViewer.ts
+++ b/apps/studio/src/lib/data/jsonViewer.ts
@@ -180,7 +180,9 @@ export function parseRowDataForJsonViewer(data: Record<string, any>, tableColumn
 
     if (isJsonColumn) {
       try {
-        data[column.field] = JSON.parse(data[column.field])
+        if (_.isString(data[column.field])) {
+          data[column.field] = JSON.parse(data[column.field])
+        }
       } catch (e) {
         log.warn(`Failed to parse JSON for column ${column.field}:`, e)
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ volumes:
   psql14:
   psql13:
   psql15_load_test_data:
+  psql17:
   mariadb:
   cockroachdb:
   oracle18:
@@ -79,6 +80,19 @@ services:
       - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
     ports:
       - 5434:5432
+
+  psql17:
+    image: postgres:17
+    platform: linux/amd64
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: example
+      POSTGRES_DB: saklia
+    volumes:
+      - psql17:/var/lib/postgresql/data
+      - ./dev/docker_psql_init:/docker-entrypoint-initdb.d
+    ports:
+      - 5437:5432
 
   psql14:
     image: postgres:14


### PR DESCRIPTION
We mutate the value of json columns from strings to objects, but we never changed them back to strings, hence they weren't being quoted in sql statements.

I'm not totally sure if this is the best approach to fix the issue though. Hopefully @azmy60 has some thoughts