### PR TITLE
fix unresizable pin list

### DIFF
--- a/apps/studio/src/components/sidebar/core/TableList.vue
+++ b/apps/studio/src/components/sidebar/core/TableList.vue
@@ -125,7 +125,7 @@
           </button>
 
           <x-button
-            v-if="!usedConfig.readOnlyMode"
+            v-if="!usedConfig?.readOnlyMode"
             class="settings-btn"
             menu
           >


### PR DESCRIPTION
Fix #3863 

The `usedConfig` is accessed when it's `null` and that causes the `TableList` to not initialize properly.