### PR TITLE
fix(mssql): bracket-wrap qualified names so dotted table names aren't mis-split

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -264,7 +264,8 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
   async listTableTriggers(table: string, schema: string) {
     // SQL Server does not have information_schema for triggers, so other way around
     // is using sp_helptrigger stored procedure to fetch triggers related to table
-    const sql = `EXEC sp_helptrigger '${escapeString(schema)}.${escapeString(table)}'`;
+    const qualified = `${D.wrapIdentifier(schema)}.${D.wrapIdentifier(table)}`;
+    const sql = `EXEC sp_helptrigger '${escapeString(qualified)}'`;
 
     const { data } = await this.driverExecuteSingle(sql, { overrideReadonly: true });
 
@@ -371,7 +372,8 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     const triggers = await this.listTableTriggers(table, schema)
     const indexes = await this.listTableIndexes(table, schema)
     const description = await this.getTableDescription(table, schema)
-    const sizeQuery = `EXEC sp_spaceused N'${escapeString(schema)}.${escapeString(table)}'; `
+    const qualified = `${D.wrapIdentifier(schema)}.${D.wrapIdentifier(table)}`;
+    const sizeQuery = `EXEC sp_spaceused N'${escapeString(qualified)}'; `
     const { data }  = await this.driverExecuteSingle(sizeQuery, { overrideReadonly: true })
     const row = data.recordset ? data.recordset[0] || {} : {}
     const relations = await this.getTableKeys(table, schema)
@@ -585,7 +587,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       return ''
     }
 
-    elementName = this.wrapValue(schema + '.' + elementName)
+    elementName = this.wrapValue(`${D.wrapIdentifier(schema)}.${D.wrapIdentifier(elementName)}`)
     newElementName = this.wrapValue(newElementName)
 
     return `EXEC sp_rename ${elementName}, ${newElementName};`

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -1,7 +1,7 @@
 import { GenericContainer, Wait } from 'testcontainers'
 import { DBTestUtil, dbtimeout } from '../../../../lib/db'
 import { runCommonTests, runReadOnlyTests } from './all'
-import { IDbConnectionServerConfig } from '@/lib/db/types'
+import { DatabaseElement, IDbConnectionServerConfig } from '@/lib/db/types'
 import fs from 'fs';
 import path from 'path';
 
