### PR TITLE
Fix fuzzy search

### DIFF
--- a/apps/studio/src/store/modules/SearchModule.ts
+++ b/apps/studio/src/store/modules/SearchModule.ts
@@ -20,7 +20,6 @@ export interface SearchResult extends IndexItem {
 const uf = new uFuzzy({
   intraMode: 0,
   intraIns: Infinity,
-  intraChars: ".",
 });
 
 export function searchItems(


### PR DESCRIPTION
Previously we had `intraChars` set to `"."`. This meant that anything could be between parts of the search when matching. Eg `public.user`. Searching `user` would match `u` in `public` and the `ser` in `user`, but would not match the `u` in `user` as that was already matched. Reverting to default means that only `[a-z\d']` can be present between the terms of match, otherwise it is discarded. We can tweak this more if want. For instance, this means that `_` can not be between search terms, so `efla` would not match `feature_flags`, and of course you can't match across `.` unless you explicitly include it in the search