### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Check for missing lodash imports
         run: bin/check-lodash.sh
 
+      - name: Build UI Kit
+        run: yarn lib:build
+
       - name: Unit Tests
         run: yarn workspace beekeeper-studio run test:unit --ci --silent
 

--- a/apps/studio/jest.config.js
+++ b/apps/studio/jest.config.js
@@ -25,6 +25,8 @@ module.exports = {
   // support the same @ -> src alias mapping in source code
   moduleNameMapper: {
     '^@libsql/core/(.*)': resolve(__dirname, '../../node_modules/@libsql/core/lib-cjs/$1'),
+    '^@marimo-team/codemirror-languageserver$':
+      '<rootDir>/tests/__mocks__/marimo-codemirror-languageserver.js',
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@shared(.*)$': '<rootDir>/src/shared/$1',
     '^@commercial(.*)$': '<rootDir>/src-commercial/$1',

--- a/apps/studio/tests/__mocks__/marimo-codemirror-languageserver.js
+++ b/apps/studio/tests/__mocks__/marimo-codemirror-languageserver.js
@@ -1,0 +1,20 @@
+// Stub for @marimo-team/codemirror-languageserver used only in Jest.
+//
+// The upstream package is ESM-only and its package.json `exports` field
+// defines only the `import` condition, which Jest's default resolver
+// cannot satisfy (it requests the `default`/`node` conditions), producing
+// ERR_PACKAGE_PATH_NOT_EXPORTED. The unit tests under tests/unit/ don't
+// exercise any LSP behavior; they only need the symbols referenced by
+// the statically-imported ui-kit text editor bundle to resolve without
+// runtime side effects.
+module.exports = {
+  LanguageServerClient: class {},
+  languageServerWithClient: () => [],
+  languageServer: () => [],
+  LanguageServerPlugin: class {},
+  signatureHelpTooltipField: {},
+  setSignatureHelpTooltip: () => {},
+  suppressSignatureHelp: () => {},
+  languageId: {},
+  documentUri: {},
+};

--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -69,7 +69,7 @@
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.2",
     "@lezer/highlight": "^1.2.1",
-    "@marimo-team/codemirror-languageserver": "^1.15.25",
+    "@marimo-team/codemirror-languageserver": "^1.16.12",
     "@replit/codemirror-emacs": "^6.1.0",
     "@replit/codemirror-vim": "^6.3.0",
     "@surrealdb/codemirror": "^1.0.0-beta.21"


### PR DESCRIPTION
Adding the editor modal to the result table meant that down the dependency chain we eventually imported the language server package, which jest doesn't like :)