### PR TITLE
Fix logo import in NotificationManager component

### DIFF
--- a/apps/studio/src/components/NotificationManager.vue
+++ b/apps/studio/src/components/NotificationManager.vue
@@ -5,6 +5,7 @@
 import Vue from 'vue'
 import Noty from 'noty'
 import { mapGetters, mapActions, mapState } from 'vuex'
+import logoUrl from '@/assets/logo.svg'
 
 export default Vue.extend({
   data: () => {
@@ -94,7 +95,7 @@ export default Vue.extend({
 
       const n = new Noty({
         text: `<div class="noty-onboarding-title">
-                <img class="noty-onboarding-logo" src="/src/assets/logo.svg">
+                <img class="noty-onboarding-logo" src="${logoUrl}">
                 Welcome to Beekeeper Studio!
               </div>
               <div class="noty-onboarding-body">

--- a/apps/studio/src/shims-vue.d.ts
+++ b/apps/studio/src/shims-vue.d.ts
@@ -4,3 +4,8 @@ declare module '*.vue' {
   export default Vue
 }
 
+declare module '*.svg' {
+  const src: string
+  export default src
+}
+


### PR DESCRIPTION
Fixes #4140

## Summary
The welcome onboarding toast rendered a broken image where the Beekeeper Studio logo should appear. The toast's HTML is passed as a raw string to Noty, so Vue/Vite's template asset rewriting never ran on it. The hardcoded `/src/assets/logo.svg` URL only resolved under the Vite dev server; in production builds the asset is hashed/bundled and that path 404s.

## Key Changes
- `apps/studio/src/components/NotificationManager.vue`: import the logo via `import logoUrl from '@/assets/logo.svg'` and interpolate `${logoUrl}` into the Noty HTML string so Vite resolves the URL correctly in both dev and production.
- `apps/studio/src/shims-vue.d.ts`: add a `declare module '*.svg'` shim so TypeScript accepts the new import (the project does not reference `vite/client` types).

## Test plan
- [ ] Fresh profile / empty app DB: run `yarn electron:serve`, confirm the onboarding toast in the bottom right shows the logo next to "Welcome to Beekeeper Studio!".
- [ ] Production build: `yarn run electron:build --linux AppImage`, launch with a fresh user-data-dir, confirm the logo renders in the onboarding toast.
- [ ] Sanity check the Titlebar logo still renders (shares the same asset, unchanged code path).

https://claude.ai/code/session_017zXBfLfynQ85sXcHART79q