### PR TITLE
FIX: Trust Server Certificate from URL

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -380,6 +380,11 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
       if (parsed.params?.sslmode && parsed.params.sslmode !== 'disable') {
         this.ssl = true
       }
+
+      if (parsed.params?.TrustServerCertificate && parsed.params.TrustServerCertificate === 'true') {
+        this.trustServerCertificate = true
+      }
+
       this.host = parsed.hostname || this.host
       this.port = parsed.port || this.port
       this.username = extractedUser ?? parsed.user


### PR DESCRIPTION
Had a problem when trying to open a database via File Associations.

```sh
xdg-open "mssql://user:pass@server?TrustServerCertificate=true"
```

This PR will make it possible to set TrustServerCertificate from URL.