### PR TITLE
Use saved connection details in recent connections list

### DIFF
--- a/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
+++ b/apps/studio/src/components/sidebar/connection/ConnectionListItem.vue
@@ -19,15 +19,15 @@
         <div class="subtitle">
           <span
             class="bastion"
-            v-if="this.config.sshBastionHost && !privacyMode"
+            v-if="displayConfig.sshBastionHost && !privacyMode"
           >
-            <span class="truncate">{{ this.config.sshBastionHost }}</span>&nbsp;>&nbsp;
+            <span class="truncate">{{ displayConfig.sshBastionHost }}</span>&nbsp;>&nbsp;
           </span>
           <span
             class="ssh"
-            v-if="this.config.sshHost && !privacyMode"
+            v-if="displayConfig.sshHost && !privacyMode"
           >
-            <span class="truncate">{{ this.config.sshHost }}</span>&nbsp;>&nbsp;
+            <span class="truncate">{{ displayConfig.sshHost }}</span>&nbsp;>&nbsp;
           </span>
           <span class="connection">
             <span>
@@ -36,7 +36,7 @@
           </span>
         </div>
       </div>
-      <span class="badge"><span>{{ config.connectionType }}</span></span>
+      <span class="badge"><span>{{ displayConfig.connectionType }}</span></span>
       <span
         v-if="!isRecentList"
         class="actions"
