### PR TITLE
Allow scrolling on tabbar

### DIFF
--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -64,13 +64,18 @@
   }
   .nav-tabs {
     position: relative;
-    overflow: hidden;
+    overflow-y: hidden;
+    overflow-x: auto;
+    white-space: nowrap;
     flex-wrap: nowrap;
     margin: 0;
     height: $tab-height;
     -webkit-app-region: no-drag;
+    &::-webkit-scrollbar {
+      display: none;
+    }
     .nav-item-wrap {
-      min-width: 28px;
+      min-width: 50px;
       overflow: hidden;
     }
     .nav-item-wrap-chosen {


### PR DESCRIPTION
When more tabs are created than fit in the tabbar, allow scrolling and hide the scrollbar on the tabstrip.

Also bumps up minimal tab width so icons can be seen (and hovered for knowing which tab to jump to).

Addresses #1403 and #1401.


To apply to an already running beekeeper instance for testing (gets close, does not include the webkit-scrollbar hiding):
`Help > Show Developer Tools > Console`
`allow pasting`
```css
document.querySelector('.nav-tabs').style.overflowY = 'hidden';
document.querySelector('.nav-tabs').style.overflowX = 'auto';
document.querySelector('.nav-tabs').style.whiteSpace = 'nowrap';

[...document.querySelectorAll('.nav-tabs .nav-item-wrap')]
  .forEach(el => el.style.minWidth = '50px');
```