### PR TITLE
Fix saving existing saved queries

### DIFF
--- a/apps/studio/src/store/modules/data/query/UtilityQueryModule.ts
+++ b/apps/studio/src/store/modules/data/query/UtilityQueryModule.ts
@@ -21,7 +21,7 @@ export const UtilQueryModule: DataStore<TransportFavoriteQuery, DataState<Transp
     setSavedQueryFilter: _.debounce(function (context, filter) {
       context.commit('savedQueryFilter', filter);
     }, 500)
-  }, {}, { text: true, title: true, database: true, excerpt: true }),
+  }, {}, { text: true, title: true, database: true, excerpt: true, id: true }),
   getters: {
     filteredQueries(state) {
       if (!state.filter) {


### PR DESCRIPTION
fix #3746 

findOne in the utility query data module wasn't pulling back the id for the saved query, which meant we couldn't just automatically save it.