### PR TITLE
fix(mysql): strip CHARACTER SET and COLLATE from non-string ALTER

### DIFF
--- a/apps/studio/src/shared/lib/sql/change_builder/MysqlChangeBuilder.ts
+++ b/apps/studio/src/shared/lib/sql/change_builder/MysqlChangeBuilder.ts
@@ -67,6 +67,24 @@ export class MySqlChangeBuilder extends ChangeBuilderBase {
     }).join(';')
   }
 
+  // CHARACTER SET / COLLATE are only valid on string/enum types in MySQL.
+  // Attaching them to numeric, date, binary, or json columns produces
+  // syntactically invalid ALTER TABLE statements.
+  private static readonly CHARSET_TYPES = new Set([
+    'char', 'varchar', 'tinytext', 'text', 'mediumtext', 'longtext',
+    'enum', 'set', 'nchar', 'nvarchar', 'national char', 'national varchar',
+  ])
+
+  private supportsCharset(dataType: string): boolean {
+    if (!dataType) return false
+    const stripped = dataType.toLowerCase().replace(/\(.*\)/, '').trim()
+    if (MySqlChangeBuilder.CHARSET_TYPES.has(stripped)) return true
+    const firstWord = stripped.split(/\s+/)[0]
+    if (MySqlChangeBuilder.CHARSET_TYPES.has(firstWord)) return true
+    const firstTwoWords = stripped.split(/\s+/).slice(0, 2).join(' ')
+    return MySqlChangeBuilder.CHARSET_TYPES.has(firstTwoWords)
+  }
+
   ddl(existing: ExtendedTableColumn, updated: SchemaItem): string {
     const column = existing.columnName
     const newName = updated.columnName
@@ -76,13 +94,15 @@ export class MySqlChangeBuilder extends ChangeBuilderBase {
     // mysql 8 allows literal values PLUS expressions like ('foo')
     // https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html
     // it's very confusing.
+    const keepCharset = this.supportsCharset(updated.dataType)
+
     let characterSet = null;
-    if (existing.characterSet) {
+    if (keepCharset && existing.characterSet) {
       characterSet = `CHARACTER SET ${existing.characterSet}`;
     }
 
     let collation = null;
-    if (existing.collation) {
+    if (keepCharset && existing.collation) {
       collation = `COLLATE ${existing.collation}`;
     }
 

--- a/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
@@ -79,5 +79,72 @@ describe("MysqlChangeBuilder", () => {
 
     expect(builder.reorderColumns(initArr, updatedArr)).toEqual(`ALTER TABLE \`beans\` ${updatedArrStuff.join(',')};`)
   }))
+
+  describe("ddl() CHARACTER SET / COLLATE handling (issue #4082)", () => {
+    const existingVarchar = {
+      columnName: 'my_field',
+      dataType: 'varchar(4)',
+      nullable: true,
+      characterSet: 'utf8mb4',
+      collation: 'utf8mb4_general_ci',
+    }
+
+    it("does not emit CHARACTER SET or COLLATE when changing varchar to INT", () => {
+      const updated = { ...existingVarchar, dataType: 'INT UNSIGNED' }
+      const result = builder.ddl(existingVarchar, updated)
+      expect(result).toContain('MODIFY `my_field` INT UNSIGNED')
+      expect(result).not.toContain('CHARACTER SET')
+      expect(result).not.toContain('COLLATE')
+    })
+
+    it("retains CHARACTER SET and COLLATE when changing varchar(4) to varchar(100)", () => {
+      const updated = { ...existingVarchar, dataType: 'varchar(100)' }
+      const result = builder.ddl(existingVarchar, updated)
+      expect(result).toContain('CHARACTER SET utf8mb4')
+      expect(result).toContain('COLLATE utf8mb4_general_ci')
+    })
+
+    it.each([
+      ['DATETIME'],
+      ['DECIMAL(10,2)'],
+      ['JSON'],
+      ['BLOB'],
+      ['BIGINT'],
+      ['DATE'],
+      ['VARBINARY(255)'],
+    ])("does not emit CHARACTER SET or COLLATE when changing varchar to %s", (dataType) => {
+      const updated = { ...existingVarchar, dataType }
+      const result = builder.ddl(existingVarchar, updated)
+      expect(result).not.toContain('CHARACTER SET')
+      expect(result).not.toContain('COLLATE')
+    })
+
+    it.each([
+      ['TEXT'],
+      ['MEDIUMTEXT'],
+      ['LONGTEXT'],
+      ['TINYTEXT'],
+      ["ENUM('a','b')"],
+      ["SET('a','b')"],
+      ['CHAR(10)'],
+    ])("retains CHARACTER SET and COLLATE when changing varchar to %s", (dataType) => {
+      const updated = { ...existingVarchar, dataType }
+      const result = builder.ddl(existingVarchar, updated)
+      expect(result).toContain('CHARACTER SET utf8mb4')
+      expect(result).toContain('COLLATE utf8mb4_general_ci')
+    })
+
+    it("emits no charset clauses when the existing column has none, regardless of new type", () => {
+      const existing = {
+        columnName: 'my_field',
+        dataType: 'varchar(4)',
+        nullable: true,
+      }
+      const updated = { ...existing, dataType: 'varchar(100)' }
+      const result = builder.ddl(existing, updated)
+      expect(result).not.toContain('CHARACTER SET')
+      expect(result).not.toContain('COLLATE')
+    })
+  })
 })
 


### PR DESCRIPTION
When changing a column's type from a string type (e.g. varchar) to a
non-string type (INT, DECIMAL, DATETIME, JSON, BLOB, etc.),
MySqlChangeBuilder.ddl() previously carried the existing column's
CHARACTER SET and COLLATE clauses into the MODIFY statement. MySQL
only accepts those clauses on character/string types, so the emitted
DDL was syntactically invalid.

Gate the clauses on the new data type via a supportsCharset() helper
that recognizes CHAR, VARCHAR, *TEXT, ENUM, SET, and NCHAR/NVARCHAR
variants. Binary, numeric, date/time, JSON, and spatial types now
produce clean ALTER statements.

Fixes #4082

https://claude.ai/code/session_013iwW3FBciZwStewCcFSq5Y