### PR TITLE
`letter-spacing` makes titles look off

### DIFF
--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -30,7 +30,9 @@ i {
   font-weight: bold;
   text-transform: uppercase;
   font-size: 80%;
-  letter-spacing: 0.05rem;
+  // NOTE: This was probably ok when we still use Roboto as a font.
+  // Now we use system font. So at least in mac, this isn't good.
+  // letter-spacing: 0.05rem;
 }
 .noselect {
   @include noselect;

--- a/apps/studio/src/assets/styles/app/sidebar/secondary-sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/secondary-sidebar.scss
@@ -17,7 +17,9 @@
 
       x-label {
         font-size: 0.85rem;
-        letter-spacing: 0.025em;
+        // NOTE: This was probably ok when we still use Roboto as a font.
+        // Now we use system font. So at least in mac, this isn't good.
+        // letter-spacing: 0.025em;
       }
 
       &[selected] {

--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -39,7 +39,9 @@
       flex: 0 1 100%;
       color: $text-dark;
       font-weight: 500;
-      letter-spacing: 0.05rem;
+      // NOTE: This was probably ok when we still use Roboto as a font.
+      // Now we use system font. So at least in mac, this isn't good.
+      // letter-spacing: 0.05rem;
       padding: 0 $gutter-h;
       // box-shadow: 0 1px darken($theme-bg, 6%);
       box-shadow: 0 1px $border-color;

--- a/apps/studio/src/components/common/modals/KeyboardShortcutsModal.vue
+++ b/apps/studio/src/components/common/modals/KeyboardShortcutsModal.vue
@@ -110,7 +110,9 @@ export default Vue.extend({
   margin: 0;
   padding-block: 0.75rem;
   font-size: 0.85rem;
-  letter-spacing: 0.05rem;
+  /* NOTE: This was probably ok when we still use Roboto as a font. */
+  /* Now we use system font. So at least in mac, this isn't good. */
+  /* letter-spacing: 0.05rem; */
   text-transform: uppercase;
   font-weight: bold;
   text-transform: uppercase;

--- a/apps/ui-kit/lib/styles/_layout.scss
+++ b/apps/ui-kit/lib/styles/_layout.scss
@@ -34,7 +34,9 @@
     font-weight: bold;
     text-transform: uppercase;
     font-size: 80%;
-    letter-spacing: 0.05rem;
+    // NOTE: This was probably ok before because we use Roboto.
+    // Now we use system font. At least in mac, this isn't good.
+    // letter-spacing: 0.05rem;
   }
   .noselect {
     @include noselect;

--- a/apps/ui-kit/lib/styles/_layout.scss
+++ b/apps/ui-kit/lib/styles/_layout.scss
@@ -34,8 +34,8 @@
     font-weight: bold;
     text-transform: uppercase;
     font-size: 80%;
-    // NOTE: This was probably ok before because we use Roboto.
-    // Now we use system font. At least in mac, this isn't good.
+    // NOTE: This was probably ok when we still use Roboto as a font.
+    // Now we use system font. So at least in mac, this isn't good.
     // letter-spacing: 0.05rem;
   }
   .noselect {


### PR DESCRIPTION
With `letter-spacing` mod (notice the "History"):
<img width="504" height="372" alt="image" src="https://github.com/user-attachments/assets/c049bdb4-88d7-47ea-acc4-0dda4fe9fb99" />

Without the mod:
<img width="494" height="270" alt="image" src="https://github.com/user-attachments/assets/81df3daa-7073-467a-97c7-df1193159063" />
