### PR TITLE
make it clear that "editing result mode" is activated

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -185,36 +185,6 @@
             >
           </x-button>
           <x-button
-            class="btn btn-flat btn-small settings-btn"
-            menu
-          >
-            <i class="material-icons">settings</i>
-            <i class="material-icons">arrow_drop_down</i>
-            <x-menu>
-              <x-menuitem disabled togglable>
-                <x-label>Editor keymap</x-label>
-              </x-menuitem>
-              <x-menuitem
-                :key="t.value"
-                v-for="t in keymapTypes"
-                togglable
-                :toggled="t.value === userKeymap"
-                @click.prevent="userKeymap = t.value"
-              >
-                <x-label>{{ t.name }}</x-label>
-              </x-menuitem>
-              <x-menuitem
-                togglable
-                :toggled="wrapText"
-                @click.prevent="wrapText = !wrapText"
-              >
-                <x-label class="flex-between">
-                  Wrap Text
-                </x-label>
-              </x-menuitem>
-            </x-menu>
-          </x-button>
-          <x-button
             @click.prevent="triggerSave"
             class="btn btn-flat btn-small"
           >
@@ -274,12 +244,6 @@
             </x-button>
           </x-buttons>
         </div>
-      </div>
-      <div class="top-panel-overlay" v-if="editingResult">
-        <div>Query editor is disabled while editing results.</div>
-        <button class="btn btn-primary" type="button" @click="stopEditing">
-          Stop Editing
-        </button>
       </div>
     </div>
     <div class="not-supported" v-if="!enabled">
@@ -363,6 +327,7 @@
         @clipboardJson="clipboardJson"
         @clipboardMarkdown="clipboardMarkdown"
         @submitCurrentQueryToFile="submitCurrentQueryToFile"
+        @wrap-text="wrapText = !wrapText"
         :execute-time="executeTime"
         :elapsed-time="elapsedTime"
         :active="active"
@@ -573,6 +538,7 @@
   import { monokaiInit } from '@uiw/codemirror-theme-monokai';
   import { SmartLocalStorage } from '@/common/LocalStorage';
   import { IdentifyResult } from 'sql-query-identifier/lib/defines'
+  import { wait } from '@/shared/lib/wait'
 
   const log = rawlog.scope('query-editor')
   const isEmpty = (s) => _.isEmpty(_.trim(s))
@@ -927,19 +893,6 @@
             this.queryMagic.extensions,
           ]
         }
-      },
-      userKeymap: {
-        get() {
-          const value = this.settings?.keymap.value;
-          return value && this.keymapTypes.map(k => k.value).includes(value) ? value : 'default';
-        },
-        set(value) {
-          if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
-          this.trigger(AppEvent.switchUserKeymap, value)
-        }
-      },
-      keymapTypes() {
-        return this.$config.defaults.keymapTypes
       },
     },
     watch: {
@@ -1542,6 +1495,7 @@
           if (found) {
             this.$store.dispatch('updateTables')
           }
+          wait(1200).then(() => this.$tour.start("ranFirstSuccessfulQuery"));
         } catch (ex) {
           log.error(ex)
           if(this.running) {
@@ -1905,15 +1859,6 @@
     color: var(--text);
     flex-direction: column;
     gap: 1rem;
-  }
-
-  .btn.settings-btn {
-    // padding-inline: 0.5rem;
-    min-width: 0;
-
-    .material-icons {
-      font-size: 1rem;
-    }
   }
 
   .query-editor:not(.editing-result) ::v-deep .tabulator-range-active::after {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="query-editor"
+    :class="{ 'editing-result': editingResult }"
     ref="container"
     v-hotkey="keymap"
   >
@@ -183,12 +184,36 @@
               v-model="dryRun"
             >
           </x-button>
-          <!-- <x-button -->
-          <!--   @click.prevent="formatterPreset" -->
-          <!--   class="btn btn-flat btn-small" -->
-          <!-- > -->
-          <!--   Open Query Formatter -->
-          <!-- </x-button> -->
+          <x-button
+            class="btn btn-flat btn-small settings-btn"
+            menu
+          >
+            <i class="material-icons">settings</i>
+            <i class="material-icons">arrow_drop_down</i>
+            <x-menu>
+              <x-menuitem disabled togglable>
+                <x-label>Editor keymap</x-label>
+              </x-menuitem>
+              <x-menuitem
+                :key="t.value"
+                v-for="t in keymapTypes"
+                togglable
+                :toggled="t.value === userKeymap"
+                @click.prevent="userKeymap = t.value"
+              >
+                <x-label>{{ t.name }}</x-label>
+              </x-menuitem>
+              <x-menuitem
+                togglable
+                :toggled="wrapText"
+                @click.prevent="wrapText = !wrapText"
+              >
+                <x-label class="flex-between">
+                  Wrap Text
+                </x-label>
+              </x-menuitem>
+            </x-menu>
+          </x-button>
           <x-button
             @click.prevent="triggerSave"
             class="btn btn-flat btn-small"
@@ -249,6 +274,12 @@
             </x-button>
           </x-buttons>
         </div>
+      </div>
+      <div class="top-panel-overlay" v-if="editingResult">
+        <div>Query editor is disabled while editing results.</div>
+        <button class="btn btn-primary" type="button" @click="stopEditing">
+          Stop Editing
+        </button>
       </div>
     </div>
     <div class="not-supported" v-if="!enabled">
@@ -332,7 +363,6 @@
         @clipboardJson="clipboardJson"
         @clipboardMarkdown="clipboardMarkdown"
         @submitCurrentQueryToFile="submitCurrentQueryToFile"
-        @wrap-text="wrapText = !wrapText"
         :execute-time="executeTime"
         :elapsed-time="elapsedTime"
         :active="active"
@@ -897,6 +927,19 @@
             this.queryMagic.extensions,
           ]
         }