@@ -271,6 +271,63 @@ function testWith(dockerTag: string, readonly: boolean) {
       expect(secondResult).toStrictEqual({
         id: 2,
         bitcol: true
+      })
+    })
+
+    // Regression test for #3722 -> dotted table names fail in sp_helptrigger /
+    // sp_spaceused / sp_rename because the schema+table were concatenated as a
+    // single quoted string, so SQL Server split on the first dot.
+    describe("Dotted table names (#3722)", () => {
+      const dottedTable = 'Common.Companies'
+
+      beforeAll(async () => {
+        // util.knex is a direct knex connection; it is not affected by
+        // Beekeeper's readOnlyMode gate, so we can set up fixtures even when
+        // the Beekeeper client is in read-only mode.
+        await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${dottedTable}]`)
+        await util.knex.schema.raw(`CREATE TABLE dbo.[${dottedTable}](id int, name varchar(255))`)
+        await util.knex.schema.raw(`INSERT INTO dbo.[${dottedTable}](id, name) VALUES (1, 'acme')`)
+      })
+
+      afterAll(async () => {
+        try {
+          await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${dottedTable}]`)
+        } catch (e) {
+          // ignore
+        }
+      })
+
+      it("listTableTriggers succeeds for a table name containing a dot", async () => {
+        const triggers = await util.connection.listTableTriggers(dottedTable, 'dbo')
+        expect(Array.isArray(triggers)).toBe(true)
+      })
+
+      it("getTableProperties succeeds for a table name containing a dot", async () => {
+        const props = await util.connection.getTableProperties(dottedTable, 'dbo')
+        expect(props).toBeDefined()
+      })
+
+      it("setElementName renames a table whose name contains a dot", async () => {
+        if (readonly) return;
+
+        const source = 'Common.ToRename'
+        const renamed = 'Common.Renamed'
+        await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${source}]`)
+        await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${renamed}]`)
+        await util.knex.schema.raw(`CREATE TABLE dbo.[${source}](id int)`)
+
+        try {
+          await util.connection.setElementName(
+            source, renamed, DatabaseElement.TABLE, 'dbo'
+          )
+
+          const names = (await util.connection.listTables()).map((t) => t.name)
+          expect(names).toContain(renamed)
+          expect(names).not.toContain(source)
+        } finally {
+          await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${source}]`)
+          await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${renamed}]`)
+        }
       })
     })
 

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -285,8 +285,12 @@ function testWith(dockerTag: string, readonly: boolean) {
         // Beekeeper's readOnlyMode gate, so we can set up fixtures even when
         // the Beekeeper client is in read-only mode.
         await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${dottedTable}]`)
-        await util.knex.schema.raw(`CREATE TABLE dbo.[${dottedTable}](id int, name varchar(255))`)
-        await util.knex.schema.raw(`INSERT INTO dbo.[${dottedTable}](id, name) VALUES (1, 'acme')`)
+        await util.knex.schema.raw(
+          `CREATE TABLE dbo.[${dottedTable}](id int, company_name varchar(255), fingerprint varchar(32))`
+        )
+        await util.knex.schema.raw(
+          `INSERT INTO dbo.[${dottedTable}](id, company_name, fingerprint) VALUES (1, 'acme', 'dotted-3722')`
+        )
       })
 
       afterAll(async () => {
@@ -295,6 +299,22 @@ function testWith(dockerTag: string, readonly: boolean) {
         } catch (e) {
           // ignore
         }
+      })
+
+      it("listTableColumns returns this table's columns (not a mis-split object)", async () => {
+        const columns = await util.connection.listTableColumns(dottedTable, 'dbo')
+        const names = columns.map((c) => c.columnName).sort()
+        expect(names).toEqual(['company_name', 'fingerprint', 'id'])
+      })
+
+      it("selectTop returns this table's row for a dotted name", async () => {
+        const top = await util.connection.selectTop(
+          dottedTable, 0, 10, [{ dir: 'ASC', field: 'id' }], [], 'dbo'
+        )
+        expect(top.result.length).toBe(1)
+        const row = top.result[0]
+        expect(row.company_name || row.COMPANY_NAME).toBe('acme')
+        expect(row.fingerprint || row.FINGERPRINT).toBe('dotted-3722')
       })
 
       it("listTableTriggers succeeds for a table name containing a dot", async () => {
@@ -314,7 +334,12 @@ function testWith(dockerTag: string, readonly: boolean) {
         const renamed = 'Common.Renamed'
         await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${source}]`)
         await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${renamed}]`)
-        await util.knex.schema.raw(`CREATE TABLE dbo.[${source}](id int)`)
+        await util.knex.schema.raw(
+          `CREATE TABLE dbo.[${source}](id int, marker_col varchar(16))`
+        )
+        await util.knex.schema.raw(
+          `INSERT INTO dbo.[${source}](id, marker_col) VALUES (42, 'rename-3722')`
+        )
 
         try {
           await util.connection.setElementName(
@@ -324,6 +349,19 @@ function testWith(dockerTag: string, readonly: boolean) {
           const names = (await util.connection.listTables()).map((t) => t.name)
           expect(names).toContain(renamed)
           expect(names).not.toContain(source)
+
+          // Columns and data must survive the rename -> proves sp_rename
+          // actually targeted the dotted source table.
+          const columns = await util.connection.listTableColumns(renamed, 'dbo')
+          const columnNames = columns.map((c) => c.columnName).sort()
+          expect(columnNames).toEqual(['id', 'marker_col'])
+
+          const top = await util.connection.selectTop(
+            renamed, 0, 10, [{ dir: 'ASC', field: 'id' }], [], 'dbo'
+          )
+          expect(top.result.length).toBe(1)
+          const row = top.result[0]
+          expect(row.marker_col || row.MARKER_COL).toBe('rename-3722')
         } finally {
           await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${source}]`)
           await util.knex.schema.raw(`DROP TABLE IF EXISTS dbo.[${renamed}]`)

