### PR TITLE
fix: change cursor to grab on drag handle hover

### DIFF
--- a/apps/ui-kit/lib/components/entity-list/entity-list.scss
+++ b/apps/ui-kit/lib/components/entity-list/entity-list.scss
@@ -150,6 +150,12 @@
     }
 
     .drag-handle.draggable {
+      cursor: grab;
+
+      &:active {
+        cursor: grabbing;
+      }
+
       .dh {
         display: none;
       }


### PR DESCRIPTION
Adds `cursor: grab` to `.drag-handle.draggable` in `entity-list.scss` so the cursor changes when hovering the reorder handle on pinned tables. Also adds `cursor: grabbing` on `:active` for visual feedback while dragging.