### PR TITLE
Add right-click copy to structural table cells

### DIFF
--- a/apps/studio/src/components/tableinfo/TableIndexes.vue
+++ b/apps/studio/src/components/tableinfo/TableIndexes.vue
@@ -128,6 +128,7 @@ const log = rawLog.scope('TableIndexVue')
 import { escapeHtml } from '@shared/lib/tabulator'
 import { parseIndexColumn as mysqlParseIndexColumn } from '@/common/utils'
 import { SelectableCellMixin } from '@/mixins/selectableCell';
+import { copyCellMenu } from '@/lib/menu/tableMenu';
 
 interface State {
   mysqlTypes: string[]
@@ -231,13 +232,14 @@ export default Vue.extend({
       // FIXME (@day): no per-db testing
       const editableName = (cell) => this.newRows.includes(cell.getRow()) && !this.loading && this.dialect != 'mongodb'
       const result = [
-        (this.dialectData?.disabledFeatures?.index?.id ? null : {title: 'Id', field: 'id', widthGrow: 0.5, cellDblClick: (_e, cell) => this.handleCellDoubleClick(cell)}),
+        (this.dialectData?.disabledFeatures?.index?.id ? null : {title: 'Id', field: 'id', widthGrow: 0.5, contextMenu: copyCellMenu, cellDblClick: (_e, cell) => this.handleCellDoubleClick(cell)}),
         {
           title:'Name',
           field: 'name',
           editable: editableName,
           editor: vueEditor(NullableInputEditorVue),
           formatter: this.cellFormatter,
+          contextMenu: copyCellMenu,
           cellDblClick: (_e, cell) => this.handleCellDoubleClick(cell),
         },
         {
@@ -264,6 +266,7 @@ export default Vue.extend({
           editable,
           editor: 'list',
           formatter: this.cellFormatter,
+          contextMenu: copyCellMenu,
           editorParams: {
             multiselect: true,
             values: this.indexColumnOptions,

--- a/apps/studio/src/components/tableinfo/TableRelations.vue
+++ b/apps/studio/src/components/tableinfo/TableRelations.vue
@@ -116,6 +116,7 @@ import ErrorAlert from '../common/ErrorAlert.vue'
 const log = rawLog.scope('TableRelations');
 import { escapeHtml } from '@shared/lib/tabulator'
 import { SelectableCellMixin } from '@/mixins/selectableCell';
+import { copyCellMenu } from '@/lib/menu/tableMenu';
 
 export default Vue.extend({
   mixins: [SelectableCellMixin],
@@ -189,6 +190,7 @@ export default Vue.extend({
           widthGrow: 2,
           editable,
           editor: vueEditor(NullableInputEditorVue),
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
@@ -200,6 +202,7 @@ export default Vue.extend({
             // @ts-expect-error Incorrectly typed
             valuesLookup: () => this.table.columns.map((c) => escapeHtml(c.columnName))
           },
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         // @ts-expect-error Incorrectly typed
@@ -211,6 +214,7 @@ export default Vue.extend({
           editorParams: {
             valuesLookup: () => this.schemas.map((s) => escapeHtml(s))
           },
+          contextMenu: copyCellMenu,
           cellEdited: (cell) => cell.getRow().getCell('toTable')?.setValue(null)
         }] : []),
         {
@@ -223,6 +227,7 @@ export default Vue.extend({
             valuesLookup: this.getTables
           },
           cellEdited: (cell) => cell.getRow().getCell('toColumn')?.setValue(null),
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
@@ -234,6 +239,7 @@ export default Vue.extend({
           editorParams: {
             valuesLookup: this.getColumns
           },
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
@@ -246,6 +252,7 @@ export default Vue.extend({
             values: this.dialectData.constraintActions,
             defaultValue: 'NO ACTION'
           },
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
         {
@@ -258,6 +265,7 @@ export default Vue.extend({
             values: this.dialectData.constraintActions,
             defaultValue: 'NO ACTION',
           },
+          contextMenu: copyCellMenu,
           cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)
         },
       ]

--- a/apps/studio/src/components/tableinfo/TableTriggers.vue
+++ b/apps/studio/src/components/tableinfo/TableTriggers.vue
@@ -42,6 +42,7 @@ import data_mutators from '../../mixins/data_mutators'
 import StatusBar from '../common/StatusBar.vue'
 import { mapGetters, mapState } from 'vuex'
 import { SelectableCellMixin } from '@/mixins/selectableCell';
+import { copyCellMenu } from '@/lib/menu/tableMenu';
 
 
 export default {
@@ -67,17 +68,17 @@ export default {
     },
     sqliteTableColumns() {
       return [
-        { field: 'name', title: 'Name', tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
-        { field: 'sql', title: 'SQL', tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
+        { field: 'name', title: 'Name', tooltip: true, contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'sql', title: 'SQL', tooltip: true, contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
       ]
     },
     normalTableColumns() {
       return [
-        { field: 'name', title: "Name", tooltip: true, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
-        { field: 'timing', title: "Timing", cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
-        { field: 'manipulation', title: "Manipulation", cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
-        { field: 'action', title: "Action", tooltip: true, widthGrow: 2.5, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
-        { field: 'condition', title: "Condition", formatter: this.cellFormatter, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
+        { field: 'name', title: "Name", tooltip: true, contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'timing', title: "Timing", contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'manipulation', title: "Manipulation", contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'action', title: "Action", tooltip: true, widthGrow: 2.5, contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)},
+        { field: 'condition', title: "Condition", formatter: this.cellFormatter, contextMenu: copyCellMenu, cellDblClick: (e, cell) => this.handleCellDoubleClick(cell)}
       ]
     },
     tableData() {

--- a/apps/studio/src/lib/menu/tableMenu.ts
+++ b/apps/studio/src/lib/menu/tableMenu.ts
@@ -402,6 +402,17 @@ export function copyActionsMenu(options: {
   return copyActions
 }
 
+export function copyCellMenu(_e: any, cell: CellComponent) {
+  const value = cell.getValue();
+  const text = value == null ? "" : String(value);
+  return [
+    {
+      label: createMenuItem("Copy"),
+      action: () => ElectronPlugin.clipboard.writeText(text),
+    },
+  ];
+}
+
 export function pasteActionsMenu(range: RangeComponent) {
   return [
     {


### PR DESCRIPTION
Adds a "Copy" option to the right-click context menu on cells in the indexes, relations, and triggers tables.

Previously there was no way to copy a value from these tables without double-clicking the cell to make it selectable and then manually selecting the text. Now you can just right-click and hit Copy.

**Changes**
- New `copyCellMenu` helper in `tableMenu.ts` that grabs the cell value and writes it to clipboard
- Added `contextMenu: copyCellMenu` to all column definitions in `TableIndexes.vue`, `TableRelations.vue`, and `TableTriggers.vue`

Closes #1458