### PR TITLE
Prevent duplicate folder names within the same parent

### DIFF
--- a/apps/studio/src/common/appdb/models/ConnectionFolder.ts
+++ b/apps/studio/src/common/appdb/models/ConnectionFolder.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany, ManyToOne, JoinColumn, BeforeRemove } from 'typeorm'
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn, BeforeRemove, BeforeInsert, BeforeUpdate, Not, IsNull } from 'typeorm'
 import { ApplicationEntity } from './application_entity'
 import { SavedConnection } from './saved_connection'
 import pluralize from 'pluralize'
@@ -37,6 +37,21 @@ export class ConnectionFolder extends ApplicationEntity {
     const count = await SavedConnection.countBy({ connectionFolderId: this.id })
     if (count > 0) {
       throw new Error(`Cannot delete folder "${this.name}" — move or remove its ${pluralize('connection', count, true)} first.`)
+    }
+  }
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async preventDuplicateName(): Promise<void> {
+    if (!this.name) return
+    const where: any = {
+      name: this.name,
+      parentId: this.parentId ?? IsNull(),
+    }
+    if (this.id) where.id = Not(this.id)
+    const existing = await ConnectionFolder.findOneBy(where)
+    if (existing) {
+      throw new Error(`A folder named "${this.name}" already exists in this location.`)
     }
   }
 }

--- a/apps/studio/src/common/appdb/models/QueryFolder.ts
+++ b/apps/studio/src/common/appdb/models/QueryFolder.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany, ManyToOne, JoinColumn, BeforeRemove } from 'typeorm'
+import { Entity, Column, OneToMany, ManyToOne, JoinColumn, BeforeRemove, BeforeInsert, BeforeUpdate, Not, IsNull } from 'typeorm'
 import { ApplicationEntity } from './application_entity'
 import { FavoriteQuery } from './favorite_query'
 import pluralize from 'pluralize'
@@ -37,6 +37,21 @@ export class QueryFolder extends ApplicationEntity {
     const count = await FavoriteQuery.countBy({ queryFolderId: this.id })
     if (count > 0) {
       throw new Error(`Cannot delete folder "${this.name}" — move or remove its ${pluralize('query', count, true)} first.`)
+    }
+  }
+
+  @BeforeInsert()
+  @BeforeUpdate()
+  async preventDuplicateName(): Promise<void> {
+    if (!this.name) return
+    const where: any = {
+      name: this.name,
+      parentId: this.parentId ?? IsNull(),
+    }
+    if (this.id) where.id = Not(this.id)
+    const existing = await QueryFolder.findOneBy(where)
+    if (existing) {
+      throw new Error(`A folder named "${this.name}" already exists in this location.`)
     }
   }
 }

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -297,7 +297,7 @@
       <modal
         class="vue-dialog beekeeper-modal"
         name="connection-folder-modal"
-        @closed="folderModalName = ''; folderModalItem = null"
+        @closed="folderModalName = ''; folderModalItem = null; folderModalError = null"
         @opened="$nextTick(() => $refs.folderNameInput && $refs.folderNameInput.focus())"
         height="auto"
         :scrollable="true"
@@ -312,21 +312,23 @@
                 v-model="folderModalName"
                 type="text"
                 placeholder="Folder name"
+                @input="folderModalError = null"
                 @keydown.esc.prevent="$modal.hide('connection-folder-modal')"
               >
             </div>
             <div class="form-group" v-if="isCloud && !folderModalItem && rootFolders.length > 0">
               <label>Parent Folder</label>
-              <select v-model="folderModalParentId">
+              <select v-model="folderModalParentId" @change="folderModalError = null">
                 <option v-for="f in rootFolders" :key="f.id" :value="f.id">{{ f.name }}</option>
               </select>
             </div>
+            <error-alert v-if="folderModalError" :error="folderModalError" />
           </div>
           <div class="vue-dialog-buttons flex-between">
             <span class="left" />
             <span class="right">
               <button class="btn btn-flat" type="button" @click.prevent="$modal.hide('connection-folder-modal')">Cancel</button>
