### PR TITLE
Add Windows Authentication auth option for SQL Server and dynamic switch to msnodesqlv8 if chosen

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -37,7 +37,8 @@ module.exports = {
   ],
   afterPack: "./build/afterPack.js",
   asarUnpack: [
-    'package.json'
+    'package.json',
+    '**/msnodesqlv8/build/Release/*.node'
   ],
   extraResources: [
     {

--- a/apps/studio/esbuild.mjs
+++ b/apps/studio/esbuild.mjs
@@ -35,7 +35,7 @@ const externals = ['better-sqlite3', 'sqlite3',
         'oracledb', '@electron/remote', "@google-cloud/bigquery",
         'pg-query-stream', 'electron', '@duckdb/node-api',
         '@mongosh/browser-runtime-electron', '@mongosh/service-provider-node-driver',
-        'mongodb-client-encryption', 'sqlanywhere', 'ws', 'kerberos',
+        'mongodb-client-encryption', 'sqlanywhere', 'ws', 'kerberos', 'msnodesqlv8',
         ...ensureInstalled,
       ]
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -157,6 +157,9 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs-parser": "^21.0.0"
   },
+  "optionalDependencies": {
+    "msnodesqlv8": "^5.1.5"
+  },
   "devDependencies": {
     "@aws-sdk/types": "^3.127.0",
     "@babel/core": "^7.29.0",

--- a/apps/studio/src-commercial/backend/lib/connection-provider.ts
+++ b/apps/studio/src-commercial/backend/lib/connection-provider.ts
@@ -57,6 +57,7 @@ export default {
       sslKeyFile: config.sslKeyFile,
       sslRejectUnauthorized: config.sslRejectUnauthorized,
       trustServerCertificate: config.trustServerCertificate,
+      windowsAuthEnabled: config.windowsAuthEnabled,
       instantClientLocation: settings?.oracleInstantClient?.stringValue || undefined,
       oracleConfigLocation: settings?.oracleConfigLocation?.stringValue || undefined,
       options: config.options,

--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -215,6 +215,9 @@ export class DbConnectionBase extends ApplicationEntity {
   @Column({ type: 'simple-json', nullable: false })
   bigQueryOptions: BigQueryOptions = {}
 
+  @Column({ type: 'boolean', nullable: false })
+  windowsAuthEnabled: boolean = false
+
   @Column({ type: 'simple-json', nullable: false, transformer: [azureEncrypt]})
   azureAuthOptions: AzureAuthOptions = {}
 

--- a/apps/studio/src/common/appdb/models/used_connection.ts
+++ b/apps/studio/src/common/appdb/models/used_connection.ts
@@ -29,6 +29,7 @@ export class UsedConnection extends DbConnectionBase implements ISimpleConnectio
       }
       this.options = other.options
       this.trustServerCertificate = other.trustServerCertificate
+      this.windowsAuthEnabled = other.windowsAuthEnabled
       this.redshiftOptions = other.redshiftOptions
       this.cassandraOptions = other.cassandraOptions
       this.socketPath = other.socketPath

--- a/apps/studio/src/common/interfaces/IConnection.ts
+++ b/apps/studio/src/common/interfaces/IConnection.ts
@@ -47,6 +47,7 @@ export interface ISimpleConnection extends Transport {
   readOnlyMode: boolean
   labelColor?: Nullable<string>
   trustServerCertificate?: boolean
+  windowsAuthEnabled?: boolean
   serviceName: Nullable<string>
   options?: any
   redshiftOptions?: RedshiftOptions

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -74,7 +74,7 @@
       :supportComplexSSL="supportComplexSSL"
     />
 
-    <div class="row gutter">
+    <div v-if="!hideCredentials" class="row gutter">
       <div class="col form-group" :class="[showPasswordForm ? 's6' : 's12']">
         <label for="user">User</label>
         <masked-input
@@ -132,6 +132,11 @@ export default {
     showPasswordForm: {
       type: Boolean,
       default: true
+    },
+    // Used by SqlServerForm to hide credentials when Windows Authentication is selected
+    hideCredentials: {
+      type: Boolean,
+      default: false
     }
   },
   components: {

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -5,11 +5,12 @@
       <!-- need to take the value -->
       <select name="" v-model="authType" id="">
         <option value="default">Username / Password</option>
+        <option value="windows">Windows Authentication</option>
         <option :key="`${t.value}-${t.name}`" v-for="t in authTypes" :value="t.value">{{t.name}}
         </option>
       </select>
     </div>
-    <common-server-inputs v-show="!azureAuthEnabled" :config="config">
+    <common-server-inputs v-show="!azureAuthEnabled" :config="config" :hide-credentials="windowsAuthEnabled">
       <div class="advanced-connection-settings">
         <h4 class="advanced-heading">
           SQL Server Options
@@ -68,12 +69,18 @@
     components: {CommonEntraId, CommonServerInputs, CommonAdvanced },
     props: ['config'],
     mounted() {
-      this.authType = this.config?.azureAuthOptions?.azureAuthType || 'default'
-      this.azureAuthEnabled = this.config?.azureAuthOptions?.azureAuthEnabled || false
+      if (this.config?.windowsAuthEnabled) {
+        this.authType = 'windows'
+        this.windowsAuthEnabled = true
+      } else {
+        this.authType = this.config?.azureAuthOptions?.azureAuthType || 'default'
+        this.azureAuthEnabled = this.config?.azureAuthOptions?.azureAuthEnabled || false
+      }
     },
     data() {
       return {
         azureAuthEnabled: false,
+        windowsAuthEnabled: false,
         authType: 'default',
         authTypes: AzureAuthTypes,
       }
@@ -82,6 +89,13 @@
       async authType() {
         if (this.authType === 'default') {
           this.azureAuthEnabled = false
+          this.windowsAuthEnabled = false
+          this.config.windowsAuthEnabled = false
+          this.config.azureAuthOptions.azureAuthType = undefined
+        } else if (this.authType === 'windows') {
+          this.azureAuthEnabled = false
+          this.windowsAuthEnabled = true
+          this.config.windowsAuthEnabled = true
           this.config.azureAuthOptions.azureAuthType = undefined
         } else {
           if (this.$store.getters.isCommunity) {
@@ -89,6 +103,8 @@
             this.authType = 'default'
           } else {
             this.azureAuthEnabled = true
+            this.windowsAuthEnabled = false
+            this.config.windowsAuthEnabled = false
             this.config.azureAuthOptions.azureAuthType = this.authType
           }
         }
@@ -97,10 +113,18 @@
         this.config.azureAuthOptions.azureAuthEnabled = this.azureAuthEnabled
       },
       config() {
-        if (this.config.azureAuthOptions.azureAuthEnabled) {
-          this.authType = this.config.azureAuthOptions.azureAuthType;
+        if (this.config.windowsAuthEnabled) {
+          this.authType = 'windows'
+          this.windowsAuthEnabled = true
+          this.azureAuthEnabled = false
+        } else if (this.config.azureAuthOptions?.azureAuthEnabled) {
+          this.authType = this.config.azureAuthOptions.azureAuthType
+          this.windowsAuthEnabled = false
+          this.azureAuthEnabled = true
         } else {
-          this.authType = 'default';
+          this.authType = 'default'
+          this.windowsAuthEnabled = false
+          this.azureAuthEnabled = false
         }
       },
     },

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -1072,7 +1072,50 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     await super.connect();
 
     this.dbConfig = await this.configDatabase(this.server, this.database, signal)
-    this.pool = await new ConnectionPool(this.dbConfig).connect();
+
+    if (this.server.config.windowsAuthEnabled) {
+      if (process.platform !== 'win32') {
+        throw new Error('Windows Authentication is only supported on Windows.')
+      }
+      // msnodesqlv8 is a Windows-only optional native module that supports
+      // SSPI passthrough (true Windows Integrated Authentication).
+      // The default mssql/tedious driver cannot do this.
+      let sqlWindows: any
+      try {
+        sqlWindows = require('mssql/msnodesqlv8')
+      } catch {
+        // msnodesqlv8 is bundled with Beekeeper Studio on Windows. This error means
+        // the native binary failed to load. Try reinstalling the application.
+        throw new Error('Windows Authentication is not available: the msnodesqlv8 native module could not be loaded. Try reinstalling Beekeeper Studio.')
+      }
+
+      // Probe for a working ODBC driver with msnodesqlv8 directly.
+      const { driver, legacy } = await this.findWindowsAuthDriver()
+
+      if (legacy) {
+        log.warn('Windows Authentication is using the legacy "{SQL Server}" ODBC driver, ' +
+          'which does not support TLS 1.2. For improved security, install ' +
+          '"ODBC Driver 17 for SQL Server" or "ODBC Driver 18 for SQL Server" from Microsoft.')
+      }
+
+      // Use beforeConnect to patch mssql v11's connection string before msnodesqlv8
+      // uses it. mssql v11's buildConnectionString ignores driver config property
+      // defaulting to "SQL Server Native Client 11.0"), passes
+      // Trusted_Connection as a boolean (should be yes/no), and doesn't include TrustServerCertificate.
+      // beforeConnect also preserves mssql's instance name and SSH tunnel server handling.
+      const trustCert = this.dbConfig.options?.trustServerCertificate
+      this.pool = await new sqlWindows.ConnectionPool({
+        ...this.dbConfig,
+        beforeConnect: (cfg: any) => {
+          cfg.conn_str = cfg.conn_str
+            .replace(/Driver=[^;]*/i, `Driver={${driver}}`)
+            .replace(/Trusted_Connection=[^;]*/i, 'Trusted_Connection=yes')
+          if (trustCert) cfg.conn_str += ';TrustServerCertificate=yes'
+        }
+      }).connect()
+    } else {
+      this.pool = await new ConnectionPool(this.dbConfig).connect()
+    }
 
     this.pool.on('error', (err) => {
       if (err instanceof ConnectionError) {
@@ -1232,6 +1275,54 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
   }
 
+  // I couldn't get mssql to surface real error messages when Windows Auth connections
+  // fail. It wraps native msnodesqlv8 errors into '[object Object]' strings. So we
+  // probe directly via msnodesqlv8 first, which gives actionable errors (wrong server,
+  // auth failure, etc.) and also tells us which ODBC driver is installed.
+  private async findWindowsAuthDriver(): Promise<{ driver: string, legacy: boolean }> {
+    const rawSql = require('msnodesqlv8')
+    const server = this.dbConfig.server
+    const port = this.dbConfig.port || 1433
+    const database = this.dbConfig.database || 'master'
+    const trustCert = this.dbConfig.options?.trustServerCertificate ? 'yes' : 'no'
+
+    // Prefer modern ODBC drivers (TLS 1.2 support). Fall back to the legacy
+    // built-in Windows driver ({SQL Server} / sqlsrv32.dll) as a last resort.
+    // It works for basic connectivity but does not support TLS 1.2.
+    const candidates = [
+      { driver: 'ODBC Driver 17 for SQL Server', legacy: false },
+      { driver: 'ODBC Driver 18 for SQL Server', legacy: false },
+      { driver: 'SQL Server', legacy: true },
+    ]
+
+    for (const candidate of candidates) {
+      const connStr = `Driver={${candidate.driver}};Server=${server},${port};Database=${database};Trusted_Connection=yes;TrustServerCertificate=${trustCert};`
+      const result: { ok: boolean, error?: string } = await new Promise((resolve) => {
+        rawSql.open(connStr, (err: any, conn: any) => {
+          if (err) {
+            const msgs = (Array.isArray(err) ? err : [err])
+              .map((e: any) => (typeof e?.message === 'string' ? e.message : String(e)))
+              .filter(Boolean).join('; ')
+            resolve({ ok: false, error: msgs })
+          } else {
+            conn.close(() => resolve({ ok: true }))
+          }
+        })
+      })
+
+      if (result.ok) return candidate
+
+      const isDriverMissing = result.error?.includes('Data source name not found') || result.error?.includes('IM002')
+      if (!isDriverMissing) {
+        // Real error (auth failure, server unreachable, etc.) - surface it directly
+        throw new Error(result.error)
+      }
+    }
+
+    throw new Error('Windows Authentication requires an ODBC Driver for SQL Server to be installed. ' +
+      'Download "ODBC Driver 17 for SQL Server" or "ODBC Driver 18 for SQL Server" from Microsoft.')
+  }
+
   private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, signal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes
     const config: any = {
       server: server.config.host,
@@ -1261,18 +1352,15 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     if (server.config.windowsAuthEnabled) {
       config.port = Number(server.config.port);
 
-      if (server.config.domain) {
-        config.domain = server.config.domain;
-      }
-
       if (server.sshTunnel) {
         config.server = server.config.localHost;
         config.port = server.config.localPort;
       }
 
+      // trustedConnection delegates authentication to Windows SSPI via msnodesqlv8
       config.options = {
+        trustedConnection: true,
         trustServerCertificate: server.config.trustServerCertificate,
-        trustedConnection: true
       };
 
       return config;

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -1258,6 +1258,26 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       return config;
     }
 
+    if (server.config.windowsAuthEnabled) {
+      config.port = Number(server.config.port);
+
+      if (server.config.domain) {
+        config.domain = server.config.domain;
+      }
+
+      if (server.sshTunnel) {
+        config.server = server.config.localHost;
+        config.port = server.config.localPort;
+      }
+
+      config.options = {
+        trustServerCertificate: server.config.trustServerCertificate,
+        trustedConnection: true
+      };
+
+      return config;
+    }
+
     config.user = server.config.user;
     config.password = server.config.password;
     config.port = Number(server.config.port);

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -208,6 +208,7 @@ export interface IDbConnectionServerConfig {
   localHost?: string,
   localPort?: number,
   trustServerCertificate?: boolean
+  windowsAuthEnabled?: boolean
   instantClientLocation?: string
   oracleConfigLocation?: string
   options?: any

--- a/apps/studio/src/migration/20260321_add_windows_auth_to_connections.js
+++ b/apps/studio/src/migration/20260321_add_windows_auth_to_connections.js
@@ -1,0 +1,12 @@
+export default {
+  name: '20260321-windows-auth-enabled',
+  async run(runner) {
+    const queries = [
+      `ALTER TABLE saved_connection ADD COLUMN windowsAuthEnabled boolean not null default false`,
+      `ALTER TABLE used_connection ADD COLUMN windowsAuthEnabled boolean not null default false`,
+    ]
+    for (let i = 0; i < queries.length; i++) {
+      await runner.query(queries[i])
+    }
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -83,6 +83,7 @@ import migrateRedshiftToIamOptions from './20250820_migrate_redshift_to_iam_opti
 import createConnectionFolders from './20260223_create_connection_folders'
 import createQueryFolders from './20260223_create_query_folders'
 import addPositionToItems from './20260227_add_position_to_items'
+import addWindowsAuthToConnections from './20260321_add_windows_auth_to_connections'
 
 import ultimate from './ultimate/index'
 
@@ -128,6 +129,7 @@ const realMigrations = [
   addIamAuthOptions, migrateRedshiftToIamOptions, addEditorFontSize,
   createConnectionFolders, createQueryFolders,
   addPositionToItems,
+  addWindowsAuthToConnections,
 ]
 
 // fixtures require the models

--- a/test-winauth.js
+++ b/test-winauth.js
@@ -1,0 +1,74 @@
+/**
+ * Standalone test for Windows Authentication with msnodesqlv8.
+ * Run from the apps/studio directory where msnodesqlv8 is installed:
+ *
+ *   node ../../test-winauth.js --server MYSERVER --port 1433 --database master
+ *
+ * Or edit the defaults below and just run:
+ *
+ *   node test-winauth.js
+ */
+
+const args = process.argv.slice(2)
+const get = (flag, def) => { const i = args.indexOf(flag); return i !== -1 ? args[i + 1] : def }
+
+const server   = get('--server',   'localhost')
+const port     = get('--port',     '1433')
+const database = get('--database', 'master')
+const trustCert = get('--trust-cert', 'yes')  // yes or no
+
+const drivers = [
+  'ODBC Driver 18 for SQL Server',
+  'ODBC Driver 17 for SQL Server',
+]
+
+async function tryDriver(driver) {
+  const connStr = `Driver={${driver}};Server=${server},${port};Database=${database};Trusted_Connection=yes;TrustServerCertificate=${trustCert};`
+  console.log(`\nTrying: ${connStr}`)
+
+  let sql
+  try {
+    sql = require('msnodesqlv8')
+  } catch (e) {
+    console.error('ERROR: msnodesqlv8 could not be loaded:', e.message)
+    process.exit(1)
+  }
+
+  return new Promise((resolve) => {
+    sql.open(connStr, (err, conn) => {
+      if (err) {
+        const msgs = (Array.isArray(err) ? err : [err])
+          .map(e => `[${e.sqlstate || '?'}] ${e.message || e}`)
+          .join('\n  ')
+        console.error(`FAILED:\n  ${msgs}`)
+        resolve(false)
+      } else {
+        console.log('SUCCESS: connection opened, running test query...')
+        conn.query('SELECT @@VERSION AS version', (qErr, rows) => {
+          if (qErr) {
+            console.error('Query error:', qErr)
+          } else {
+            console.log('Server version:', rows[0]?.version?.split('\n')[0])
+          }
+          conn.close()
+          resolve(true)
+        })
+      }
+    })
+  })
+}
+
+;(async () => {
+  console.log(`Testing Windows Auth connection to ${server}:${port} / ${database}`)
+
+  for (const driver of drivers) {
+    const ok = await tryDriver(driver)
+    if (ok) {
+      console.log(`\nWorking driver: ${driver}`)
+      process.exit(0)
+    }
+  }
+
+  console.error('\nAll drivers failed.')
+  process.exit(1)
+})()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11934,6 +11934,15 @@ ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msnodesqlv8@^5.1.5:
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/msnodesqlv8/-/msnodesqlv8-5.1.5.tgz#9320b480b0599f290fd7424477bce2c4c917aa38"
+  integrity sha512-19PJY7FT/i5Do+b7A3K6uOSh6lgUbEPxOrWdVauNrnKpKdNyzX2lf4vN5aba+5y7eE/ERsMUelK6royuiL5MVg==
+  dependencies:
+    node-abi "^4.24.0"
+    node-addon-api "^8.5.0"
+    prebuild-install "^7.1.3"
+
 mssql@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/mssql/-/mssql-11.0.1.tgz#a32ab7763bfbb3f5d970e47563df3911fc04e21d"
@@ -12059,6 +12068,13 @@ node-abi@^4.2.0:
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.24.0.tgz#fcc1b4c645ffb4c0f39e2dbfb9c41698ba7e782e"
   integrity sha512-u2EC1CeNe25uVtX3EZbdQ275c74zdZmmpzrHEQh2aIYqoVjlglfUpOX9YY85x1nlBydEKDVaSmMNhR7N82Qj8A==
+  dependencies:
+    semver "^7.6.3"
+
+node-abi@^4.24.0:
+  version "4.28.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.28.0.tgz#2c93b89b6bc2208155b3c3ed5620211da8eb62a5"
+  integrity sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==
   dependencies:
     semver "^7.6.3"
 


### PR DESCRIPTION
With Microsoft ending support for Azure Data Studio in Feb 2026, I am left without a clean, DB focused tool that I can use to keep my SQL queries separate from VSCode at work. Beekeeper Studio seems like a great fit, but the requirement of storing credentials isn't ideal for my corporate windows environment, and we aren't fully on Entra ID yet. Unfortunately the pure javascript Tedious driver cannot leverage Microsoft's SSPI bindings required for kerberos without a wrapper of some kind.

There are several open issues on beekeeper-studio that are requesting a solution to this:
#1186, #48, and #534 
as well as more on tedious github repo to show discussion on tedious limitations/roadmap.
[#660](https://github.com/tediousjs/tedious/issues/660), [#415](https://github.com/tediousjs/tedious/issues/415), [#1009](https://github.com/tediousjs/tedious/issues/1009), and [#306](https://github.com/tediousjs/tedious/issues/306)

So I know I am not alone in hoping for this to be addressed, and with ADS end of support I assume this is only increasing recently

The cleanest solution I could come up with involved an added optional dependency for msnodesqlv8 which does offer this support. On top of this node module, the SQL driver on the local system must be ODBC 17 or 18 to fully support TLS1.2
The basic SQL Server driver works without TLS 1.2, but is no longer officially supported by Microsoft past SQL 2012.

I do not notice any difference in the experience between connecting with integrated auth with msnodesqlv8 and using password with mssql + the tedious driver, but I haven't tested every edge case.

I ran the unit test in /app/studio and all passed.

If you have any feedback, even harsh criticism please share. I am happy to consider this just a learning experience since it is my first work with electron and first time contributing to a project. I would love to learn if there is a plan to include this feature some other way, and what architecture is planned to do so, or if the plan is to simply support Azure auth only. 

Thank you for all your work!

