### PR TITLE
Add Flatpak file permission docs for SQLite users

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -87,6 +87,13 @@ Flatpak (.flatpak) files are provided separately for both x86_64 and ARM64 syste
 
 Flathub integration coming soon.
 
+!!! note "SQLite file access"
+    Flatpak sandboxes file access by default. If you need to open SQLite databases outside the sandbox, grant filesystem access with:
+    ```bash
+    sudo flatpak override io.beekeeperstudio.Studio --filesystem=host
+    ```
+    See [Troubleshooting](../support/troubleshooting.md#i-get-permission-denied-or-unable-to-open-database-file-when-trying-to-access-a-sqlite-database) for more details.
+
 ## Snap
 
 You can also install Beekeeper Studio through Snapcraft (also part of the Ubuntu Store). Use either the Snap Store link below, or install through the terminal.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -120,15 +120,27 @@ select 'string' as my_column from foo
 
 
 
-### I get 'permission denied' when trying to access a database on an external drive
+### I get 'permission denied' or 'unable to open database file' when trying to access a SQLite database
 
-If you're on Linux and using the `snap` version of Beekeeper you need to give the app an extra permission.
+This is usually caused by the sandboxed packaging format (Snap or Flatpak) not having permission to access the file's location.
+
+**Flatpak users:**
+
+Flatpak restricts file access by default. The file picker may show a sandboxed path (e.g. `/run/user/1000/...`) instead of the real path. To grant Beekeeper Studio access to your files:
+
+```bash
+sudo flatpak override io.beekeeperstudio.Studio --filesystem=host
+```
+
+**Snap users:**
+
+If the database is on an external or removable drive, you need to grant extra permissions:
 
 ```bash
 sudo snap connect beekeeper-studio:removable-media :removable-media
 ```
 
-If you're on another platform, please [open a ticket][bug] and we'll try to help you debug the problem.
+If neither of these applies, please [open a ticket][bug] and we'll try to help you debug the problem.
 
 [bug]: https://github.com/beekeeper-studio/beekeeper-studio/issues/new?template=bug_report.md&title=BUG:
 


### PR DESCRIPTION
## Summary

- Flatpak sandboxes file access by default, so SQLite users get "unable to open database file" errors. Added the workaround (`flatpak override --filesystem=host`) to the troubleshooting page alongside the existing Snap instructions.
- Added a note on the Linux installation page under the Flatpak section.

Addresses #1582