### PR TITLE
Some editing fixes

### DIFF
--- a/apps/studio/config-metadata.json
+++ b/apps/studio/config-metadata.json
@@ -81,6 +81,13 @@
         { "key": "firstPage", "label": "First Page" },
         { "key": "lastPage", "label": "Last Page" }
       ]
+    },
+    {
+      "key": "keybindings.resultTable",
+      "label": "Result Table",
+      "properties": [
+        { "key": "openEditorModal", "label": "Open Editor Modal" }
+      ]
     }
   ]
 }

--- a/apps/studio/default.config.ini
+++ b/apps/studio/default.config.ini
@@ -301,6 +301,9 @@ closeTableFilter = esc
 manualCommit = ctrlOrCmd+shift+c
 manualRollback = ctrlOrCmd+shift+r
 
+[keybindings.resultTable]
+openEditorModal = shift+enter
+
 [keybindings.tableTable]
 nextPage = ctrlOrCmd+right
 previousPage = ctrlOrCmd+left

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -52,7 +52,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
       background: $row-add;
       border: 0;
       .tabulator-cell {
-        &.primary-key {
+        &.primary-key, &.read-only-field {
           > * {
             opacity: initial;
           }
@@ -372,7 +372,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
     &:hover, &.editable:hover {
       background: rgba($theme-base,0.05);
     }
-    &.primary-key {
+    &.primary-keye, &.read-only-field {
       cursor: default;
       & > * {
         opacity: 0.5;
@@ -423,7 +423,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
   background: transparent;
   .tabulator-headers {
     .tabulator-col:first-of-type {
-      &.foreign-key, &.primary-key {
+      &.foreign-key, &.primary-key, &.read-only-field {
         &:before{
           left: $gutter-w * 0.8;
         }
@@ -528,13 +528,12 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
           }
         }
       }
-      &.foreign-key, &.primary-key {
+      &.foreign-key, &.primary-key, &.read-only-field {
         .tabulator-col-content {
           width: calc(100% - #{$foreign-key-width});
         }
         &:before{
           $font-size: 13px;
-          content: 'vpn_key';
           font-family: 'Material Icons';
           font-size: $font-size;
           color: $theme-primary;
@@ -542,6 +541,15 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
           display: inline-flex;
           align-items: center;
         }
+      }
+      &.foreign-key, &.primary-key {
+        &:before {
+          content: 'vpn_key'
+        }
+      }
+      &.read-only-field:before {
+        color: $text-disabled;
+        content: 'edit_off';
       }
       &.primary-key:before {
         color: $theme-secondary;
@@ -831,7 +839,7 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
       }
 
       &.tabulator-range-selected {
-        &.primary-key:before {
+        &.primary-key:before, &.read-only-field:before {
           color: black;
         }
         &.foreign-key:before {

--- a/apps/studio/src/common/bksConfig/BksConfigProvider.ts
+++ b/apps/studio/src/common/bksConfig/BksConfigProvider.ts
@@ -137,6 +137,25 @@ const uiModifierMap: ModifierMap = {
   PAGEDOWN: "PageDown",
 };
 
+const contextMenuModifierMap: ModifierMap = {
+  CTRL: "Control",
+  CMD: "Control",
+  CTRLORCMD: "Control",
+  CMDORCTRL: "Control",
+  COMMAND: "Control",
+  CONTROLORCOMMAND: "Control",
+  COMMANDORCONTROL: "Control",
+  SHIFT: "Shift",
+  ALT: "Alt",
+  OPTION: "Alt",
+  ALTGR: "AltGraph",
+  SUPER: "Super",
+  META: "Meta",
+  PageUp: "PageUp",
+  PageDown: "PageDown",
+  ENTER: "Enter"
+}
+
 export function convertKeybinding(
   target: KeybindingTarget,
   keybinding: string,
@@ -148,7 +167,7 @@ export function convertKeybinding(
   platform: Platform
 ): string[];
 export function convertKeybinding(
-  target: "electron" | "v-hotkey" | "codemirror" | "ui",
+  target: "electron" | "v-hotkey" | "codemirror" | "ui" | "tabulator" | "context-menu",
   keybinding: string,
   platform: Platform
 ): string[] | string {
@@ -172,6 +191,10 @@ export function convertKeybinding(
       joinChar = ' + ';
     case "ui":
       modifierMap = uiModifierMap;
+      break;
+    case "context-menu":
+      modifierMap = contextMenuModifierMap;
+      joinChar = '+'
       break;
     default:
       log.error("Unrecognized target for keybinding conversion: ", target)
@@ -206,8 +229,8 @@ export function convertKeybinding(
     if (target === "tabulator" && !modifierMap[key]) {
       mod = mod.toLowerCase();
     }
-    
-    if (target === "ui" && !modifierMap[key]) {
+
+    if ((target === "ui" || target === "context-menu") && !modifierMap[key]) {
       mod = _.upperFirst(mod.toLowerCase());
     }
 

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1392,6 +1392,7 @@
         this.results = []
         this.resultsEditData = []
         this.resultEditableMap = []
+        this.editingResult = false
         this.selectedResult = 0
         let identification = []
         try {

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -53,7 +53,7 @@
   import dateFormat from 'dateformat'
   import Converter from '../../mixins/data_converter'
   import Mutators from '../../mixins/data_mutators'
-  import { escapeHtml } from '@shared/lib/tabulator'
+  import { escapeHtml, FormatterParams } from '@shared/lib/tabulator'
   import { dialectFor, FormatterDialect } from '@shared/lib/dialects/models'
   import { FkLinkMixin } from '@/mixins/fk_click'
   import MagicColumnBuilder from '@/lib/magic/MagicColumnBuilder'
@@ -70,7 +70,7 @@
   import { vueEditor } from '@shared/lib/tabulator/helpers';
   import NullableInputEditorVue from '@shared/components/tabulator/NullableInputEditor.vue';
   import rawLog from '@bksLogger';
-  import { FieldDescriptor, FieldEditData, NgQueryResult, TableUpdate } from '@/lib/db/models'
+  import { FieldDescriptor, FieldEditData, FieldReadOnlyReason, NgQueryResult, TableUpdate } from '@/lib/db/models'
   import { CellComponent, RowComponent } from 'tabulator-tables'
   import { PropType } from 'vue'
   import { format } from 'sql-formatter'
@@ -377,50 +377,102 @@
           cssClass += ' generated-column';
         }
 
+        if (this.editData && !editData?.editable && !editData?.isPK) {
+          cssClass += ` read-only-field`;
+        }
+
         if (magic.formatterParams?.fk) {
           magic.formatterParams.fkOnClick = (_e, cell) => this.fkClick(magic.formatterParams.fk[0], cell)
         }
 
         const magicStuff = _.pick(magic, ['formatter', 'formatterParams'])
-        const defaults = {
-          formatter: this.cellFormatter,
-          formatterParams: {
-            binaryEncoding: this.binaryEncoding,
-          },
-        }
 
         const editorType = this.editorType(editData?.dataType);
+        const useVerticalNavigation = editorType === 'textarea'
+
+        const formatterParams: FormatterParams = {
+          fk: false,
+          fkOnClick: undefined,
+          isPK: editData?.isPK,
+          binaryEncoding: this.$bksConfig.ui.general.binaryEncoding,
+        }
+
+        let headerTooltip = escapeHtml(column.name);
+
+        if (editData) {
+          headerTooltip = escapeHtml(`${editData?.generated ? '[Generated]' : ''}${editData?.columnName ?? column.name} ${editData?.dataType ?? ''}`);
+
+          if (!editData.editable) {
+            switch (editData.readOnlyReason) {
+              case FieldReadOnlyReason.NoLinkedTable:
+                headerTooltip += ' -> Could not find a table to link this column to within the query.';
+                break;
+              case FieldReadOnlyReason.MissingPK:
+                headerTooltip += ' -> Could not find all required Primary Keys for this column within the query.';
+                break;
+              case FieldReadOnlyReason.ImproperMapping:
+                headerTooltip == ' -> Could not map field to an existing table column.';
+                break;
+              case FieldReadOnlyReason.IsGenerated:
+                headerTooltip += ' -> Cannot edit generated columns.';
+                break;
+            }
+          }
+        }
 
         const result = {
-          ...defaults,
           title,
+          field: column.id,
           titleFormatter: this.headerFormatter,
           titleFormatterParams: {
             columnName: title,
             dataType: editData?.dataType,
             generated: editData?.generated
           },
-          field: column.id,
           titleDownload: escapeHtml(column.name),
           dataType: editData?.dataType,
           width: columnWidth,
           mutator: this.resolveTabulatorMutator(column.dataType, dialectFor(this.connectionType)),
-          formatter: this.cellFormatter,
           maxInitialWidth: this.$bksConfig.ui.tableTable.maxColumnWidth,
           tooltip: this.cellTooltip,
           contextMenu: cellMenu,
           headerContextMenu: columnMenu,
           headerMenu: columnMenu,
+          headerTooltip,
           resizable: 'header',
           cssClass,
           editable: this.cellEditCheck,
           editor: editorType,
+          cellEditCancelled: (cell: CellComponent) => cell.getRow().normalizeHeight(),
+          formatter: this.cellFormatter,
+          formatterParams,
+          editorParams: {
+            verticalNavigation: useVerticalNavigation ? 'editor' : undefined,
+            dataType: editData?.dataType,
+            search: true,
+            allowEmpty: true,
+            preserveObject: editData?.array,
+            onPreserveObjectFail: (value: unknown) => {
+              log.error('Failed to preserve object for', value)
+              return true
+            },
+            typeHint: editData?.dataType?.toLowerCase(),
+            bksField: editData?.bksField,
+            binaryEncoding: this.$bksConfig.ui.general.binaryEncoding,
+          },
           ...magicStuff
         }
 
         if (column.dataType === 'INTERVAL') {
           // add interval sorter
           result['sorter'] = this.intervalSorter;
+        } else if (editData?.dataType && /^(bool|boolean)$/i.test(editData?.dataType)) {
+          const values = [
+            { label: 'false', value: this.dialectData.boolean?.false ?? false },
+            { label: 'true', value: this.dialectData.boolean?.true ?? true },
+          ];
+          if (editData?.nullable) values.push({ label: '(NULL)', value: null });
+          result.editorParams['values'] = values;
         }
 
         const results = [];

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -4,6 +4,11 @@
     :class="{ 'hidden-filter': hiddenFilter }"
     v-hotkey="keymap"
   >
+    <editor-modal
+      ref="editorModal"
+      :binary-encoding="$bksConfig.ui.general.binaryEncoding"
+      @save="onSaveEditorModal"
+    />
     <form
       class="table-search-wrapper table-filter"
       @submit.prevent="searchHandler"
@@ -62,19 +67,21 @@
   import { markdownTable } from 'markdown-table'
   import intervalParse from 'postgres-interval'
   import * as td from 'tinyduration'
-  import { copyRanges, copyActionsMenu, commonColumnMenu, resizeAllColumnsToFitContent, resizeAllColumnsToFixedWidth, createMenuItem } from '@/lib/menu/tableMenu';
+  import { copyRanges, copyActionsMenu, commonColumnMenu, resizeAllColumnsToFitContent, resizeAllColumnsToFixedWidth, createMenuItem, pasteActionsMenu, pasteRange } from '@/lib/menu/tableMenu';
   import { tabulatorForTableData } from '@/common/tabulator';
+  import EditorModal from '../tableview/EditorModal.vue'
   import { AppEvent } from "@/common/AppEvent";
   import XLSX from 'xlsx';
   import { parseRowDataForJsonViewer } from '@/lib/data/jsonViewer'
   import { vueEditor } from '@shared/lib/tabulator/helpers';
   import NullableInputEditorVue from '@shared/components/tabulator/NullableInputEditor.vue';
   import rawLog from '@bksLogger';
-  import { FieldDescriptor, FieldEditData, FieldReadOnlyReason, NgQueryResult, TableUpdate } from '@/lib/db/models'
-  import { CellComponent, RowComponent } from 'tabulator-tables'
+  import { FieldDescriptor, FieldEditData, FieldReadOnlyReasonStr, NgQueryResult, TableUpdate } from '@/lib/db/models'
+  import { CellComponent, RangeComponent, RowComponent } from 'tabulator-tables'
   import { PropType } from 'vue'
   import { format } from 'sql-formatter'
   import pluralize from 'pluralize'
+import { stringToTypedArray } from '@/common/utils'
 
   const log = rawLog.scope('ResultTable');
 
@@ -95,6 +102,7 @@
   }
 
   export default {
+    components: { EditorModal },
     mixins: [Converter, Mutators, FkLinkMixin],
     data() {
       return {
@@ -111,7 +119,8 @@
         internalClassTrackerColumn: "__beekeeper_internal_class_tracker",
         propogatedChangesFilters: new Map<string, Filter[]>(),
         fieldOriginalClassMap: new Map<string, string>(),
-        saveError: null
+        saveError: null,
+        globalAllowTablePopup: true
       }
     },
     props: {
@@ -163,6 +172,9 @@
         return this.$vHotkeyKeymap({
           'queryEditor.copyResultSelection': this.copySelection.bind(this),
           'queryEditor.openTableFilter': this.focusOnFilterInput.bind(this),
+          'general.save': this.saveChanges.bind(this),
+          'general.openInSqlEditor': this.copyToSql.bind(this),
+          'resultTable.openEditorModal': this.openEditorMenuByShortcut.bind(this)
         });
       },
       tableFilterKeymap() {
@@ -321,6 +333,67 @@
           element.classList.add(classToAdd);
         }
       },
+      setAsNullMenuItem(range: RangeComponent) {
+        const areAllCellsReadOnly = range
+          .getColumns()
+          .every((col) => !this.cellEditCheck(col, false));
+        return {
+          label: createMenuItem("Set as NULL"),
+          action: () => {
+            // we have to globally disable the popups because for some reason
+            // when setting the value, the edit check is run for every cell in a the row
+            this.globalAllowTablePopup = false;
+            const targets = range.getCells().flat().map((cell) => ({
+              row: cell.getRow(),
+              field: cell.getField()
+            }));
+
+            for (const { row, field } of targets) {
+              const cell = row.getCell(field);
+              if (!cell) continue;
+              if (this.cellEditCheck(cell)) cell.setValue(null);
+            }
+
+            this.globalAllowTablePopup = true;
+          },
+          disabled: areAllCellsReadOnly || !this.editingData,
+        }
+      },
+      openEditorMenuByShortcut() {
+        const range: RangeComponent = _.last(this.tabulator.getRanges())
+        const cell = range.getCells().flat()[0];
+        // (copied from TableTable.vue)
+        // FIXME maybe we can avoid calling child methods directly like this?
+        // it should be done by calling an event using this.$modal.show(modalName)
+        // or this.$trigger(AppEvent.something) if possible
+        this.openCellEditorModal(cell, !this.cellEditCheck(cell, false))
+      },
+      openEditorMenu(cell: CellComponent) {
+        const isReadOnly = !this.cellEditCheck(cell, false);
+        let keybind = this.$bksConfig.getKeybindings("context-menu", 'resultTable.openEditorModal');
+        keybind = Array.isArray(keybind) ? keybind[0] : keybind;
+        return {
+          label: createMenuItem(isReadOnly ? "View in modal" : "Edit in modal", keybind),
+          action: () => {
+            this.openCellEditorModal(cell, isReadOnly)
+          }
+        }
+      },
+      openCellEditorModal(cell: CellComponent, isReadOnly: boolean) {
+        const eventParams = { cell, isReadOnly };
+        this.$refs.editorModal.openModal(cell.getValue(), undefined, eventParams)
+      },
+      onSaveEditorModal(content: string, _l: any, cell: CellComponent){
+        const editData = this.editData?.get(cell.getField());
+        const isBinary = editData?.bksField?.bksType === 'BINARY' || _.isTypedArray(cell.getValue());
+
+        let value = content;
+        if (isBinary) {
+          value = stringToTypedArray(content);
+        }
+
+        cell.setValue(value);
+      },
       createColumnFromProps(column: FieldDescriptor, index: number) {
         const columnWidth = this.result.fields.length > 30 ? this.$bksConfig.ui.tableTable.defaultColumnWidth : undefined
 
@@ -331,13 +404,28 @@
           }
         }
 
-        const cellMenu = (_e, cell) => {
+        const cellMenu = (_e, cell: CellComponent) => {
+          const ranges = cell.getRanges();
+          const range = _.last(ranges);
+
           return [
+            this.openEditorMenu(cell),
+            this.setAsNullMenuItem(range),
+            { separator: true },
             ...copyActionsMenu({
               ranges: cell.getRanges(),
               table: this.result.tableName,
               schema: this.defaultSchema,
             }),
+            { separator: true },
+            {
+              label: createMenuItem("Paste", "Control+V"),
+              action: () => {
+                this.globalAllowTablePopup = false;
+                pasteRange(range);
+                this.globalAllowTablePopup = true;
+              },
+            },
             { separator: true },
             filterMenuItem,
             ...this.getExtraPopupMenu('results.cell', { transform: "tabulator" }),
@@ -402,21 +490,8 @@
         if (editData) {
           headerTooltip = escapeHtml(`${editData?.generated ? '[Generated]' : ''}${editData?.columnName ?? column.name} ${editData?.dataType ?? ''}`);
 
-          if (!editData.editable) {
-            switch (editData.readOnlyReason) {
-              case FieldReadOnlyReason.NoLinkedTable:
-                headerTooltip += ' -> Could not find a table to link this column to within the query.';
-                break;
-              case FieldReadOnlyReason.MissingPK:
-                headerTooltip += ' -> Could not find all required Primary Keys for this column within the query.';
-                break;
-              case FieldReadOnlyReason.ImproperMapping:
-                headerTooltip == ' -> Could not map field to an existing table column.';
-                break;
-              case FieldReadOnlyReason.IsGenerated:
-                headerTooltip += ' -> Cannot edit generated columns.';
-                break;
-            }
+          if (!editData.editable && !_.isNil(editData.readOnlyReason)) {
+            headerTooltip += ` -> Read-Only: ${FieldReadOnlyReasonStr[editData.readOnlyReason]}`
           }
         }
 
@@ -509,7 +584,7 @@
           default: return ne
         }
       },
-      cellEditCheck(cell: CellComponent): boolean {
+      cellEditCheck(cell: CellComponent, allowPopup: boolean = true): boolean {
         if (!this.editingData) return false
 
         const fieldEditData: FieldEditData = this.editData?.get(cell.getField());
@@ -517,6 +592,9 @@
           return false;
         }
 
+        if (this.globalAllowTablePopup && allowPopup && !fieldEditData.editable && !_.isNil(fieldEditData.readOnlyReason)) {
+          cell.popup(`Read-Only: ${FieldReadOnlyReasonStr[fieldEditData.readOnlyReason]}`, "bottom")
+        }
         return fieldEditData.editable;
       },
       cellEdited(cell: CellComponent) {
@@ -675,10 +753,12 @@
       },
       discardChanges() {
         this.saveError = null;
+        this.globalAllowTablePopup = false;
 
         this.pendingChanges.updates.forEach((edit: TableUpdatePayload) => this.discardUpdate(edit));
 
         this.resetPendingChanges();
+        this.globalAllowTablePopup = true;
       },
       discardUpdate(pendingUpdate: TableUpdatePayload) {
         const filters = this.propogatedChangesFilters.get(pendingUpdate.key);
@@ -766,6 +846,8 @@
       async copyToSql() {
         this.saveError = null;
 
+        if (!this.editingData) return;
+
         try {
           const changes = {
             inserts: [],
@@ -809,6 +891,8 @@
       },
       async saveChanges() {
         this.saveError = null;
+
+        if (!this.editingData) return;
 
         try {
           const payload = {

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -33,11 +33,6 @@ export interface QueryLogOptions {
     error?: string
 }
 
-// TODO (@day): not sure if I really want this
-export interface QueryResultEditData {
-
-}
-
 interface TableMetadata {
   name: string,
   alias?: string,
@@ -275,12 +270,6 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
         return editData;
       }
 
-      if (!table.isEditable) {
-        // In the future we could actually say what PK we are missing?
-        editData.readOnlyReason = FieldReadOnlyReason.MissingPK;
-        return editData;
-      }
-
       editData = {
         id: field.id,
         editable: false,
@@ -289,11 +278,18 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
         linkedSchema: table.schema,
         isPK: false,
         generated: tableColumn.generated,
+        nullable: tableColumn.nullable,
+        array: tableColumn.array,
         dataType: tableColumn.dataType,
+        bksField: tableColumn.bksField,
       };
 
-      if (table?.isEditable) {
-        editData.isPK = table.pks.some((pk) => pk.columnName === fieldColumn.name);
+      editData.isPK = table.pks.some((pk) => pk.columnName === fieldColumn.name);
+
+      if (!table.isEditable) {
+        // In the future we could actually say what PK we are missing?
+        editData.readOnlyReason = FieldReadOnlyReason.MissingPK;
+        return editData;
       }
 
       editData.editable = !editData.isPK && !tableColumn.generated;

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -261,6 +261,13 @@ export enum FieldReadOnlyReason {
   IsGenerated
 }
 
+export const FieldReadOnlyReasonStr = {
+  [FieldReadOnlyReason.NoLinkedTable]: 'Could not find a table to link this column to within the query',
+  [FieldReadOnlyReason.MissingPK]: `Could not find all primary keys for this column's linked table`,
+  [FieldReadOnlyReason.ImproperMapping]: 'Could not map field to an existing table column',
+  [FieldReadOnlyReason.IsGenerated]: 'Cannot edit generated columns',
+}
+
 export interface FieldEditData {
   editable: boolean;
   id?: string; // this is what the field is referred to as in the object

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -269,8 +269,11 @@ export interface FieldEditData {
   linkedSchema?: string;
   isPK?: boolean;
   generated?: boolean;
+  nullable?: boolean;
+  array?: boolean;
   readOnlyReason?: FieldReadOnlyReason;
   dataType?: string;
+  bksField?: BksField;
 }
 
 export interface FieldDescriptor {

--- a/apps/studio/src/types.ts
+++ b/apps/studio/src/types.ts
@@ -31,7 +31,7 @@ export type ExternalMenuItem<TabContext = {}> = {
 
 export type Platform = "windows" | "mac" | "linux";
 
-export type KeybindingTarget = "electron" | "v-hotkey" | "codemirror" | "ui" | "tabulator";
+export type KeybindingTarget = "electron" | "v-hotkey" | "codemirror" | "ui" | "tabulator" | "context-menu";
 
 export type FileHelpers = {
   save: (options: SaveFileOptions) => Promise<void>;

--- a/apps/studio/src/typings/bksConfig.d.ts
+++ b/apps/studio/src/typings/bksConfig.d.ts
@@ -374,6 +374,9 @@ declare interface IBksConfig {
             selectDown: string[];
             selectUp: string[];
         };
+        resultTable: {
+            openEditorModal: string;
+        };
         tab: {
             closeTab: string;
             forceCloseTab: string;

--- a/apps/ui-kit/lib/components/table/mixins/data_mutators.ts
+++ b/apps/ui-kit/lib/components/table/mixins/data_mutators.ts
@@ -45,7 +45,7 @@ export default {
       return cellValue.map(cv => `<span class="mapper-pill">${cv}</span>`).join('')
     },
     cellTooltip(_event, cell: CellComponent) {
-      const params: TabulatorFormatterParams = cell.getColumn().getDefinition().formatterParams || {}
+      const params: TabulatorFormatterParams = cell.getColumn().getDefinition().formatterParams as any || {}
       const binaryEncoding = params.binaryEncoding
       let cellValue = cell.getValue()
       if (cellValue instanceof Uint8Array) {

--- a/apps/ui-kit/lib/components/table/table.scss
+++ b/apps/ui-kit/lib/components/table/table.scss
@@ -163,7 +163,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
         background: $row-add;
         border: 0;
         .tabulator-cell {
-          &.primary-key {
+          &.primary-key, &.read-only-field {
             &:hover {
               background: rgba($theme-base,0.05);
               cursor: pointer;
@@ -442,7 +442,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
   .tabulator-row {
     .tabulator-cell {
       cursor: pointer;
-      &.primary-key {
+      &.primary-key, &.read-only-field {
         cursor: default;
         & > * {
           opacity: 0.5;
@@ -462,7 +462,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
     width: 100%;
     .tabulator-headers {
       .tabulator-col:first-of-type {
-        &.foreign-key, &.primary-key {
+        &.foreign-key, &.primary-key, &.read-only-field {
           &:before{
             left: $gutter-w * 0.8;
           }
@@ -529,13 +529,12 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
           margin: 0 0 0 0.3rem;
         }
 
-        &.foreign-key, &.primary-key {
+        &.foreign-key, &.primary-key, &.read-only-field {
           .tabulator-col-content {
             width: calc(100% - #{$foreign-key-width});
           }
           &:before{
             $font-size: 13px;
-            content: 'vpn_key';
             font-family: 'Material Icons';
             font-size: $font-size;
             color: $theme-primary;
@@ -543,6 +542,15 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
             display: inline-flex;
             align-items: center;
           }
+        }
+        &.foreign-key, &.primary-key {
+          &:before {
+            content: 'vpn_key'
+          }
+        }
+        &.read-only-field:before {
+          color: $text-disabled;
+          content: 'edit_off';
         }
         &.primary-key:before {
           color: $theme-secondary;
@@ -776,7 +784,7 @@ $columnResizeGuideColor:      mix($query-editor-bg, $theme-base, 80%) !default;
     .tabulator-col {
 
       &.tabulator-range-selected {
-        &.primary-key:before {
+        &.primary-key:before, &.read-only-field:before {
           color: black;
         }
         &.foreign-key:before {


### PR DESCRIPTION
Add an icon to the header of columns that are read-only in result editing, and also add a tooltip that gives a reason for why the column is read only (Couldn't map table, couldn't map column, missing PK, or column is generated).

Add the boolean dropdown for bool columns

<img width="1117" height="739" alt="image" src="https://github.com/user-attachments/assets/3cd30c8a-debd-419f-b95a-cd84cf980046" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a551d4ae-93e3-45ec-a5b0-f0fe09c900ca" />
