### PR TITLE
fix duplicating plugin tabs

### DIFF
--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -9,7 +9,7 @@ export type PluginTabType = 'plugin-base' | 'plugin-shell';
 export type CoreTabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
 export type TabType = CoreTabType | PluginTabType
 
-const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName']
+const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName', 'context']
 
 export interface TransportOpenTab<Context = {}> extends Transport {
   tabType: TabType,


### PR DESCRIPTION
The duplicate function did not pick up the `context` property which is where plugin "context" (plugin id, view id, data scoped to a tab) is stored.

[screen-recording-1768490803572.webm](https://github.com/user-attachments/assets/317b2c39-f6aa-4113-8a3f-1d1ce956419a)