@@ -121,16 +121,16 @@ export default {
     label() {
       if (this.savedConnection && this.savedConnection.name && this.savedConnection.name.trim()) {
         return this.savedConnection.name
-      } else if ((this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') && this.config.defaultDatabase) {
-        return window.main.basename(this.config.defaultDatabase)
-      } else if (this.config.connectionType === 'sqlanywhere' && this.config.sqlAnywhereOptions?.mode === 'file' && this.config.sqlAnywhereOptions?.databaseFile) {
-        return window.main.basename(this.config.sqlAnywhereOptions.databaseFile);
+      } else if ((this.displayConfig.connectionType === 'sqlite' || this.displayConfig.connectionType === 'libsql') && this.displayConfig.defaultDatabase) {
+        return window.main.basename(this.displayConfig.defaultDatabase)
+      } else if (this.displayConfig.connectionType === 'sqlanywhere' && this.displayConfig.sqlAnywhereOptions?.mode === 'file' && this.displayConfig.sqlAnywhereOptions?.databaseFile) {
+        return window.main.basename(this.displayConfig.sqlAnywhereOptions.databaseFile);
       }
 
-      return this.$bks.simpleConnectionString(this.config)
+      return this.$bks.simpleConnectionString(this.displayConfig)
     },
     connectionType() {
-      if (this.config.connectionType === 'sqlite' || this.config.connectionType === 'libsql') {
+      if (this.displayConfig.connectionType === 'sqlite' || this.displayConfig.connectionType === 'libsql') {
         return 'path'
       }
 
@@ -140,13 +140,13 @@ export default {
       if (this.isRecentList) {
         return this.timeAgo.format(this.config.updatedAt)
       } else {
-        return this.$bks.simpleConnectionString(this.config)
+        return this.$bks.simpleConnectionString(this.displayConfig)
       }
     },
     title() {
       return this.privacyMode ?
         'Connection details hidden by Privacy Mode' :
-        this.$bks.buildConnectionString(this.config)
+        this.$bks.buildConnectionString(this.displayConfig)
     },
     savedConnection() {
 
@@ -161,12 +161,20 @@ export default {
         return this.config
       }
     },
+    // For display purposes only: prefer the linked saved connection when this
+    // is a recent-list row, so edits to the saved connection (host, port, ssh,
+    // etc.) propagate to the recent connections list. Falls back to the
+    // used_connection snapshot when the saved connection is gone (orphan
+    // recent entry).
+    displayConfig() {
+      return this.savedConnection || this.config
+    },
   },
   methods: {
     showContextMenu(event) {
       const ultimateCheck = this.$store.getters.isUltimate
         ? true
-        : !isUltimateType(this.config.connectionType)
+        : !isUltimateType(this.displayConfig.connectionType)
 
       const options = [
         {
@@ -252,7 +260,7 @@ export default {
     },
     async copyUrl() {
       try {
-        await this.$copyText(this.$bks.buildConnectionString(this.config))
+        await this.$copyText(this.$bks.buildConnectionString(this.displayConfig))
         this.$noty.success(`The ${this.connectionType} was successfully copied!`)
       } catch (err) {
         this.$noty.success(`The ${this.connectionType} could not be copied!`)

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -31,8 +31,19 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
       });
       log.debug("Found used config", lastUsedConnection);
       if (lastUsedConnection) {
-        lastUsedConnection.updatedAt = new Date();
-        await context.dispatch('save', lastUsedConnection);
+        // Overlay the latest connection details from `config` (which is the
+        // saved connection the user is connecting to) onto the existing
+        // used_connection row, so subsequent reads reflect the current
+        // host/port/credentials/etc., not the snapshot from the first connect.
+        await context.dispatch('save', {
+          ...config,
+          id: lastUsedConnection.id,
+          connectionId: config.id,
+          workspaceId: config.workspaceId,
+          createdAt: lastUsedConnection.createdAt,
+          updatedAt: new Date(),
+        });
+        config = context.state.items.find((item) => item.id === lastUsedConnection.id);
       } else {
         const id = await context.dispatch('save', config);
         config = context.state.items.find((item) => item.id === id);

--- a/apps/studio/tests/unit/components/sidebar/connection/ConnectionListItem.spec.ts
+++ b/apps/studio/tests/unit/components/sidebar/connection/ConnectionListItem.spec.ts
@@ -1,0 +1,134 @@
+import { shallowMount } from '@vue/test-utils'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import TimeAgo from 'javascript-time-ago'
+import en from 'javascript-time-ago/locale/en'
+import ConnectionListItem from '@/components/sidebar/connection/ConnectionListItem.vue'
+
+Vue.use(Vuex)
+TimeAgo.addLocale(en)
+
+function buildStore(savedConnections: any[] = []) {
+  return new Vuex.Store({
+    state: { workspaceId: -1 },
+    getters: {
+      isCloud: () => false,
+      isUltimate: () => true,
+    },
+    modules: {
+      'data/connections': {
+        namespaced: true,
+        state: { items: savedConnections },
+      },
+      'data/connectionFolders': {
+        namespaced: true,
+        state: { items: [] },
+      },
+    },
+  })
+}
+
+function buildBksMock() {
+  return {
+    simpleConnectionString: (c: any) => `${c.host}:${c.port}/${c.defaultDatabase}`,
+    buildConnectionString: (c: any) =>
+      `${c.connectionType}://${c.username}@${c.host}:${c.port}/${c.defaultDatabase}`,
+  }
+}
+
+function mountItem(opts: { config: any; isRecentList: boolean; saved?: any[] }) {
+  return shallowMount(ConnectionListItem as any, {
+    store: buildStore(opts.saved ?? []),
+    propsData: {
+      config: opts.config,
+      isRecentList: opts.isRecentList,
+      selectedConfig: null,
+      showDuplicate: false,
+      pinned: false,
+      privacyMode: false,
+    },
+    mocks: { $bks: buildBksMock() },
+  })
+}
+
+describe('ConnectionListItem displayConfig', () => {
+  it('uses the linked saved connection for display when in the recent list', () => {
+    // The used_connection has stale snapshot data
+    const usedConfig = {
+      id: 100,
+      connectionId: 7,
+      workspaceId: -1,
+      connectionType: 'postgresql',
+      host: 'old-host.example.com',
+      port: 5432,
+      username: 'olduser',
+      defaultDatabase: 'mydb',
+      sshHost: 'old-ssh.example.com',
+      updatedAt: new Date(),
+    }
+
+    // The saved connection has fresh data
+    const saved = {
+      id: 7,
+      workspaceId: -1,
+      name: 'My DB',
+      connectionType: 'postgresql',
+      host: 'new-host.example.com',
+      port: 6543,
+      username: 'newuser',
+      defaultDatabase: 'mydb',
+      sshHost: 'new-ssh.example.com',
+      labelColor: 'default',
+    }
+
+    const wrapper = mountItem({ config: usedConfig, isRecentList: true, saved: [saved] })
+
+    expect(wrapper.vm['displayConfig']).toBe(saved)
+    expect(wrapper.vm['title']).toContain('new-host.example.com')
+    expect(wrapper.vm['title']).toContain('newuser')
+    expect(wrapper.vm['title']).not.toContain('old-host.example.com')
+    expect(wrapper.html()).toContain('new-ssh.example.com')
+    expect(wrapper.html()).not.toContain('old-ssh.example.com')
+  })
+
+  it('falls back to the snapshot when the linked saved connection is missing', () => {
+    // Orphan recent entry: connectionId points at a saved connection that no
+    // longer exists. The display falls back to the snapshot.
+    const usedConfig = {
+      id: 100,
+      connectionId: 999,
+      workspaceId: -1,
+      connectionType: 'postgresql',
+      host: 'snapshot-host.example.com',
+      port: 5432,
+      username: 'snapshotuser',
+      defaultDatabase: 'mydb',
+      updatedAt: new Date(),
+    }
+
+    const wrapper = mountItem({ config: usedConfig, isRecentList: true, saved: [] })
+
+    expect(wrapper.vm['displayConfig']).toBe(usedConfig)
+    expect(wrapper.vm['title']).toContain('snapshot-host.example.com')
+  })
+
+  it('uses the row config directly when not a recent-list item', () => {
+    // A saved-connection row in the sidebar - displayConfig is the config itself.
+    const saved = {
+      id: 7,
+      workspaceId: -1,
+      name: 'My DB',
+      connectionType: 'postgresql',
+      host: 'saved-host.example.com',
+      port: 5432,
+      username: 'user',
+      defaultDatabase: 'mydb',
+      labelColor: 'default',
+    }
+
+    const wrapper = mountItem({ config: saved, isRecentList: false, saved: [saved] })
+
+    expect(wrapper.vm['displayConfig']).toBe(saved)
+    expect(wrapper.vm['title']).toContain('saved-host.example.com')
+  })
+})

--- a/apps/studio/tests/unit/store/used_connection/UtilUsedConnectionModule.spec.ts
+++ b/apps/studio/tests/unit/store/used_connection/UtilUsedConnectionModule.spec.ts
@@ -1,0 +1,112 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+import { SavedConnection } from '@/common/appdb/models/saved_connection'
+import { UsedConnection } from '@/common/appdb/models/used_connection'
+import { AppDbHandlers } from '@/handlers/appDbHandlers'
+import { UtilUsedConnectionModule } from '@/store/modules/data/used_connection/UtilityUsedConnectionModule'
+
+Vue.use(Vuex)
+
+const WORKSPACE_ID = -1
+
+function buildSavedConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const c = new SavedConnection()
+  c.connectionType = 'postgresql'
+  c.name = 'My Saved Conn'
+  c.host = 'old-host.example.com'
+  c.port = 5432
+  c.username = 'olduser'
+  c.defaultDatabase = 'mydb'
+  Object.assign(c, overrides)
+  return c
+}
+
+// Build a plain object that mirrors the saved connection. We can't just spread
+// `saved` because `connectionType` is implemented as a getter/setter backed by
+// `_connectionType`, which a spread would copy as `_connectionType` only.
+function asConfig(saved: SavedConnection, workspaceId: number) {
+  return {
+    ...saved,
+    connectionType: saved.connectionType,
+    workspaceId,
+  }
+}
+
+function buildStore() {
+  return new Vuex.Store({
+    state: { workspaceId: WORKSPACE_ID },
+    modules: {
+      'data/usedconnections': UtilUsedConnectionModule,
+    }
+  })
+}
+
+describe('UtilUsedConnectionModule.recordUsed', () => {
+  let store: ReturnType<typeof buildStore>
+
+  beforeEach(async () => {
+    await TestOrmConnection.connect()
+
+    // Wire the Vuex action's $util.send to call the real AppDbHandlers
+    Vue.prototype.$util = {
+      send: async (channel: string, args: any) => {
+        const handler = (AppDbHandlers as any)[channel]
+        if (!handler) throw new Error(`No handler for ${channel}`)
+        return await handler(args)
+      }
+    }
+
+    store = buildStore()
+  })
+
+  afterEach(async () => {
+    await TestOrmConnection.disconnect()
+  })
+
+  it('creates a new used_connection on first use', async () => {
+    const saved = buildSavedConnection()
+    await saved.save()
+
+    await store.dispatch('data/usedconnections/recordUsed',
+      asConfig(saved, WORKSPACE_ID))
+
+    const all = await UsedConnection.find()
+    expect(all).toHaveLength(1)
+    expect(all[0].connectionId).toBe(saved.id)
+    expect(all[0].host).toBe('old-host.example.com')
+  })
+
+  it('updates the used_connection details when the saved_connection has been edited', async () => {
+    // First, save and "use" a saved connection
+    const saved = buildSavedConnection()
+    await saved.save()
+
+    await store.dispatch('data/usedconnections/recordUsed',
+      asConfig(saved, WORKSPACE_ID))
+
+    // Reload the store's items so the second recordUsed call sees the
+    // existing used_connection (mirrors what `data/usedconnections/load`
+    // does on app startup).
+    await store.dispatch('data/usedconnections/load')
+
+    // Now imagine the user edits the saved connection's host/port/etc.
+    saved.host = 'new-host.example.com'
+    saved.port = 6543
+    saved.username = 'newuser'
+    await saved.save()
+
+    // Connect again with the updated config
+    await store.dispatch('data/usedconnections/recordUsed',
+      asConfig(saved, WORKSPACE_ID))
+
+    // There should still be exactly one used_connection, and it should
+    // reflect the *new* connection details.
+    const all = await UsedConnection.find()
+    expect(all).toHaveLength(1)
+    expect(all[0].connectionId).toBe(saved.id)
+    expect(all[0].host).toBe('new-host.example.com')
+    expect(all[0].port).toBe(6543)
+    expect(all[0].username).toBe('newuser')
+  })
+})

--- a/apps/studio/tests/unit/store/used_connection/UtilUsedConnectionModule.spec.ts
+++ b/apps/studio/tests/unit/store/used_connection/UtilUsedConnectionModule.spec.ts
@@ -22,15 +22,17 @@ function buildSavedConnection(overrides: Partial<SavedConnection> = {}): SavedCo
   return c
 }
 
-// Build a plain object that mirrors the saved connection. We can't just spread
-// `saved` because `connectionType` is implemented as a getter/setter backed by
-// `_connectionType`, which a spread would copy as `_connectionType` only.
-function asConfig(saved: SavedConnection, workspaceId: number) {
-  return {
-    ...saved,
-    connectionType: saved.connectionType,
-    workspaceId,
-  }
+// Build a plain object that mirrors what the renderer receives for a saved
+// connection. We can't just spread `saved` because several fields (e.g.
+// `connectionType`, `port`, `socketPath`) are implemented as getter/setters
+// backed by underscored fields - a raw spread would only copy the underscored
+// versions. Round-tripping through the find handler matches production, where
+// the renderer gets a plain object via `transformConn`.
+async function asConfig(saved: SavedConnection, workspaceId: number) {
+  const fetched = await AppDbHandlers['appdb/saved/findOneBy']({
+    options: { id: saved.id }
+  })
+  return { ...fetched, workspaceId }
 }
 
 function buildStore() {
@@ -69,7 +71,7 @@ describe('UtilUsedConnectionModule.recordUsed', () => {
     await saved.save()
 
     await store.dispatch('data/usedconnections/recordUsed',
-      asConfig(saved, WORKSPACE_ID))
+      await asConfig(saved, WORKSPACE_ID))
 
     const all = await UsedConnection.find()
     expect(all).toHaveLength(1)
@@ -83,7 +85,7 @@ describe('UtilUsedConnectionModule.recordUsed', () => {
     await saved.save()
 
     await store.dispatch('data/usedconnections/recordUsed',
-      asConfig(saved, WORKSPACE_ID))
+      await asConfig(saved, WORKSPACE_ID))
 
     // Reload the store's items so the second recordUsed call sees the
     // existing used_connection (mirrors what `data/usedconnections/load`
@@ -98,7 +100,7 @@ describe('UtilUsedConnectionModule.recordUsed', () => {
 
     // Connect again with the updated config
     await store.dispatch('data/usedconnections/recordUsed',
-      asConfig(saved, WORKSPACE_ID))
+      await asConfig(saved, WORKSPACE_ID))
 
     // There should still be exactly one used_connection, and it should
     // reflect the *new* connection details.


### PR DESCRIPTION
## Summary
When displaying recent connections, the UI now shows the current details from the linked saved connection instead of the stale snapshot stored in the used_connection record. This ensures that edits to a saved connection (host, port, SSH settings, etc.) are immediately reflected in the recent connections list.

## Key Changes

- **ConnectionListItem.vue**: Added a new `displayConfig` computed property that prefers the linked saved connection for display purposes when in the recent list, falling back to the snapshot when the saved connection is missing (orphan entries). Updated all display-related computed properties and methods to use `displayConfig` instead of `config`.

- **UtilityUsedConnectionModule.ts**: Modified the `recordUsed` action to update the used_connection record with the latest connection details from the current config, rather than just updating the timestamp. This ensures the snapshot stays reasonably fresh and reflects the saved connection's current state.

- **Tests**: Added comprehensive test coverage:
  - `ConnectionListItem.spec.ts`: Tests that verify the component correctly uses the linked saved connection for display, handles orphan recent entries, and displays saved connections directly.
  - `UtilUsedConnectionModule.spec.ts`: Tests that verify the module creates new used_connection records and updates existing ones with fresh connection details when the saved connection is edited.

## Implementation Details

The `displayConfig` property implements a fallback strategy: it returns the saved connection if available (when `isRecentList` is true and a matching saved connection exists), otherwise returns the config itself. This allows the UI to stay in sync with saved connection edits while gracefully handling cases where a saved connection has been deleted.

https://claude.ai/code/session_018vFqqct5z3EdgF7HLwHEMn