### PR TITLE
fix: Windows Pageant SSH agent forwarding silently fails since v3.9.0

### DIFF
--- a/apps/studio/src/vendor/node-ssh-forward/index.ts
+++ b/apps/studio/src/vendor/node-ssh-forward/index.ts
@@ -193,7 +193,7 @@ class SSHConnection {
         if (this.isWindows) {
           // null or undefined
           if (agentDefault == null) {
-            agentDefault = ElectronFriendlyPageantAgent
+            agentDefault = new ElectronFriendlyPageantAgent()
           }
         }
 


### PR DESCRIPTION
Fixes #4092

## Summary

Pass an instance of `ElectronFriendlyPageantAgent` instead of the class itself when setting up Pageant agent forwarding on Windows.

## Problem

Since v3.9.0 (ba97de543), the code passes the class reference `ElectronFriendlyPageantAgent` as the `agent` config to ssh2. ssh2's `client.js` validates this with `isAgent()` (`val instanceof BaseAgent`), which returns `false` for a class — causing agent to silently become `undefined`.

The original code used the string `'pageant'`, which ssh2 handled via `createAgent('pageant')` → `new PageantAgent()`. When it was replaced with the custom `ElectronFriendlyPageantAgent`, instantiation was missed.

## Change

One-line fix in `apps/studio/src/vendor/node-ssh-forward/index.ts`:

```diff
- agentDefault = ElectronFriendlyPageantAgent
+ agentDefault = new ElectronFriendlyPageantAgent()
```

## Testing

Tested on Windows 11 with Pageant running — SSH agent forwarding now works correctly.