### PR TITLE
Fixes bug #4068 for Postgres + 'contains' filter in SQL queries

### DIFF
--- a/apps/studio/src/lib/data/jsonViewer.ts
+++ b/apps/studio/src/lib/data/jsonViewer.ts
@@ -169,7 +169,10 @@ export function parseRowDataForJsonViewer(data: Record<string, any>, tableColumn
 
       if (isColumnHasStringAndNotEmpty) {
         const trimmedValue = columnValue.trim()
-        const isJsonObjectString = trimmedValue.startsWith('{') && trimmedValue.endsWith('}')
+        const isJsonObjectString =
+          trimmedValue.startsWith('{') &&
+          trimmedValue.endsWith('}') &&
+          (trimmedValue === '{}' || /^\{\s*"/.test(trimmedValue))
         const isJsonArrayString = trimmedValue.startsWith('[') && trimmedValue.endsWith(']')
 
         if (isJsonObjectString || isJsonArrayString) {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -125,7 +125,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
       restore: true,
       indexNullsNotDistinct: this.version.number >= 150_000,
       transactions: true,
-      filterTypes: ['standard', 'ilike']
+      filterTypes: ['standard', 'ilike', 'contains']
     };
   }
 
@@ -1431,6 +1431,13 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
           })
           paramIdx += values.length
           return `${wrapIdentifier(item.field)} ${item.type.toUpperCase()} (${values.join(',')})`
+        } else if (item.type === 'contains') {
+          const value = options.inlineParams
+            ? knex.raw('?', [item.value]).toQuery()
+            : `$${paramIdx}`
+          paramIdx += 1
+          const field = wrapIdentifier(item.field)
+          return `(CASE WHEN jsonb_typeof(to_jsonb(${field})) = 'array' THEN EXISTS (SELECT 1 FROM jsonb_array_elements_text(to_jsonb(${field})) AS element(value) WHERE element.value = ${value}) ELSE ${field}::text ILIKE '%' || ${value} || '%' END)`
         } else if (item.type.includes('is')) {
           return `${wrapIdentifier(item.field)} ${item.type.toUpperCase()} NULL`
         }
@@ -1773,17 +1780,20 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
     })
   }
 
