### PR TITLE
Fix mariadb generated support check

### DIFF
--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -439,7 +439,9 @@ export class MysqlClient extends BasicDatabaseClient<ResultType> {
     _schema?: string,
     connection?: Connection
   ): Promise<ExtendedTableColumn[]> {
-    const hasGeneratedSupport = !isVersionLessThanOrEqual(this.versionInfo, { major: 5, minor: 7, patch: 5 });
+    const hasGeneratedSupport = this.connectionType == 'mariadb' ?
+     !isVersionLessThanOrEqual(this.versionInfo, { major: 10, minor: 2, patch: 4 }):
+     !isVersionLessThanOrEqual(this.versionInfo, { major: 5, minor: 7, patch: 5 });
     const clause = table ? `AND table_name = ?` : "";
     const sql = `
       SELECT


### PR DESCRIPTION
fix #3682 

The column we are referencing to get generation expression information in listTableColumns was introduced much later in mariadb, so we need to have a version check specifically for that in the `listTableColumns` function.