### PR TITLE
feat: support redis:// and rediss:// protocol schemes

### DIFF
--- a/apps/studio/electron-builder-config-test.js
+++ b/apps/studio/electron-builder-config-test.js
@@ -103,6 +103,11 @@ module.exports = {
       name: "SQL Server URL scheme",
       schemes: ["sqlserver", "microsoftsqlserver", "mssql"],
       role: "Editor"
+    },
+    {
+      "name": "Redis URL scheme",
+      "schemes": ["redis", "rediss"],
+      "role": "Editor"
     }
   ],
   mac: {

--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -139,6 +139,11 @@ module.exports = {
       name: "SQL Server URL scheme",
       schemes: ["sqlserver", "microsoftsqlserver", "mssql"],
       role: "Editor"
+    },
+    {
+      "name": "Redis URL scheme",
+      "schemes": ["redis", "rediss"],
+      "role": "Editor"
     }
   ],
   mac: {


### PR DESCRIPTION
Registered 'redis://' and 'rediss://' protocol schemes in the electron builder configuration. 

This allows the desktop application to be opened directly via deep links from browsers or terminals. I have manually verified this by updating the Info.plist in my local environment and confirmed that running 'open redis://localhost:6379' successfully triggers the application.