### PR TITLE
switch apt source to deb822 .sources and specify signed-by key inside it rather…

### DIFF
--- a/apps/studio/build/deb-postinstall
+++ b/apps/studio/build/deb-postinstall
@@ -19,7 +19,7 @@ if [ -f $OLD_FILE ]; then
   rm -f $OLD_FILE.save
 fi
 
-if [ ! -f /usr/bin/beekeeper-studio ]; then
+if [ ! -e /usr/bin/beekeeper-studio ]; then
   ln -s /opt/Beekeeper\ Studio/beekeeper-studio /usr/bin/beekeeper-studio
 fi
 


### PR DESCRIPTION
… than using deprecated apt-key

The follow-up of https://github.com/beekeeper-studio/beekeeper-studio/pull/1785#issuecomment-1839185386 that never was. 
Related to https://github.com/beekeeper-studio/beekeeper-studio/issues/1342 and https://github.com/beekeeper-studio/beekeeper-studio/issues/1218