### PR TITLE
fix random modals popping up after authentication with azure

### DIFF
--- a/apps/studio/src/components/common/modals/LoadingSSOModal.vue
+++ b/apps/studio/src/components/common/modals/LoadingSSOModal.vue
@@ -57,5 +57,8 @@ export default Vue.extend({
       this.$emit('cancel');
     },
   },
+  beforeDestroy() {
+    this.$modal.hide(this.modalName);
+  }
 });
 </script>


### PR DESCRIPTION
This was caused by a race condition between the connection interface unloading  and the loading SSO modal being hidden. The fix is just to ensure that before destroying the modal we hide it.