### PR TITLE
fix: include PKs in demo query so Edit Data works (#4141)

### DIFF
--- a/apps/studio/src/migration/20240421_seed_with_demo_data.js
+++ b/apps/studio/src/migration/20240421_seed_with_demo_data.js
@@ -15,11 +15,14 @@ function escapeString(value, quote) {
 const demoQuerySql = escapeString(`
 -- You can run this script directly to see how data is queried in this database.
 -- Press "ctrl/cmd+enter" to run the query and see the results. Yum.
+-- Tip: click "Edit Data" above the results to edit cheeses inline.
 
 SELECT
+    cheeses.id AS CheeseId,
     cheeses.name AS Cheese,
     cheeses.cheese_type AS Type,
     cheeses.description AS Description,
+    countries.id AS CountryId,
     countries.name AS OriginCountry
 FROM
     cheeses

--- a/apps/studio/src/migration/20240421_seed_with_demo_data.js
+++ b/apps/studio/src/migration/20240421_seed_with_demo_data.js
@@ -15,7 +15,7 @@ function escapeString(value, quote) {
 const demoQuerySql = escapeString(`
 -- You can run this script directly to see how data is queried in this database.
 -- Press "ctrl/cmd+enter" to run the query and see the results. Yum.
--- Tip: click "Edit Data" above the results to edit cheeses inline.
+-- Tip: click "Edit Data" in the footer to edit cheese data inline.
 
 SELECT
     cheeses.id AS CheeseId,


### PR DESCRIPTION
Fixes #4141.

## Summary
Clicking **Edit Data** on the result of the seeded "Demo Query" warned *"There is not enough information in the result set to generate an update query. Make sure all primary keys are present."*

The bundled `demo.db` already declares `id INTEGER PRIMARY KEY AUTOINCREMENT` on both `cheeses` and `countries`. The problem was the demo SQL itself: `BasicDatabaseClient.fetchTableMetadata()` only marks a table's columns editable when every PK from `getPrimaryKeys()` appears in the SELECT list, and the demo query selected neither `cheeses.id` nor `countries.id`.

## Key changes
- Added `cheeses.id AS CheeseId` and `countries.id AS CountryId` to the seeded demo query's SELECT list.
- Added a one-line comment tip pointing new users at the **Edit Data** button.

Scope is limited to **new installs** — the `20240421_seed_with_demo_data` migration is already gated on `used_connection` being empty, so existing users who already have the demo query are unaffected.

## Test plan
- [ ] Delete local app DB, start `yarn bks:dev`, open the Demo Database → Demo Query tab, run it, click **Edit Data**, and confirm the editable grid opens with no warning toast.
- [ ] Edit a `Cheese` cell, save, re-run the query, and confirm the change persisted.
- [ ] `yarn lint` and `yarn test:unit` from `apps/studio/`.

https://claude.ai/code/session_01KyQYvES2tsdN94AvpgMBgH