### PR TITLE
feat: added support for creating sqlite file

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -88,11 +88,6 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
   async connect(): Promise<void> {
     await super.connect();
 
-    // Create the database file if it doesn't exist; if it exists, opening it validates it's a valid SQLite file.
-    if (!this.isTempDB && this.databasePath) {
-      this._createDatabase(this.databasePath);
-    }
-
     // verify that the connection is valid
     await this.driverExecuteSingle('PRAGMA schema_version', { overrideReadonly: true });
 


### PR DESCRIPTION
Fixes #3848 

**SQLite: create DB from connection form and validate on connect**

- **SqliteForm.vue**: Database file field is editable and has a “Create” button (same pattern as DuckDB). Label uses input-id="Database" for accessibility.
- **sqlite.ts**: On connect, for file-based (non–in-memory) paths, create the DB file if it’s missing and open it to validate; in-memory/empty paths are unchanged.

<img width="638" height="522" alt="Screenshot from 2026-02-15 21-41-47" src="https://github.com/user-attachments/assets/bbec1cb3-a1bf-4a33-bce6-80aeb500334f" />
