### PR TITLE
fix dependencies for pacman package

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -158,6 +158,9 @@ module.exports = {
     },
     publish: ['github']
   },
+  pacman: {
+    depends: ["c-ares", "ffmpeg", "gtk3", "llhttp", "libevent", "libvpx", "libxslt", "libxss", "minizip", "nss", "re2", "snappy", "libnotify", "libappindicator-gtk3"]
+  },
   deb: {
     publish: [
       'github'


### PR DESCRIPTION
Electron builder has defaults for the dependencies for pacman packages, but `http-parser` has now been removed from the arch repositories as it is unmaintained and nodejs now uses `llhttp`. https://archlinux.org/todo/move-to-llhttp-from-http-parser/

This just manually sets the dependencies for the pacman package and replaces `http-parser` with `llhttp`