### PR TITLE
Fix import mapper

### DIFF
--- a/apps/studio/src/components/importtable/ImportMapper.vue
+++ b/apps/studio/src/components/importtable/ImportMapper.vue
@@ -275,7 +275,7 @@ export default {
       const dt = new Set(dataTypes)
       dt.delete('null')
 
-      if (dt.size > 1) {
+      if (dt.size < 1) {
         return this.importDataTypes.defaultType
       }
 


### PR DESCRIPTION
fix #3687 

There seems to be a logic issue in the getColumnType function of the import mapper, which allows it to sometimes return undefined. I'm not totally sure what the logic *should* be, but either way, there was an edge case where the set was empty and thus missed the canary.