### PR TITLE
upgrade tabulator

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -128,7 +128,7 @@
     "sqlanywhere": "beekeeper-studio/node-sqlanywhere#54d1ef2052ccdfe963f0956a3e4d024ee6f1fd8d",
     "ssh2": "^1.14.0",
     "surrealdb": "^1.3.2",
-    "tabulator-tables": "beekeeper-studio/tabulator#137018661b71291b18f19324ef39484496da281b",
+    "tabulator-tables": "beekeeper-studio/tabulator#f9d3c0cdf0933a9a1bc5056b773c02a68a309fa1",
     "tinyduration": "^3.2.4",
     "trino-client": "^0.2.7",
     "typeface-roboto": "^0.0.75",

--- a/apps/studio/src/assets/styles/app.scss
+++ b/apps/studio/src/assets/styles/app.scss
@@ -2,7 +2,7 @@
 @import "codemirror/lib/codemirror";
 @import "codemirror/addon/hint/show-hint";
 @import "noty/lib/noty";
-@import "tabulator-tables/dist/css/tabulator_midnight";
+@import "tabulator-tables/dist/css/tabulator_midnight.css";
 @import "codemirror/theme/monokai";
 @import "codemirror/addon/merge/merge";
 @import "codemirror/addon/search/matchesonscrollbar";

--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -116,7 +116,7 @@
     "split.js": "^1.5.11",
     "sql-formatter": "15.6.10",
     "sql-query-identifier": "^2.8.0",
-    "tabulator-tables": "beekeeper-studio/tabulator#137018661b71291b18f19324ef39484496da281b",
+    "tabulator-tables": "beekeeper-studio/tabulator#f9d3c0cdf0933a9a1bc5056b773c02a68a309fa1",
     "tinyduration": "^3.2.4",
     "typescript": "~5.8.3",
     "vite": "~5.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13584,9 +13584,9 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tabulator-tables@beekeeper-studio/tabulator#137018661b71291b18f19324ef39484496da281b:
-  version "6.2.0-bks.7"
-  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/137018661b71291b18f19324ef39484496da281b"
+tabulator-tables@beekeeper-studio/tabulator#f9d3c0cdf0933a9a1bc5056b773c02a68a309fa1:
+  version "6.3.1-bks.1"
+  resolved "https://codeload.github.com/beekeeper-studio/tabulator/tar.gz/f9d3c0cdf0933a9a1bc5056b773c02a68a309fa1"
 
 tar-fs@^2.0.0, tar-fs@~2.1.2:
   version "2.1.2"


### PR DESCRIPTION
This version of tabulator contains:
- Version 6.3.1
- fix navigation conflict with SelectRange and Edit https://github.com/olifolkerd/tabulator/pull/4516
- blur editor after pressing next/prev https://github.com/olifolkerd/tabulator/pull/4517
- fix errors when handling BigInt https://github.com/beekeeper-studio/tabulator/commit/13f9a9b99a7fb7bb8359a6f991afbd874835e2fd