### PR TITLE
Disable write action shortcuts in readonly mode

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1432,6 +1432,7 @@ export default Vue.extend({
       }
     },
     cloneSelection(range?: RangeComponent) {
+      if (!this.editable) return;
       const rows = range && range.getRows ? range.getRows() : this.getSelectedRows()
       rows.forEach((row) => {
         const data = { ...row.getData() }
@@ -1468,9 +1469,10 @@ export default Vue.extend({
       })
     },
     cellAddRow() {
-      if (this.dialectData.disabledFeatures?.tableTable) {
+      if (!this.editable) {
         return;
       }
+
       this.tabulator.addRow({}, true).then(row => {
         this.addRowToPendingInserts(row)
         this.tabulator.scrollToRow(row, 'center', true)
@@ -1604,6 +1606,9 @@ export default Vue.extend({
     },
     async saveChanges() {
         this.saveError = null
+
+        // guard to make sure we don't do anything in readonly mode
+        if (!this.editable) return;
 
         let replaceData = false
 


### PR DESCRIPTION
Some of our actions had their buttons disabled but not their shortcuts in readonly mode, so added some guards to make sure they can't be triggered by either.

These write actions should be caught in the backend anyways (I think), so it's not a huge deal, just not super clean