### PR TITLE
Remove MongoDB alpha warning and update documentation

### DIFF
--- a/apps/studio/src/components/connection/MongoDBForm.vue
+++ b/apps/studio/src/components/connection/MongoDBForm.vue
@@ -1,13 +1,5 @@
 <template>
   <div class="mongodb-form">
-    <div class="alert alert-warning">
-      <i class="material-icons">warning</i>
-      <span>
-        MongoDB support is in alpha.
-        <a href="https://docs.beekeeperstudio.io/user_guide/connecting/mongodb">Supported features</a>,
-        <a href="https://github.com/beekeeper-studio/beekeeper-studio/issues/new/choose">report an issue</a>.
-      </span>
-    </div>
     <div class="form-group">
       <!-- NOTE(@day): this means that the password will be stored plaintext, we need a better solution -->
       <label for="url" required>

--- a/docs/user_guide/connecting/mongodb.es.md
+++ b/docs/user_guide/connecting/mongodb.es.md
@@ -1,15 +1,11 @@
 ---
 title: MongoDB
-summary: "El soporte de MongoDB esta actualmente en alpha temprano"
+summary: "Conectate a MongoDB con Beekeeper Studio"
 icon: simple/mongodb
 description: "Usa una shell de MongoDB o editor SQL para ejecutar consultas contra MongoDB usando Beekeeper Studio"
 ---
 
 # Soporte de MongoDB
-
-Vuelve frecuentemente ya que estamos haciendo actualizaciones continuas a nuestro soporte de MongoDB.
-
-Super emocionados de tener soporte de MongoDB aqui para todos ustedes. Por favor ten en cuenta que MongoDB solo esta en las etapas iniciales de implementacion, pero queriamos lanzarlo para que lo prueben.
 
 ## Funciones soportadas
 

--- a/docs/user_guide/connecting/mongodb.md
+++ b/docs/user_guide/connecting/mongodb.md
@@ -1,15 +1,11 @@
 ---
 title: MongoDB
-summary: "MongoDB support is currently in early alpha"
+summary: "Connect to MongoDB with Beekeeper Studio"
 icon: simple/mongodb
 description: "Use a MongoDB shell or SQL editor to run queries against MongoDB by using Beekeeper Studio"
 ---
 
 # MongoDB Support
-
-Check back frequently as we are making continual updates to our MongoDB support.
-
-Super excited to have MongoDB support here for you all. Please bear in mind that MongoDB is only in the early stages of implementation, but we wanted to release it to y'all for testing.
 
 ## Supported Features
 


### PR DESCRIPTION
## Summary
This PR removes the alpha status messaging for MongoDB support from the UI and documentation, indicating that MongoDB support has matured beyond the early alpha stage.

## Key Changes
- **MongoDBForm.vue**: Removed the alpha warning alert banner that was displayed at the top of the MongoDB connection form
- **Documentation (English)**: Updated the MongoDB documentation summary from "MongoDB support is currently in early alpha" to "Connect to MongoDB with Beekeeper Studio" and removed the early-stage implementation disclaimer
- **Documentation (Spanish)**: Updated the MongoDB documentation summary from "El soporte de MongoDB esta actualmente en alpha temprano" to "Conectate a MongoDB con Beekeeper Studio" and removed the early-stage implementation disclaimer

## Notable Details
The removal of these warnings suggests that MongoDB support has reached a stable enough state to no longer require prominent alpha disclaimers. The documentation has been simplified to focus on connecting to MongoDB rather than emphasizing its experimental nature.

https://claude.ai/code/session_01KkkujR2yu6P45FGva92EYk