### PR TITLE
Add troubleshooting docs for cloud IP allowlist idle timeout

### DIFF
--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -157,6 +157,29 @@ CREATE table foo("myColumn" int);
 
 See [this StackOverflow answer](https://stackoverflow.com/a/20880247/18818) or [this section in the PostgreSQL manual](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)
 
+## Cloud Databases (Google Cloud SQL, Amazon RDS)
+
+### Connections drop after IP allowlist expires
+
+If you use a time-limited IP allowlist to connect to your database (for example, `gcloud sql connect` which allowlists your IP for 5 minutes), you may find that queries fail after the allowlist window closes.
+
+Beekeeper Studio uses a connection pool that keeps connections alive while idle. By default, idle connections are dropped after 20 seconds. Once dropped, the pool creates new connections on demand — but if your IP is no longer allowlisted, those new connections will be rejected.
+
+To work around this, you can increase the idle timeout in your [user configuration file](../user_guide/configuration.md) so that connections stay alive longer:
+
+```ini
+; Keep idle connections alive for 5 minutes instead of the default 20 seconds.
+; Adjust this to match your IP allowlist window.
+
+[db.postgres]
+idleTimeout = 300000
+
+[db.mysql]
+idleTimeout = 300000
+```
+
+For a more permanent solution, consider using an [SSH tunnel](../user_guide/connecting/connecting.md#ssh) to connect to your database instead of relying on IP allowlisting.
+
 ## Linux (Wayland)
 
 ### Weird colors on Wayland (wrong saturation, contrast, or readability)

--- a/docs/user_guide/connecting/amazon-rds.md
+++ b/docs/user_guide/connecting/amazon-rds.md
@@ -38,7 +38,8 @@ Below is an example config in Beekeeper Studio once IAM permissions are setup, y
 
 ## Things to note
 
-- SSL has is required on most RDS instances, so ensure this is checked.
+- If you use security groups with time-limited IP allowlisting, idle connections may be dropped and fail to reconnect after the allowlist expires. See [Troubleshooting: Connections drop after IP allowlist expires](../../support/troubleshooting.md#connections-drop-after-ip-allowlist-expires) for how to adjust idle timeouts.
+- SSL is required on most RDS instances, so ensure this is checked.
 - You will need a credentials file configured and would need to follow the guide linked to set this up:
 [AWS CLI Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
 


### PR DESCRIPTION
## Summary

- Added a troubleshooting section for users who connect via time-limited IP allowlists (Google Cloud SQL's `gcloud sql connect`, AWS security groups, etc). Explains that idle pool connections get dropped after 20 seconds by default, and shows how to increase `idleTimeout` in `user.config.ini`.
- Added a note on the Amazon RDS page linking to the new troubleshooting section.
- Recommends SSH tunneling as a more permanent solution.

Addresses #1539