### PR TITLE
Fix Oracle thick client crashing utility process on connection retry

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
@@ -62,6 +62,11 @@ oracle.fetchAsBuffer = [oracle.BLOB]
 let oracleInitialized = false
 let oracleInitConfigDir: string | null = null
 
+export function _resetOracleStateForTesting() {
+  oracleInitialized = false
+  oracleInitConfigDir = null
+}
+
 export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Connection> {
   pool: oracle.Pool;
   server: IDbConnectionServer

--- a/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
@@ -51,6 +51,7 @@ import { ChangeBuilderBase } from '@shared/lib/sql/change_builder/ChangeBuilderB
 import { IDbConnectionServer } from '@/lib/db/backendTypes';
 import { GenericBinaryTranscoder } from '@/lib/db/serialization/transcoders';
 import Client_Oracledb from '@shared/lib/knex-oracledb';
+import fs from 'fs';
 
 const log = rawLog.scope('oracle')
 
@@ -59,6 +60,7 @@ oracle.fetchAsString = [oracle.CLOB]
 oracle.fetchAsBuffer = [oracle.BLOB]
 
 let oracleInitialized = false
+let oracleInitConfigDir: string | null = null
 
 export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Connection> {
   pool: oracle.Pool;
@@ -778,17 +780,42 @@ export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Conne
     const configLocation = this.platformPath(this.server.config.oracleConfigLocation)
 
     if (cliLocation && !oracleInitialized) {
-      const payload = {}
-      payload['libDir'] = cliLocation
+      // Validate paths before calling initOracleClient — once it's called
+      // (even if it fails) it can never be called again in this process.
+      if (!fs.existsSync(cliLocation)) {
+        throw new Error(`Oracle Instant Client directory does not exist: ${cliLocation}`)
+      }
+      if (configLocation && !fs.existsSync(configLocation)) {
+        throw new Error(`Oracle configuration directory does not exist: ${configLocation}`)
+      }
+
+      const payload: Record<string, string> = { libDir: cliLocation }
       if (configLocation) {
-        payload['configDir'] = configLocation
+        payload.configDir = configLocation
       }
       log.debug("initializing oracle client with", payload)
-      oracle.initOracleClient(payload)
+      try {
+        oracle.initOracleClient(payload)
+      } catch (err) {
+        // initOracleClient can only be called once per process — even if it
+        // fails, a second call will crash the native addon (DPI-1050).
+        // Mark it as initialized so we never call it again.
+        oracleInitialized = true
+        oracleInitConfigDir = configLocation || null
+        throw new Error(`Failed to initialize Oracle client: ${err.message}`)
+      }
       oracleInitialized = true
+      oracleInitConfigDir = configLocation || null
     } else {
       if (!cliLocation) {
         log.warn("Oracle is connecting using THIN mode -- some functionality might not be supported. Provide a path to the Oracle Instant client for full functionality")
+      }
+      if (cliLocation && oracleInitialized && configLocation && configLocation !== oracleInitConfigDir) {
+        throw new Error(
+          `Oracle configuration directory cannot be changed after the client has been initialized. ` +
+          `Current: "${oracleInitConfigDir || '(none)'}",  requested: "${configLocation}". ` +
+          `Please restart Beekeeper Studio to use a different configuration directory.`
+        )
       }
     }
 
@@ -819,7 +846,7 @@ export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Conne
         connectString: str,
       }
     }
-    // we only do this in thin mode
+    // In thin mode (no instant client), also pass configDir directly to the pool
     if (configLocation && !cliLocation) {
       poolConfig['configDir'] = configLocation
     }

--- a/apps/studio/src/components/connection/OracleForm.vue
+++ b/apps/studio/src/components/connection/OracleForm.vue
@@ -14,8 +14,8 @@
         <div v-if="oracleExpanded" class="advanced-body">
           <settings-input setting-key="oracleInstantClient" input-type="directory" @changed="restart"
           title="Instant Client Location" :help="help" />
