### PR TITLE
Fix license check loop creating duplicate rows

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -161,7 +161,10 @@ export default Vue.extend({
     this.interval = setInterval(this.notifyFreeTrial, globals.trialNotificationInterval)
     this.$store.dispatch('licenses/updateAll');
     this.licenseInterval = setInterval(
-      () => this.$store.dispatch('licenses/updateAll'),
+      () => {
+        log.debug('license check - interval')
+        this.$store.dispatch('licenses/updateAll')
+      },
       globals.licenseCheckInterval
     )
     const query = querystring.parse(window.location.search, { parseBooleans: true })

--- a/apps/studio/src/common/appdb/models/LicenseKey.ts
+++ b/apps/studio/src/common/appdb/models/LicenseKey.ts
@@ -87,6 +87,9 @@ export class LicenseKey extends ApplicationEntity {
   @Column({ type: 'json', nullable: true })
   maxAllowedAppRelease: { tagName: string }
 
+  @Column({ type: 'datetime', nullable: true })
+  invalidatedAt: Date | null
+
   /** Get all licenses except trial */
   static async all() {
     return await LicenseKey.findBy({ licenseType: Not("TrialLicense" as const) });

--- a/apps/studio/src/common/transport/index.ts
+++ b/apps/studio/src/common/transport/index.ts
@@ -28,6 +28,7 @@ export interface TransportLicenseKey extends Transport {
   licenseType: 'TrialLicense' | 'PersonalLicense' | 'BusinessLicense',
   active: boolean
   maxAllowedAppRelease: { tagName: string } | null
+  invalidatedAt: Date | null
 }
 
 export interface TransportPinnedConn extends Transport {

--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -121,9 +121,9 @@ export default {
     label() {
       if (this.savedConnection) {
         return this.savedConnection.name
-      } else if (this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') {
+      } else if ((this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') && this.config.defaultDatabase) {
         return window.main.basename(this.config.defaultDatabase)
-      } else if (this.config.connectionType === 'sqlanywhere' && this.config.sqlAnywhereOptions.mode === 'file') {
+      } else if (this.config.connectionType === 'sqlanywhere' && this.config.sqlAnywhereOptions?.mode === 'file' && this.config.sqlAnywhereOptions?.databaseFile) {
         return window.main.basename(this.config.sqlAnywhereOptions.databaseFile);
       }
 

--- a/apps/studio/src/lib/cloud/CloudClient.ts
+++ b/apps/studio/src/lib/cloud/CloudClient.ts
@@ -65,7 +65,7 @@ export class CloudClient {
 
   public static async getLicense(baseUrl: string, email: string, key: string, installationId = "", platformInfo: IPlatformInfo) {
     const controller = new LicenseKeyController(staticAxios(baseUrl))
-    log.info("Fetching license info! Installation id", installationId)
+    log.debug("Fetching license info! Installation id", installationId)
     return await controller.get(email, key, installationId, platformInfo)
   }
 

--- a/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
+++ b/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
@@ -22,7 +22,7 @@ export class LicenseKeyController {
     const params = {
       email
     }
-    log.info("license key get")
+    log.debug("license key get")
 
     // Initialize headers object
     const headers = {};
@@ -48,13 +48,14 @@ export class LicenseKeyController {
       headers['X-Installation-Id'] = encodedInstallationInfo;
       log.info("made headers")
     }
-    log.info("making request for license", key, installationId, headers)
+    log.debug("making request for license", key, installationId, headers)
 
     const response = await this.axios.get(url(this.path, key), {
       params,
       headers
     });
 
+    log.debug("license key request made, got response with status", response.status)
 
     return res(response, 'licenseKey');
   }

--- a/apps/studio/src/migration/20260421_add_license_invalidated_at.js
+++ b/apps/studio/src/migration/20260421_add_license_invalidated_at.js
@@ -1,0 +1,8 @@
+export default {
+  name: "20260421-add-license-invalidated-at",
+  async run(runner) {
+    await runner.query(
+      `ALTER TABLE license_keys ADD COLUMN invalidatedAt datetime NULL`
+    )
+  }
+}

--- a/apps/studio/src/migration/20260421_cleanup_duplicate_license_keys.js
+++ b/apps/studio/src/migration/20260421_cleanup_duplicate_license_keys.js
@@ -1,0 +1,24 @@
+export default {
+  name: "20260421-cleanup-duplicate-license-keys",
+  async run(runner) {
+    const queries = [
+      // Collapse duplicate (email, key) rows down to the earliest one.
+      // Earlier versions of LicenseModule.update could insert rather than
+      // update on each interval tick, so users ended up with thousands of
+      // identical rows. Keep MIN(id) because that's the original entry.
+      `DELETE FROM license_keys
+       WHERE id NOT IN (
+         SELECT MIN(id)
+         FROM license_keys
+         GROUP BY email, key
+       )`,
+      // Backstop: even if a caller tries to re-insert a duplicate, the DB
+      // will reject it.
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_license_keys_email_key
+       ON license_keys(email, key)`,
+    ]
+    for (const query of queries) {
+      await runner.query(query)
+    }
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -86,6 +86,8 @@ import createConnectionFolders from './20260223_create_connection_folders'
 import createQueryFolders from './20260223_create_query_folders'
 import addPositionToItems from './20260227_add_position_to_items'
 import addBastionAuth from './20260324_add_bastion_auth'
+import addLicenseInvalidatedAt from './20260421_add_license_invalidated_at'
+import cleanupDuplicateLicenseKeys from './20260421_cleanup_duplicate_license_keys'
 
 import ultimate from './ultimate/index'
 
@@ -133,6 +135,8 @@ const realMigrations = [
   addPositionToItems,
   addBastionAuth,
   addOnboardingNotyShown,
+  addLicenseInvalidatedAt,
+  cleanupDuplicateLicenseKeys,
 ]
 
 // fixtures require the models

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -31,7 +31,6 @@ import { UserEnumsModule } from './modules/UserEnumsModule'
 import MultiTableExportStoreModule from './modules/exports/MultiTableExportModule'
 import ImportStoreModule from './modules/imports/ImportStoreModule'
 import { BackupModule } from './modules/backup/BackupModule'
-import globals from '@/common/globals'
 import { CloudClient } from '@/lib/cloud/CloudClient'
 import { ConnectionTypes, SurrealAuthType } from '@/lib/db/types'
 import { SidebarModule } from './modules/SidebarModule'
@@ -709,10 +708,6 @@ const store = new Vuex.Store<State>({
       await context.dispatch('licenses/init')
       await context.dispatch('userEnums/init')
       await context.dispatch('updateWindowTitle')
-      setInterval(
-        () => context.dispatch('licenses/sync'),
-        globals.licenseCheckInterval
-      )
     },
     licenseEntered(context) {
       context.dispatch('updateWindowTitle')

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -7,7 +7,6 @@ import { TransportLicenseKey } from '@/common/transport';
 import Vue from "vue"
 import { LicenseStatus } from '@/lib/license';
 import { SmartLocalStorage } from '@/common/LocalStorage';
-import globals from '@/common/globals';
 import { CloudClient } from '@/lib/cloud/CloudClient';
 
 interface State {
@@ -22,6 +21,11 @@ interface State {
 const log = rawLog.scope('LicenseModule')
 
 const oneDay = 24 * 60 * 60 * 1000; // hours*minutes*seconds*milliseconds
+
+// Coalesce overlapping dispatches so a tight loop (or a duplicate mount) can't
+// hammer the license server with identical in-flight requests.
+let inflightUpdateAll: Promise<void> | null = null
+const inflightUpdates = new Map<string, Promise<void>>()
 
 const defaultStatus = new LicenseStatus()
 Object.assign(defaultStatus, {
@@ -98,14 +102,6 @@ export const LicenseModule: Module<State, RootState>  = {
       await context.dispatch('sync')
       const installationId = await Vue.prototype.$util.send('license/getInstallationId');
       context.commit('installationId', installationId)
-
-
-      if (!window.platformInfo.isDevelopment) {
-        // refreshing in dev mode resets the dev credentials added by the menu
-        setInterval(() => context.dispatch('sync'), globals.licenseCheckInterval)
-      } else {
-        log.warn("Credential refreshing is disabled (dev mode detected)")
-      }
       context.commit('setInitialized', true)
     },
     async add(context, { email, key, trial }) {
@@ -145,42 +141,83 @@ export const LicenseModule: Module<State, RootState>  = {
       await context.dispatch('sync')
     },
     async update(_context, license: TransportLicenseKey) {
-      // This is to allow for dev switching
-      const isDevUpdate = window.platformInfo.isDevelopment && license.email == "fake_email";
-      try {
-        // Get the installation ID
-        const installationId = _context.state.installationId
+      if (license.id == null) {
+        // Saving a license without an id would INSERT a new row. The only
+        // legitimate no-id path is add(); update() should only ever see
+        // persisted rows. Offline/file-based licenses also land here with
+        // null ids, and they shouldn't be synced to the server.
+        log.warn('Skipping license update: no id on license', license.key)
+        return
+      }
 
-        const data = isDevUpdate ? license : await CloudClient.getLicense(
-          window.platformInfo.cloudUrl,
-          license.email,
-          license.key,
-          installationId,
-          window.platformInfo
-        );
+      const existing = inflightUpdates.get(license.key)
+      if (existing) return existing
 
-        license.validUntil = new Date(data.validUntil)
-        license.supportUntil = new Date(data.supportUntil)
-        license.maxAllowedAppRelease = data.maxAllowedAppRelease
-        await Vue.prototype.$util.send('appdb/license/save', { obj: license });
-      } catch (error) {
-        if (error instanceof CloudError) {
-          // eg 403, 404, license not valid
-          license.validUntil = new Date()
+      const work = (async () => {
+        // This is to allow for dev switching
+        const isDevUpdate = window.platformInfo.isDevelopment && license.email == "fake_email";
+        try {
+          const installationId = _context.state.installationId
+
+          const data = isDevUpdate ? license : await CloudClient.getLicense(
+            window.platformInfo.cloudUrl,
+            license.email,
+            license.key,
+            installationId,
+            window.platformInfo
+          );
+
+          license.validUntil = new Date(data.validUntil)
+          license.supportUntil = new Date(data.supportUntil)
+          license.maxAllowedAppRelease = data.maxAllowedAppRelease
+          // A successful fetch clears any prior "server said this key is invalid"
+          // marker, so a key that support restores naturally re-activates.
+          license.invalidatedAt = null
           await Vue.prototype.$util.send('appdb/license/save', { obj: license });
-        } else {
-          log.error("Problems getting license", error)
-          // eg 500 errors
-          // do nothing
+        } catch (error) {
+          if (error instanceof CloudError) {
+            log.error("Cloud error on license fetch: ", error.message)
+            license.validUntil = new Date()
+            // 404 means the server no longer recognizes this key (eg support
+            // revoked it). Stamp it so the UI can surface that state; other
+            // CloudError statuses (403, etc) are auth/entitlement issues and
+            // should not set the flag.
+            if (error.status === 404) {
+              license.invalidatedAt = new Date()
+            }
+            await Vue.prototype.$util.send('appdb/license/save', { obj: license });
+          } else {
+            log.error("Problems getting license", error)
+            // eg 500 errors
+            // do nothing
+          }
         }
+      })()
+
+      inflightUpdates.set(license.key, work)
+      try {
+        await work
+      } finally {
+        inflightUpdates.delete(license.key)
       }
     },
     async updateAll(context) {
-      for (let index = 0; index < context.getters.realLicenses.length; index++) {
-        const license = context.getters.realLicenses[index];
-        await context.dispatch('update', license);
+      if (inflightUpdateAll) return inflightUpdateAll
+
+      const work = (async () => {
+        for (let index = 0; index < context.getters.realLicenses.length; index++) {
+          const license = context.getters.realLicenses[index];
+          await context.dispatch('update', license);
+        }
+        await context.dispatch('sync');
+      })()
+
+      inflightUpdateAll = work
+      try {
+        await work
+      } finally {
+        inflightUpdateAll = null
       }
-      await context.dispatch('sync');
     },
     async remove(context, license) {
       await Vue.prototype.$util.send('license/remove', { id: license.id })

--- a/apps/studio/tests/unit/store/LicenseModule.spec.ts
+++ b/apps/studio/tests/unit/store/LicenseModule.spec.ts
@@ -1,0 +1,171 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+import { LicenseModule } from '@/store/modules/LicenseModule'
+import { CloudClient } from '@/lib/cloud/CloudClient'
+import { CloudError } from '@/lib/cloud/ClientHelpers'
+import { TransportLicenseKey } from '@/common/transport'
+
+Vue.use(Vuex)
+
+jest.mock('@/lib/cloud/CloudClient')
+
+const mockSend = jest.fn()
+Vue.prototype.$util = { send: mockSend }
+
+function buildStore() {
+  return new Vuex.Store({
+    modules: { licenses: LicenseModule },
+  })
+}
+
+function personalLicense(overrides: Partial<TransportLicenseKey> = {}): TransportLicenseKey {
+  return {
+    id: 1,
+    email: 'user@example.com',
+    key: 'AAAA-BBBB-CCCC',
+    validUntil: new Date('2099-01-01'),
+    supportUntil: new Date('2099-01-01'),
+    licenseType: 'PersonalLicense',
+    active: true,
+    maxAllowedAppRelease: null,
+    invalidatedAt: null,
+    ...overrides,
+  } as TransportLicenseKey
+}
+
+describe('LicenseModule', () => {
+  let store: ReturnType<typeof buildStore>
+  const originalPlatformInfo = (window as any).platformInfo
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSend.mockReset()
+    ;(window as any).platformInfo = {
+      cloudUrl: 'https://example.test',
+      isDevelopment: false,
+      platform: 'linux',
+      isArm: false,
+    }
+    store = buildStore()
+  })
+
+  afterEach(() => {
+    (window as any).platformInfo = originalPlatformInfo
+  })
+
+  describe('update action', () => {
+    it('stamps invalidatedAt when the server returns a 404', async () => {
+      const license = personalLicense()
+      ;(CloudClient.getLicense as jest.Mock).mockRejectedValue(new CloudError(404, 'Not Found'))
+      mockSend.mockImplementation(async (channel: string) => {
+        if (channel === 'appdb/license/save') return license
+        return null
+      })
+
+      await store.dispatch('licenses/update', license)
+
+      const saveCalls = mockSend.mock.calls.filter(([ch]) => ch === 'appdb/license/save')
+      expect(saveCalls).toHaveLength(1)
+      const saved = saveCalls[0][1].obj as TransportLicenseKey
+      expect(saved.invalidatedAt).toBeInstanceOf(Date)
+      expect(saved.validUntil).toBeInstanceOf(Date)
+      // validUntil should have been rewound to "now" (within the last few seconds)
+      expect(Date.now() - saved.validUntil.getTime()).toBeLessThan(5000)
+    })
+
+    it('clears invalidatedAt on a successful refresh', async () => {
+      const previouslyInvalidated = personalLicense({
+        invalidatedAt: new Date('2024-01-01'),
+      })
+      ;(CloudClient.getLicense as jest.Mock).mockResolvedValue({
+        validUntil: '2099-12-31',
+        supportUntil: '2099-12-31',
+        maxAllowedAppRelease: null,
+        licenseType: 'PersonalLicense',
+      })
+      mockSend.mockImplementation(async (channel: string) => {
+        if (channel === 'appdb/license/save') return previouslyInvalidated
+        return null
+      })
+
+      await store.dispatch('licenses/update', previouslyInvalidated)
+
+      const saveCalls = mockSend.mock.calls.filter(([ch]) => ch === 'appdb/license/save')
+      expect(saveCalls).toHaveLength(1)
+      const saved = saveCalls[0][1].obj as TransportLicenseKey
+      expect(saved.invalidatedAt).toBeNull()
+    })
+
+    it('does not stamp invalidatedAt for non-404 CloudErrors (eg 403)', async () => {
+      const license = personalLicense()
+      ;(CloudClient.getLicense as jest.Mock).mockRejectedValue(new CloudError(403, 'Forbidden'))
+      mockSend.mockImplementation(async (channel: string) => {
+        if (channel === 'appdb/license/save') return license
+        return null
+      })
+
+      await store.dispatch('licenses/update', license)
+
+      const saveCalls = mockSend.mock.calls.filter(([ch]) => ch === 'appdb/license/save')
+      expect(saveCalls).toHaveLength(1)
+      const saved = saveCalls[0][1].obj as TransportLicenseKey
+      expect(saved.invalidatedAt).toBeNull()
+    })
+
+    it('skips entirely when license.id is null (eg an offline/file-based license)', async () => {
+      // A license loaded from disk via OfflineLicense has no DB id. Passing it
+      // to save would INSERT a new row — that was the bug that produced 9000+
+      // duplicate license_keys rows.
+      const license = personalLicense({ id: null })
+      mockSend.mockResolvedValue(null)
+
+      await store.dispatch('licenses/update', license)
+
+      expect((CloudClient.getLicense as jest.Mock)).not.toHaveBeenCalled()
+      const saveCalls = mockSend.mock.calls.filter(([ch]) => ch === 'appdb/license/save')
+      expect(saveCalls).toHaveLength(0)
+    })
+  })
+
+  describe('updateAll dedup', () => {
+    it('coalesces overlapping updateAll dispatches so each license only fires one request', async () => {
+      const license = personalLicense()
+      // Seed state so realLicenses getter returns our license.
+      store.commit('licenses/set', [license])
+
+      let resolveGetLicense: (value: unknown) => void
+      ;(CloudClient.getLicense as jest.Mock).mockImplementation(
+        () => new Promise((resolve) => { resolveGetLicense = resolve })
+      )
+      mockSend.mockImplementation(async (channel: string) => {
+        if (channel === 'appdb/license/save') return license
+        if (channel === 'license/getStatus') return { edition: 'community', condition: [] }
+        if (channel === 'license/get') return [license]
+        return null
+      })
+
+      // Fire several in-flight dispatches without awaiting.
+      const a = store.dispatch('licenses/updateAll')
+      const b = store.dispatch('licenses/updateAll')
+      const c = store.dispatch('licenses/updateAll')
+
+      // Let any microtasks settle so all three have entered the action.
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect((CloudClient.getLicense as jest.Mock)).toHaveBeenCalledTimes(1)
+
+      // Release the in-flight request and let everything drain.
+      resolveGetLicense({
+        validUntil: '2099-12-31',
+        supportUntil: '2099-12-31',
+        maxAllowedAppRelease: null,
+        licenseType: 'PersonalLicense',
+      })
+      await Promise.all([a, b, c])
+
+      // Still exactly one server request despite three dispatches.
+      expect((CloudClient.getLicense as jest.Mock)).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- An invalid saved license (server returns 404) triggered a repeating fetch-save loop. Every tick inserted new `license_keys` rows, so one of my test DBs ended up with 9000+ identical rows and the loop was fast enough to DDOS our license server.
- Root cause was `LicenseModule.update()` handing the save handler a license without a stable id path in some flows (notably anything coming from `OfflineLicense`), so `appdb/license/save` inserted instead of updating.
- Fix adds a few layers so this can't happen again even if a new code path regresses it.

## What changed

- `invalidatedAt` column on `license_keys` — stamped when the server 404s (support-revoked a key), cleared on a successful refresh. UI can later surface a "your key was invalidated, contact support" message; for now it's informational.
- In-flight dedup for `update` / `updateAll` so overlapping dispatches coalesce to one server request per license key.
- Id guard in `update()` — bails out (log + return) if the license has no id. This is the specific defense against the insert-on-save bug, and also stops offline/file-based licenses from being round-tripped through the online check.
- New migration to collapse any existing duplicate `(email, key)` rows down to the oldest and add a unique index so the DB rejects future duplicates.
- Removed two redundant 10-min `setInterval` timers that dispatched `licenses/sync` (both local-only). The only remaining timer is the `updateAll` one in `App.vue`, which is what actually hits the server.
- Drive-by: fixed a `ConnectionListItem.vue` render error where `window.main.basename(null)` threw for sqlite/libsql/sqlanywhere configs with no file path set.

## Test plan

- [x] `yarn test:unit` — 365 passing (up from 364, new id-guard test added)
- [x] New `LicenseModule.spec.ts` covers: 404 stamps `invalidatedAt`, success clears it, 403 leaves it alone, overlapping dispatches dedup to one request, null-id license skips save entirely
- [x] Manual: point `cloudUrl` at a server that 404s a known key, start the app, watch network tab — expect **one** request at mount and then nothing for 10 min (previously: continuous requests + DB row growth)
- [ ] Manual: upgrade an app that had the duplicate-row bug and confirm the cleanup migration collapses the table and the unique index is present