### PR TITLE
fix saved query value

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1165,6 +1165,14 @@
             this.$modal.hide(`save-modal-${this.tab.id}`)
             const id = await this.$store.dispatch('data/queries/save', payload)
             this.tab.queryId = id
+            try {
+              const savedQuery = await this.$store.dispatch('data/queries/findOne', id)
+              this.fullQuery = savedQuery
+            } catch (e) {
+              log.error("Could not find saved query", e);
+              // fallback to payload
+              this.fullQuery = payload;
+            }
 
             this.$nextTick(async () => {
               this.unsavedText = this.query.text


### PR DESCRIPTION
Fixes #3752 

Obviously, there's a better way to fix this and clean up the mess, but for this one, I don't want to touch it too much if it doesn't break lol.

In summary, what happened was, notice that just after the added lines, we called `$nextTick` and `this.query.text` was `undefined`. Before, `this.query` was set by something else magically, which explains why we use `$nextTick` (and using it in this scenario is a smell I think).