-          <settings-input setting-key="oracleConfigLocation" input-type="directory" title="TNS_ADMIN override"
-          help="The directory containing tnsnames.ora, sqlnet.ora, and wallets" />
+          <settings-input setting-key="oracleConfigLocation" input-type="directory" @changed="configDirChanged" title="TNS_ADMIN override"
+          help="The directory containing tnsnames.ora, sqlnet.ora, and wallets. Changing this after connecting requires a restart." />
         </div>
       </div>
 
@@ -117,6 +117,9 @@ export default Vue.extend({
       if(this.$config.isLinux) {
         this.restartNotification.show()
       }
+    },
+    configDirChanged() {
+      this.restartNotification.show()
     },
   },
 

--- a/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
+++ b/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
@@ -22,6 +22,19 @@ const errorMappings = {
       pattern: 'thin mode',
       help: "You likely need to enable 'thick mode' which supports all connection types. Please provide the path to the Oracle Instant client to Beekeeper Studio in the box above",
       link: "https://docs.beekeeperstudio.io/user_guide/connecting/oracle-database/"
+    },
+    {
+      pattern: 'please restart beekeeper studio',
+      help: "In thick mode, Oracle locks the configuration directory when the client first connects. To use a different configuration directory, restart the app.",
+    },
+    {
+      pattern: 'directory does not exist',
+      help: "Double-check the path in your Global Oracle Configuration settings above.",
+    },
+    {
+      pattern: 'failed to initialize oracle client',
+      help: "The Oracle Instant Client could not be loaded. Verify the Instant Client path is correct and the required libraries are present.",
+      link: "https://docs.beekeeperstudio.io/user_guide/connecting/oracle-database/"
     }
   ]
 }

--- a/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
+++ b/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
@@ -22,19 +22,6 @@ const errorMappings = {
       pattern: 'thin mode',
       help: "You likely need to enable 'thick mode' which supports all connection types. Please provide the path to the Oracle Instant client to Beekeeper Studio in the box above",
       link: "https://docs.beekeeperstudio.io/user_guide/connecting/oracle-database/"
-    },
-    {
-      pattern: 'please restart beekeeper studio',
-      help: "In thick mode, Oracle locks the configuration directory when the client first connects. To use a different configuration directory, restart the app.",
-    },
-    {
-      pattern: 'directory does not exist',
-      help: "Double-check the path in your Global Oracle Configuration settings above.",
-    },
-    {
-      pattern: 'failed to initialize oracle client',
-      help: "The Oracle Instant Client could not be loaded. Verify the Instant Client path is correct and the required libraries are present.",
-      link: "https://docs.beekeeperstudio.io/user_guide/connecting/oracle-database/"
     }
   ]
 }

