### PR TITLE
Add safeOpenExternal to prevent RCE via file:// URLs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,17 @@ module.exports = {
     "vue/require-prop-types": "off",
     "vue/require-default-prop": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
-    "vue/max-attributes-per-line": "off"
+    "vue/max-attributes-per-line": "off",
+    // Block plugin RCE via file:// URLs (CVE — see safeOpenExternal.ts).
+    // shell.openExternal must only be reached via safeOpenExternal so the
+    // http(s)-only protocol allowlist is enforced.
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "MemberExpression[property.name='openExternal']",
+        "message": "Do not call shell.openExternal directly. Use safeOpenExternal() from @/background/lib/electron/safeOpenExternal so the URL protocol allowlist is enforced."
+      }
+    ]
   },
   "parser": "vue-eslint-parser",
   "parserOptions": {
@@ -41,6 +51,15 @@ module.exports = {
       ],
       "env": {
         "jest": true
+      }
+    },
+    {
+      // The single trusted entry point that wraps shell.openExternal.
+      "files": [
+        "apps/studio/src/background/lib/electron/safeOpenExternal.ts"
+      ],
+      "rules": {
+        "no-restricted-syntax": "off"
       }
     }
   ]

--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -28,6 +28,7 @@ import { manageUpdates } from '@/background/update_manager'
 import * as sms from 'source-map-support'
 import { initializeSecurity } from '@/backend/lib/security'
 import { initializeFileHelpers } from '@/backend/lib/FileHelpers'
