### PR TITLE
Fix switch connection menu

### DIFF
--- a/apps/studio/src/components/quicksearch/QuickSearch.vue
+++ b/apps/studio/src/components/quicksearch/QuickSearch.vue
@@ -265,6 +265,7 @@ export default Vue.extend({
           break;
         case 'connection':
           if (!this.isUltimate && isUltimateType(result.item.connectionType)) {
+            this.$noty.error('Cannot switch to Ultimate only connection.')
             return
           }
 

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -269,6 +269,7 @@ export default {
     },
     async selectConnection(config) {
       if (!this.isUltimate && isUltimateType(config?.connectionType)) {
+        this.$noty.error('Cannot switch to Ultimate only connection.')
         return;
       }
 


### PR DESCRIPTION
The switch connection menu was not properly passing the config to the store action. It also looks like we weren't doing license checks in those methods so it could be possible for users to circumvent license restrictions.