### PR TITLE
Add DELIMITER preprocessing for MySQL stored procedures

### DIFF
--- a/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/RoutineListItem.vue
@@ -18,7 +18,10 @@
           class="dropdown-icon material-icons"
         >keyboard_arrow_right</i>
       </span>
-      <span class="item-wrapper flex flex-middle expand">
+      <span
+        class="item-wrapper flex flex-middle expand"
+        @dblclick.prevent="openRoutine"
+      >
         <div
           :title="draggable ? 'drag me!' : ''"
           class="table-item-wrapper"
@@ -122,7 +125,12 @@ import { AppEvent } from "@/common/AppEvent";
     data() {
       return {
         showArgs: false,
-        selected: false
+        selected: false,
+        clickState: {
+          timer: null,
+          openClicks: 0,
+          delay: 500
+        }
       }
     },
     watch: {
@@ -165,6 +173,16 @@ import { AppEvent } from "@/common/AppEvent";
     methods: {
       toggleArgs() {
         this.showArgs = !this.showArgs
+      },
+      openRoutine() {
+        if (this.clickState.openClicks > 0) {
+          return
+        }
+        this.$root.$emit('loadRoutineCreate', this.routine)
+        this.clickState.openClicks++
+        this.clickState.timer = setTimeout(() => {
+          this.clickState.openClicks = 0
+        }, this.clickState.delay)
       },
       pin() {
         this.trigger(AppEvent.togglePinTableList, this.routine, true);

--- a/apps/studio/src/components/sidebar/core/table_list/StatelessRoutineListItem.vue
+++ b/apps/studio/src/components/sidebar/core/table_list/StatelessRoutineListItem.vue
@@ -19,7 +19,10 @@
           class="dropdown-icon material-icons"
         >keyboard_arrow_right</i>
       </span>
-      <span class="item-wrapper flex flex-middle expand">
+      <span
+        class="item-wrapper flex flex-middle expand"
+        @dblclick.prevent="openRoutine"
+      >
         <div
           :title="draggable ? 'drag me!' : ''"
           class="table-item-wrapper"
@@ -115,6 +118,11 @@ export default Vue.extend({
   data() {
     return {
       selected: false,
+      clickState: {
+        timer: null,
+        openClicks: 0,
+        delay: 500,
+      },
     };
   },
   watch: {
@@ -143,6 +151,18 @@ export default Vue.extend({
     },
     title() {
       return RoutineTypeNames[this.routine.type];
+    },
+  },
+  methods: {
+    openRoutine() {
+      if (this.clickState.openClicks > 0) {
+        return;
+      }
+      this.$root.$emit("loadRoutineCreate", this.routine);
+      this.clickState.openClicks++;
+      this.clickState.timer = setTimeout(() => {
+        this.clickState.openClicks = 0;
+      }, this.clickState.delay);
     },
   },
 });

--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -17,7 +17,7 @@ import {
   buildInsertQuery,
   buildSelectTopQuery,
   escapeString,
-  ClientError, refreshTokenIfNeeded,
+  refreshTokenIfNeeded,
   errorMessages
 } from "./utils";
 import {
@@ -25,6 +25,7 @@ import {
   DatabaseElement,
 } from "../types";
 import { MysqlCursor } from "./mysql/MySqlCursor";
+import { preprocessDelimiters } from "./mysql/delimiter";
 import {createCancelablePromise} from "@/common/utils";
 import { errors } from "@/lib/errors";
 import { identify } from "sql-query-identifier";
@@ -1101,6 +1102,7 @@ export class MysqlClient extends BasicDatabaseClient<ResultType, mysql.PoolConne
   }
 
   async query(queryText: string, tabId: number): Promise<CancelableQuery> {
+    const preparedQuery = preprocessDelimiters(queryText);
     let pid = null;
     let canceling = false;
     const cancelable = createCancelablePromise({
@@ -1123,7 +1125,7 @@ export class MysqlClient extends BasicDatabaseClient<ResultType, mysql.PoolConne
           try {
             const data: QueryResult = await Promise.race([
               cancelable.wait(),
-              this.executeQuery(queryText, { rowsAsArray: true, connection }),
+              this.executeQuery(preparedQuery, { rowsAsArray: true, connection }),
             ]);
 
             pid = null;
@@ -1133,18 +1135,8 @@ export class MysqlClient extends BasicDatabaseClient<ResultType, mysql.PoolConne
               canceling = false;
               err.sqlectronError = "CANCELED_BY_USER";
               throw err;
-            } else if (
-              queryText &&
-              _.trim(queryText).toUpperCase().startsWith("DELIMITER")
-            ) {
-              const nuError = new ClientError(
-                `DELIMITER is only supported in the command line client, ${err.message}`,
-                "https://docs.beekeeperstudio.io/support/troubleshooting/#mysql"
-              );
-              throw nuError;
-            } else {
-              throw err;
             }
+            throw err;
           } finally {
             cancelable.discard();
           }

--- a/apps/studio/src/lib/db/clients/mysql/delimiter.ts
+++ b/apps/studio/src/lib/db/clients/mysql/delimiter.ts
@@ -1,0 +1,165 @@
+/**
+ * Rewrites MySQL/MariaDB scripts that use `DELIMITER` directives into a form
+ * the MySQL wire protocol can accept directly. `DELIMITER` is a client-side
+ * convention (used by the `mysql` CLI and tools like HeidiSQL) that lets users
+ * terminate compound statements like `CREATE PROCEDURE ... BEGIN ... END`
+ * without the inner `;` tokens being mistaken for statement boundaries.
+ *
+ * The MySQL server itself already understands BEGIN/END compound statements,
+ * so once DELIMITER directives are stripped and the user's custom delimiter
+ * is rewritten to `;`, the resulting script is valid input for a single
+ * multi-statement query.
+ */
+
+const DELIMITER_KEYWORD_RE = /\bDELIMITER\b/i;
+
+export function preprocessDelimiters(sql: string): string {
+  if (!DELIMITER_KEYWORD_RE.test(sql)) {
+    return sql;
+  }
+
+  const out: string[] = [];
+  let activeDelimiter = ";";
+  let i = 0;
+  let atLineStart = true;
+
+  while (i < sql.length) {
+    if (atLineStart) {
+      const match = matchDelimiterDirective(sql, i);
+      if (match) {
+        activeDelimiter = match.delimiter;
+        i = match.nextIndex;
+        atLineStart = true;
+        continue;
+      }
+    }
+
+    const ch = sql[i];
+
+    if (ch === "'" || ch === '"' || ch === "`") {
+      const end = consumeQuoted(sql, i, ch);
+      out.push(sql.slice(i, end));
+      i = end;
+      atLineStart = false;
+      continue;
+    }
+
+    if (ch === "-" && sql[i + 1] === "-" && isLineCommentBoundary(sql[i + 2])) {
+      const end = consumeLineComment(sql, i);
+      out.push(sql.slice(i, end));
+      i = end;
+      atLineStart = sql[end - 1] === "\n";
+      continue;
+    }
+
+    if (ch === "#") {
+      const end = consumeLineComment(sql, i);
+      out.push(sql.slice(i, end));
+      i = end;
+      atLineStart = sql[end - 1] === "\n";
+      continue;
+    }
+
+    if (ch === "/" && sql[i + 1] === "*") {
+      const end = consumeBlockComment(sql, i);
+      out.push(sql.slice(i, end));
+      i = end;
+      atLineStart = false;
+      continue;
+    }
+
+    if (activeDelimiter !== ";" && startsWith(sql, i, activeDelimiter)) {
+      out.push(";");
+      i += activeDelimiter.length;
+      atLineStart = false;
+      continue;
+    }
+
+    out.push(ch);
+    atLineStart = ch === "\n";
+    i += 1;
+  }
+
+  return out.join("");
+}
+
+function matchDelimiterDirective(
+  sql: string,
+  from: number
+): { delimiter: string; nextIndex: number } | null {
+  let p = from;
+  while (p < sql.length && (sql[p] === " " || sql[p] === "\t")) p += 1;
+
+  if (!/^delimiter\b/i.test(sql.slice(p, p + 9))) return null;
+  p += 9;
+
+  const wsStart = p;
+  while (p < sql.length && (sql[p] === " " || sql[p] === "\t")) p += 1;
+  if (p === wsStart) return null;
+
+  const delimStart = p;
+  while (
+    p < sql.length &&
+    sql[p] !== " " &&
+    sql[p] !== "\t" &&
+    sql[p] !== "\n" &&
+    sql[p] !== "\r"
+  ) {
+    p += 1;
+  }
+  if (p === delimStart) return null;
+  const delimiter = sql.slice(delimStart, p);
+
+  while (p < sql.length && sql[p] !== "\n") p += 1;
+  if (sql[p] === "\n") p += 1;
+
+  return { delimiter, nextIndex: p };
+}
+
+function consumeQuoted(sql: string, from: number, quote: string): number {
+  let p = from + 1;
+  while (p < sql.length) {
+    const c = sql[p];
+    if (c === "\\" && quote !== "`") {
+      p += 2;
+      continue;
+    }
+    if (c === quote) {
+      if (sql[p + 1] === quote) {
+        p += 2;
+        continue;
+      }
+      return p + 1;
+    }
+    p += 1;
+  }
+  return p;
+}
+
+function consumeLineComment(sql: string, from: number): number {
+  let p = from;
+  while (p < sql.length && sql[p] !== "\n") p += 1;
+  if (sql[p] === "\n") p += 1;
+  return p;
+}
+
+function consumeBlockComment(sql: string, from: number): number {
+  let p = from + 2;
+  while (p < sql.length - 1) {
+    if (sql[p] === "*" && sql[p + 1] === "/") return p + 2;
+    p += 1;
+  }
+  return sql.length;
+}
+
+function isLineCommentBoundary(ch: string | undefined): boolean {
+  return ch === undefined || ch === " " || ch === "\t" || ch === "\n" || ch === "\r";
+}
+
+function startsWith(sql: string, index: number, needle: string): boolean {
+  if (index + needle.length > sql.length) return false;
+  for (let k = 0; k < needle.length; k += 1) {
+    if (sql[index + k] !== needle[k]) return false;
+  }
+  return true;
+}

--- a/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
@@ -1,4 +1,5 @@
 import { testOnly } from '../../../../../src/lib/db/clients/mysql'
+import { preprocessDelimiters } from '../../../../../src/lib/db/clients/mysql/delimiter'
 import { parseIndexColumn } from '../../../../../src/common/utils'
 import { MySqlChangeBuilder } from "@shared/lib/sql/change_builder/MysqlChangeBuilder"
 
@@ -34,6 +35,128 @@ describe("MySQL UNIT tests (no connection required)", () => {
     for (const [input, output] of Object.entries(samples)) {
       expect(parseIndexColumn(input)).toMatchObject(output)
     }
+  })
+})
+
+describe("preprocessDelimiters", () => {
+  it("returns input unchanged when no DELIMITER directive is present", () => {
+    const sql = "SELECT 1;\nSELECT 2;"
+    expect(preprocessDelimiters(sql)).toBe(sql)
+  })
+
+  it("handles the classic DELIMITER $$ ... END$$ DELIMITER ; pattern", () => {
+    const input = [
+      "DELIMITER $$",
+      "CREATE PROCEDURE p()",
+      "BEGIN",
+      "  SELECT 1;",
+      "  SELECT 2;",
+      "END$$",
+      "DELIMITER ;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).not.toMatch(/DELIMITER/i)
+    expect(result).toContain("BEGIN")
+    expect(result).toContain("  SELECT 1;")
+    expect(result).toContain("  SELECT 2;")
+    expect(result).toContain("END;")
+    expect(result).not.toContain("$$")
+  })
+
+  it("supports // delimiter and preserves nested BEGIN/END", () => {
+    const input = [
+      "DELIMITER //",
+      "CREATE PROCEDURE outer_proc()",
+      "BEGIN",
+      "  BEGIN",
+      "    SELECT 1;",
+      "  END;",
+      "  SELECT 2;",
+      "END//",
+      "DELIMITER ;",
+      "SELECT 3;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).not.toContain("//")
+    expect(result).toContain("END;")
+    expect(result).toContain("SELECT 3;")
+  })
+
+  it("ignores the delimiter literal inside a single-quoted string", () => {
+    const input = [
+      "DELIMITER //",
+      "SELECT 'hello // world'//",
+      "DELIMITER ;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("SELECT 'hello // world';")
+  })
+
+  it("ignores the delimiter literal inside a block comment", () => {
+    const input = [
+      "DELIMITER //",
+      "/* comment with // inside */ SELECT 1//",
+      "DELIMITER ;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("/* comment with // inside */ SELECT 1;")
+  })
+
+  it("preserves -- and # line comments inside a procedure body", () => {
+    const input = [
+      "DELIMITER $$",
+      "CREATE PROCEDURE p()",
+      "BEGIN",
+      "  -- a line comment",
+      "  # another line comment",
+      "  SELECT 1;",
+      "END$$",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("-- a line comment")
+    expect(result).toContain("# another line comment")
+  })
+
+  it("ignores the delimiter inside backtick-quoted identifiers", () => {
+    const input = [
+      "DELIMITER //",
+      "SELECT `col//name` FROM t//",
+      "DELIMITER ;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("`col//name`")
+  })
+
+  it("handles unterminated DELIMITER session without error", () => {
+    const input = [
+      "DELIMITER $$",
+      "CREATE PROCEDURE p() BEGIN SELECT 1; END$$",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).not.toMatch(/DELIMITER/i)
+    expect(result).toContain("END;")
+  })
+
+  it("recognises lowercase 'delimiter' keyword", () => {
+    const input = "delimiter $$\nSELECT 1$$"
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("SELECT 1;")
+    expect(result).not.toContain("$$")
+  })
+
+  it("does not touch a DELIMITER keyword embedded mid-line", () => {
+    const sql = "SELECT 'DELIMITER' AS name;"
+    expect(preprocessDelimiters(sql)).toBe(sql)
+  })
+
+  it("leaves backslash-escaped quotes intact", () => {
+    const input = [
+      "DELIMITER //",
+      "SELECT 'it\\'s fine'//",
+      "DELIMITER ;",
+    ].join("\n")
+    const result = preprocessDelimiters(input)
+    expect(result).toContain("SELECT 'it\\'s fine';")
   })
 })
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -66,35 +66,6 @@ If you edit your indexes in Beekeeper Studio and create a `DESC` index it will s
 
 As of version 8.0 this issue has been solved.
 
-### I get a SQL syntax error when trying to create a stored procedure
-
-When using the `mysql` command line client you need to remap delimiters using `DELIMITER`, however this syntax isn't supported by MySQL server itself, so it errors when run through Beekeeper Studio.
-
-You'll likely get an error like `You have an error in your SQL syntax`. Simply remove the delimiter statements to fix it.
-
-For example, change this:
-```sql
-DELIMITER //
-
-CREATE PROCEDURE simpleproc (OUT param1 INT)
- BEGIN
-  SELECT COUNT(*) INTO param1 FROM t;
- END;
-//
-
-DELIMITER ;
-```
-
-To this:
-
-```sql
-CREATE PROCEDURE simpleproc (OUT param1 INT)
- BEGIN
-  SELECT COUNT(*) INTO param1 FROM t;
- END;
-```
-
-
 ### Access denied for user (using password: YES)
 
 If you get an `Access denied for user 'xxx' (using password: YES)` error when connecting, try toggling **Enable SSL** on in the connection settings.


### PR DESCRIPTION
## Summary
This PR adds support for MySQL `DELIMITER` directives in Beekeeper Studio, allowing users to paste stored procedure scripts directly from the `mysql` CLI without manual editing. The implementation preprocesses SQL scripts to convert client-side `DELIMITER` syntax into server-compatible format.

## Key Changes

- **New delimiter preprocessor module** (`apps/studio/src/lib/db/clients/mysql/delimiter.ts`):
  - Implements `preprocessDelimiters()` function that rewrites MySQL/MariaDB scripts using `DELIMITER` directives
  - Strips `DELIMITER` keywords and converts custom delimiters back to `;` for wire protocol compatibility
  - Properly handles quoted strings, comments (line and block), and backtick identifiers to avoid false matches
  - Supports any custom delimiter (e.g., `$$`, `//`, etc.)

- **Integration with MySQL client** (`apps/studio/src/lib/db/clients/mysql.ts`):
  - Applies `preprocessDelimiters()` to all incoming queries before execution
  - Removes the previous error handling that rejected `DELIMITER` statements
  - Eliminates the troubleshooting documentation workaround

- **Comprehensive test coverage** (`apps/studio/tests/unit/lib/db/clients/mysql.spec.js`):
  - 11 new test cases covering various scenarios: classic `$$` pattern, alternative delimiters (`//`), nested BEGIN/END blocks, quoted strings, comments, backtick identifiers, case-insensitivity, and edge cases

- **UI improvements** for routine management:
  - Added double-click support to open routine editor in both `RoutineListItem.vue` and `StatelessRoutineListItem.vue`
  - Implements debouncing to prevent multiple simultaneous opens

- **Documentation update** (`docs/support/troubleshooting.md`):
  - Removed the workaround section explaining how to manually remove `DELIMITER` statements

## Implementation Details

The preprocessor uses a state machine approach that:
- Tracks the active delimiter (defaults to `;`)
- Maintains line-start position to only match `DELIMITER` directives at line boundaries
- Properly escapes quoted content (single, double, and backtick quotes)
- Handles MySQL escape sequences (backslash escaping in non-backtick strings)
- Preserves all comments and whitespace in the output
- Converts matched custom delimiters to `;` for server compatibility

This allows users to paste scripts like:
```sql
DELIMITER $$
CREATE PROCEDURE p() BEGIN SELECT 1; END$$
DELIMITER ;
```

Without modification, and it will execute correctly.

https://claude.ai/code/session_015RUxcHoUqg4FxR2bjKJcd2