### PR TITLE
update vim docs

### DIFF
--- a/docs/user_guide/sql_editor/editor.md
+++ b/docs/user_guide/sql_editor/editor.md
@@ -15,8 +15,8 @@ We have tried to make our code completion useful but not intrusive.
 
 Code suggestions will automatically appear in the following situations:
 
-- `tables` will be suggested after typing `from` or `join`
-- `columns` will be suggested after typing a tablename, or table alias, followed by a period, eg `film.`
+-   `tables` will be suggested after typing `from` or `join`
+-   `columns` will be suggested after typing a tablename, or table alias, followed by a period, eg `film.`
 
 In these situations, Beekeeper will automatically resolve the correct table and column names for the entity you are querying.
 
@@ -57,6 +57,7 @@ select * from table where foo = :one and bar = :two
 
 select * from table where foo = $1 and bar = $2
 ```
+
 ![Image Alt Tag](../../assets/images/using-the-sql-editor-13.gif)
 
 You can configure which syntax is active for your database engine using the [config file](../configuration.md).
@@ -75,7 +76,6 @@ quoted[] = ':'
 quoted[] = '@'
 quoted[] = '$'
 ```
-
 
 ## Downloading Results
 
@@ -101,9 +101,9 @@ Beekeeper Studio has a built-in keyboard shortcuts reference. Open it from the `
 
 You can adjust the font size of the SQL editor from the `View` menu:
 
-- **Increase Editor Font Size** - `Ctrl+Shift+.`
-- **Decrease Editor Font Size** - `Ctrl+Shift+,`
-- **Reset Editor Font Size** - restores the default size
+-   **Increase Editor Font Size** - `Ctrl+Shift+.`
+-   **Decrease Editor Font Size** - `Ctrl+Shift+,`
+-   **Reset Editor Font Size** - restores the default size
 
 ![Adjusting editor font size](../../assets/images/adjust-editor-font-size.png)
 
@@ -114,9 +114,10 @@ Beekeeper Studio keeps a history of queries you have run. You can access your qu
 Query history is **scoped per connection**, so you will only see queries that were run against the current database connection. This makes it easy to find and re-run previous queries without sifting through history from other databases.
 
 ## Vim Mode
+
 Along with the default query editor, Beekeeper supports Vim mode, which allows you to write queries in a Vim-like text editor.
 
-To enable this, you can click the cog in the bottom left corner of the query editor:
+To enable this, you can click the cog in the bottom right corner of the query editor:
 
 ![editor mode selection](../../assets/images/using-the-sql-editor-155.png)
 
@@ -125,12 +126,14 @@ And then you're off to the races with a vim editor in Beekeeper!
 Whichever editor you prefer will be preserved across all connections/restarts/etc.
 
 ### Customisation
+
 You can also add your own keybindings and motions to the vim editor by placing a `.beekeeper.vimrc` file in the `userDirectory` for Beekeeper Studio and writing out your custom mappings.
 
 `userDirectory` locations:
-- Windows: `%APPDATA%\beekeeper-studio`
-- Linux: `~/.config/beekeeper-studio`
-- MacOS: `~/Library/Application Support/beekeeper-studio`
+
+-   Windows: `%APPDATA%\beekeeper-studio`
+-   Linux: `~/.config/beekeeper-studio`
+-   MacOS: `~/Library/Application Support/beekeeper-studio`
 
 For instance, if you're a Helix user, you can add `gl` and `gh` commands like this:
 
@@ -142,5 +145,3 @@ nmap gh ^
 These commands add motions for `gl` to go to the end of a line, and `gh` to go to the beginning of a line
 
 We currently only support the `nmap`, `imap`, and `vmap` commands, but we hope to introduce more in the future!
-
-


### PR DESCRIPTION
Turns out you have great docs on the vim and vimrc implementation. The only tweak I added (outside of my markdown lsp triggering some changes on save) was that the cog is now in the bottom right of the query editor and not on the left.