### PR TITLE
Less strict CodeMirror styles in UI Kit

### DIFF
--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -20,11 +20,6 @@
     color: rgba($theme-base, 0.25);
   }
 
-  .cm-completionMatchedText {
-    text-decoration: none;
-    font-weight: 700;
-  }
-
   .bks-error-marker {
     text-decoration-line: underline;
     text-decoration-style: wavy;

--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -200,6 +200,7 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   --bks-text-editor-highlight-bg-color: #{rgba($brand-warning, 0.3)};
   --bks-text-editor-keyword-fg-color: #{$brand-pink};
   --bks-text-editor-variableName-fg-color: #{$text-dark};
+  --bks-text-editor-variable-fg-color: #{$brand-secondary};
   --bks-text-editor-variable-2-fg-color: #{$brand-secondary};
   --bks-text-editor-selected-bg-color: #{rgba($theme-base, 0.25)};
   --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.15)};

--- a/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
@@ -759,6 +759,8 @@ x-switch {
   --bks-tab-link: #{$tab-link};
   --bks-badge-bg: #{$badge-bg};
 
+  --bks-table-icon-color: #{$theme-primary};
+
   --bks-text-editor-bg-color: #{$query-editor-bg};
   --bks-text-editor-error-bg-color: #{rgba($brand-danger, 0.1)};
   --bks-text-editor-error-fg-color: #{$brand-danger};

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -355,6 +355,7 @@
   import ShortcutHints from './editor/ShortcutHints.vue'
   import SqlTextEditor from "@beekeeperstudio/ui-kit/vue/sql-text-editor"
   import SurrealTextEditor from "@beekeeperstudio/ui-kit/vue/surreal-text-editor"
+  import type { Entity } from "@beekeeperstudio/ui-kit";
 
   import QueryEditorStatusBar from './editor/QueryEditorStatusBar.vue'
   import rawlog from '@bksLogger'
@@ -628,7 +629,11 @@
         return this.rowCount > 0
       },
       entities() {
-        return this.tables.map((t: TableOrView) => ({ schema: t.schema, name: t.name }))
+        return this.tables.map((t: TableOrView) => ({
+          schema: t.schema,
+          name: t.name,
+          entityType: t.entityType,
+        }) as Entity)
       },
       queryDialect() {
         return this.dialectData.queryDialectOverride ?? this.connectionType;

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/customSql.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/customSql.ts
@@ -10,7 +10,7 @@ import { EditorView } from "@codemirror/view";
 import { buildSchema } from "../utils";
 import { sql } from "./vendor/@codemirror/lang-sql/src/sql";
 import { ColumnsGetter } from "./sqlContextComplete";
-import { setSchema } from "./vendor/@codemirror/lang-sql/src/complete";
+import { completeConfig, setSchema } from "./vendor/@codemirror/lang-sql/src/complete";
 
 type SQLConfig = CMSQLConfig & {
   disableSchemaCompletion?: boolean;
@@ -51,7 +51,11 @@ function applyEntities(
   entities: Entity[] = [],
   defaultSchema?: string
 ) {
-  const schema = buildSchema(entities, defaultSchema);
+  const schema = buildSchema(
+    entities,
+    defaultSchema,
+    view.state.facet(completeConfig).dialect
+  );
   view.dispatch({
     effects: [
       setEntities.of(entities),

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
@@ -263,7 +263,7 @@ class CompletionLevel {
 
 }
 
-function nameCompletion(label: string, type: string, idQuote: string, idCaseInsensitive: boolean): Completion {
+export function nameCompletion(label: string, type: string, idQuote: string, idCaseInsensitive: boolean): Completion {
   if ((new RegExp("^[a-z_][a-z_\\d]*$", idCaseInsensitive ? "i" : "")).test(label)) return {label, type}
   return {label, type, apply: idQuote + label + idQuote}
 }

--- a/apps/ui-kit/lib/components/sql-text-editor/utils.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/utils.ts
@@ -1,6 +1,8 @@
 import { Entity, TableEntity } from "../types";
 import { Completion } from "@codemirror/autocomplete";
 import getAliases from "./getAliases";
+import type { SQLDialect, SQLNamespace } from "@codemirror/lang-sql";
+import { nameCompletion } from "./extensions/vendor/@codemirror/lang-sql/src/complete";
 
 export { getAliases };
 
@@ -22,9 +24,12 @@ export function columnsToCompletions(columns: string[]): Completion[] {
  */
 export function buildSchema(
   entities: Entity[],
-  defaultSchema?: string
-): Record<string, string[]> {
-  const tables: Record<string, string[]> = {};
+  defaultSchema?: string,
+  dialect?: SQLDialect
+): SQLNamespace {
+  const tables: SQLNamespace = {};
+  const idQuote = dialect?.spec.identifierQuotes?.[0] || '"'
+  const caseInsensitiveIdentifiers = !!dialect?.spec.caseInsensitiveIdentifiers;
 
   entities.forEach((entity) => {
     // Only include table-like entities
@@ -34,15 +39,23 @@ export function buildSchema(
     if (/\./.test(entity.name)) return;
 
     const columns = entity.columns?.map((c) => c.field) || [];
+    // Is it a table? a view? or none?
+    const type = entity.entityType || "type";
 
     // Add unqualified name for default schema or no schema
     if (!entity.schema || (defaultSchema && entity.schema === defaultSchema)) {
-      tables[entity.name] = columns;
+      tables[entity.name] = {
+        self: nameCompletion(entity.name, type, idQuote, caseInsensitiveIdentifiers),
+        children: columns,
+      };
     }
 
     // Add fully qualified name if it has a schema
     if (entity.schema) {
-      tables[`${entity.schema}.${entity.name}`] = columns;
+      tables[`${entity.schema}.${entity.name}`] = {
+        self: nameCompletion(entity.name, type, idQuote, caseInsensitiveIdentifiers),
+        children: columns,
+      };
     }
   });
 

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -160,6 +160,88 @@ export function extensions(config: ExtensionConfiguration = {}) {
         overflow: "auto",
         height: "100%",
       },
+      // Selection
+      ".cm-selectionBackground": {
+        backgroundColor: "var(--bks-text-editor-selected-bg-color)",
+      },
+      "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground": {
+        backgroundColor: "var(--bks-text-editor-selected-bg-color)",
+      },
+      ".cm-selectionMatch": {
+        backgroundColor: "var(--bks-text-editor-matchingselection-bg-color)",
+      },
+      // Search
+      ".cm-searchMatch": {
+        backgroundColor: "var(--bks-text-editor-searchmatch-bg-color)",
+      },
+      ".cm-searchMatch-selected": {
+        backgroundColor: "var(--bks-text-editor-searchmatch-selected-bg-color)",
+      },
+      // Gutters and line numbers
+      ".cm-gutters": {
+        backgroundColor: "var(--bks-text-editor-gutter-bg-color)",
+        borderColor: "var(--bks-text-editor-gutter-border-color)",
+      },
+      ".cm-foldgutter": {
+        fontSize: "1.2rem",
+        color: "var(--bks-text-editor-foldgutter-fg-color)",
+      },
+      ".cm-foldgutter:hover": {
+        color: "var(--bks-text-editor-foldgutter-fg-color-hover)",
+      },
+      ".cm-lineNumbers .cm-gutterElement": {
+        color: "var(--bks-text-editor-linenumber-fg-color)",
+      },
+      // Focused state
+      "&.cm-focused": {
+        outlineColor: "var(--bks-text-editor-focused-outline-color)",
+      },
+      // Cursor
+      ".cm-cursor": {
+        borderLeftColor: "var(--bks-text-editor-cursor-bg-color)",
+      },
+      ".cm-fat-cursor:not(.CodeMirror)": {
+        backgroundColor: "var(--bks-text-editor-fatcursor-bg-color)",
+      },
+      // Active line
+      ".cm-activeLine": {
+        backgroundColor: "var(--bks-text-editor-activeline-bg-color)",
+      },
+      ".cm-activeLineGutter": {
+        backgroundColor: "var(--bks-text-editor-activeline-gutter-bg-color)",
+      },
+      // Matching brackets
+      "&.cm-focused .cm-matchingBracket": {
+        color: "var(--bks-text-editor-matchingbracket-fg-color)",
+        backgroundColor: "var(--bks-text-editor-matchingbracket-bg-color)",
+        textDecoration: "underline",
+      },
+      // Marker styles
+      ".cm-error": {
+        backgroundColor: "var(--bks-text-editor-error-bg-color)",
+        borderBottom: "1px solid var(--bks-text-editor-error-fg-color)",
+        borderRadius: "2px",
+      },
+      ".cm-highlight": {
+        backgroundColor: "var(--bks-text-editor-highlight-bg-color)",
+        borderRadius: "2px",
+      },
+      // Panel
+      ".cm-panel": {
+        backgroundColor: "var(--bks-query-editor-bg)",
+        color: "var(--bks-text-dark)",
+      },
+      // Autocomplete hints
+      ".cm-tooltip": {
+        backgroundColor: "var(--bks-text-editor-context-menu-bg-color)",
+        color: "var(--bks-text-editor-context-menu-fg-color)",
+        borderColor: "var(--bks-text-editor-context-menu-border-color)",
+      },
+      ".cm-tooltip-autocomplete ul li[aria-selected]": {
+        backgroundColor: "var(--bks-text-editor-context-menu-item-bg-color-active)",
+        color: "var(--bks-text-editor-context-menu-item-fg-color-active)",
+        padding: "0.2rem 0.4rem",
+      },
     }),
   ];
 }

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -106,6 +106,7 @@
   // Context Menu
   --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
   --bks-text-editor-context-menu-fg-color: #{$text-dark};
+  --bks-text-editor-context-menu-border-color: transparent;
   --bks-text-editor-context-menu-item-bg-color-active: #{$brand-info};
   --bks-text-editor-context-menu-item-fg-color-active: #ffffff;
   --bks-text-editor-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
@@ -204,84 +205,6 @@
   .cm-emphasis { color: var(--bks-text-editor-emphasis-fg-color); }
   .cm-strikethrough { color: var(--bks-text-editor-strikethrough-fg-color); }
 
-  // Selection
-  .cm-selectionBackground,
-  .cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground {
-    background-color: var(--bks-text-editor-selected-bg-color);
-  }
-  .cm-selectionMatch {
-    background-color: var(--bks-text-editor-matchingselection-bg-color);
-  }
-
-  // Search
-  .cm-searchMatch { background-color: var(--bks-text-editor-searchmatch-bg-color); }
-  .cm-searchMatch-selected { background-color: var(--bks-text-editor-searchmatch-selected-bg-color); }
-
-  // Gutters and line numbers
-  .cm-gutters {
-    background-color: var(--bks-text-editor-gutter-bg-color);
-    border-color: var(--bks-text-editor-gutter-border-color);
-  }
-
-  .cm-foldgutter {
-    font-size: 1.2rem;
-    color: var(--bks-text-editor-foldgutter-fg-color);
-
-    &:hover {
-      color: var(--bks-text-editor-foldgutter-fg-color-hover);
-    }
-  }
-
-  .cm-lineNumbers .cm-gutterElement {
-    color: var(--bks-text-editor-linenumber-fg-color);
-  }
-
-  // Focused state
-  .cm-focused {
-    outline-color: var(--bks-text-editor-focused-outline-color);
-  }
-
-  // Cursor
-  .cm-cursor {
-    border-left-color: var(--bks-text-editor-cursor-bg-color);
-  }
-  .cm-fat-cursor:not(.CodeMirror) {
-    background-color: var(--bks-text-editor-fatcursor-bg-color);
-  }
-
-  // Active line
-  .cm-activeLine {
-    background-color: var(--bks-text-editor-activeline-bg-color);
-  }
-
-  .cm-activeLineGutter {
-    background-color: var(--bks-text-editor-activeline-gutter-bg-color);
-  }
-
-  // Matching brackets
-  .cm-focused .cm-matchingBracket {
-    color: var(--bks-text-editor-matchingbracket-fg-color);
-    background-color: var(--bks-text-editor-matchingbracket-bg-color);
-    text-decoration: underline;
-  }
-
-  // Marker styles
-  .cm-error {
-    background-color: var(--bks-text-editor-error-bg-color);
-    border-bottom: 1px solid var(--bks-text-editor-error-fg-color);
-    border-radius: 2px;
-  }
-
-  .cm-highlight {
-    background-color: var(--bks-text-editor-highlight-bg-color);
-    border-radius: 2px;
-  }
-
-  .cm-panel {
-    background-color: var(--bks-query-editor-bg);
-    color: var(--bks-text-dark);
-  }
-
   .cm-textfield {
     @include bk-form-input;
     width: 15em;
@@ -345,34 +268,28 @@
   padding: $gutter-h 0;
   border: 0;
   border-radius: 6px;
-  &, &.cm-tooltip {
-    background-color: var(--bks-text-editor-context-menu-bg-color);
-    color: var(--bks-text-editor-context-menu-fg-color);
-    @include card-shadow;
+  @include card-shadow;
+
+  .cm-completionIcon-table::before,
+  .cm-completionIcon-view::before,
+  .cm-completionIcon-materialized-view::before {
+    font-family: "Material Icons";
+    content: "grid_on"; // Table icon
+    font-weight: 600;
   }
 
   .cm-completionIcon-table::before {
-    font-family: "Material Icons";
-    content: "grid_on"; // Table icon
+    color: var(--bks-icon-table-color);
   }
 
-  .cm-completionIcon-view::before, .cm-completionIcon-materialized-view::before {
-    font-family: "Material Icons";
-    content: "grid_on"; // View icon
+  .cm-completionIcon-view::before {
+    color: var(--bks-icon-view-color);
   }
 
-  .cm-completionIcon {
-    display: inline-block;
-    font-size: 90%;
-    font-family: 'Material Design Icons';
-    margin-right: 0.5em;
-    width: 0.8em;
-    text-align: center;
+  .cm-completionIcon-materialized-view::before {
+    color: var(--bks-icon-materialized-view-color);
   }
-  &.cm-tooltip-autocomplete ul li[aria-selected] {
-    background-color: var(--bks-text-editor-context-menu-item-bg-color-active);
-    color: var(--bks-text-editor-context-menu-item-fg-color-active);
-  }
+
   ul li {
     padding: ($gutter-h * 0.5) $gutter-h;
     border-radius: 0;
@@ -406,73 +323,10 @@
     &.bks-autocomplete-option-property {
       color: var(--bks-text-editor-property-fg-color);
     }
+  }
 
-    // SQL specific completion items - table icons
-    &[data-completion="table"]::before,
-    &.cm-completionIcon-table::before,
-    &.cm-completionLabel-table::before {
-      content: "󰓫"; // Table icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      color: #{$brand-primary};
-      vertical-align: middle;
-    }
-
-    &[data-completion="view"]::before,
-    &.cm-completionIcon-view::before,
-    &.cm-completionLabel-view::before {
-      content: "󰯃"; // View icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      color: #{$brand-secondary};
-      vertical-align: middle;
-    }
-
-    &[data-completion="materialized-view"]::before,
-    &.cm-completionIcon-materialized-view::before,
-    &.cm-completionLabel-materialized-view::before {
-      content: "󰅒"; // Materialized view icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      color: #{$brand-info};
-      vertical-align: middle;
-    }
-
-    // Column icon
-    &[data-completion="column"]::before,
-    &.cm-completionIcon-column::before,
-    &.cm-completionLabel-column::before {
-      content: "󰓼"; // Column icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      color: #{$brand-success};
-      vertical-align: middle;
-    }
-
-    // Type-based icons
-    &.cm-completionIcon-keyword::before,
-    &.cm-completionLabel-keyword::before {
-      content: "󰌆"; // Keyword icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      color: var(--bks-text-editor-keyword-fg-color);
-      vertical-align: middle;
-    }
-
-    &.cm-completionIcon-text::before,
-    &.cm-completionLabel-text::before,
-    &.cm-completionIcon-type::before,
-    &.cm-completionLabel-type::before {
-      content: "󰦪"; // Text icon
-      margin-right: 6px;
-      font-family: 'Material Design Icons';
-      font-size: 16px;
-      vertical-align: middle;
-    }
+  .cm-completionMatchedText {
+    text-decoration: none;
+    font-weight: 600;
   }
 }

--- a/apps/ui-kit/lib/styles/_variables-v2.scss
+++ b/apps/ui-kit/lib/styles/_variables-v2.scss
@@ -78,4 +78,9 @@ based on the following:
 
   --bks-tab-link: #{hsl(from var(--bks-theme-bg) h s calc(l - 4))};
   --bks-badge-bg: #{rgb(from var(--bks-theme-base) r g b / 10%)};
+
+  // Icons
+  --bks-icon-table-color: hsl(from var(--bks-theme-primary) h s calc(l - 6));
+  --bks-icon-view-color: var(--bks-brand-secondary);
+  --bks-icon-materialized-view-color: var(--bks-brand-success);
 }

--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -7,7 +7,7 @@
     "url": "https://beekeeperstudio.io"
   },
   "private": false,
-  "version": "0.2.1",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/beekeeper-studio/beekeeper-studio.git",


### PR DESCRIPTION
I can't override CodeMirror styles by using the custom UI Kit css in AI Shell. Technically it's possible, but I'd need to specify all cm class names manually like this:

```css
.BksTextEditor.BksSqlTextEditor {
  .cm-keyword {
    color: var(--bks-text-editor-keyword-fg-color);
  }
  .cm-linenumber {
    color: var(--bks-text-editor-linenumber-fg-color);
  }
  ...
}
```

This PR should remove the hassle so we don't have to do to that.

Also, this fixes the autocomplete icons for tables and views:

<img width="238" height="125" alt="image" src="https://github.com/user-attachments/assets/525c6700-d92d-4bd7-8eff-4a56416523ea" />

NOTE: Will be used for AI Shell [editable query](https://github.com/beekeeper-studio/bks-ai-shell/pull/26) feature.