### PR TITLE
doc: AUR (now Arch Linux) and Flatpak installation instructions

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -68,15 +68,15 @@ sudo dnf install beekeeper-studio
 sudo yum install beekeeper-studio
 ```
 
-## AUR
+## Arch Linux (and derivatives)
 
-AUR files are provided for both x86_64 and ARM64 systems, you can download them from [the latest release](https://github.com/beekeeper-studio/beekeeper-studio).
+Pacman (installed as local packages using `pacman -U`) packages are provided for both x86_64 and ARM64 systems, you can download them from [the latest release](https://github.com/beekeeper-studio/beekeeper-studio).
 
 Real AUR integration coming soon.
 
 ## Flatpak
 
-AUR files are provided for both x86_64 and ARM64 systems, you can download them from [the latest release](https://github.com/beekeeper-studio/beekeeper-studio).
+Flatpak (.flatpak) files are provided separately for both x86_64 and ARM64 systems, you can download them from [the latest release](https://github.com/beekeeper-studio/beekeeper-studio).
 
 Flathub integration coming soon.
 


### PR DESCRIPTION
- changed AUR section to clarify package format
- changed the title to "Arch Linux (and derivatives)
- fixed a typo where Flatpak was packages were called "AUR" packages

Note: While I don't know exactly which package format is an "AUR package", especially one ending in file extension `.pacman` (AUR packages typically come as PKGBUILD manifests), looking into the actual `.pacman` file in the releases tells me these are simply 'local' packages as the [Wiki calls them](https://wiki.archlinux.org/title/Pacman#Additional_commands). Local packages are not specific to AUR, they're simply local packages and AUR helps as a centralized repository for commonly needed "local" (or custom) packages. They are not maintained by the Arch Linux team, so they are largely [chaotic](url).