### PR TITLE
fix saving multiple models in appdb handlers

### DIFF
--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -67,7 +67,7 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
             await niceValidateOrReject(newEnt);
             return newEnt;
           }));
-          return (await cls.save(newEnts, options)).map((e) => transform(e, cls));
+          return await Promise.all((await cls.save(newEnts, options)).map((e) => transform(e, cls)));
       } else {
         let dbObj: any = obj.id ? await cls.findOneBy({ id: obj.id }) : new cls().withProps(obj);
         if (dbObj && obj.id) {


### PR DESCRIPTION
The saving was happening, but the return value was bad. Not sure if this actually affected anything, but it was throwing errors.