### PR TITLE
Fix SSH agent mode attempting to read non-existent private key files

### DIFF
--- a/apps/studio/src/lib/db/tunnel.ts
+++ b/apps/studio/src/lib/db/tunnel.ts
@@ -51,19 +51,13 @@ export default function connectTunnel(config: IDbConnectionServerConfig): Promis
           sshConfig.agentSocket = appConfig.sshAuthSock
         }
 
-        if (config.ssh.privateKey) {
+        if (config.ssh.privateKey && !config.ssh.useAgent) {
           sshConfig.privateKey = fs.readFileSync(path.resolve(resolveHomePathToAbsolute(config.ssh.privateKey)))
         }
 
-        if (config.ssh.bastionPrivateKey) {
+        if (config.ssh.bastionPrivateKey && config.ssh.bastionMode !== 'agent') {
           sshConfig.bastionPrivateKey = fs.readFileSync(path.resolve(resolveHomePathToAbsolute(config.ssh.bastionPrivateKey)))
         }
-
-        // if (config.ssh.privateKey && !config.ssh.useAgent) {
-        //   sshConfig.privateKey = fs.readFileSync(path.resolve(resolveHomePathToAbsolute(config.ssh.privateKey)))
-        // } else {
-        //   sshConfig.privateKey = undefined
-        // }
 
         const connection = new SSHConnection(sshConfig)
         logger().debug("connection created!")

--- a/apps/studio/tests/integration/lib/db/clients/ssh-agent.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-agent.spec.js
@@ -1,0 +1,128 @@
+// Regression test for https://github.com/beekeeper-studio/beekeeper-studio/issues/4193
+//
+// SSH Agent mode must succeed even when ssh.privateKey is set to a path that
+// does not exist on disk. The connection-provider populates ssh.privateKey
+// from the IdentityFile in ~/.ssh/config when sshMode === 'agent', and we
+// must not try to read that file from disk in agent mode.
+
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import * as net from 'net'
+import * as os from 'os'
+import * as path from 'path'
+import { DockerComposeEnvironment, Wait } from 'testcontainers'
+import { dbtimeout } from '../../../../lib/db'
+
+let mockSshAuthSock
+jest.mock('@/common/platform_info', () => {
+  const actual = jest.requireActual('@/common/platform_info')
+  return {
+    __esModule: true,
+    default: new Proxy(actual.default, {
+      get(target, prop) {
+        if (prop === 'sshAuthSock') return mockSshAuthSock
+        return target[prop]
+      },
+    }),
+  }
+})
+
+import connectTunnel from '@/lib/db/tunnel'
+
+describe('SSH Tunnel agent mode (#4193)', () => {
+  jest.setTimeout(dbtimeout)
+
+  let environment
+  let container
+  let keyDir
+  let agentPid
+  let publicKey
+
+  beforeAll(async () => {
+    keyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bks-ssh-agent-'))
+    const keyPath = path.join(keyDir, 'id_ed25519')
+    execSync(`ssh-keygen -t ed25519 -f "${keyPath}" -N "" -q`)
+    publicKey = fs.readFileSync(`${keyPath}.pub`, 'utf-8').trim()
+
+    const sock = path.join(keyDir, 'agent.sock')
+    const agentOut = execSync(`ssh-agent -a "${sock}"`).toString()
+    const m = agentOut.match(/SSH_AGENT_PID=(\d+)/)
+    if (!m) throw new Error(`Failed to start ssh-agent: ${agentOut}`)
+    agentPid = Number(m[1])
+    mockSshAuthSock = sock
+
+    execSync(`ssh-add "${keyPath}"`, {
+      env: { ...process.env, SSH_AUTH_SOCK: sock },
+      stdio: 'pipe',
+    })
+
+    environment = await new DockerComposeEnvironment('tests/docker', 'ssh.yml')
+      .withWaitStrategy('test_ssh', Wait.forListeningPorts())
+      .up(['ssh'])
+    container = environment.getContainer('test_ssh')
+
+    // Push the public key into the container's authorized_keys.
+    // The linuxserver/openssh-server image creates the user under /config.
+    await container.exec([
+      'sh',
+      '-c',
+      `mkdir -p /config/.ssh && echo '${publicKey}' >> /config/.ssh/authorized_keys && chmod 700 /config/.ssh && chmod 600 /config/.ssh/authorized_keys && chown -R abc:abc /config/.ssh`,
+    ])
+  })
+
+  afterAll(async () => {
+    if (agentPid) {
+      try { process.kill(agentPid) } catch (_e) { /* ignore */ }
+    }
+    if (keyDir && fs.existsSync(keyDir)) {
+      fs.rmSync(keyDir, { recursive: true, force: true })
+    }
+    if (environment) {
+      await environment.stop()
+    }
+  })
+
+  it('opens a tunnel via SSH agent even when privateKey points to a non-existent file', async () => {
+    const tunnelConfig = {
+      client: 'postgresql',
+      host: '127.0.0.1',
+      port: 22,
+      ssh: {
+        host: container.getHost(),
+        port: container.getMappedPort(2222),
+        user: 'beekeeper',
+        password: null,
+        // Mimics connection-provider populating privateKey from ~/.ssh/config IdentityFile
+        // when sshMode === 'agent'. Before #4193 was fixed, this caused ENOENT.
+        privateKey: path.join(keyDir, 'does-not-exist'),
+        passphrase: null,
+        useAgent: true,
+        bastionHost: null,
+        bastionPort: null,
+        bastionUser: null,
+        bastionPassword: null,
+        bastionPrivateKey: null,
+        bastionPassphrase: null,
+        bastionMode: null,
+        keepaliveInterval: 0,
+      },
+    }
+
+    const tunnel = await connectTunnel(tunnelConfig)
+    try {
+      expect(tunnel.localPort).toBeGreaterThan(0)
+
+      // Verify the tunnel is actually listening locally; this proves the SSH
+      // handshake completed via the agent.
+      await new Promise((resolve, reject) => {
+        const probe = net.connect(tunnel.localPort, tunnel.localHost, () => {
+          probe.end()
+          resolve()
+        })
+        probe.on('error', reject)
+      })
+    } finally {
+      await tunnel.connection.shutdown()
+    }
+  })
+})

--- a/apps/studio/tests/integration/lib/db/clients/ssh-agent.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-agent.spec.js
@@ -1,17 +1,17 @@
 // Regression test for https://github.com/beekeeper-studio/beekeeper-studio/issues/4193
 //
-// SSH Agent mode must succeed even when ssh.privateKey is set to a path that
-// does not exist on disk. The connection-provider populates ssh.privateKey
-// from the IdentityFile in ~/.ssh/config when sshMode === 'agent', and we
-// must not try to read that file from disk in agent mode.
+// SSH Agent mode must succeed even when the user's ~/.ssh/config has an
+// IdentityFile pointing at a path that doesn't exist on disk. Before the
+// fix, connection-provider populated ssh.privateKey from that IdentityFile
+// and tunnel.ts then tried to readFileSync() it, throwing ENOENT.
 
 import { execSync } from 'child_process'
 import * as fs from 'fs'
-import * as net from 'net'
 import * as os from 'os'
 import * as path from 'path'
 import { DockerComposeEnvironment, Wait } from 'testcontainers'
 import { dbtimeout } from '../../../../lib/db'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
 
 let mockSshAuthSock
 jest.mock('@/common/platform_info', () => {
@@ -27,24 +27,28 @@ jest.mock('@/common/platform_info', () => {
   }
 })
 
-import connectTunnel from '@/lib/db/tunnel'
+const ConnectionProvider = require('@commercial/backend/lib/connection-provider').default
 
-describe('SSH Tunnel agent mode (#4193)', () => {
+describe('SSH Tunnel Tests (agent mode, #4193)', () => {
   jest.setTimeout(dbtimeout)
 
   let environment
   let container
-  let keyDir
+  let database
+  let connection
+  let workDir
   let agentPid
-  let publicKey
+  let originalHome
 
   beforeAll(async () => {
-    keyDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bks-ssh-agent-'))
-    const keyPath = path.join(keyDir, 'id_ed25519')
-    execSync(`ssh-keygen -t ed25519 -f "${keyPath}" -N "" -q`)
-    publicKey = fs.readFileSync(`${keyPath}.pub`, 'utf-8').trim()
+    await TestOrmConnection.connect()
 
-    const sock = path.join(keyDir, 'agent.sock')
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bks-ssh-agent-'))
+    const keyPath = path.join(workDir, 'id_ed25519')
+    execSync(`ssh-keygen -t ed25519 -f "${keyPath}" -N "" -q`)
+    const publicKey = fs.readFileSync(`${keyPath}.pub`, 'utf-8').trim()
+
+    const sock = path.join(workDir, 'agent.sock')
     const agentOut = execSync(`ssh-agent -a "${sock}"`).toString()
     const m = agentOut.match(/SSH_AGENT_PID=(\d+)/)
     if (!m) throw new Error(`Failed to start ssh-agent: ${agentOut}`)
@@ -56,73 +60,74 @@ describe('SSH Tunnel agent mode (#4193)', () => {
       stdio: 'pipe',
     })
 
+    // Build a fake HOME with an SSH config whose IdentityFile points at a
+    // path that does not exist. This is what connection-provider reads in
+    // agent mode and is the exact shape that triggered #4193.
+    const fakeHome = path.join(workDir, 'home')
+    fs.mkdirSync(path.join(fakeHome, '.ssh'), { recursive: true })
+    fs.writeFileSync(
+      path.join(fakeHome, '.ssh', 'config'),
+      `Host *\n  IdentityFile ${path.join(workDir, 'does-not-exist')}\n`,
+    )
+    originalHome = process.env.HOME
+    process.env.HOME = fakeHome
+
     environment = await new DockerComposeEnvironment('tests/docker', 'ssh.yml')
+      .withWaitStrategy('test_ssh_postgres', Wait.forLogMessage('database system is ready to accept connections', 2))
       .withWaitStrategy('test_ssh', Wait.forListeningPorts())
-      .up(['ssh'])
+      .up(['postgres', 'ssh'])
+
     container = environment.getContainer('test_ssh')
 
-    // Push the public key into the container's authorized_keys.
-    // The linuxserver/openssh-server image creates the user under /config.
     await container.exec([
       'sh',
       '-c',
       `mkdir -p /config/.ssh && echo '${publicKey}' >> /config/.ssh/authorized_keys && chmod 700 /config/.ssh && chmod 600 /config/.ssh/authorized_keys && chown -R abc:abc /config/.ssh`,
     ])
+
+    const config = {
+      connectionType: 'postgresql',
+      host: 'postgres',
+      port: 5432,
+      username: 'postgres',
+      password: 'example',
+      sshEnabled: true,
+      sshMode: 'agent',
+      sshHost: container.getHost(),
+      sshPort: container.getMappedPort(2222),
+      sshUsername: 'beekeeper',
+    }
+
+    connection = ConnectionProvider.for(config)
+    database = connection.createConnection('integration_test')
+    await database.connect()
+  })
+
+  describe('Can SSH via agent and run a query', () => {
+    it('should work even when ~/.ssh/config IdentityFile path does not exist', async () => {
+      const query = await database.query('select 1')
+      await query.execute()
+    })
   })
 
   afterAll(async () => {
-    if (agentPid) {
-      try { process.kill(agentPid) } catch (_e) { /* ignore */ }
-    }
-    if (keyDir && fs.existsSync(keyDir)) {
-      fs.rmSync(keyDir, { recursive: true, force: true })
+    if (database) {
+      await database.disconnect()
     }
     if (environment) {
       await environment.stop()
     }
-  })
-
-  it('opens a tunnel via SSH agent even when privateKey points to a non-existent file', async () => {
-    const tunnelConfig = {
-      client: 'postgresql',
-      host: '127.0.0.1',
-      port: 22,
-      ssh: {
-        host: container.getHost(),
-        port: container.getMappedPort(2222),
-        user: 'beekeeper',
-        password: null,
-        // Mimics connection-provider populating privateKey from ~/.ssh/config IdentityFile
-        // when sshMode === 'agent'. Before #4193 was fixed, this caused ENOENT.
-        privateKey: path.join(keyDir, 'does-not-exist'),
-        passphrase: null,
-        useAgent: true,
-        bastionHost: null,
-        bastionPort: null,
-        bastionUser: null,
-        bastionPassword: null,
-        bastionPrivateKey: null,
-        bastionPassphrase: null,
-        bastionMode: null,
-        keepaliveInterval: 0,
-      },
+    if (originalHome === undefined) {
+      delete process.env.HOME
+    } else {
+      process.env.HOME = originalHome
     }
-
-    const tunnel = await connectTunnel(tunnelConfig)
-    try {
-      expect(tunnel.localPort).toBeGreaterThan(0)
-
-      // Verify the tunnel is actually listening locally; this proves the SSH
-      // handshake completed via the agent.
-      await new Promise((resolve, reject) => {
-        const probe = net.connect(tunnel.localPort, tunnel.localHost, () => {
-          probe.end()
-          resolve()
-        })
-        probe.on('error', reject)
-      })
-    } finally {
-      await tunnel.connection.shutdown()
+    if (agentPid) {
+      try { process.kill(agentPid) } catch (_e) { /* ignore */ }
     }
+    if (workDir && fs.existsSync(workDir)) {
+      fs.rmSync(workDir, { recursive: true, force: true })
+    }
+    await TestOrmConnection.disconnect()
   })
 })

--- a/apps/studio/tests/unit/lib/db/tunnel.spec.ts
+++ b/apps/studio/tests/unit/lib/db/tunnel.spec.ts
@@ -1,0 +1,175 @@
+// Regression tests for https://github.com/beekeeper-studio/beekeeper-studio/issues/4193
+// SSH agent mode must not attempt to read a private key file from disk.
+
+import type { IDbConnectionServerConfig, IDbConnectionServerSSHConfig } from "@/lib/db/types";
+
+const mockReadFileSync = jest.fn();
+const mockSshConnectionForward = jest.fn().mockResolvedValue({});
+const mockSshConnectionCtor = jest.fn();
+let lastSshConfig: any;
+
+jest.mock("fs", () => {
+  const actual = jest.requireActual("fs");
+  return { ...actual, readFileSync: (...args: any[]) => mockReadFileSync(...args) };
+});
+
+jest.mock("@/vendor/node-ssh-forward/index", () => ({
+  SSHConnection: class {
+    constructor(opts: any) {
+      lastSshConfig = opts;
+      mockSshConnectionCtor(opts);
+    }
+    forward = mockSshConnectionForward;
+  },
+}));
+
+jest.mock("portfinder", () => ({
+  __esModule: true,
+  default: { getPortPromise: jest.fn().mockResolvedValue(12345) },
+  getPortPromise: jest.fn().mockResolvedValue(12345),
+}));
+
+jest.mock("@/common/platform_info", () => ({
+  __esModule: true,
+  default: { sshAuthSock: "/tmp/test-agent.sock" },
+}));
+
+jest.mock("@bksLogger", () => ({
+  __esModule: true,
+  default: {
+    scope: () => ({
+      warn: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock("@/handlers/utils", () => ({
+  resolveHomePathToAbsolute: (p: string) => p,
+}));
+
+import connectTunnel from "@/lib/db/tunnel";
+
+function buildSsh(overrides: Partial<IDbConnectionServerSSHConfig> = {}): IDbConnectionServerSSHConfig {
+  return {
+    host: "remote.example.com",
+    port: 22,
+    user: "admin",
+    password: null,
+    privateKey: null,
+    passphrase: null,
+    bastionHost: null,
+    bastionPort: null,
+    bastionUser: null,
+    bastionPassword: null,
+    bastionPrivateKey: null,
+    bastionPassphrase: null,
+    bastionMode: null,
+    keepaliveInterval: 0,
+    useAgent: false,
+    ...overrides,
+  };
+}
+
+function buildConfig(ssh: IDbConnectionServerSSHConfig): IDbConnectionServerConfig {
+  return {
+    client: "postgresql" as any,
+    host: "127.0.0.1",
+    port: 5432,
+    domain: null,
+    socketPath: null,
+    socketPathEnabled: false,
+    user: "user",
+    osUser: "user",
+    password: null,
+    ssh,
+    sslCaFile: null,
+    sslCertFile: null,
+    sslKeyFile: null,
+    sslRejectUnauthorized: false,
+    ssl: false,
+    readOnlyMode: false,
+  } as IDbConnectionServerConfig;
+}
+
+describe("connectTunnel SSH agent handling (#4193)", () => {
+  beforeEach(() => {
+    mockReadFileSync.mockReset();
+    mockSshConnectionCtor.mockReset();
+    lastSshConfig = undefined;
+    // Default: pretend any file read succeeds, returning a buffer.
+    mockReadFileSync.mockReturnValue(Buffer.from("KEY"));
+  });
+
+  it("does not read the private key file when useAgent is true, even if privateKey is set", async () => {
+    const ssh = buildSsh({
+      useAgent: true,
+      // Mimics connection-provider populating privateKey from SSH config IdentityFile
+      privateKey: "/nonexistent/.ssh/id_rsa",
+    });
+
+    await connectTunnel(buildConfig(ssh));
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(lastSshConfig.privateKey).toBeUndefined();
+    expect(lastSshConfig.agentForward).toBe(true);
+    expect(lastSshConfig.agentSocket).toBe("/tmp/test-agent.sock");
+  });
+
+  it("does not surface ENOENT when SSH agent mode is used and the IdentityFile path is missing", async () => {
+    mockReadFileSync.mockImplementation((p: string) => {
+      const err: any = new Error(`ENOENT: no such file or directory, open '${p}'`);
+      err.code = "ENOENT";
+      throw err;
+    });
+
+    const ssh = buildSsh({
+      useAgent: true,
+      privateKey: "/Users/anyone/.ssh/id_rsa",
+    });
+
+    await expect(connectTunnel(buildConfig(ssh))).resolves.toBeDefined();
+  });
+
+  it("reads the private key file when useAgent is false and privateKey is set", async () => {
+    const ssh = buildSsh({
+      useAgent: false,
+      privateKey: "/keys/keyfile",
+    });
+
+    await connectTunnel(buildConfig(ssh));
+
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+    expect(mockReadFileSync.mock.calls[0][0]).toContain("/keys/keyfile");
+    expect(lastSshConfig.privateKey).toEqual(Buffer.from("KEY"));
+  });
+
+  it("does not read the bastion private key file when bastionMode is 'agent'", async () => {
+    const ssh = buildSsh({
+      bastionHost: "bastion.example.com",
+      bastionMode: "agent",
+      bastionPrivateKey: "/nonexistent/bastion_key",
+    });
+
+    await connectTunnel(buildConfig(ssh));
+
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+    expect(lastSshConfig.bastionPrivateKey).toBeUndefined();
+    expect(lastSshConfig.bastionAgentForward).toBe(true);
+  });
+
+  it("reads the bastion private key file when bastionMode is 'keyfile'", async () => {
+    const ssh = buildSsh({
+      bastionHost: "bastion.example.com",
+      bastionMode: "keyfile",
+      bastionPrivateKey: "/keys/bastion_key",
+    });
+
+    await connectTunnel(buildConfig(ssh));
+
+    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
+    expect(mockReadFileSync.mock.calls[0][0]).toContain("/keys/bastion_key");
+  });
+});


### PR DESCRIPTION
Fix #4193

## Summary
Fixes a regression where SSH agent mode would attempt to read private key files from disk even when agent forwarding was enabled, causing connection failures when the key path didn't exist.

## Changes
- **tunnel.ts**: Added conditional checks to prevent reading private key files when they shouldn't be used:
  - Only read `privateKey` from disk when `useAgent` is `false`
  - Only read `bastionPrivateKey` from disk when `bastionMode` is not `'agent'`
  - Removed commented-out code that was attempting to implement this logic

## Details
The issue occurred because `connection-provider` populates `ssh.privateKey` from the user's `~/.ssh/config` IdentityFile entries, even in agent mode. The tunnel code was then unconditionally attempting to read these files, which would fail with ENOENT if the path didn't exist on disk.

The fix ensures that private key files are only read when actually needed:
- In agent mode (`useAgent: true`), the SSH agent socket is used instead
- In bastion agent mode (`bastionMode: 'agent'`), bastion agent forwarding is used instead

Includes comprehensive unit and integration tests to prevent regression.

https://claude.ai/code/session_01UBTVakegpDkya7bpJar4Da