+import { safeOpenExternal } from '@/background/lib/electron/safeOpenExternal'
 
 if (platformInfo.env.development || platformInfo.env.test) {
   sms.install()
@@ -41,24 +42,6 @@ function initUserDirectory(d: string) {
 
 let utilityProcess: Electron.UtilityProcess
 let newWindows: number[] = [];
-
-// Only http(s) URLs may be passed to shell.openExternal — other protocols
-// (file:, javascript:, etc.) can launch local programs and lead to RCE.
-function safeOpenExternal(url: unknown): void {
-  if (typeof url !== 'string' || !url) return
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    log.warn('Refusing to open external URL — invalid URL:', url)
-    return
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    log.warn('Refusing to open external URL — disallowed protocol:', parsed.protocol)
-    return
-  }
-  electron.shell.openExternal(parsed.toString())
-}
 
 async function createUtilityProcess() {
   if (utilityProcess) {

--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -42,6 +42,24 @@ function initUserDirectory(d: string) {
 let utilityProcess: Electron.UtilityProcess
 let newWindows: number[] = [];
 
+// Only http(s) URLs may be passed to shell.openExternal — other protocols
+// (file:, javascript:, etc.) can launch local programs and lead to RCE.
+function safeOpenExternal(url: unknown): void {
+  if (typeof url !== 'string' || !url) return
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    log.warn('Refusing to open external URL — invalid URL:', url)
+    return
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    log.warn('Refusing to open external URL — disallowed protocol:', parsed.protocol)
+    return
+  }
+  electron.shell.openExternal(parsed.toString())
+}
+
 async function createUtilityProcess() {
   if (utilityProcess) {
     return;
@@ -76,7 +94,7 @@ async function createUtilityProcess() {
 
   utilityProcess.on("message", (msg: UtilProcMessage) => {
     if (msg.type === 'openExternal') {
-      electron.shell.openExternal(msg.url)
+      safeOpenExternal(msg.url)
     }
   })
 
@@ -154,9 +172,7 @@ async function initBasics() {
   log.debug("managing updates")
   manageUpdates(settings.useBeta.valueAsBool)
   ipcMain.on(AppEvent.openExternally, (_e: electron.IpcMainEvent, args: any[]) => {
-    const url = args[0]
-    if (!url) return
-    electron.shell.openExternal(url)
+    safeOpenExternal(args?.[0])
   })
   return settings
 }

--- a/apps/studio/src-commercial/entrypoints/preload.ts
+++ b/apps/studio/src-commercial/entrypoints/preload.ts
@@ -28,18 +28,6 @@ function fileExistsSync(filename: string): boolean {
   }
 }
 
-// Only http(s) URLs may be passed to shell.openExternal — other protocols
-// (file:, javascript:, etc.) can launch local programs and lead to RCE.
-function isSafeExternalUrl(link: unknown): link is string {
-  if (typeof link !== 'string' || !link) return false;
-  try {
-    const parsed = new URL(link);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 export const api = {
   async requestPlatformInfo() {
     const platformInfo = await ipcRenderer.invoke('platformInfo')
@@ -84,7 +72,7 @@ export const api = {
     ipcRenderer.send('install-update');
   },
   openExternally(link: string) {
-    if (!isSafeExternalUrl(link)) return;
+    // URL protocol is validated in the main process by safeOpenExternal.
     ipcRenderer.send(AppEvent.openExternally, [link]);
   },
   resolve(toResolve: string) {
@@ -116,8 +104,9 @@ export const api = {
     return electron.dialog.showSaveDialogSync(args);
   },
   openLink(link: string) {
-    if (!isSafeExternalUrl(link)) return;
-    return electron.shell.openExternal(link);
+    // Route through the main process so safeOpenExternal validates the
+    // protocol — never call shell.openExternal directly from preload.
+    ipcRenderer.send(AppEvent.openExternally, [link]);
   },
   onMaximize(func: any, sId: string) {
     ipcRenderer.on(`maximize-${sId}`, func);

--- a/apps/studio/src-commercial/entrypoints/preload.ts
+++ b/apps/studio/src-commercial/entrypoints/preload.ts
@@ -28,6 +28,18 @@ function fileExistsSync(filename: string): boolean {
   }
 }
 
+// Only http(s) URLs may be passed to shell.openExternal — other protocols
+// (file:, javascript:, etc.) can launch local programs and lead to RCE.
+function isSafeExternalUrl(link: unknown): link is string {
+  if (typeof link !== 'string' || !link) return false;
+  try {
+    const parsed = new URL(link);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export const api = {
   async requestPlatformInfo() {
     const platformInfo = await ipcRenderer.invoke('platformInfo')
@@ -72,6 +84,7 @@ export const api = {
     ipcRenderer.send('install-update');
   },
   openExternally(link: string) {
+    if (!isSafeExternalUrl(link)) return;
     ipcRenderer.send(AppEvent.openExternally, [link]);
   },
   resolve(toResolve: string) {
@@ -103,6 +116,7 @@ export const api = {
     return electron.dialog.showSaveDialogSync(args);
   },
   openLink(link: string) {
+    if (!isSafeExternalUrl(link)) return;
     return electron.shell.openExternal(link);
   },
   onMaximize(func: any, sId: string) {

--- a/apps/studio/src/background/NativeMenuActionHandlers.ts
+++ b/apps/studio/src/background/NativeMenuActionHandlers.ts
@@ -1,7 +1,8 @@
 import _ from 'lodash'
 import {AppEvent} from '../common/AppEvent'
 import { buildWindow, getActiveWindows, OpenOptions } from './WindowBuilder'
-import { app , shell } from 'electron'
+import { app } from 'electron'
+import { safeOpenExternal } from './lib/electron/safeOpenExternal'
 import platformInfo from '../common/platform_info'
 import path from 'path'
 import { IGroupedUserSettings } from '../common/appdb/models/user_setting'
@@ -112,15 +113,15 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
   }
 
   opendocs(): void {
-    shell.openExternal("https://docs.beekeeperstudio.io/")
+    safeOpenExternal("https://docs.beekeeperstudio.io/")
   }
 
   contactSupport(): void {
-    shell.openExternal("https://docs.beekeeperstudio.io/support/contact-support/")
+    safeOpenExternal("https://docs.beekeeperstudio.io/support/contact-support/")
   }
 
   openGettingStarted(): void {
-    shell.openExternal("https://docs.beekeeperstudio.io/getting-started-guide/")
+    safeOpenExternal("https://docs.beekeeperstudio.io/getting-started-guide/")
   }
 
   checkForUpdates(_menuItem: Electron.MenuItem, _win: Electron.BrowserWindow): void {

--- a/apps/studio/src/background/WindowBuilder.ts
+++ b/apps/studio/src/background/WindowBuilder.ts
@@ -6,6 +6,7 @@ import platformInfo from '../common/platform_info'
 import { IGroupedUserSettings } from '../common/appdb/models/user_setting'
 import rawLog from '@bksLogger'
 import querystring from 'query-string'
+import { safeOpenExternal } from './lib/electron/safeOpenExternal'
 
 
 // eslint-disable-next-line
@@ -79,9 +80,15 @@ class BeekeeperWindow {
       if (url === this.appUrl) return // this is good
       log.info("navigate to", url)
       e.preventDefault()
-      const u = new URL(url)
+      let u: URL
+      try {
+        u = new URL(url)
+      } catch {
+        log.warn('will-navigate: ignoring invalid URL', url)
+        return
+      }
       u.searchParams.append('ref', 'bks-app')
-      electron.shell.openExternal(u.toString());
+      safeOpenExternal(u.toString());
     })
 
     this.win.webContents.setWindowOpenHandler(({ url }) => {

--- a/apps/studio/src/background/lib/electron/safeOpenExternal.ts
+++ b/apps/studio/src/background/lib/electron/safeOpenExternal.ts
@@ -1,0 +1,32 @@
+import { shell } from 'electron'
+import rawLog from '@bksLogger'
+
+const log = rawLog.scope('safeOpenExternal')
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+/**
+ * Single trusted entry point for shell.openExternal in the main process.
+ *
+ * Other protocols (file:, javascript:, vbs:, ms-…:, etc.) can launch local
+ * programs, so any URL that arrives from the renderer, a plugin, the utility
+ * process, or a will-navigate event must pass through here. Direct calls to
+ * shell.openExternal elsewhere are blocked by the no-restricted-syntax
+ * ESLint rule (see .eslintrc.js).
+ */
+export function safeOpenExternal(url: unknown): boolean {
+  if (typeof url !== 'string' || !url) return false
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    log.warn('Refusing to open external URL — invalid URL:', url)
+    return false
+  }
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    log.warn('Refusing to open external URL — disallowed protocol:', parsed.protocol)
+    return false
+  }
+  shell.openExternal(parsed.toString())
+  return true
+}

--- a/apps/studio/src/background/lib/electron/safeOpenExternal.ts
+++ b/apps/studio/src/background/lib/electron/safeOpenExternal.ts
@@ -6,27 +6,36 @@ const log = rawLog.scope('safeOpenExternal')
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
 
 /**
+ * Pure predicate — true iff `url` is a string that parses as an absolute
+ * URL with an http(s) scheme. No side effects, no Electron deps; safe to
+ * unit-test exhaustively.
+ *
+ * Other protocols (file:, javascript:, vbs:, smb:, data:, ms-…:, etc.) can
+ * launch local programs and must never reach shell.openExternal.
+ */
+export function isSafeExternalUrl(url: unknown): url is string {
+  if (typeof url !== 'string' || !url) return false
+  try {
+    const parsed = new URL(url)
+    return ALLOWED_PROTOCOLS.has(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+/**
  * Single trusted entry point for shell.openExternal in the main process.
  *
- * Other protocols (file:, javascript:, vbs:, ms-…:, etc.) can launch local
- * programs, so any URL that arrives from the renderer, a plugin, the utility
- * process, or a will-navigate event must pass through here. Direct calls to
+ * Any URL that arrives from the renderer, a plugin, the utility process,
+ * or a will-navigate event must pass through here. Direct calls to
  * shell.openExternal elsewhere are blocked by the no-restricted-syntax
  * ESLint rule (see .eslintrc.js).
  */
 export function safeOpenExternal(url: unknown): boolean {
-  if (typeof url !== 'string' || !url) return false
-  let parsed: URL
-  try {
-    parsed = new URL(url)
-  } catch {
-    log.warn('Refusing to open external URL — invalid URL:', url)
+  if (!isSafeExternalUrl(url)) {
+    log.warn('Refusing to open external URL — invalid or disallowed protocol:', url)
     return false
   }
-  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
-    log.warn('Refusing to open external URL — disallowed protocol:', parsed.protocol)
-    return false
-  }
-  shell.openExternal(parsed.toString())
+  shell.openExternal(url)
   return true
 }

--- a/apps/studio/tests/unit/background/lib/electron/safeOpenExternal.spec.ts
+++ b/apps/studio/tests/unit/background/lib/electron/safeOpenExternal.spec.ts
@@ -17,7 +17,141 @@ jest.mock("@bksLogger", () => ({
   },
 }));
 
-import { safeOpenExternal } from "@/background/lib/electron/safeOpenExternal";
+import {
+  isSafeExternalUrl,
+  safeOpenExternal,
+} from "@/background/lib/electron/safeOpenExternal";
+
+describe("isSafeExternalUrl", () => {
+  describe("returns true for http(s) URLs", () => {
+    it.each([
+      "http://example.com",
+      "http://example.com/",
+      "http://localhost",
+      "http://localhost:3000",
+      "http://localhost:3000/foo?bar=1#baz",
+      "http://127.0.0.1:8080/",
+      "http://[::1]/",
+      "http://user:pass@example.com/",
+      "http://example.com/path%20with%20spaces",
+      "http://xn--bcher-kva.example/", // punycode
+      "https://example.com",
+      "https://example.com/",
+      "https://docs.beekeeperstudio.io/",
+      "https://example.com/path?query=value&other=1",
+      "https://example.com/path#fragment",
+      "https://sub.domain.example.com:8443/deep/path/",
+      "HTTPS://EXAMPLE.COM/", // scheme is case-insensitive
+      "Http://Example.Com/",
+    ])("%s", (url) => {
+      expect(isSafeExternalUrl(url)).toBe(true);
+    });
+  });
+
+  describe("returns false for known RCE / dangerous schemes", () => {
+    it.each([
+      // file: — the originally reported plugin RCE vector
+      "file:///etc/passwd",
+      "file:///C:/Windows/System32/calc.exe",
+      "file:///C:/Users/victim/AppData/Local/Temp/payload.exe",
+      "file://server/share/payload.exe",
+      "FILE:///etc/passwd",
+      // file:// followed by an http-looking host should still be file:
+      "file://https.example.com/calc.exe",
+      "file://http/foo",
+      // script-execution schemes
+      "javascript:alert(1)",
+      "javascript:void(0)",
+      "JavaScript:alert(1)",
+      "vbscript:msgbox(1)",
+      // data: can render arbitrary HTML/JS in browsers
+      "data:text/html,<script>alert(1)</script>",
+      "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+      // local IPC / network protocols that can pivot
+      "smb://attacker/share/payload",
+      "ftp://example.com/",
+      "ftps://example.com/",
+      "ssh://example.com/",
+      "telnet://example.com/",
+      "gopher://example.com/",
+      // Windows-only handler abuse
+      "ms-cxh-full:foo",
+      "ms-msdt:/id PCWDiagnostic",
+      "search-ms:query=foo",
+      "ms-officecmd:foo",
+      // mail/chat handlers — out of scope for an "external link"
+      "mailto:user@example.com",
+      "tel:+15551234",
+      "sms:+15551234",
+      // custom app protocols
+      "steam://run/",
+      "slack://channel",
+      "vscode://foo",
+      // chrome: / about: / view-source:
+      "chrome://settings/",
+      "about:blank",
+      "view-source:https://example.com",
+      // app-internal protocols registered by Beekeeper itself
+      "app://index.html",
+      "plugin://some-plugin/index.html",
+      // intent: (Android), edge: (Windows)
+      "intent://example.com/#Intent;scheme=https;end",
+    ])("%s", (url) => {
+      expect(isSafeExternalUrl(url)).toBe(false);
+    });
+  });
+
+  describe("returns false for malformed strings", () => {
+    it.each([
+      "",
+      " ",
+      "not a url",
+      "://broken",
+      "http//missing-colon.com",
+      "://example.com",
+      "example.com", // no scheme
+      "/relative/path",
+      "//protocol-relative.com",
+      "javascript",
+      "file",
+      "http: //space-after-colon.com",
+      "\t\n",
+    ])("%j", (url) => {
+      expect(isSafeExternalUrl(url)).toBe(false);
+    });
+  });
+
+  describe("returns false for non-string input", () => {
+    it.each([
+      [null],
+      [undefined],
+      [0],
+      [42],
+      [true],
+      [false],
+      [NaN],
+      [{}],
+      [{ url: "https://example.com" }],
+      [["https://example.com"]],
+      [Symbol("https://example.com")],
+      [() => "https://example.com"],
+      [Buffer.from("https://example.com")],
+    ])("%p", (input) => {
+      expect(isSafeExternalUrl(input as unknown)).toBe(false);
+    });
+  });
+
+  it("acts as a TypeScript type predicate narrowing to string", () => {
+    const maybe: unknown = "https://example.com";
+    if (isSafeExternalUrl(maybe)) {
+      // After narrowing, this must compile as a string operation.
+      const upper: string = maybe.toUpperCase();
+      expect(upper).toBe("HTTPS://EXAMPLE.COM");
+    } else {
+      throw new Error("predicate should have narrowed to string");
+    }
+  });
+});
 
 describe("safeOpenExternal", () => {
   beforeEach(() => {
@@ -25,61 +159,30 @@ describe("safeOpenExternal", () => {
     mockWarn.mockClear();
   });
 
-  describe("allowed protocols", () => {
-    it.each([
-      "https://docs.beekeeperstudio.io/",
-      "http://localhost:3000/foo?bar=1",
-      "https://example.com/path#hash",
-    ])("opens %s", (url) => {
-      expect(safeOpenExternal(url)).toBe(true);
-      expect(mockOpenExternal).toHaveBeenCalledTimes(1);
-      expect(mockOpenExternal).toHaveBeenCalledWith(expect.stringMatching(/^https?:\/\//));
-      expect(mockWarn).not.toHaveBeenCalled();
-    });
+  it("calls shell.openExternal and returns true for a safe URL", () => {
+    expect(safeOpenExternal("https://docs.beekeeperstudio.io/")).toBe(true);
+    expect(mockOpenExternal).toHaveBeenCalledTimes(1);
+    expect(mockOpenExternal).toHaveBeenCalledWith("https://docs.beekeeperstudio.io/");
+    expect(mockWarn).not.toHaveBeenCalled();
   });
 
-  describe("blocked protocols (RCE vectors)", () => {
-    it.each([
-      ["file:///etc/passwd"],
-      ["file:///C:/Windows/System32/calc.exe"],
-      ["javascript:alert(1)"],
-      ["vbscript:msgbox(1)"],
-      ["ms-cxh-full:foo"],
-      ["smb://attacker/share"],
-      ["ftp://example.com/"],
-      ["data:text/html,<script>alert(1)</script>"],
-    ])("blocks %s", (url) => {
-      expect(safeOpenExternal(url)).toBe(false);
-      expect(mockOpenExternal).not.toHaveBeenCalled();
-      expect(mockWarn).toHaveBeenCalled();
-    });
-  });
-
-  describe("invalid input", () => {
-    it.each([
-      ["", "empty string"],
-      ["not a url", "non-URL string"],
-      ["://broken", "malformed"],
-      ["http:/example.com", "missing slash"],
-    ])("rejects %p (%s)", (url) => {
-      expect(safeOpenExternal(url as string)).toBe(false);
-      expect(mockOpenExternal).not.toHaveBeenCalled();
-    });
-
-    it.each([
-      [null],
-      [undefined],
-      [42],
-      [{ url: "https://example.com" }],
-      [["https://example.com"]],
-    ])("rejects non-string input %p", (input) => {
-      expect(safeOpenExternal(input as unknown)).toBe(false);
-      expect(mockOpenExternal).not.toHaveBeenCalled();
-    });
-  });
-
-  it("does not let a file:// URL with an http-looking host through", () => {
-    expect(safeOpenExternal("file://https.example.com/calc.exe")).toBe(false);
+  it("does not call shell.openExternal for a file:// URL", () => {
+    expect(safeOpenExternal("file:///etc/passwd")).toBe(false);
     expect(mockOpenExternal).not.toHaveBeenCalled();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it("does not call shell.openExternal for non-string input", () => {
+    expect(safeOpenExternal(null)).toBe(false);
+    expect(safeOpenExternal(undefined)).toBe(false);
+    expect(safeOpenExternal(42 as unknown)).toBe(false);
+    expect(safeOpenExternal({ url: "https://example.com" } as unknown)).toBe(false);
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when refusing a URL", () => {
+    safeOpenExternal("javascript:alert(1)");
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(mockWarn.mock.calls[0].join(" ")).toMatch(/Refusing to open/i);
   });
 });

--- a/apps/studio/tests/unit/background/lib/electron/safeOpenExternal.spec.ts
+++ b/apps/studio/tests/unit/background/lib/electron/safeOpenExternal.spec.ts
@@ -1,0 +1,85 @@
+const mockOpenExternal = jest.fn();
+const mockWarn = jest.fn();
+
+jest.mock("electron", () => ({
+  shell: { openExternal: mockOpenExternal },
+}));
+
+jest.mock("@bksLogger", () => ({
+  __esModule: true,
+  default: {
+    scope: () => ({
+      warn: mockWarn,
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+import { safeOpenExternal } from "@/background/lib/electron/safeOpenExternal";
+
+describe("safeOpenExternal", () => {
+  beforeEach(() => {
+    mockOpenExternal.mockClear();
+    mockWarn.mockClear();
+  });
+
+  describe("allowed protocols", () => {
+    it.each([
+      "https://docs.beekeeperstudio.io/",
+      "http://localhost:3000/foo?bar=1",
+      "https://example.com/path#hash",
+    ])("opens %s", (url) => {
+      expect(safeOpenExternal(url)).toBe(true);
+      expect(mockOpenExternal).toHaveBeenCalledTimes(1);
+      expect(mockOpenExternal).toHaveBeenCalledWith(expect.stringMatching(/^https?:\/\//));
+      expect(mockWarn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("blocked protocols (RCE vectors)", () => {
+    it.each([
+      ["file:///etc/passwd"],
+      ["file:///C:/Windows/System32/calc.exe"],
+      ["javascript:alert(1)"],
+      ["vbscript:msgbox(1)"],
+      ["ms-cxh-full:foo"],
+      ["smb://attacker/share"],
+      ["ftp://example.com/"],
+      ["data:text/html,<script>alert(1)</script>"],
+    ])("blocks %s", (url) => {
+      expect(safeOpenExternal(url)).toBe(false);
+      expect(mockOpenExternal).not.toHaveBeenCalled();
+      expect(mockWarn).toHaveBeenCalled();
+    });
+  });
+
+  describe("invalid input", () => {
+    it.each([
+      ["", "empty string"],
+      ["not a url", "non-URL string"],
+      ["://broken", "malformed"],
+      ["http:/example.com", "missing slash"],
+    ])("rejects %p (%s)", (url) => {
+      expect(safeOpenExternal(url as string)).toBe(false);
+      expect(mockOpenExternal).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [null],
+      [undefined],
+      [42],
+      [{ url: "https://example.com" }],
+      [["https://example.com"]],
+    ])("rejects non-string input %p", (input) => {
+      expect(safeOpenExternal(input as unknown)).toBe(false);
+      expect(mockOpenExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not let a file:// URL with an http-looking host through", () => {
+    expect(safeOpenExternal("file://https.example.com/calc.exe")).toBe(false);
+    expect(mockOpenExternal).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements a security fix to prevent remote code execution (RCE) vulnerabilities through malicious URL schemes, particularly `file://` URLs that could be exploited by plugins. All external URL opening is now routed through a single validated entry point.

## Key Changes
- **New `safeOpenExternal` module** (`apps/studio/src/background/lib/electron/safeOpenExternal.ts`):
  - `isSafeExternalUrl()`: Pure predicate function that validates URLs are strings with `http://` or `https://` schemes only
  - `safeOpenExternal()`: Single trusted wrapper around `shell.openExternal()` that enforces the protocol allowlist
  - Comprehensive unit tests covering safe URLs, dangerous schemes (file://, javascript:, vbscript:, data:, smb:, ftp:, ms-*:, etc.), malformed strings, and non-string inputs

- **ESLint enforcement** (`.eslintrc.js`):
  - Added `no-restricted-syntax` rule to block direct calls to `shell.openExternal()`
  - Exception carved out for the `safeOpenExternal.ts` module itself
  - Enforces all external URL opens go through the validated entry point

- **Updated all call sites** to use `safeOpenExternal()`:
  - `WindowBuilder.ts`: will-navigate event handler
  - `NativeMenuActionHandlers.ts`: documentation and support links
  - `src-commercial/entrypoints/main.ts`: utility process message handler and IPC event handler
  - `src-commercial/entrypoints/preload.ts`: `openLink()` API now routes through main process validation

## Implementation Details
- The `isSafeExternalUrl()` function uses the native `URL` constructor for robust parsing and protocol validation
- Type predicate (`url is string`) enables TypeScript type narrowing for safe URLs
- All dangerous protocols are implicitly blocked by the allowlist approach rather than maintaining a blocklist
- Preload process no longer directly calls `shell.openExternal()`; all requests go through the main process for validation

https://claude.ai/code/session_01SaGn6Uq8LYRcua7BqwsmkH

Reported by @osageling