### PR TITLE
add [DEV] Make Fake Remote Change context menu item to query editor

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1679,6 +1679,16 @@
             id: "formatter",
             handler: this.formatterPreset
           },
+          ...(window.platformInfo.isDevelopment && this.isCloud && this.query?.id
+            ? [
+                { type: "divider" },
+                {
+                  label: "[DEV] Make Fake Remote Change",
+                  id: "fake-remote-change",
+                  handler: this.fakeRemoteChange,
+                },
+              ]
+            : []),
           ...this.getExtraPopupMenu("editor.query", { transform: "ui-kit" }),
         ];
       },


### PR DESCRIPTION
Re-adds a dev trigger for MergeManager (originally added in 0f38160d3, removed in 70fbb4c34). Lives in the editor right-click menu, gated to dev builds, cloud workspace connections, and saved queries so it only appears where the merge UI can actually mount.