### PR TITLE
fix: decoding connection password from url

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -386,7 +386,7 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
       this.host = parsed.hostname || this.host
       this.port = parsed.port || this.port
       this.username = extractedUser ?? parsed.user
-      this.password = extractedPassword ?? parsed.password
+      this.password = decodeURIComponent(extractedPassword ?? parsed.password)
       this.defaultDatabase = parsed.path?.join('/') ?? this.defaultDatabase
       return true
     } catch (ex) {


### PR DESCRIPTION
Simply wrapped password in the [decodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent).

[connection-string](https://github.com/vitaly-t/connection-string) by default doesn't parse them, and [provides a .toString method](https://github.com/vitaly-t/connection-string?tab=readme-ov-file#api) for that.

Fixes: #3840 
Useful info: vitaly-t/connection-string#48
Related TODO: #1495 