### PR TITLE
Fix Transaction timeout

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -626,6 +626,7 @@ export const ConnHandlers: IConnectionHandlers = {
 function clearTransactionTimeout(sId: string, tabId: number) {
   if (state(sId).transactionTimeouts.has(tabId)) {
     const timeout = state(sId).transactionTimeouts.get(tabId);
+    state(sId).transactionTimeouts.delete(tabId);
     clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
the timeout for transactions was appearing in auto commit mode sometimes. If you went to manual commit mode, ran a query, then finished that transaction and went back to auto commit mode, any query run would be subject to the transaction timeout. This is because when clearing the timeout we didn't remove the cleared timeout from the map so the app thought that there was a timeout that needed to be extended.