-              <button class="btn btn-primary" type="submit" :disabled="!folderModalName.trim()">
+              <button class="btn btn-primary" type="submit" :disabled="!folderModalName.trim() || folderModalSubmitting">
                 {{ folderModalItem ? 'Rename' : 'Create' }}
               </button>
             </span>
@@ -380,6 +382,8 @@ export default {
     folderModalName: '',
     folderModalItem: null,
     folderModalParentId: null,
+    folderModalError: null,
+    folderModalSubmitting: false,
     folderExpandedState: {},
     draggingConnection: null
   }),
@@ -547,6 +551,7 @@ export default {
       }
       this.folderModalName = ''
       this.folderModalItem = null
+      this.folderModalError = null
       this.folderModalParentId = (this.isCloud && this.rootFolders.length > 0)
         ? this.rootFolders[0].id
         : null
@@ -576,6 +581,7 @@ export default {
       }
       this.folderModalName = ''
       this.folderModalItem = null
+      this.folderModalError = null
       this.folderModalParentId = parentFolder.id
       this.$modal.show('connection-folder-modal')
     },
@@ -589,6 +595,7 @@ export default {
     renameFolder(folder) {
       this.folderModalName = folder.name
       this.folderModalItem = folder
+      this.folderModalError = null
       this.$modal.show('connection-folder-modal')
     },
     async moveFolderToParent(folder, newParent) {
@@ -703,12 +710,20 @@ export default {
     async submitFolderModal() {
       const name = this.folderModalName.trim()
       if (!name) return
-      if (this.folderModalItem) {
-        await this.$store.dispatch('data/connectionFolders/save', { ...this.folderModalItem, name })
-      } else {
-        await this.$store.dispatch('data/connectionFolders/save', { id: null, name, parentId: this.folderModalParentId ?? null })
+      this.folderModalError = null
+      this.folderModalSubmitting = true
+      try {
+        if (this.folderModalItem) {
+          await this.$store.dispatch('data/connectionFolders/save', { ...this.folderModalItem, name })
+        } else {
+          await this.$store.dispatch('data/connectionFolders/save', { id: null, name, parentId: this.folderModalParentId ?? null })
+        }
+        this.$modal.hide('connection-folder-modal')
+      } catch (e) {
+        this.folderModalError = e.userMessage ?? e.message ?? 'Failed to save folder'
+      } finally {
+        this.folderModalSubmitting = false
       }
-      this.$modal.hide('connection-folder-modal')
     },
   }
 }

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -191,7 +191,7 @@
       <modal
         class="vue-dialog beekeeper-modal"
         name="query-folder-modal"
-        @closed="folderModalName = ''; folderModalItem = null"
+        @closed="folderModalName = ''; folderModalItem = null; folderModalError = null"
         @opened="$nextTick(() => $refs.folderNameInput && $refs.folderNameInput.focus())"
         height="auto"
         :scrollable="true"
@@ -206,21 +206,23 @@
                 v-model="folderModalName"
                 type="text"
                 placeholder="Folder name"
+                @input="folderModalError = null"
                 @keydown.esc.prevent="$modal.hide('query-folder-modal')"
               >
             </div>
             <div class="form-group" v-if="isCloud && !folderModalItem && rootFolders.length > 0">
               <label>Parent Folder</label>
-              <select v-model="folderModalParentId">
+              <select v-model="folderModalParentId" @change="folderModalError = null">
                 <option v-for="f in rootFolders" :key="f.id" :value="f.id">{{ f.name }}</option>
               </select>
             </div>
+            <error-alert v-if="folderModalError" :error="folderModalError" />
           </div>
           <div class="vue-dialog-buttons flex-between">
             <span class="left" />
             <span class="right">
               <button class="btn btn-flat" type="button" @click.prevent="$modal.hide('query-folder-modal')">Cancel</button>
-              <button class="btn btn-primary" type="submit" :disabled="!folderModalName.trim()">
+              <button class="btn btn-primary" type="submit" :disabled="!folderModalName.trim() || folderModalSubmitting">
                 {{ folderModalItem ? 'Rename' : 'Create' }}
               </button>
             </span>
@@ -273,6 +275,8 @@ export default {
       folderModalName: '',
       folderModalItem: null,
       folderModalParentId: null,
+      folderModalError: null,
+      folderModalSubmitting: false,
       folderExpandedState: {},
       draggingQuery: null
     }
@@ -393,6 +397,7 @@ export default {
       }
       this.folderModalName = ''
       this.folderModalItem = null
+      this.folderModalError = null
       this.folderModalParentId = (this.isCloud && this.rootFolders.length > 0)
         ? this.rootFolders[0].id
         : null
@@ -422,6 +427,7 @@ export default {
       }
       this.folderModalName = ''
       this.folderModalItem = null
+      this.folderModalError = null
       this.folderModalParentId = parentFolder.id
       this.$modal.show('query-folder-modal')
     },
@@ -441,6 +447,7 @@ export default {
     renameQueryFolder(folder) {
       this.folderModalName = folder.name
       this.folderModalItem = folder
+      this.folderModalError = null
       this.$modal.show('query-folder-modal')
     },
     async moveFolderToParent(folder, newParent) {
@@ -503,12 +510,20 @@ export default {
     async submitFolderModal() {
       const name = this.folderModalName.trim()
       if (!name) return
-      if (this.folderModalItem) {
-        await this.$store.dispatch('data/queryFolders/save', { ...this.folderModalItem, name })
-      } else {
-        await this.$store.dispatch('data/queryFolders/save', { id: null, name, parentId: this.folderModalParentId ?? null })
+      this.folderModalError = null
+      this.folderModalSubmitting = true
+      try {
+        if (this.folderModalItem) {
+          await this.$store.dispatch('data/queryFolders/save', { ...this.folderModalItem, name })
+        } else {
+          await this.$store.dispatch('data/queryFolders/save', { id: null, name, parentId: this.folderModalParentId ?? null })
+        }
+        this.$modal.hide('query-folder-modal')
+      } catch (e) {
+        this.folderModalError = e.userMessage ?? e.message ?? 'Failed to save folder'
+      } finally {
+        this.folderModalSubmitting = false
       }
-      this.$modal.hide('query-folder-modal')
     },
   }
 }

--- a/apps/studio/tests/unit/common/appdb/models/connection_folder.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/connection_folder.spec.ts
@@ -126,4 +126,73 @@ describe('ConnectionFolder', () => {
     expect(foundChild).not.toBeNull()
     expect(foundChild.parentId).toBeNull()
   })
+
+  it('prevents creating a duplicate folder at the root', async () => {
+    const a = new ConnectionFolder()
+    a.name = 'Work'
+    await a.save()
+
+    const b = new ConnectionFolder()
+    b.name = 'Work'
+    await expect(b.save()).rejects.toThrow('A folder named "Work" already exists in this location.')
+    expect(await ConnectionFolder.count()).toBe(1)
+  })
+
+  it('prevents creating a duplicate subfolder within the same parent', async () => {
+    const parent = new ConnectionFolder()
+    parent.name = 'Parent'
+    await parent.save()
+
+    const a = new ConnectionFolder()
+    a.name = 'Shared'
+    a.parentId = parent.id
+    await a.save()
+
+    const b = new ConnectionFolder()
+    b.name = 'Shared'
+    b.parentId = parent.id
+    await expect(b.save()).rejects.toThrow('A folder named "Shared" already exists in this location.')
+  })
+
+  it('allows the same folder name in different parents', async () => {
+    const root = new ConnectionFolder()
+    root.name = 'Shared'
+    await root.save()
+
+    const parent = new ConnectionFolder()
+    parent.name = 'Parent'
+    await parent.save()
+
+    const child = new ConnectionFolder()
+    child.name = 'Shared'
+    child.parentId = parent.id
+    await child.save()
+
+    expect(await ConnectionFolder.count()).toBe(3)
+  })
+
+  it('allows updating a folder without renaming', async () => {
+    const folder = new ConnectionFolder()
+    folder.name = 'Folder'
+    await folder.save()
+
+    folder.expanded = false
+    await folder.save()
+
+    const found = await ConnectionFolder.findOneBy({ id: folder.id })
+    expect(found.expanded).toBe(false)
+  })
+
+  it('prevents renaming a folder to collide with a sibling', async () => {
+    const a = new ConnectionFolder()
+    a.name = 'Alpha'
+    await a.save()
+
+    const b = new ConnectionFolder()
+    b.name = 'Beta'
+    await b.save()
+
+    b.name = 'Alpha'
+    await expect(b.save()).rejects.toThrow('A folder named "Alpha" already exists in this location.')
+  })
 })

--- a/apps/studio/tests/unit/common/appdb/models/query_folder.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/query_folder.spec.ts
@@ -129,4 +129,73 @@ describe('QueryFolder', () => {
     expect(foundChild).not.toBeNull()
     expect(foundChild.parentId).toBeNull()
   })
+
+  it('prevents creating a duplicate folder at the root', async () => {
+    const a = new QueryFolder()
+    a.name = 'Reports'
+    await a.save()
+
+    const b = new QueryFolder()
+    b.name = 'Reports'
+    await expect(b.save()).rejects.toThrow('A folder named "Reports" already exists in this location.')
+    expect(await QueryFolder.count()).toBe(1)
+  })
+
+  it('prevents creating a duplicate subfolder within the same parent', async () => {
+    const parent = new QueryFolder()
+    parent.name = 'Parent'
+    await parent.save()
+
+    const a = new QueryFolder()
+    a.name = 'Shared'
+    a.parentId = parent.id
+    await a.save()
+
+    const b = new QueryFolder()
+    b.name = 'Shared'
+    b.parentId = parent.id
+    await expect(b.save()).rejects.toThrow('A folder named "Shared" already exists in this location.')
+  })
+
+  it('allows the same folder name in different parents', async () => {
+    const root = new QueryFolder()
+    root.name = 'Shared'
+    await root.save()
+
+    const parent = new QueryFolder()
+    parent.name = 'Parent'
+    await parent.save()
+
+    const child = new QueryFolder()
+    child.name = 'Shared'
+    child.parentId = parent.id
+    await child.save()
+
+    expect(await QueryFolder.count()).toBe(3)
+  })
+
+  it('allows updating a folder without renaming', async () => {
+    const folder = new QueryFolder()
+    folder.name = 'Folder'
+    await folder.save()
+
+    folder.expanded = false
+    await folder.save()
+
+    const found = await QueryFolder.findOneBy({ id: folder.id })
+    expect(found.expanded).toBe(false)
+  })
+
+  it('prevents renaming a folder to collide with a sibling', async () => {
+    const a = new QueryFolder()
+    a.name = 'Alpha'
+    await a.save()
+
+    const b = new QueryFolder()
+    b.name = 'Beta'
+    await b.save()
+
+    b.name = 'Alpha'
+    await expect(b.save()).rejects.toThrow('A folder named "Alpha" already exists in this location.')
+  })
 })


