### PR TITLE
Fix read-only editor context menu

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -34,7 +34,7 @@
       <component
         :is="editorComponent"
         :value="unsavedText"
-        :read-only="editor.readOnly"
+        :read-only="readOnly"
         :is-focused="focusingElement === 'text-editor'"
         :markers="editorMarkers"
         :formatter-dialect="formatterDialect"
@@ -567,7 +567,6 @@
         editor: {
           height: 100,
           selection: null,
-          readOnly: false,
           cursorIndex: 0,
           cursorIndexAnchor: 0,
           initialized: false,
@@ -635,6 +634,12 @@
       ...mapState('settings', ['settings']),
       ...mapState('tabs', { 'activeTab': 'active' }),
       ...mapGetters('popupMenu', ['getExtraPopupMenu']),
+      readOnly() {
+        if (this.remoteDeleted || this.editingResult) {
+          return true;
+        }
+        return false;
+      },
       queryTabTitle() {
         if (this.tab.query && this.tab.query.title) {
           return this.tab.query.title;
@@ -930,11 +935,8 @@
       },
       remoteDeleted() {
         if (this.remoteDeleted) {
-          this.editor.readOnly = 'nocursor'
           this.tab.unsavedChanges = false
           this.tab.alert = true
-        } else {
-          this.editor.readOnly = false
         }
       },
       unsavedChanges() {
@@ -1665,6 +1667,12 @@
         this.timerInterval = null;
       },
       editorContextMenu(_event, _context, items) {
+        if (this.readOnly) {
+          return [
+            ...items,
+            ...this.getExtraPopupMenu("editor.query", { transform: "ui-kit" }),
+          ]
+        }
         return [
           ...items,
           {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -635,7 +635,7 @@
       ...mapState('tabs', { 'activeTab': 'active' }),
       ...mapGetters('popupMenu', ['getExtraPopupMenu']),
       readOnly() {
-        if (this.remoteDeleted || this.editingResult) {
+        if (this.remoteDeleted) {
           return true;
         }
         return false;

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
@@ -70,11 +70,7 @@ export default Vue.extend({
         entities: this.entities,
       });
     },
-    contextMenuItemsModifier(
-      _event,
-      items: InternalContextItem<unknown>[],
-      context: TextEditorMenuContext
-    ): ReturnType<ContextMenuExtension<SqlTextEditorMenuContext>> {
+    addFormatItemsToContextMenu(items: InternalContextItem<unknown>[]) {
       const formatItem: InternalContextItem<unknown> = {
         label: `Format Query`,
         id: "text-format",
@@ -100,13 +96,23 @@ export default Vue.extend({
           }))
         ];
       }
-      
-      const modifiedItems = [
+
+      return [
         ...items,
         formatItem
       ];
+    },
+    contextMenuItemsModifier(
+      _event,
+      items: InternalContextItem<unknown>[],
+      context: TextEditorMenuContext
+    ): ReturnType<ContextMenuExtension<SqlTextEditorMenuContext>> {
+      if (!this.readOnly) {
+        items = this.addFormatItemsToContextMenu(items);
+      }
+
       return {
-        items: modifiedItems,
+        items,
         context: {
           ...context,
           selectedQuery: this.selectedQuery,

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -280,7 +280,7 @@ export default {
           },
           divider,
           {
-            label: "Find & Replace",
+            label: this.readOnly ? "Find" : "Find & Replace",
             id: "text-find",
             handler: () => {
               this.textEditor.execCommand("findAndReplace");


### PR DESCRIPTION
The context menu shows "write" actions even though the editor is in read only mode.

When read-only is enabled:

<img width="224" height="147" alt="Screenshot 2026-04-22 at 13 21 59" src="https://github.com/user-attachments/assets/82c6e4ae-c5c3-4a21-a6d7-650aadd0be47" />


When read-only is disabled:

<img width="253" height="343" alt="Screenshot 2026-04-22 at 13 22 17" src="https://github.com/user-attachments/assets/35c6058b-4c50-402b-be45-b1e4bd7060dd" />
