### PR TITLE
Fix Ctrl-P shows the wrong plugin icons

### DIFF
--- a/apps/studio/src/components/quicksearch/QuickSearch.vue
+++ b/apps/studio/src/components/quicksearch/QuickSearch.vue
@@ -54,6 +54,10 @@
             v-else-if="blob.tabType === 'database' || blob.tabDetails?.tabType === 'database'"
           >storage</i>
           <i
+            class="material-icons item-icon plugin"
+            v-else-if="blob.tabType.startsWith('plugin-')"
+          >{{ $bksPlugin.pluginOf(blob.generatedPluginId)?.manifest.icon }}</i>
+          <i
             class="material-icons item-icon database"
             v-else
           >code</i>


### PR DESCRIPTION
<img width="535" height="254" alt="image" src="https://github.com/user-attachments/assets/9fcaa22d-928d-477c-affb-ee39db28d45e" />