+      },
+      userKeymap: {
+        get() {
+          const value = this.settings?.keymap.value;
+          return value && this.keymapTypes.map(k => k.value).includes(value) ? value : 'default';
+        },
+        set(value) {
+          if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
+          this.trigger(AppEvent.switchUserKeymap, value)
+        }
+      },
+      keymapTypes() {
+        return this.$config.defaults.keymapTypes
       },
     },
     watch: {
@@ -1845,6 +1888,36 @@
     100% {
       box-shadow: 0 0 3px 0 rgb(from var(--brand-warning) r g b / 1);
     }
+  }
+
+  .top-panel {
+    position: relative;
+  }
+
+  .top-panel-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    background-color: rgba(from var(--theme-bg) r g b / 70%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text);
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .btn.settings-btn {
+    // padding-inline: 0.5rem;
+    min-width: 0;
+
+    .material-icons {
+      font-size: 1rem;
+    }
+  }
+
+  .query-editor:not(.editing-result) ::v-deep .tabulator-range-active::after {
+    visibility: hidden;
   }
 </style>
 

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1189,6 +1189,7 @@
           }
         }
         this.editingResult = true;
+        wait(800).then(() => this.$tour.start("startedEditingResult"));
       },
       async saveChanges() {
         // This covers the instance where someone runs a query, toggles manual commit on, and then makes edits and tries to save them. This ensures it will then be inside a transaction
@@ -1495,7 +1496,7 @@
           if (found) {
             this.$store.dispatch('updateTables')
           }
-          wait(1200).then(() => this.$tour.start("ranFirstSuccessfulQuery"));
+          wait(1200).then(() => this.$tour.start("ranQuerySuccessfully"));
         } catch (ex) {
           log.error(ex)
           if(this.running) {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1862,6 +1862,7 @@
     gap: 1rem;
   }
 
+  // Hide the dot on the range highlight when not editing result
   .query-editor:not(.editing-result) ::v-deep .tabulator-range-active::after {
     visibility: hidden;
   }

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -6,11 +6,12 @@
     <slot name="left-actions"></slot>
     <template v-if="results?.length > 0">
       <div
+        id="query-editor-statusbar"
         class="truncate statusbar-info"
         v-hotkey="keymap"
       >
         <span
-          v-show="results?.length > 1 && !editing"
+          v-show="results?.length > 1"
           class="statusbar-item result-selector"
           :title="'Results'"
         >
@@ -53,7 +54,7 @@
         </div>
         <div
           class="statusbar-item affected-rows"
-          v-if="!editing && affectedRowsText"
+          v-if="affectedRowsText"
           :title="affectedRowsText + ' ' + 'Rows Affected'"
         >
           <i class="material-icons">clear_all</i>
@@ -61,17 +62,11 @@
         </div>
         <span
           class="statusbar-item execute-time "
-          v-if="!editing && executeTimeText"
+          v-if="executeTimeText"
           :title="executionTimeTitle"
         >
           <i class="material-icons">update</i>
           <span>{{ executeTimeText }}</span>
-        </span>
-        <span
-          class="statusbar-item editing-count"
-          v-if="editing"
-        >
-          <span>Total changes: {{ changesCount }}</span>
         </span>
       </div>
     </template>
@@ -93,7 +88,11 @@
     >
       Reset
     </x-button>
-    <x-buttons v-if="canEdit && editing && changesCount > 0" class="pending-changes">
+    <x-buttons
+      v-show="canEdit && editing && changesCount > 0"
+      id="apply-changes-btn"
+      class="pending-changes"
+    >
       <x-button
         class="btn btn-primary btn-badge btn-icon"
         @click.prevent="saveChanges"
@@ -122,8 +121,30 @@
         </x-menu>
       </x-button>
     </x-buttons>
+    <span
+      v-tooltip="resultEditable ?
+        'Edit table data directly from query results' :
+        'There is not enough information in the result set to generate an update query.'"
+    >
+      <x-button
+        v-if="canEdit && !editing"
+        :disabled="results?.length === 0 || !resultEditable"
+        class="btn btn-flat btn-icon"
+        id="edit-data-btn"
+        @click.prevent="editResults"
+      >
+        <i class="material-icons">edit</i>
+        Edit Data
+      </x-button>
+    </span>
     <x-button
-      v-show="!editing"
+      v-if="canEdit && editing && changesCount <= 0"
+      class="btn btn-primary"
+      @click.prevent="stopEditing"
+    >
+      Stop Editing
+    </x-button>
+    <x-button
       class="btn btn-flat btn-icon end"
       :disabled="results?.length === 0"
       menu
@@ -180,27 +201,35 @@
         </x-menuitem>
       </x-menu>
     </x-button>
-    <span
-      v-tooltip="resultEditable ?
-        'Edit table data directly from query results' :
-        'There is not enough information in the result set to generate an update query.'"
-    >
-      <x-button
-        v-if="canEdit && !editing"
-        :disabled="results?.length === 0 || !resultEditable"
-        class="btn btn-flat btn-icon"
-        @click.prevent="editResults"
-      >
-        <i class="material-icons">edit</i>
-        Edit Data
-      </x-button>
-    </span>
     <x-button
-      v-if="canEdit && editing"
-      class="btn btn-primary"
-      @click.prevent="stopEditing"
+      class="actions-btn btn btn-flat settings-btn"
+      menu
     >
-      Stop Editing
+      <i class="material-icons">settings</i>
+      <i class="material-icons">arrow_drop_down</i>
+      <x-menu>
+        <x-menuitem disabled togglable>
+          <x-label>Editor keymap</x-label>
+        </x-menuitem>
+        <x-menuitem
+          :key="t.value"
+          v-for="t in keymapTypes"
+          togglable
+          :toggled="t.value === userKeymap"
+          @click.prevent="userKeymap = t.value"
+        >
+          <x-label>{{ t.name }}</x-label>
+        </x-menuitem>
+        <x-menuitem
+          togglable
+          :toggled="wrapText"
+          @click.prevent="$emit('wrap-text')"
+        >
+          <x-label class="flex-between">
+            Wrap Text
+          </x-label>
+        </x-menuitem>
+      </x-menu>
     </x-button>
   </statusbar>
 </template>
@@ -208,6 +237,7 @@
 import humanizeDuration from 'humanize-duration';
 import Statusbar from '../common/StatusBar.vue';
 import { mapState, mapGetters } from 'vuex';
+import { AppEvent } from '@/common/AppEvent';
 import formatSeconds from "@/lib/time/formatSeconds";
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
@@ -227,7 +257,7 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 });
 
 export default {
-  props: ['results', 'running', 'value', 'executeTime', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable'],
+  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable', 'showApplyForcefully'],
   components: { Statusbar },
   data() {
     return {
@@ -261,6 +291,19 @@ export default {
   computed: {
     ...mapGetters(['dialect', 'dialectData']),
     ...mapState('settings', ['settings']),
+    userKeymap: {
+      get() {
+        const value = this.settings?.keymap.value;
+        return value && this.keymapTypes.map(k => k.value).includes(value) ? value : 'default';
+      },
+      set(value) {
+        if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
+        this.trigger(AppEvent.switchUserKeymap, value)
+      }
+    },
+    keymapTypes() {
+      return this.$config.defaults.keymapTypes
+    },
     hasUsedDropdown: {
       get() {
         return this.settings?.hideResultsDropdown?.value ?? false
@@ -377,5 +420,8 @@ export default {
 .global-status-bar x-button.btn.btn-primary {
   background-color: var(--theme-base);
   color: rgb(from var(--theme-bg) r g b / 87%);
+}
+#apply-changes-btn.force-show {
+  display: flex !important;
 }
 </style>

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -88,7 +88,7 @@
     >
       Reset
     </x-button>
-    <x-buttons v-show="canEdit && editing && changesCount > 0" class="pending-changes">
+    <x-buttons v-if="canEdit && editing && changesCount > 0" class="pending-changes">
       <x-button
         class="btn btn-primary btn-badge btn-icon"
         @click.prevent="saveChanges"
@@ -135,7 +135,7 @@
     </span>
     <x-button
       v-if="canEdit && editing && changesCount <= 0"
-      class="btn btn-primary"
+      class="btn btn-flat"
       @click.prevent="stopEditing"
     >
       Stop Editing
@@ -411,10 +411,3 @@ export default {
   }
 }
 </script>
-
-<style scoped>
-.global-status-bar x-button.btn.btn-primary {
-  background-color: var(--theme-base);
-  color: rgb(from var(--theme-bg) r g b / 87%);
-}
-</style>

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -88,11 +88,7 @@
     >
       Reset
     </x-button>
-    <x-buttons
-      v-show="canEdit && editing && changesCount > 0"
-      id="apply-changes-btn"
-      class="pending-changes"
-    >
+    <x-buttons v-show="canEdit && editing && changesCount > 0" class="pending-changes">
       <x-button
         class="btn btn-primary btn-badge btn-icon"
         @click.prevent="saveChanges"
@@ -257,7 +253,7 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 });
 
 export default {
-  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable', 'showApplyForcefully'],
+  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable'],
   components: { Statusbar },
   data() {
     return {
@@ -420,8 +416,5 @@ export default {
 .global-status-bar x-button.btn.btn-primary {
   background-color: var(--theme-base);
   color: rgb(from var(--theme-bg) r g b / 87%);
-}
-#apply-changes-btn.force-show {
-  display: flex !important;
 }
 </style>

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -10,7 +10,7 @@
         v-hotkey="keymap"
       >
         <span
-          v-show="results?.length > 1"
+          v-show="results?.length > 1 && !editing"
           class="statusbar-item result-selector"
           :title="'Results'"
         >
@@ -53,7 +53,7 @@
         </div>
         <div
           class="statusbar-item affected-rows"
-          v-if="affectedRowsText"
+          v-if="!editing && affectedRowsText"
           :title="affectedRowsText + ' ' + 'Rows Affected'"
         >
           <i class="material-icons">clear_all</i>
@@ -61,11 +61,17 @@
         </div>
         <span
           class="statusbar-item execute-time "
-          v-if="executeTimeText"
+          v-if="!editing && executeTimeText"
           :title="executionTimeTitle"
         >
           <i class="material-icons">update</i>
           <span>{{ executeTimeText }}</span>
+        </span>
+        <span
+          class="statusbar-item editing-count"
+          v-if="editing"
+        >
+          <span>Total changes: {{ changesCount }}</span>
         </span>
       </div>
     </template>
@@ -80,20 +86,6 @@
       </span>
     </template>
     <span class="expand" />
-    <span
-      v-tooltip="resultEditable ?
-        'Edit table data directly from query results' :
-        'There is not enough information in the result set to generate an update query.'"
-    >
-      <x-button
-        v-if="canEdit && !editing"
-        :disabled="results?.length === 0 || !resultEditable"
-        class="btn btn-flat"
-        @click.prevent="editResults"
-      >
-        Edit Data
-      </x-button>
-    </span>
     <x-button
       v-if="canEdit && editing && changesCount > 0"
       class="btn btn-flat"
@@ -131,13 +123,7 @@
       </x-button>
     </x-buttons>
     <x-button
-      v-if="canEdit && editing && changesCount <= 0"
-      class="btn btn-flat"
-      @click.prevent="stopEditing"
-    >
-      Stop Editing
-    </x-button>
-    <x-button
+      v-show="!editing"
       class="btn btn-flat btn-icon end"
       :disabled="results?.length === 0"
       menu
@@ -194,35 +180,27 @@
         </x-menuitem>
       </x-menu>
     </x-button>
-    <x-button
-      class="actions-btn btn btn-flat settings-btn"
-      menu
+    <span
+      v-tooltip="resultEditable ?
+        'Edit table data directly from query results' :
+        'There is not enough information in the result set to generate an update query.'"
     >
-      <i class="material-icons">settings</i>
-      <i class="material-icons">arrow_drop_down</i>
-      <x-menu>
-        <x-menuitem disabled togglable>
-          <x-label>Editor keymap</x-label>
-        </x-menuitem>
-        <x-menuitem
-          :key="t.value"
-          v-for="t in keymapTypes"
-          togglable
-          :toggled="t.value === userKeymap"
-          @click.prevent="userKeymap = t.value"
-        >
-          <x-label>{{ t.name }}</x-label>
-        </x-menuitem>
-        <x-menuitem
-          togglable
-          :toggled="wrapText"
-          @click.prevent="$emit('wrap-text')"
-        >
-          <x-label class="flex-between">
-            Wrap Text
-          </x-label>
-        </x-menuitem>
-      </x-menu>
+      <x-button
+        v-if="canEdit && !editing"
+        :disabled="results?.length === 0 || !resultEditable"
+        class="btn btn-flat btn-icon"
+        @click.prevent="editResults"
+      >
+        <i class="material-icons">edit</i>
+        Edit Data
+      </x-button>
+    </span>
+    <x-button
+      v-if="canEdit && editing"
+      class="btn btn-primary"
+      @click.prevent="stopEditing"
+    >
+      Stop Editing
     </x-button>
   </statusbar>
 </template>
@@ -230,7 +208,6 @@
 import humanizeDuration from 'humanize-duration';
 import Statusbar from '../common/StatusBar.vue';
 import { mapState, mapGetters } from 'vuex';
-import { AppEvent } from '@/common/AppEvent';
 import formatSeconds from "@/lib/time/formatSeconds";
 
 const shortEnglishHumanizer = humanizeDuration.humanizer({
@@ -250,7 +227,7 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 });
 
 export default {
-  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable'],
+  props: ['results', 'running', 'value', 'executeTime', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable'],
   components: { Statusbar },
   data() {
     return {
@@ -284,19 +261,6 @@ export default {
   computed: {
     ...mapGetters(['dialect', 'dialectData']),
     ...mapState('settings', ['settings']),
-    userKeymap: {
-      get() {
-        const value = this.settings?.keymap.value;
-        return value && this.keymapTypes.map(k => k.value).includes(value) ? value : 'default';
-      },
-      set(value) {
-        if (value === this.userKeymap || !this.keymapTypes.map(k => k.value).includes(value)) return;
-        this.trigger(AppEvent.switchUserKeymap, value)
-      }
-    },
-    keymapTypes() {
-      return this.$config.defaults.keymapTypes
-    },
     hasUsedDropdown: {
       get() {
         return this.settings?.hideResultsDropdown?.value ?? false
@@ -408,3 +372,10 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.global-status-bar x-button.btn.btn-primary {
+  background-color: var(--theme-base);
+  color: rgb(from var(--theme-bg) r g b / 87%);
+}
+</style>

--- a/apps/studio/src/plugins/ProductTourPlugin.ts
+++ b/apps/studio/src/plugins/ProductTourPlugin.ts
@@ -91,7 +91,7 @@ const flows: Record<
   ranQuerySuccessfully: {
     steps: [
       {
-        element: ".tab-pane.active #edit-data-btn",
+        element: ".global-status-bar #edit-data-btn",
         popover: {
           title: `<div class="main-title"><i class="material-icons">edit</i> Edit Query Results</div>`,
           description: `Click <strong>Edit Data</strong> to change rows directly from your query results.`,

--- a/apps/studio/src/plugins/ProductTourPlugin.ts
+++ b/apps/studio/src/plugins/ProductTourPlugin.ts
@@ -9,7 +9,7 @@ type Context = {
   utility: UtilityConnection;
 };
 
-type FlowId = "connectedScreen" | "ranFirstSuccessfulQuery";
+type FlowId = "connectedScreen" | "ranQuerySuccessfully" | "startedEditingResult";
 
 type FlowStep = DriveStep & {
   shouldShow?: (context: Context) => boolean | Promise<boolean>;
@@ -20,8 +20,6 @@ type FlowStep = DriveStep & {
 const flows: Record<
   FlowId,
   {
-    canStart?: (context: Context) => boolean | Promise<boolean>;
-    cleanup?: () => void;
     steps: FlowStep[];
   }
 > = {
@@ -90,64 +88,67 @@ const flows: Record<
   /**
    * This is triggered after the user runs their first successful query.
    **/
-  ranFirstSuccessfulQuery: {
-    canStart(context) {
-      if (window.platformInfo.testMode) {
-        return false;
-      }
-
-      if (context.store.getters.isCommunity) {
-        return false;
-      }
-
-      if (context.store.getters.editResultsHintShown) {
-        return false;
-      }
-
-      return true;
-    },
-    cleanup() {
-      document
-        .querySelector(".global-status-bar #apply-changes-btn")
-        .classList
-        .remove("force-show");
-    },
+  ranQuerySuccessfully: {
     steps: [
       {
-        element: "#edit-data-btn",
+        element: ".tab-pane.active #edit-data-btn",
         popover: {
-          title: `<div class="main-title">Edit query results</div>`,
+          title: `<div class="main-title"><i class="material-icons">edit</i> Edit Query Results</div>`,
           description: `Click <strong>Edit Data</strong> to change rows directly from your query results.`,
           side: "top",
           showButtons: ["next"],
+          doneBtnText: "Okay",
+        },
+        shouldShow(context) {
+          if (window.platformInfo.testMode) {
+            return false;
+          }
+
+          if (context.store.getters.isCommunity) {
+            return false;
+          }
+
+          if (context.store.getters["settings/editResultsHintShown"]) {
+            return false;
+          }
+
+          return true;
+        },
+        onFinished(context) {
+          context.store.dispatch("settings/setEditResultsHintShown");
         },
       },
+    ],
+  },
+
+  startedEditingResult: {
+    steps: [
       {
-        element: ".result-table",
+        element: ".tab-pane.active .result-table .tabulator-tableholder",
         popover: {
-          title: `<div class="main-title">Edit any cell</div>`,
+          title: `<div class="main-title">Edit Cells</div>`,
           description: `Double-click a cell to change its value.`,
           side: "top",
           showButtons: ["next"],
+          doneBtnText: "Okay",
         },
-      },
-      {
-        element: "#apply-changes-btn",
-        popover: {
-          title: `<div class="main-title">Apply your changes</div>`,
-          description: `When you're done editing, click <strong>Apply</strong> to save your changes to the database.`,
-          side: "top",
-          showButtons: ["next"],
-          doneBtnText: "Got it",
-        },
-        onHighlightStarted() {
-          document
-            .querySelector(".global-status-bar #apply-changes-btn")
-            .classList
-            .add("force-show");
+        shouldShow(context) {
+          if (window.platformInfo.testMode) {
+            return false;
+          }
+
+          if (context.store.getters.isCommunity) {
+            return false;
+          }
+
+          if (context.store.getters["settings/startedEditingResult"]) {
+            return false;
+          }
+
+          return true;
         },
         onFinished(context) {
-          context.store.dispatch("setEditResultsHintShown");
+          context.store.dispatch("settings/setStartedEditingResult");
         },
       },
     ],
@@ -156,16 +157,12 @@ const flows: Record<
 
 const tour = {
   async start(context: Context, flow: FlowId) {
-    if (!flows[flow].canStart(context)) {
-      return;
-    }
-
     const allSteps = flows[flow].steps;
     const steps: FlowStep[] = [];
     const finishedSteps: FlowStep[] = [];
 
     for (const step of allSteps) {
-      if (typeof step.shouldShow === 'undefined' || await step.shouldShow(context)) {
+      if (await step.shouldShow(context)) {
         steps.push({
           ...step,
           popover: {
@@ -211,7 +208,6 @@ const tour = {
           steps[i].onFinished?.(context);
         }
         delete document.body.dataset.driverStepElement;
-        flows[flow].cleanup?.();
         driver.destroy();
       },
     }).drive();

--- a/apps/studio/src/plugins/ProductTourPlugin.ts
+++ b/apps/studio/src/plugins/ProductTourPlugin.ts
@@ -9,17 +9,19 @@ type Context = {
   utility: UtilityConnection;
 };
 
-type FlowId = "connectedScreen";
+type FlowId = "connectedScreen" | "ranFirstSuccessfulQuery";
 
 type FlowStep = DriveStep & {
-  shouldShow: (context: Context) => boolean | Promise<boolean>;
-  onFinished: (context: Context) => void | Promise<void>;
+  shouldShow?: (context: Context) => boolean | Promise<boolean>;
+  onFinished?: (context: Context) => void | Promise<void>;
   onRender?: (popover: PopoverDOM, context: Context) => void;
 };
 
 const flows: Record<
   FlowId,
   {
+    canStart?: (context: Context) => boolean | Promise<boolean>;
+    cleanup?: () => void;
     steps: FlowStep[];
   }
 > = {
@@ -84,16 +86,86 @@ const flows: Record<
       },
     ],
   },
+
+  /**
+   * This is triggered after the user runs their first successful query.
+   **/
+  ranFirstSuccessfulQuery: {
+    canStart(context) {
+      if (window.platformInfo.testMode) {
+        return false;
+      }
+
+      if (context.store.getters.isCommunity) {
+        return false;
+      }
+
+      if (context.store.getters.editResultsHintShown) {
+        return false;
+      }
+
+      return true;
+    },
+    cleanup() {
+      document
+        .querySelector(".global-status-bar #apply-changes-btn")
+        .classList
+        .remove("force-show");
+    },
+    steps: [
+      {
+        element: "#edit-data-btn",
+        popover: {
+          title: `<div class="main-title">Edit query results</div>`,
+          description: `Click <strong>Edit Data</strong> to change rows directly from your query results.`,
+          side: "top",
+          showButtons: ["next"],
+        },
+      },
+      {
+        element: ".result-table",
+        popover: {
+          title: `<div class="main-title">Edit any cell</div>`,
+          description: `Double-click a cell to change its value.`,
+          side: "top",
+          showButtons: ["next"],
+        },
+      },
+      {
+        element: "#apply-changes-btn",
+        popover: {
+          title: `<div class="main-title">Apply your changes</div>`,
+          description: `When you're done editing, click <strong>Apply</strong> to save your changes to the database.`,
+          side: "top",
+          showButtons: ["next"],
+          doneBtnText: "Got it",
+        },
+        onHighlightStarted() {
+          document
+            .querySelector(".global-status-bar #apply-changes-btn")
+            .classList
+            .add("force-show");
+        },
+        onFinished(context) {
+          context.store.dispatch("setEditResultsHintShown");
+        },
+      },
+    ],
+  },
 };
 
 const tour = {
   async start(context: Context, flow: FlowId) {
+    if (!flows[flow].canStart(context)) {
+      return;
+    }
+
     const allSteps = flows[flow].steps;
     const steps: FlowStep[] = [];
     const finishedSteps: FlowStep[] = [];
 
     for (const step of allSteps) {
-      if (await step.shouldShow(context)) {
+      if (typeof step.shouldShow === 'undefined' || await step.shouldShow(context)) {
         steps.push({
           ...step,
           popover: {
@@ -125,7 +197,7 @@ const tour = {
       overlayOpacity: 0.25,
       onNextClick(_el, _step, { state, driver }) {
         const step = steps[state.activeIndex];
-        step.onFinished(context);
+        step.onFinished?.(context);
         finishedSteps.push(step);
         driver.moveNext();
       },
@@ -136,9 +208,10 @@ const tour = {
           if (finishedSteps.includes(step)) {
             continue;
           }
-          steps[i].onFinished(context);
+          steps[i].onFinished?.(context);
         }
         delete document.body.dataset.driverStepElement;
+        flows[flow].cleanup?.();
         driver.destroy();
       },
     }).drive();

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -296,6 +296,9 @@ const store = new Vuex.Store<State>({
     aiShellHintShown(_state, getters) {
       return !_.isEmpty(getters["settings/settings"]["tabDropdownAIShellHintShown"]?.value);
     },
+    editResultsHintShown(_state, getters) {
+      return !_.isEmpty(getters["settings/settings"]["editResultsHintShown"]?.value);
+    },
     aiShellAvailable(_state, getters) {
       return getters["tabs/newTabDropdownItems"].some(
         ({ config }) => config.pluginId === "bks-ai-shell"
@@ -732,6 +735,12 @@ const store = new Vuex.Store<State>({
     setAiShellHintShown(context) {
       context.dispatch("settings/save", {
         key: "tabDropdownAIShellHintShown",
+        value: new Date(),
+      });
+    },
+    setEditResultsHintShown(context) {
+      context.dispatch("settings/save", {
+        key: "editResultsHintShown",
         value: new Date(),
       });
     },

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -296,9 +296,6 @@ const store = new Vuex.Store<State>({
     aiShellHintShown(_state, getters) {
       return !_.isEmpty(getters["settings/settings"]["tabDropdownAIShellHintShown"]?.value);
     },
-    editResultsHintShown(_state, getters) {
-      return !_.isEmpty(getters["settings/settings"]["editResultsHintShown"]?.value);
-    },
     aiShellAvailable(_state, getters) {
       return getters["tabs/newTabDropdownItems"].some(
         ({ config }) => config.pluginId === "bks-ai-shell"
@@ -735,12 +732,6 @@ const store = new Vuex.Store<State>({
     setAiShellHintShown(context) {
       context.dispatch("settings/save", {
         key: "tabDropdownAIShellHintShown",
-        value: new Date(),
-      });
-    },
-    setEditResultsHintShown(context) {
-      context.dispatch("settings/save", {
-        key: "editResultsHintShown",
         value: new Date(),
       });
     },

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -55,7 +55,15 @@ const SettingStoreModule: Module<State, any> = {
       const newSetting = await Vue.prototype.$util.send('appdb/setting/save', { obj: setting });
       _.merge(setting, newSetting);
       context.commit(M.ADD, newSetting);
-    }
+    },
+    async setEditResultsHintShown(context) {
+      const options = { key: "editResultsHintShown", value: new Date() };
+      await context.dispatch("save", options);
+    },
+    async setStartedEditingResult(context) {
+      const options = { key: "startedEditingResult", value: new Date() };
+      await context.dispatch("save", options);
+    },
   },
   getters: {
     settings(state) {
@@ -100,8 +108,12 @@ const SettingStoreModule: Module<State, any> = {
     privacyMode(state) {
       if (!state.settings.privacyMode) return false;
       return state.settings.privacyMode.value;
-    }
-  }
+    },
+    editResultsHintShown: (state) =>
+      !_.isEmpty(state.settings["editResultsHintShown"]?.value),
+    startedEditingResult: (state) =>
+      !_.isEmpty(state.settings["startedEditingResult"]?.value),
+  },
 }
 
 


### PR DESCRIPTION
So one thing in common that I noticed in many apps is that when a "mode" is activated, specifically professional apps, beside adding a label "This mode is activated", they usually disable/hide/swap elements.

For example,

- In Google Docs, if you click version history, all tools at the top are removed except print and zoom. So it shows you the tools that are usable only, cause you can't edit while navigating the version history.
- In Unity3D (used to play with this a while ago), if you click play, all elements are dim, except the camera view, which gives the effect of "hey, your game has started, you should focus on this view". You still can edit parameters/properties and all that, but the focus is now on the camera view.

The current solution hides the entire query editor, including the toolbar, with an overlay that shows a label and a "stop editing" button:

https://github.com/user-attachments/assets/77cbacdc-9fc2-439a-ae90-f7733808821a

## Alternative solution

We dim the query editor and the toolbar, and then we add an alert box with the same label and button:

<img width="835" height="771" alt="Screenshot 2026-04-22 at 18 31 02" src="https://github.com/user-attachments/assets/efdad64a-4ad2-4fe2-b570-3f07bab705c3" />

In this one, the editor is in read-only, so we can still select & copy the text. But toolbar buttons are disabled.