### PR DESCRIPTION
fix #4148 

## Summary
This PR adds validation to prevent creating or renaming folders to duplicate names within the same parent directory, while allowing the same folder name to exist in different parent folders.

## Key Changes

**Database Models:**
- Added `@BeforeInsert()` and `@BeforeUpdate()` hooks to `ConnectionFolder` and `QueryFolder` models
- Implemented `preventDuplicateName()` validation that checks for existing folders with the same name in the same parent location
- Validation properly handles root-level folders (where `parentId` is null) and nested folders

**UI Components:**
- Updated `ConnectionSidebar.vue` and `FavoriteList.vue` folder modals to display validation errors
- Added error state management with `folderModalError` and `folderModalSubmitting` data properties
- Implemented try-catch error handling in `submitFolderModal()` to capture and display validation errors
- Clear error messages when user modifies input or changes parent folder selection
- Disable submit button during submission to prevent duplicate requests

**Tests:**
- Added comprehensive test coverage for both `ConnectionFolder` and `QueryFolder` models:
  - Prevents duplicate folders at root level
  - Prevents duplicate subfolders within the same parent
  - Allows same folder name in different parents
  - Allows updating folder properties without renaming
  - Prevents renaming to collide with sibling folders

## Implementation Details
- Validation uses TypeORM's `Not()` and `IsNull()` operators to properly query for existing folders
- Error messages are user-friendly and indicate the specific location of the conflict
- The validation respects the folder hierarchy, allowing duplicate names across different parent folders

https://claude.ai/code/session_01Mf4PQVZaMDG2p574jJaNMR