### PR TITLE
Fix idle-disconnect notifications firing on every interval tick

### DIFF
--- a/apps/studio/src/backend/lib/security.ts
+++ b/apps/studio/src/backend/lib/security.ts
@@ -17,14 +17,22 @@ export function initializeSecurity() {
   }
 
   if (bksConfig.security.disconnectOnIdle) {
+    let hasDisconnectedWhileIdle = false;
     idleCheckInterval = setInterval(() => {
-      if (
+      const overThreshold =
         powerMonitor.getSystemIdleTime() >
-        bksConfig.security.idleThresholdSeconds
-      ) {
-        log.info("User has been idle, disconnecting.");
-        disconnect("User has been idle");
+        bksConfig.security.idleThresholdSeconds;
+
+      if (!overThreshold) {
+        hasDisconnectedWhileIdle = false;
+        return;
       }
+
+      if (hasDisconnectedWhileIdle) return;
+
+      log.info("User has been idle, disconnecting.");
+      disconnect("User has been idle");
+      hasDisconnectedWhileIdle = true;
     }, (bksConfig.security.idleCheckIntervalSeconds || 1) * 1000);
     log.info("Idle checker started");
   }

--- a/apps/studio/tests/unit/backend/lib/security.spec.ts
+++ b/apps/studio/tests/unit/backend/lib/security.spec.ts
@@ -1,0 +1,71 @@
+import { AppEvent } from "@/common/AppEvent";
+
+const mockState = { idleSeconds: 0 };
+const mockSend = jest.fn();
+
+jest.mock("electron", () => ({
+  powerMonitor: {
+    getSystemIdleTime: () => mockState.idleSeconds,
+    on: jest.fn(),
+  },
+}));
+
+jest.mock("@/background/WindowBuilder", () => ({
+  getActiveWindows: () => [{ send: mockSend }],
+}));
+
+jest.mock("@/common/bksConfig", () => ({
+  __esModule: true,
+  default: {
+    security: {
+      disconnectOnIdle: true,
+      idleThresholdSeconds: 10,
+      idleCheckIntervalSeconds: 1,
+      disconnectOnSuspend: false,
+      disconnectOnLock: false,
+    },
+  },
+}));
+
+describe("security idle disconnect", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+    mockSend.mockClear();
+    mockState.idleSeconds = 0;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("only fires disconnect once while the user remains idle", () => {
+    const { initializeSecurity } = require("@/backend/lib/security");
+    initializeSecurity();
+
+    mockState.idleSeconds = 20;
+    jest.advanceTimersByTime(5000);
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledWith(AppEvent.disconnect, {
+      reason: "User has been idle",
+    });
+  });
+
+  it("re-arms after the user returns and then goes idle again", () => {
+    const { initializeSecurity } = require("@/backend/lib/security");
+    initializeSecurity();
+
+    mockState.idleSeconds = 20;
+    jest.advanceTimersByTime(5000);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+
+    mockState.idleSeconds = 0;
+    jest.advanceTimersByTime(2000);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+
+    mockState.idleSeconds = 20;
+    jest.advanceTimersByTime(2000);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

The idle auto-disconnect (`security.disconnectOnIdle`) was spamming notifications. Once the user crossed `idleThresholdSeconds`, the `setInterval` in `apps/studio/src/backend/lib/security.ts` sent `AppEvent.disconnect` every tick (default 1s) until they came back, so `LockManager.vue` stacked up a toast a second.

Added a `hasDisconnectedWhileIdle` latch so disconnect only fires on the transition into idle. The latch clears as soon as `powerMonitor.getSystemIdleTime()` drops below the threshold, so the next idle session re-fires exactly once.

## Test plan

- [x] New unit test `apps/studio/tests/unit/backend/lib/security.spec.ts` — failed against the old code (5 sends instead of 1), passes with the fix. Covers both the single-fire case and the re-arm-after-user-returns case.
- [ ] Manual smoke: set a short `idleThresholdSeconds` in `default.config.ini`, stay idle past the threshold, confirm exactly one "Disconnected: User has been idle" toast (not a flood), then interact and idle again to confirm it fires a second time.