--- a/apps/studio/tests/integration/lib/db/clients/oracle.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/oracle.spec.js
@@ -61,7 +61,7 @@ function testWith(info) {
       const tsaContent = `
 BEEKEEPER =
   (DESCRIPTION =
-    (ADDRESS = (PROTOCOL = TCP)(HOST = ${container.getHost()})(PORT = ${1521}))
+    (ADDRESS = (PROTOCOL = TCP)(HOST = ${container.getHost()})(PORT = ${container.getMappedPort(1521)}))
     (CONNECT_DATA =
       (SERVICE_NAME = BEEKEEPER)
     )
@@ -279,6 +279,57 @@ BEEKEEPER =
     // })
 
 
+
+    describe("Connection error handling", () => {
+      it("should return a real error for bad credentials, not crash the utility process", async () => {
+        const { createServer } = require('@commercial/backend/lib/db/server')
+
+        const badConfig = {
+          client: 'oracle',
+          host: container.getHost(),
+          port: container.getMappedPort(1521),
+          user: 'wrong_user',
+          password: 'wrong_password',
+          serviceName: 'BEEKEEPER',
+          instantClientLocation: process.env['ORACLE_CLI_PATH'],
+          oracleConfigLocation: tsaDir,
+          options: { connectionMethod: 'manual' },
+        }
+
+        const server = createServer(badConfig)
+        const connection = server.createConnection('BEEKEEPER')
+
+        // Should throw a meaningful Oracle error, not crash.
+        await expect(connection.connect()).rejects.toThrow(/ORA-/)
+      })
+
+      it("should connect via TNS alias using configDir from initOracleClient", async () => {
+        // The initial beforeAll connection set configDir = tsaDir via
+        // initOracleClient. Verify a new connection can resolve the
+        // BEEKEEPER alias from that same directory's tnsnames.ora.
+        const { createServer } = require('@commercial/backend/lib/db/server')
+
+        const aliasConfig = {
+          client: 'oracle',
+          user: 'beekeeper',
+          password: 'password',
+          instantClientLocation: process.env['ORACLE_CLI_PATH'],
+          oracleConfigLocation: tsaDir,
+          options: {
+            connectionMethod: 'connectionString',
+            connectionString: 'BEEKEEPER',
+          },
+        }
+
+        const server = createServer(aliasConfig)
+        const connection = server.createConnection('BEEKEEPER')
+        await connection.connect()
+
+        const result = await connection.executeQuery('SELECT 1 FROM dual')
+        expect(result).toBeDefined()
+        await connection.disconnect()
+      })
+    })
 
     describe("Common DB Tests", () => {
       runCommonTests(getUtil, false)

--- a/apps/studio/tests/unit/lib/db/clients/oracle.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/oracle.spec.ts
@@ -17,7 +17,7 @@ jest.mock('oracledb', () => {
 });
 
 import fs from 'fs';
-import { OracleClient } from '@commercial/backend/lib/db/clients/oracle';
+import { OracleClient, _resetOracleStateForTesting } from '@commercial/backend/lib/db/clients/oracle';
 
 function buildServer(overrides: Record<string, any> = {}) {
   return {
@@ -40,21 +40,16 @@ function buildDatabase() {
   return { database: 'testdb', connecting: false, connected: false } as any;
 }
 
-// IMPORTANT: oracleInitialized is a module-level flag that persists across
-// tests and can only transition false→true. Tests are ordered deliberately
-// to work with this constraint.
 describe('OracleClient connection error handling', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    // Default: all paths exist
+    _resetOracleStateForTesting();
     jest.spyOn(fs, 'existsSync').mockReturnValue(true);
   });
 
-  afterAll(() => {
+  afterEach(() => {
     jest.restoreAllMocks();
   });
-
-  // === Path validation tests (run first while oracleInitialized is false) ===
 
   it('should reject with a clear error when instantClientLocation does not exist', async () => {
     jest.spyOn(fs, 'existsSync').mockReturnValue(false);
@@ -74,8 +69,6 @@ describe('OracleClient connection error handling', () => {
     expect(mockInitOracleClient).not.toHaveBeenCalled();
   });
 
-  // === initOracleClient error handling (oracleInitialized is still false) ===
-
   it('should return the real error when initOracleClient throws', async () => {
     mockInitOracleClient.mockImplementation(() => {
       throw new Error('DPI-1047: Cannot locate a 64-bit Oracle Client library');
@@ -90,17 +83,27 @@ describe('OracleClient connection error handling', () => {
     });
   });
 
-  // === Post-init tests (oracleInitialized is now true) ===
-
   it('should not call initOracleClient again after a failed first attempt', async () => {
+    // First connect: initOracleClient throws
+    mockInitOracleClient.mockImplementation(() => {
+      throw new Error('ORA-28759: failure to open file');
+    });
+
+    const client1 = new OracleClient(buildServer(), buildDatabase());
+    await expect(client1.connect()).rejects.toThrow('ORA-28759');
+    expect(mockInitOracleClient).toHaveBeenCalledTimes(1);
+
+    // Second connect: same process, oracleInitialized is now true
+    mockInitOracleClient.mockClear();
     mockCreatePool.mockRejectedValue(new Error('ORA-28759: failure to open file'));
 
-    const client = new OracleClient(buildServer(), buildDatabase());
-    await expect(client.connect()).rejects.toThrow('ORA-28759');
+    const client2 = new OracleClient(buildServer(), buildDatabase());
+    await expect(client2.connect()).rejects.toThrow('ORA-28759');
     expect(mockInitOracleClient).not.toHaveBeenCalled();
   });
 
   it('should return the real error when createPool throws', async () => {
+    mockInitOracleClient.mockImplementation(() => {});
     mockCreatePool.mockRejectedValue(new Error('ORA-12154: TNS:could not resolve the connect identifier specified'));
 
     const client = new OracleClient(buildServer(), buildDatabase());
@@ -108,17 +111,21 @@ describe('OracleClient connection error handling', () => {
   });
 
   it('should tell user to restart when config directory changes after init', async () => {
-    mockCreatePool.mockRejectedValue(new Error('pool error'));
+    // First connect succeeds
+    mockInitOracleClient.mockImplementation(() => {});
+    mockCreatePool.mockResolvedValue({});
 
-    const client = new OracleClient(
+    const client1 = new OracleClient(buildServer(), buildDatabase());
+    client1.driverExecuteSimple = jest.fn().mockResolvedValue([{ BANNER: 'Oracle 19c' }]);
+    await client1.connect();
+
+    // Second connect with different config dir
+    const client2 = new OracleClient(
       buildServer({ oracleConfigLocation: '/different/config/path' }),
       buildDatabase()
     );
-    await expect(client.connect()).rejects.toThrow('Please restart Beekeeper Studio');
-    expect(mockCreatePool).not.toHaveBeenCalled();
+    await expect(client2.connect()).rejects.toThrow('Please restart Beekeeper Studio');
   });
-
-  // === Thin mode (no instantClientLocation) ===
 
   it('should return the real error when createPool rejects in thin mode', async () => {
     mockCreatePool.mockRejectedValue(new Error('NJS-510: connections to this database server version are not supported'));

--- a/apps/studio/tests/unit/lib/db/clients/oracle.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/oracle.spec.ts
@@ -1,0 +1,136 @@
+// Mock oracledb before any imports that use it
+const mockInitOracleClient = jest.fn();
+const mockCreatePool = jest.fn();
+
+jest.mock('oracledb', () => {
+  return {
+    __esModule: true,
+    default: {
+      CLOB: 2017,
+      BLOB: 2019,
+      fetchAsString: [],
+      fetchAsBuffer: [],
+      initOracleClient: mockInitOracleClient,
+      createPool: mockCreatePool,
+    },
+  };
+});
+
+import fs from 'fs';
+import { OracleClient } from '@commercial/backend/lib/db/clients/oracle';
+
+function buildServer(overrides: Record<string, any> = {}) {
+  return {
+    config: {
+      host: 'localhost',
+      port: 1521,
+      user: 'testuser',
+      password: 'testpass',
+      serviceName: 'ORCL',
+      ssl: false,
+      instantClientLocation: '/fake/client/path',
+      oracleConfigLocation: '/fake/config/path',
+      options: {},
+      ...overrides,
+    },
+  } as any;
+}
+
+function buildDatabase() {
+  return { database: 'testdb', connecting: false, connected: false } as any;
+}
+
+// IMPORTANT: oracleInitialized is a module-level flag that persists across
+// tests and can only transition false→true. Tests are ordered deliberately
+// to work with this constraint.
+describe('OracleClient connection error handling', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    // Default: all paths exist
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  // === Path validation tests (run first while oracleInitialized is false) ===
+
+  it('should reject with a clear error when instantClientLocation does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    const client = new OracleClient(buildServer(), buildDatabase());
+    await expect(client.connect()).rejects.toThrow('Oracle Instant Client directory does not exist');
+    expect(mockInitOracleClient).not.toHaveBeenCalled();
+  });
+
+  it('should reject with a clear error when oracleConfigLocation does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockImplementation((p: fs.PathLike) => {
+      return !String(p).includes('config');
+    });
+
+    const client = new OracleClient(buildServer(), buildDatabase());
+    await expect(client.connect()).rejects.toThrow('Oracle configuration directory does not exist');
+    expect(mockInitOracleClient).not.toHaveBeenCalled();
+  });
+
+  // === initOracleClient error handling (oracleInitialized is still false) ===
+
+  it('should return the real error when initOracleClient throws', async () => {
+    mockInitOracleClient.mockImplementation(() => {
+      throw new Error('DPI-1047: Cannot locate a 64-bit Oracle Client library');
+    });
+
+    const client = new OracleClient(buildServer(), buildDatabase());
+    await expect(client.connect()).rejects.toThrow('Failed to initialize Oracle client: DPI-1047');
+    expect(mockInitOracleClient).toHaveBeenCalledTimes(1);
+    expect(mockInitOracleClient).toHaveBeenCalledWith({
+      libDir: '/fake/client/path',
+      configDir: '/fake/config/path',
+    });
+  });
+
+  // === Post-init tests (oracleInitialized is now true) ===
+
+  it('should not call initOracleClient again after a failed first attempt', async () => {
+    mockCreatePool.mockRejectedValue(new Error('ORA-28759: failure to open file'));
+
+    const client = new OracleClient(buildServer(), buildDatabase());
+    await expect(client.connect()).rejects.toThrow('ORA-28759');
+    expect(mockInitOracleClient).not.toHaveBeenCalled();
+  });
+
+  it('should return the real error when createPool throws', async () => {
+    mockCreatePool.mockRejectedValue(new Error('ORA-12154: TNS:could not resolve the connect identifier specified'));
+
+    const client = new OracleClient(buildServer(), buildDatabase());
+    await expect(client.connect()).rejects.toThrow('ORA-12154');
+  });
+
+  it('should tell user to restart when config directory changes after init', async () => {
+    mockCreatePool.mockRejectedValue(new Error('pool error'));
+
+    const client = new OracleClient(
+      buildServer({ oracleConfigLocation: '/different/config/path' }),
+      buildDatabase()
+    );
+    await expect(client.connect()).rejects.toThrow('Please restart Beekeeper Studio');
+    expect(mockCreatePool).not.toHaveBeenCalled();
+  });
+
+  // === Thin mode (no instantClientLocation) ===
+
+  it('should return the real error when createPool rejects in thin mode', async () => {
+    mockCreatePool.mockRejectedValue(new Error('NJS-510: connections to this database server version are not supported'));
+
+    const server = buildServer({
+      instantClientLocation: null,
+      options: {
+        connectionMethod: 'connectionString',
+        connectionString: 'bad_connection_string',
+      },
+    });
+    const client = new OracleClient(server, buildDatabase());
+    await expect(client.connect()).rejects.toThrow('NJS-510');
+  });
+});


### PR DESCRIPTION
## Summary

- Oracle's `initOracleClient` can only be called once per process. When it threw an error (e.g. bad wallet/config path), the `oracleInitialized` flag stayed `false`, causing the next connection attempt to call it again — crashing the native addon and the utility process. Now the flag is set even on failure, and the error is returned to the user instead.
- Validates that the instant client and config directories exist on disk *before* calling `initOracleClient`, so a simple path typo doesn't waste the one-shot initialization.
- Tracks the config directory used at init time. If the user changes it after connecting, returns a clear error asking them to restart the app (Oracle thick client locks `configDir` for the process lifetime). The Oracle connection form now shows a restart prompt when the TNS_ADMIN override is changed.
- Adds friendly error text in the connection form for init failures, missing directories, and the restart-required scenario.
- Fixes the `tnsnames.ora` port in integration tests (was using container-internal port 1521 instead of the mapped port, which is why the commented-out TNS alias tests never worked).

## Test plan

- [x] Unit tests: path validation rejects missing dirs before init, `initOracleClient` errors return real message, no double-call after failure, config dir change after init returns restart message, thin mode errors propagate
- [x] Integration tests: bad credentials return real Oracle error (not crash), TNS alias connection works via `configDir`, all 70 existing Oracle integration tests pass
- [ ] Manual: configure Oracle with a bad config directory path, verify error message, change the path and verify restart prompt appears