### PR TITLE
Fix #3521 : Add relations shortcut is also adding a column

### DIFF
--- a/apps/studio/src/components/tableinfo/TableSchema.vue
+++ b/apps/studio/src/components/tableinfo/TableSchema.vue
@@ -183,6 +183,7 @@ export default Vue.extend({
     ...mapGetters(['dialect', 'dialectData']),
     ...mapState(['database', 'connection', 'usedConfig']),
     hotkeys() {
+      if (!this.active) return {}
       return this.$vHotkeyKeymap({
         'general.refresh': this.refreshColumns,
         'general.addRow': this.addRow,


### PR DESCRIPTION
The CMD+N shortcut was mapped to general.addRow in multiple components. The TableRelations.vue component already had a safeguard if (!this.active) return {} to ensure that hotkeys are only registered when the tab is active. However, TableSchema.vue did not have this check, causing the column handler to trigger even when the user was in a different tab.

The issue is demonstrated and resolved in the following link.
https://youtu.be/qZ20rcTtEfY