### PR TITLE
fix: 🐛 esc doesn't autofocus to results

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -325,6 +325,7 @@
       },
       closeTableFilter() {
         this.hiddenFilter = true
+        if (this.$refs.filterInput !== document.activeElement) return
         this.triggerFocus()
       },
       searchHandler() {


### PR DESCRIPTION
Unless the search filter in the results is active, don't autofocus. Still close if showing, but don't focus out

resolves #3823 
![3823_Autocomplete-Esc](https://github.com/user-attachments/assets/0619218d-9335-4534-ab0d-259724aafc64)
