### PR TITLE
fix bastion host background and padding

### DIFF
--- a/apps/studio/src/assets/styles/app/connection-interface.scss
+++ b/apps/studio/src/assets/styles/app/connection-interface.scss
@@ -165,7 +165,6 @@
     margin-bottom: -$gutter-h;
   }
   &.bastion-host {
-    padding: 0;
 
     .advanced-heading {
       font-size: 0.831rem;

--- a/apps/studio/src/components/connection/CommonAdvanced.vue
+++ b/apps/studio/src/components/connection/CommonAdvanced.vue
@@ -374,4 +374,8 @@ export default {
   opacity: 0.6;
   vertical-align: middle;
 }
+
+body.theme-dark .bastion-host {
+  background-color: rgb(from var(--theme-base) r g b / 3.5%);
+}
 </style>


### PR DESCRIPTION
## Summary

Bastion host section doesn't look good in three themes: light, solarized light, solarized dark.

<img width="529" height="159" alt="Screenshot 2026-05-01 at 13 47 51" src="https://github.com/user-attachments/assets/990d64c1-fe06-4bbb-bec4-ae2dc32f8e2a" />

<img width="531" height="179" alt="Screenshot 2026-05-01 at 13 48 49" src="https://github.com/user-attachments/assets/3c6e7262-0cef-4cd5-9080-a276ec2ffba0" />