-
-
-
-
-  // If a type starts with an underscore - it's an array
+    // If a type starts with an underscore - it's an array
   // so we need to turn the string representation back to an array
   private normalizeValue(value: string, column?: ExtendedTableColumn) {
     if (column?.array && _.isString(value)) {
-      return JSON.parse(value)
+      const trimmedValue = value.trim();
+      if (trimmedValue.startsWith("{")) {
+        // Array enum values are entered as postgres literals ({a,b}).
+        return value;
+      }
+      if (trimmedValue.startsWith("[")) {
+        return JSON.parse(value);
+      }
     }
-    return value
+    return value;
   }
 
   private async getSchema() {

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -236,7 +236,7 @@ export interface Routine extends DatabaseEntity {
   type: RoutineType;
 }
 
-export type IncludedFilterTypes = 'standard' | 'ilike'
+export type IncludedFilterTypes = 'standard' | 'ilike' | 'contains'
 
 // NOTE (day): note sure if this is really where we want to put edit partitions?
 export interface SupportedFeatures {

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -51,7 +51,8 @@ export const TableFilterSymbols = [
     { value: ">=", label: "greater than or equal", type: 'standard' },
     { value: "in", label: 'in', arrayInput: true, type: 'standard' },
     { value: "is", label: "is null", nullOnly: true, type: 'standard' },
-    { value: "is not", label: "is not null", nullOnly: true, type: 'standard' }
+    { value: "is not", label: "is not null", nullOnly: true, type: 'standard' },
+    { value: 'contains', label: 'contains', type: 'contains' }
 ]
 
 export enum AzureAuthType {

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -260,6 +260,29 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
 
     })
 
+    it("Should allow me to update enum array values using postgres array literal", async () => {
+      const columns = await util.connection.listTableColumns("extra_moody_people")
+      const moodsColumn = columns.find((c) => c.columnName === "current_moods")
+
+      const updates = [{
+        value: "{ok,happy}",
+        column: "current_moods",
+        columnObject: moodsColumn,
+        primaryKeys: [
+          { column: 'id', value: 1 }
+        ],
+        columnType: "_this_is_a_mood",
+        table: "extra_moody_people",
+      }]
+
+      if (util.connection.readOnlyMode) {
+        await expect(util.connection.applyChanges({ updates, inserts: [], deletes: [] })).rejects.toThrow(errorMessages.readOnly)
+      } else {
+        await util.knex("extra_moody_people").insert({ id: 1, current_moods: ['sad', 'happy'] })
+        const result = await util.connection.applyChanges({ updates, inserts: [], deletes: [] })
+        expect(result).toMatchObject([{ id: 1, current_moods: ['ok', 'happy'] }])
+      }
+    })
 
     it("Should allow me to update rows with array types when passed as string", async () => {
       const columns = await util.connection.listTableColumns("witharrays")
@@ -412,6 +435,45 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
 
       const expectedDefault = `SELECT * FROM "public"."jobs" WHERE "job_name" IN ($1,$2) ORDER BY "hourly_rate" ASC LIMIT 100 OFFSET 0`
       const expectedInline = `SELECT * FROM "public"."jobs" WHERE "job_name" IN ('Programmer','Surgeon''s Assistant') ORDER BY "hourly_rate" ASC LIMIT 100 OFFSET 0`
+
+      expect(fmt(defaultQuery)).toBe(fmt(expectedDefault))
+      expect(fmt(inlineParams)).toBe(fmt(expectedInline))
+    });
+
+    it("should build contains filter SQL for arrays and text columns", async () => {
+      const client = new PostgresClient(null, null);
+      const fmt = (sql: string) =>
+        safeSqlFormat(sql, { language: 'postgresql' })
+
+      const options: STQOptions = {
+        table: "jobs",
+        offset: 0,
+        limit: 100,
+        orderBy: [{ field: "hourly_rate", dir: "ASC" }],
+        filters: [
+          {
+            field: "tags",
+            type: "contains",
+            value: "urgent",
+          },
+        ],
+        selects: ["*"],
+        schema: "public",
+        version: {
+          version: "",
+          number: 0,
+          hasPartitions: false,
+        },
+      }
+
+      const { query: defaultQuery } = client.buildSelectTopQueries(options)
+      const { query: inlineParams } = client.buildSelectTopQueries({
+        ...options,
+        inlineParams: true
+      })
+
+      const expectedDefault = `SELECT * FROM "public"."jobs" WHERE (CASE WHEN jsonb_typeof(to_jsonb("tags")) = 'array' THEN EXISTS (SELECT 1 FROM jsonb_array_elements_text(to_jsonb("tags")) AS element(value) WHERE element.value = $1) ELSE "tags"::text ILIKE '%' || $1 || '%' END) ORDER BY "hourly_rate" ASC LIMIT 100 OFFSET 0`
+      const expectedInline = `SELECT * FROM "public"."jobs" WHERE (CASE WHEN jsonb_typeof(to_jsonb("tags")) = 'array' THEN EXISTS (SELECT 1 FROM jsonb_array_elements_text(to_jsonb("tags")) AS element(value) WHERE element.value = 'urgent') ELSE "tags"::text ILIKE '%' || 'urgent' || '%' END) ORDER BY "hourly_rate" ASC LIMIT 100 OFFSET 0`
 
       expect(fmt(defaultQuery)).toBe(fmt(expectedDefault))
       expect(fmt(inlineParams)).toBe(fmt(expectedInline))

--- a/apps/studio/tests/unit/lib/data/detail_view.spec.js
+++ b/apps/studio/tests/unit/lib/data/detail_view.spec.js
@@ -160,6 +160,26 @@ describe("Detail View", () => {
       expect(result.jsonLikeField).toEqual({ key: 'value', nested: { prop: true } })
       expect(result.textField).toBe('normal text')
     })
+
+    it('should not parse postgres array literals when dataType is not JSON', () => {
+      const rowData = {
+        id: 31,
+        categories: '{foo,bar}',
+        textField: 'normal text'
+      }
+
+      const tableColumns = [
+        { field: 'id', dataType: 'integer' },
+        { field: 'categories', dataType: '_text' },
+        { field: 'textField', dataType: 'varchar' }
+      ]
+
+      const result = parseRowDataForJsonViewer(rowData, tableColumns)
+
+      expect(result.id).toBe(31)
+      expect(result.categories).toBe('{foo,bar}')
+      expect(result.textField).toBe('normal text')
+    })
     
     it('should detect and parse JSON array strings even when dataType is not JSON', () => {
       const rowData = {


### PR DESCRIPTION
## Summary
This basically fixes https://github.com/beekeeper-studio/beekeeper-studio/issues/4068 for Postgres.

## Problem
Postgres arrays of enum values are represented as `{VALUE_1, VALUE_2}`, not as JSON arrays. The current implementation attempts to parse these values as JSON, which results in errors such as:
`Expected property name or '}' in JSON at position (line 1 column 2)`

This was driving me crazy and resulted in using other GUIs just to change enum array columns.

## Solution

•	Detect when a column is an array and avoid parsing its value as JSON.
•	Add a simple check to see if the value starts with `{` or `[` before deciding how to handle it.
•	Apply similar handling in the JSON Viewer to prevent parsing errors when displaying enum arrays.

## Additional Changes

•	Added a Postgres-only contains filter. I guess you may not want to have it in the same PR, but I still give it a shot :)
•	For array columns: uses `ANY()` to check if the provided value exists in the array.
•	For non-array columns: casts the value to text and checks if the resulting string contains the value.

This is extremely useful when working a lot with arrays in Postgres, and it was something I was really missing.