### PR TITLE
Add menu icons for macOS by assigning the role to some menu items

### DIFF
--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -11,6 +11,7 @@ export default class extends DefaultMenu {
   viewMenu(): Electron.MenuItemConstructorOptions {
     const result: Electron.MenuItemConstructorOptions = {
       label: 'View',
+      role: 'viewMenu',
       submenu: [
         this.menuItems.zoomreset,
         this.menuItems.zoomin,
@@ -46,9 +47,10 @@ export default class extends DefaultMenu {
   }
 
   helpMenu() {
-    const helpMenu = {
+    const helpMenu: Electron.MenuItemConstructorOptions = {
       id: "help",
       label: "Help",
+      role: "help",
       submenu: [
         this.menuItems.keyboardShortcuts,
         this.menuItems.enterLicense,
@@ -74,6 +76,7 @@ export default class extends DefaultMenu {
     if (this.platformInfo.isMac) {
       appMenu.push({
         label: "Beekeeper Studio",
+        role: "appMenu",
         submenu: [
           this.menuItems.about,
           { role: 'services' },
@@ -85,9 +88,10 @@ export default class extends DefaultMenu {
       })
     }
 
-    const fileMenu = {
+    const fileMenu: Electron.MenuItemConstructorOptions = {
       id: 'file',
       label: 'File',
+      role: 'fileMenu',
       submenu: [
         this.menuItems.newWindow,
         this.menuItems.newTab,
@@ -113,6 +117,7 @@ export default class extends DefaultMenu {
       {
         id: 'edit',
         label: 'Edit',
+        role: 'editMenu',
         submenu: [
           this.menuItems.undo,
           this.menuItems.redo,
@@ -121,7 +126,7 @@ export default class extends DefaultMenu {
           this.menuItems.paste,
           this.menuItems.selectAll,
         ]
-      },
+      } as Electron.MenuItemConstructorOptions,
       this.viewMenu(),
       {
         id: "tools",

--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -23,42 +23,47 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
       id: 'undo',
       label: "Undo",
       accelerator: "CommandOrControl+Z",
-      click: actionHandler.undo
+      click: actionHandler.undo,
+      role: 'undo',
     },
     redo: {
       id: "redo",
       label: "Redo",
       accelerator: platformInfo.isWindows ? 'Ctrl+Y' : 'Shift+CommandOrControl+Z',
-      click: actionHandler.redo
+      click: actionHandler.redo,
+      role: 'redo',
     },
     cut: {
       id: 'cut',
       label: 'Cut',
       accelerator: 'CommandOrControl+X',
       click: actionHandler.cut,
-      registerAccelerator: false
-
+      registerAccelerator: false,
+      role: 'cut',
     },
     copy: {
       id: 'copy',
       label: 'Copy',
       accelerator: 'CommandOrControl+C',
       click: actionHandler.copy,
-      registerAccelerator: false
+      registerAccelerator: false,
+      role: 'copy',
     },
     paste: {
       id: 'paste',
       label: 'Paste',
       accelerator: 'CommandOrControl+V',
       click: actionHandler.paste,
-      registerAccelerator: false
+      registerAccelerator: false,
+      role: 'paste',
     },
 
     selectAll: {
       id: 'select-all',
       label: 'Select All',
       accelerator: 'CommandOrControl+A',
-      click: actionHandler.selectAll
+      click: actionHandler.selectAll,
+      role: 'selectAll',
     },
     // view
     zoomreset: {
@@ -120,7 +125,8 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
     about: {
       id: 'about',
       label: 'About Beekeeper Studio',
-      click: actionHandler.about
+      click: actionHandler.about,
+      role: 'about',
     },
     devtools: {
       id: 'dev-tools',


### PR DESCRIPTION
Related to #3997 

This only fixes the icons for "About Beekeeper Studio" and all items in Edit menu. It also adds the search feature in the Help menu.

<img width="267" height="197" alt="Screenshot 2026-03-25 at 21 11 31" src="https://github.com/user-attachments/assets/97631ed4-9874-4fbe-8623-0eacf9c587e8" /> <img width="295" height="89" alt="Screenshot 2026-03-25 at 21 11 48" src="https://github.com/user-attachments/assets/ddccc21d-d53d-464e-987c-f0652533ac29" /> <img width="397" height="178" alt="Screenshot 2026-03-25 at 21 11 58" src="https://github.com/user-attachments/assets/d966a5ba-b79c-4e3a-a1eb-f47ad9792e0f" />
