### PR TITLE
Validate SavedConnection name field is not empty

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -1,3 +1,4 @@
+import { IsNotEmpty, IsString } from "class-validator"
 import { Entity, Column, BeforeInsert, BeforeUpdate, ManyToOne, JoinColumn } from "typeorm"
 import { ApplicationEntity } from './application_entity'
 import { loadEncryptionKey } from '../../encryption_key'
@@ -280,6 +281,8 @@ export class SavedConnection extends DbConnectionBase implements IConnection {
     return this;
   }
 
+  @IsString({ message: 'Name is required' })
+  @IsNotEmpty({ message: 'Name is required' })
   @Column("varchar")
   name!: string
 

--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -119,7 +119,7 @@ export default {
       return this.savedConnection ? this.savedConnection.labelColor : 'default'
     },
     label() {
-      if (this.savedConnection) {
+      if (this.savedConnection && this.savedConnection.name && this.savedConnection.name.trim()) {
         return this.savedConnection.name
       } else if ((this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') && this.config.defaultDatabase) {
         return window.main.basename(this.config.defaultDatabase)

--- a/apps/studio/tests/unit/common/appdb/appDbHandlers.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/appDbHandlers.spec.ts
@@ -76,4 +76,51 @@ describe('AppDbHandlers - appdb/saved/save', () => {
     const fromDb = await SavedConnection.findOneBy({ id: conn.id })
     expect(fromDb.connectionFolderId).toBe(folderB.id)
   })
+
+  it('rejects saving a new connection with no name', async () => {
+    const conn = buildConnection()
+    delete conn.name
+
+    await expect(
+      AppDbHandlers['appdb/saved/save']({ obj: conn, options: undefined })
+    ).rejects.toThrow(/name/i)
+
+    expect(await SavedConnection.count()).toBe(0)
+  })
+
+  it('rejects saving a new connection with an empty-string name', async () => {
+    const conn = buildConnection({ name: '' })
+
+    await expect(
+      AppDbHandlers['appdb/saved/save']({ obj: conn, options: undefined })
+    ).rejects.toThrow(/name/i)
+
+    expect(await SavedConnection.count()).toBe(0)
+  })
+
+  it('rejects updating an existing connection to have no name', async () => {
+    const conn = buildConnection()
+    await conn.save()
+
+    await expect(
+      AppDbHandlers['appdb/saved/save']({
+        obj: { ...conn, name: '' },
+        options: undefined
+      })
+    ).rejects.toThrow(/name/i)
+
+    const fromDb = await SavedConnection.findOneBy({ id: conn.id })
+    expect(fromDb.name).toBe('Test Connection')
+  })
+
+  it('rejects saving a batch when any connection has no name', async () => {
+    const good = buildConnection({ name: 'Good One' })
+    const bad = buildConnection({ name: '' })
+
+    await expect(
+      AppDbHandlers['appdb/saved/save']({ obj: [good, bad], options: undefined })
+    ).rejects.toThrow(/name/i)
+
+    expect(await SavedConnection.count()).toBe(0)
+  })
 })

--- a/apps/studio/tests/unit/common/appdb/models/saved_connection.spec.js
+++ b/apps/studio/tests/unit/common/appdb/models/saved_connection.spec.js
@@ -27,6 +27,25 @@ describe("Saved Connection", () => {
 
   })
 
+  it("should reject a connection with an empty-string name via class-validator", async () => {
+    const { validate } = require('class-validator')
+    const conn = new SavedConnection()
+    conn.connectionType = 'sqlite'
+    conn.defaultDatabase = ':memory:'
+    conn.name = ""
+    const errors = await validate(conn)
+    expect(errors.some(e => e.property === 'name')).toBe(true)
+  })
+
+  it("should reject a connection with no name via class-validator", async () => {
+    const { validate } = require('class-validator')
+    const conn = new SavedConnection()
+    conn.connectionType = 'sqlite'
+    conn.defaultDatabase = ':memory:'
+    const errors = await validate(conn)
+    expect(errors.some(e => e.property === 'name')).toBe(true)
+  })
+
   const urls = [
     { t: 'sqlite', p: '/a/b/c/database.sqlite3'},
     { t: 'sqlite', p: '/a/b/c/database.sqlite'},


### PR DESCRIPTION
fix #4151

## Summary
Add validation to ensure that SavedConnection names are required and non-empty, with a sidebar fallback so legacy rows never render as `undefined`.

## Key Changes
- Added `@IsString()` and `@IsNotEmpty()` class-validator decorators to `SavedConnection.name`. The existing `niceValidateOrReject` call in `appDbHandlers.ts` now rejects empty names across every save path (main form, import, duplicate, folder move, reorder).
- Updated `ConnectionListItem.vue` so `label()` falls through to the URL/filename fallback when `savedConnection.name` is nullish or whitespace, handling rows saved before this fix.
- Added unit tests that exercise both the decorators directly and the `AppDbHandlers['appdb/saved/save']` handler to confirm it rejects empty names for new, updated, and batch saves.

## Cloud
Cloud-saved connections are already guarded by the Rails `Connection` model's `validates_presence_of :name, :connection_type` and the API returns 400 on validation failure. The client's `actionsFor.save` does not optimistically commit on error, so no cloud-side changes are needed.

https://claude.ai/code/session_01AnLSjdaXpPsBePNpYBSDXX