--- a/apps/studio/tests/unit/lib/db/clients/sqlserver.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/sqlserver.spec.js
@@ -1,4 +1,6 @@
 import { SqlServerChangeBuilder } from '@shared/lib/sql/change_builder/SqlServerChangeBuilder';
+import { SQLServerClient } from '@/lib/db/clients/sqlserver';
+import { DatabaseElement } from '@/lib/db/types';
 
 describe("SQL Server alter table codegen", () => {
 
@@ -101,5 +103,59 @@ describe("SQL Server alter table codegen", () => {
     const builder = new SqlServerChangeBuilder('foo', 'dbo', [], defaultConstraints)
     const result = builder.alterTable(input)
     const expected = 'ALTER TABLE [dbo].[foo] DROP CONSTRAINT [DF_foo];'
+  })
+})
+
+describe("SQL Server qualified-name handling for dotted table names (#3722)", () => {
+  function makeClient() {
+    const server = { config: { readOnlyMode: false } }
+    const database = { database: 'test' }
+    const client = new SQLServerClient(server, database)
+    // Swallow the real driver path entirely.
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({ data: { recordset: [] } })
+    return client
+  }
+
+  it("listTableTriggers wraps schema and table in brackets before quoting", async () => {
+    const client = makeClient()
+    await client.listTableTriggers('Common.Companies', 'dbo')
+    const sql = client.driverExecuteSingle.mock.calls[0][0]
+    expect(sql).toBe("EXEC sp_helptrigger '[dbo].[Common.Companies]'")
+  })
+
+  it("getTableProperties sizeQuery wraps schema and table in brackets before quoting", async () => {
+    const client = makeClient()
+    client.listTableTriggers = jest.fn().mockResolvedValue([])
+    client.listTableIndexes = jest.fn().mockResolvedValue([])
+    client.getTableKeys = jest.fn().mockResolvedValue([])
+    // getTableDescription is private; it still calls driverExecuteSingle, which is mocked.
+    await client.getTableProperties('Common.Companies', 'dbo')
+    const sqls = client.driverExecuteSingle.mock.calls.map((c) => c[0])
+    const sizeQuery = sqls.find((s) => s.includes('sp_spaceused'))
+    expect(sizeQuery).toBe("EXEC sp_spaceused N'[dbo].[Common.Companies]'; ")
+  })
+
+  it("setElementNameSql wraps a dotted element name correctly", async () => {
+    const client = makeClient()
+    const sql = await client.setElementNameSql(
+      'Common.Companies', 'NewName', DatabaseElement.TABLE, 'dbo'
+    )
+    expect(sql).toBe("EXEC sp_rename '[dbo].[Common.Companies]', 'NewName';")
+  })
+
+  it("setElementNameSql still emits canonical bracketed form for simple names", async () => {
+    const client = makeClient()
+    const sql = await client.setElementNameSql(
+      'foo', 'bar', DatabaseElement.TABLE, 'dbo'
+    )
+    expect(sql).toBe("EXEC sp_rename '[dbo].[foo]', 'bar';")
+  })
+
+  it("setElementNameSql doubles embedded closing brackets", async () => {
+    const client = makeClient()
+    const sql = await client.setElementNameSql(
+      'weird]name', 'new', DatabaseElement.TABLE, 'dbo'
+    )
+    expect(sql).toBe("EXEC sp_rename '[dbo].[weird]]name]', 'new';")
   })
 })


### PR DESCRIPTION
sp_helptrigger, sp_spaceused, and sp_rename received 'schema.table' as a
single quoted string, so a table named 'Common.Companies' in schema 'dbo'
would be parsed as schema 'dbo.Common', table 'Companies'. Wrap each part
with SqlServerData.wrapIdentifier first so the emitted form is
'[dbo].[Common.Companies]'.

Closes #3722