### PR TITLE
Notify user when auto-disconnected for idle/lock/suspend

### DIFF
--- a/apps/studio/src/lib/events/AppEventHandler.js
+++ b/apps/studio/src/lib/events/AppEventHandler.js
@@ -17,6 +17,7 @@ export default class {
     window.main.on(AppEvent.beekeeperAdded, this.addBeekeeper.bind(this))
     window.main.on(AppEvent.switchLicenseState, this.switchLicenseState.bind(this))
     window.main.on(AppEvent.simulatePlatform, this.simulatePlatform.bind(this))
+    this.forward(AppEvent.disconnect)
     this.forward(AppEvent.closeTab)
     this.forward(AppEvent.newTab)
     this.forward(AppEvent.newCustomTab)


### PR DESCRIPTION
## Summary

- The security config's auto-disconnect options (`disconnectOnIdle`, `disconnectOnLock`, `disconnectOnSuspend`) silently kicked the user off their session with no indication of why.
- The pieces for a toast were already in place — `backend/lib/security.ts` sends `AppEvent.disconnect` with a reason string, and `LockManager.vue` has a `noty.warning("Disconnected: ${reason}")` handler registered via `$root.$on`.
- The renderer's `AppEventHandler` was the broken link: it caught the IPC event and only dispatched the store action, never forwarding it onto the Vue root bus, so the `LockManager` handler never fired.

This just adds `this.forward(AppEvent.disconnect)` alongside the existing handler so both the store dispatch and the toast run. Menu-driven disconnects still send no reason and `LockManager` bails in that case, so manual disconnects stay quiet.

FYI for anyone reviewing: the idle check is based on `powerMonitor.getSystemIdleTime()`, which is true system-wide idle (no keyboard/mouse input anywhere on the OS), not app-focus time.

## Test plan

- [ ] Set `disconnectOnIdle = true` and a short `idleThresholdSeconds` in config, connect to a DB, leave the machine alone, confirm you're disconnected *and* see a "Disconnected: User has been idle" toast.
- [ ] Set `disconnectOnLock = true`, connect, lock the screen, unlock, confirm the "Screen was locked" toast is visible.
- [ ] Disconnect manually from the menu, confirm no toast appears (unchanged behavior).