### PR TITLE
fix jsonviewer being able to edit when editing is disabled

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -620,7 +620,7 @@ export default Vue.extend({
       return signs
     },
     editablePaths() {
-      if (!this.table.columns) return []
+      if (!this.table.columns || !this.editable) return []
 
       const paths = []
       for (const column of this.table.columns) {
@@ -2050,6 +2050,9 @@ export default Vue.extend({
       ])
     },
     handleJsonValueChange({key, value}) {
+      // this is just a safeguard, we shouldn't hit it but if we do it can save us from catastrophe
+      if (!this.editable) return;
+
       const column = this.table.columns.find((c) => c.columnName === key);
       if (column) {
         const isJsonColumn = String(column.dataType).toUpperCase() === 'JSON' || String(column.dataType).toUpperCase() === 'JSONB'


### PR DESCRIPTION
The Json viewer editing was not being disabled when editing for the table was disabled. So if we didn't have primary keys for the table, this meant the user was able to edit a record in the sidebar, apply the changes, and those changes would apply to every record in the table 