### PR TITLE
chore: add BaseModal wrapper component

### DIFF
--- a/apps/studio/src/components/common/modals/BaseModal.vue
+++ b/apps/studio/src/components/common/modals/BaseModal.vue
@@ -3,7 +3,7 @@
     <modal :name="name" class="base-modal-root">
       <div v-kbd-trap="true" class="base-modal">
         <div class="base-modal-header">
-          <div class="base-modal-title"><slot name="title" /></div>
+          <div class="base-modal-title"><slot name="title" :close="close" /></div>
           <a
             href="#"
             class="base-modal-close"
@@ -13,10 +13,10 @@
           </a>
         </div>
         <div class="base-modal-body">
-          <slot />
+          <slot :close="close" />
         </div>
         <div class="base-modal-footer">
-          <slot name="footer" />
+          <slot name="footer" :close="close" />
         </div>
       </div>
     </modal>

--- a/apps/studio/src/components/common/modals/BaseModal.vue
+++ b/apps/studio/src/components/common/modals/BaseModal.vue
@@ -51,10 +51,6 @@ export default Vue.extend({
   flex-direction: column;
 }
 
-.base-modal > * {
-  box-sizing: border-box;
-}
-
 .base-modal-header {
   display: flex;
   align-items: center;
@@ -80,11 +76,11 @@ export default Vue.extend({
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  min-width: 26px;
-  height: 26px;
-  line-height: 26px;
-  border-radius: 26px;
+  width: 1.625rem;
+  min-width: 1.625rem;
+  height: 1.625rem;
+  line-height: 1.625rem;
+  border-radius: 1.625rem;
   padding: 0;
   margin: 0;
   margin-right: -0.35em;
@@ -101,7 +97,7 @@ export default Vue.extend({
 
 .base-modal-close .material-icons,
 .base-modal-close .material-icons-outlined {
-  font-size: 20px;
+  font-size: 1.25rem;
   color: var(--text-dark);
 }
 
@@ -116,7 +112,6 @@ export default Vue.extend({
   gap: 0.5rem;
   width: 100%;
   justify-content: flex-end;
-  border: 0 !important;
   padding-inline: 1.2rem;
   padding-bottom: 0.8rem;
 }

--- a/apps/studio/src/components/common/modals/BaseModal.vue
+++ b/apps/studio/src/components/common/modals/BaseModal.vue
@@ -1,6 +1,6 @@
 <template>
   <portal to="modals">
-    <modal :name="name">
+    <modal :name="name" class="base-modal-root">
       <div v-kbd-trap="true" class="base-modal">
         <div class="base-modal-header">
           <div class="base-modal-title"><slot name="title" /></div>
@@ -42,6 +42,10 @@ export default Vue.extend({
 </script>
 
 <style scoped>
+.base-modal-root ::v-deep .v--modal {
+  min-height: 6rem;
+}
+
 .base-modal {
   display: flex;
   flex-direction: column;
@@ -56,8 +60,8 @@ export default Vue.extend({
   align-items: center;
   justify-content: space-between;
   gap: 0.8rem;
-  padding: 1.2rem;
-  padding-bottom: 0.8rem;
+  padding-inline: 1.2rem;
+  padding-block: 0.8rem;
 }
 
 .base-modal-title {
@@ -113,8 +117,7 @@ export default Vue.extend({
   width: 100%;
   justify-content: flex-end;
   border: 0 !important;
-  padding: 0 0.4rem 0.8rem;
   padding-inline: 1.2rem;
-  margin-right: -0.25rem;
+  padding-bottom: 0.8rem;
 }
 </style>

--- a/apps/studio/src/components/common/modals/BaseModal.vue
+++ b/apps/studio/src/components/common/modals/BaseModal.vue
@@ -1,0 +1,120 @@
+<template>
+  <portal to="modals">
+    <modal :name="name">
+      <div v-kbd-trap="true" class="base-modal">
+        <div class="base-modal-header">
+          <div class="base-modal-title"><slot name="title" /></div>
+          <a
+            href="#"
+            class="base-modal-close"
+            @click.prevent="close"
+          >
+            <i class="material-icons">clear</i>
+          </a>
+        </div>
+        <div class="base-modal-body">
+          <slot />
+        </div>
+        <div class="base-modal-footer">
+          <slot name="footer" />
+        </div>
+      </div>
+    </modal>
+  </portal>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+  props: {
+    name: {
+      type: String,
+      required: true,
+    },
+  },
+  methods: {
+    close() {
+      this.$modal.hide(this.name);
+    },
+  },
+});
+</script>
+
+<style scoped>
+.base-modal {
+  display: flex;
+  flex-direction: column;
+}
+
+.base-modal > * {
+  box-sizing: border-box;
+}
+
+.base-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 1.2rem;
+  padding-bottom: 0.8rem;
+}
+
+.base-modal-title {
+  font-size: 1.1rem;
+  line-height: 1;
+  font-weight: 500;
+  margin: 0;
+}
+
+.base-modal-title i.material-icons {
+  vertical-align: middle;
+  font-size: 1.1rem;
+}
+
+.base-modal-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  min-width: 26px;
+  height: 26px;
+  line-height: 26px;
+  border-radius: 26px;
+  padding: 0;
+  margin: 0;
+  margin-right: -0.35em;
+  text-align: center;
+  box-shadow: none;
+  user-select: none;
+  transition: background 0.15s ease-in-out;
+}
+
+.base-modal-close:hover,
+.base-modal-close:focus {
+  background: rgb(from var(--theme-base) r g b / 10%);
+}
+
+.base-modal-close .material-icons,
+.base-modal-close .material-icons-outlined {
+  font-size: 20px;
+  color: var(--text-dark);
+}
+
+.base-modal-body {
+  flex: 1 0 auto;
+  width: 100%;
+  padding: 0 1.2rem 0.8rem;
+}
+
+.base-modal-footer {
+  display: flex;
+  gap: 0.5rem;
+  width: 100%;
+  justify-content: flex-end;
+  border: 0 !important;
+  padding: 0 0.4rem 0.8rem;
+  padding-inline: 1.2rem;
+  margin-right: -0.25rem;
+}
+</style>


### PR DESCRIPTION
I was working on the UI for version history and it was going to use a modal. So I thought of making a PR for simplifying the modal component, because I feel like our modals are unnecessarily verbose, they are not as straight forward to style. Each modal can have different styles. This should solve those things.

This has the same style, with some modification on paddings for perfect alignment.

<img width="838" height="335" alt="Screenshot 2026-04-21 at 19 54 19" src="https://github.com/user-attachments/assets/dc5420a1-8542-4555-a0af-6c0c69c30cce" />

## Comparison: rolling your own vs. using `BaseModal`

Today, every modal re-implements the same scaffolding — `portal`, `modal`, the `vue-dialog` / `dialog-content` / `dialog-c-title` / `vue-dialog-buttons` class hierarchy, and a close handler. There is no shared close button, and each modal styles its header/footer slightly differently.

**Without `BaseModal`** — typical of what we have today (e.g. `CreatePinModal.vue`):

```vue
<template>
  <portal to="modals">
    <modal
      :name="modalName"
      :click-to-close="false"
      class="vue-dialog beekeeper-modal example-modal"
    >
      <form v-kbd-trap="true" @submit.prevent="submit">
        <div class="dialog-content">
          <div class="dialog-c-title has-icon">
            <i class="material-icons">lock</i>
            Example title
          </div>
          <!-- body content -->
        </div>
        <div class="vue-dialog-buttons">
          <button class="btn btn-flat" type="button" @click="close">Cancel</button>
          <button class="btn btn-primary" type="submit">Submit</button>
        </div>
      </form>
    </modal>
  </portal>
</template>

<script lang="ts">
import Vue from "vue";

export default Vue.extend({
  data() {
    return { modalName: "example-modal" };
  },
  methods: {
    close() {
      this.$modal.hide(this.modalName);
    },
    submit() { /* ... */ },
  },
});
</script>
```

**With `BaseModal`**:

```vue
<template>
  <base-modal name="example-modal">
    <template #title>
      <i class="material-icons">lock</i>
      Example title
    </template>
    <form @submit.prevent="submit">
      <!-- body content NOTE: It doesn't have to be a form. It could be anything you need. -->
    </form>
    <template #footer="{ close }">
      <button class="btn btn-flat" type="button" @click="close">Cancel</button>
      <button class="btn btn-primary" type="submit" @click="submit">Submit</button>
    </template>
  </base-modal>
</template>

<script lang="ts">
import Vue from "vue";
import BaseModal from "@/components/common/modals/BaseModal.vue";

export default Vue.extend({
  components: { BaseModal },
  methods: {
    submit() { /* ... */ },
  },
});
</script>
```

What you get for free with `BaseModal`:

- No more `portal` + `modal` + `vue-dialog` boilerplate.
- A consistent header (title + close button) and footer across every modal.
- No need to track `modalName` in `data()` or wire up a `close()` method — `close` is exposed as a slot prop on the `title`, default, and `footer` slots.
- `v-kbd-trap` is applied by the wrapper, so individual modals don't need to remember it.
- Padding/alignment is fixed once in the wrapper instead of being re-tweaked per modal.