### PR TITLE
Plugin initialization should not be blocking

### DIFF
--- a/apps/studio/src-commercial/entrypoints/utility.ts
+++ b/apps/studio/src-commercial/entrypoints/utility.ts
@@ -167,11 +167,9 @@ async function init() {
   ormConnection = new ORMConnection(platformInfo.appDbPath, false);
   await ormConnection.connect();
 
-  try {
-    await pluginManager.initialize();
-  } catch (e) {
+  pluginManager.initialize().catch((e) => {
     log.error("Error initializing plugin manager", e);
-  }
+  });
 
   process.parentPort.postMessage({ type: 'ready' });
 }


### PR DESCRIPTION
## Scenario 1: Scanning installed plugins takes 10 seconds
[screen-recording-1766509387431.webm](https://github.com/user-attachments/assets/b4047fad-202e-4a89-9d9a-64d73bc6069c)

## Scenario 2: Fetching network (for installing/updating core plugins) takes 10 seconds
[screen-recording-1766510981487.webm](https://github.com/user-attachments/assets/2197a556-0534-4737-9a72-4284bc98879a)
