### PR TITLE
fix(autocomplete): suggest columns for quoted tables and joins

### DIFF
--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
@@ -57,7 +57,12 @@ export default Vue.extend({
           this.$emit("bks-query-selection-change", params)
         },
         columnsGetter: (entity: Entity) => {
-          return this.columnsGetter?.(entity.name) || [];
+          // Pass the schema-qualified name when schema is known, so consumers
+          // can disambiguate between e.g. "public.users" and "other.users".
+          const tableName = entity.schema
+            ? `${entity.schema}.${entity.name}`
+            : entity.name;
+          return this.columnsGetter?.(tableName) || [];
         },
       });
     },

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/sqlContextComplete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/sqlContextComplete.ts
@@ -109,6 +109,10 @@ function sqlCompletionSource(columnsGetter: ColumnsGetter) {
         } else {
           table = path[0];
         }
+      } else if (parents.length >= 2) {
+        // Schema-qualified table without an alias (e.g. `public.users.|`)
+        // The segment before `last` is the schema.
+        schema = parents[parents.length - 2];
       }
 
       const entity = getEntity(context.state, table, schema);
@@ -159,6 +163,15 @@ async function loadColumnsFromQueryContext(
  * Check if cursor is at a position where column completion makes sense
  */
 function isColumnCompletionPosition(textBeforeCursor: string): boolean {
+  // If we're directly after FROM/JOIN (i.e. in a table-name position),
+  // the cursor is not on a column — bail out so we don't suggest columns
+  // while the user is typing a table identifier.
+  // Matches FROM/JOIN followed by whitespace and an optional partial
+  // identifier (including an opening quote/bracket) at end of input.
+  if (/\b(?:FROM|JOIN)\s+["`\[]?[a-zA-Z0-9_]*$/i.test(textBeforeCursor)) {
+    return false;
+  }
+
   const completionPatterns = [
     /\bSELECT\s+/i, // After SELECT (with or without trailing content)
     /\bSELECT.+,\s*/i, // After comma in SELECT
@@ -200,12 +213,13 @@ function getTablesFromContext(
     }
   }
 
-  // Add tables from FROM clauses
-  const fromMatches = contextText.match(/\bFROM\s+([a-zA-Z0-9_]+)/gi);
-  if (fromMatches) {
-    for (const match of fromMatches) {
-      tables.add(match.replace(/\bFROM\s+/i, "").trim());
-    }
+  // Add tables from FROM and JOIN clauses
+  // Supports unquoted, "double quotes", `backticks`, and [brackets]
+  const tableRegex = /\b(?:FROM|JOIN)\s+(?:"([^"]+)"|`([^`]+)`|\[([^\]]+)\]|([a-zA-Z0-9_]+))/gi;
+  let m: RegExpExecArray | null;
+  while ((m = tableRegex.exec(contextText)) !== null) {
+    const tableName = m[1] || m[2] || m[3] || m[4];
+    if (tableName) tables.add(tableName);
   }
 
   return tables;

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/sqlContextComplete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/sqlContextComplete.ts
@@ -140,7 +140,12 @@ async function loadColumnsFromQueryContext(
 ): Promise<string[]> {
   const doc = state.doc;
   const line = doc.lineAt(cursor);
-  const textBeforeCursor = line.text.substring(0, cursor - line.from);
+
+  // Look back up to 5 lines so the position check sees keywords like
+  // SELECT/WHERE/ORDER BY even when the cursor is on a different line.
+  const lookbackLine = Math.max(1, line.number - 5);
+  const lookbackStart = doc.line(lookbackLine).from;
+  const textBeforeCursor = doc.sliceString(lookbackStart, cursor);
 
   if (!isColumnCompletionPosition(textBeforeCursor)) {
     return [];
@@ -174,10 +179,10 @@ function isColumnCompletionPosition(textBeforeCursor: string): boolean {
 
   const completionPatterns = [
     /\bSELECT\s+/i, // After SELECT (with or without trailing content)
-    /\bSELECT.+,\s*/i, // After comma in SELECT
+    /\bSELECT[\s\S]+,\s*/i, // After comma in SELECT (may span lines)
     /\b(WHERE|AND|OR)\s+/i, // After WHERE/AND/OR
     /\b(ORDER\s+BY|GROUP\s+BY|HAVING)\s+/i, // After ORDER BY/GROUP BY/HAVING
-    /\bJOIN.+\bON\s+/i, // After JOIN...ON
+    /\bJOIN[\s\S]+\bON\s+/i, // After JOIN...ON (may span lines)
   ];
 
   return completionPatterns.some((pattern) => pattern.test(textBeforeCursor));

--- a/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
@@ -271,4 +271,177 @@ describe("SQL completion", () => {
   it("can transform keyword completions", async () => {
     ist((await get("s|", {keywords: true, keywordCompletion: l => ({label: l, type: "x"})}))!.options.every(c => c.type == "x"))
   })
+
+  // ---------------------------------------------------------------------------
+  // Regression tests for issue #3567:
+  // "The autocomplete does not suggest columns if the table is quoted"
+  // and related context-based completion bugs (JOIN extraction,
+  // schema-qualified parents).
+  // ---------------------------------------------------------------------------
+
+  it("completes column names when double-quoted table is specified after from (#3567)", async () => {
+    const list = get('select | from "users"', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) => entity.name === "users" ? ["apple", "banana"] : [],
+    })
+    ist(await str(list), "apple, banana, products, users")
+  })
+
+  it("completes column names when backtick-quoted table is specified after from", async () => {
+    const list = get('select | from `users`', {
+      schema: schema1,
+      dialect: MySQL,
+      explicit: true,
+      columnsGetter: (entity) => entity.name === "users" ? ["apple", "banana"] : [],
+    })
+    // Tables/columns are simple lowercase words, so MySQL doesn't add backticks
+    // (see nameCompletion -- only quotes labels with non-word chars).
+    ist(await str(list), "apple, banana, products, users")
+  })
+
+  it("completes column names when bracket-quoted table is specified after from", async () => {
+    const list = get('select | from [users]', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) => entity.name === "users" ? ["apple", "banana"] : [],
+    })
+    const result = await str(list)
+    ist(result.includes("apple"))
+    ist(result.includes("banana"))
+  })
+
+  it("completes column names from joined tables (unaliased)", async () => {
+    const list = get(
+      "select | from users join orders on users.id = orders.user_id",
+      {
+        schema: schema1,
+        explicit: true,
+        columnsGetter: (entity) => {
+          if (entity.name === "users") return ["user_apple"]
+          if (entity.name === "orders") return ["order_x"]
+          return []
+        },
+      }
+    )
+    const result = await str(list)
+    ist(result.includes("user_apple"))
+    ist(result.includes("order_x"))
+  })
+
+  it("completes column names from joined quoted tables (unaliased)", async () => {
+    const list = get(
+      'select | from "users" join "orders" on "users".id = "orders".user_id',
+      {
+        schema: schema1,
+        explicit: true,
+        columnsGetter: (entity) => {
+          if (entity.name === "users") return ["user_apple"]
+          if (entity.name === "orders") return ["order_x"]
+          return []
+        },
+      }
+    )
+    const result = await str(list)
+    ist(result.includes("user_apple"))
+    ist(result.includes("order_x"))
+  })
+
+  it("completes column names with case-insensitive FROM keyword and quoted table", async () => {
+    const list = get('select | FROM "users"', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) => entity.name === "users" ? ["cherry"] : [],
+    })
+    ist((await str(list)).includes("cherry"))
+  })
+
+  it("preserves schema in entity passed to columnsGetter for schema-qualified table without alias", async () => {
+    const seenEntities: Array<{schema?: string, name: string}> = []
+    const list = get('select public.users.|', {
+      schema: schema2,
+      columnsGetter: (entity) => {
+        seenEntities.push({ schema: entity.schema, name: entity.name })
+        return entity.schema === "public" && entity.name === "users"
+          ? ["dynamic_a", "dynamic_b"]
+          : []
+      },
+    })
+    ist(await str(list), "dynamic_a, dynamic_b, email, id")
+    ist(seenEntities.some((e) => e.schema === "public" && e.name === "users"))
+  })
+
+  it("preserves schema in entity passed to columnsGetter for schema-qualified quoted table", async () => {
+    const list = get('select "public"."users".|', {
+      schema: schema2,
+      columnsGetter: (entity) => {
+        return entity.schema === "public" && entity.name === "users"
+          ? ["dynamic_a", "dynamic_b"]
+          : []
+      },
+    })
+    ist(await str(list), "dynamic_a, dynamic_b, email, id")
+  })
+
+  it("uses alias resolution for aliased schema-qualified table", async () => {
+    const list = get("select u.| from public.users u", {
+      schema: schema2,
+      columnsGetter: (entity) =>
+        entity.schema === "public" && entity.name === "users"
+          ? ["dynamic_a"]
+          : [],
+    })
+    ist((await str(list)).includes("dynamic_a"))
+  })
+
+  it("does not break existing aliased quoted table completion", async () => {
+    // Regression: ensure the FROM-regex change didn't disturb the alias path.
+    const list = get('select u.| from "users" u', {
+      schema: schema1,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["dynamic_x"] : [],
+    })
+    const result = await str(list)
+    ist(result.includes("dynamic_x"))
+    ist(result.includes("address"))
+  })
+
+  it("returns no extra columns when cursor is not at a column completion position", async () => {
+    let calls = 0
+    const list = get('select * from "us|"', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: () => {
+        calls++
+        return ["should_not_appear"]
+      },
+    })
+    const result = await str(list)
+    // We're typing a table name (after FROM), not a column position.
+    // The columnsGetter may still be invoked by the completion machinery
+    // with the table-name lookup, but the dynamic-context path
+    // (loadColumnsFromQueryContext) must not inject column completions.
+    ist(!result.includes("should_not_appear"))
+  })
+
+  it("extracts multiple distinct tables across FROM and JOIN", async () => {
+    const list = get(
+      'select | from "a" join b join `c` on true',
+      {
+        schema: schema1,
+        explicit: true,
+        dialect: MySQL,
+        columnsGetter: (entity) => {
+          if (entity.name === "a") return ["col_a"]
+          if (entity.name === "b") return ["col_b"]
+          if (entity.name === "c") return ["col_c"]
+          return []
+        },
+      }
+    )
+    const result = await str(list)
+    ist(result.includes("col_a"))
+    ist(result.includes("col_b"))
+    ist(result.includes("col_c"))
+  })
 })

--- a/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
@@ -444,4 +444,152 @@ describe("SQL completion", () => {
     ist(result.includes("col_b"))
     ist(result.includes("col_c"))
   })
+
+  // ---------------------------------------------------------------------------
+  // Column completion in WHERE / ORDER BY / GROUP BY / HAVING / JOIN ON
+  // ---------------------------------------------------------------------------
+
+  it("suggests columns in WHERE clause for quoted FROM table", async () => {
+    const list = get('select * from "users" where |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["where_col"] : [],
+    })
+    ist((await str(list)).includes("where_col"))
+  })
+
+  it("suggests columns in ORDER BY for quoted FROM table", async () => {
+    const list = get('select * from "users" order by |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["order_col"] : [],
+    })
+    ist((await str(list)).includes("order_col"))
+  })
+
+  it("suggests columns in GROUP BY for quoted FROM table", async () => {
+    const list = get('select * from "users" group by |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["group_col"] : [],
+    })
+    ist((await str(list)).includes("group_col"))
+  })
+
+  it("suggests columns in HAVING for quoted FROM table", async () => {
+    const list = get('select count(*) from "users" group by id having |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["having_col"] : [],
+    })
+    ist((await str(list)).includes("having_col"))
+  })
+
+  it("suggests columns in JOIN...ON for both quoted tables", async () => {
+    const list = get(
+      'select * from "users" join "orders" on |',
+      {
+        schema: schema1,
+        explicit: true,
+        columnsGetter: (entity) => {
+          if (entity.name === "users") return ["uid"]
+          if (entity.name === "orders") return ["oid"]
+          return []
+        },
+      }
+    )
+    const result = await str(list)
+    ist(result.includes("uid"))
+    ist(result.includes("oid"))
+  })
+
+  it("suggests columns after a comma in SELECT with quoted FROM", async () => {
+    const list = get('select id, | from "users"', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: (entity) =>
+        entity.name === "users" ? ["second_col"] : [],
+    })
+    ist((await str(list)).includes("second_col"))
+  })
+
+  // ---------------------------------------------------------------------------
+  // Negative tests for the table-name-position guard
+  // ---------------------------------------------------------------------------
+
+  it("does not suggest columns when cursor is right after FROM (no table yet)", async () => {
+    const list = get('select * from |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: () => ["should_not_appear_after_from"],
+    })
+    ist(!(await str(list)).includes("should_not_appear_after_from"))
+  })
+
+  it("does not suggest columns when cursor is inside an unquoted table name", async () => {
+    const list = get('select * from us|', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: () => ["should_not_appear_inside_unquoted"],
+    })
+    ist(!(await str(list)).includes("should_not_appear_inside_unquoted"))
+  })
+
+  it("does not suggest columns when cursor is inside a backtick-quoted table name", async () => {
+    const list = get('select * from `us|`', {
+      schema: schema1,
+      dialect: MySQL,
+      explicit: true,
+      columnsGetter: () => ["should_not_appear_inside_backtick"],
+    })
+    ist(!(await str(list)).includes("should_not_appear_inside_backtick"))
+  })
+
+  it("does not suggest columns when cursor is right after JOIN (no table yet)", async () => {
+    const list = get('select * from users join |', {
+      schema: schema1,
+      explicit: true,
+      columnsGetter: () => ["should_not_appear_after_join"],
+    })
+    ist(!(await str(list)).includes("should_not_appear_after_join"))
+  })
+
+  // ---------------------------------------------------------------------------
+  // Multi-line queries (the context window is +/- 5 lines around the cursor)
+  // ---------------------------------------------------------------------------
+
+  it("extracts a quoted table from FROM on a previous line", async () => {
+    const list = get(
+      'select\n  |\nfrom "users"',
+      {
+        schema: schema1,
+        explicit: true,
+        columnsGetter: (entity) =>
+          entity.name === "users" ? ["multi_line_col"] : [],
+      }
+    )
+    ist((await str(list)).includes("multi_line_col"))
+  })
+
+  it("extracts FROM and JOIN tables across multiple lines", async () => {
+    const list = get(
+      'select\n  |\nfrom "users"\njoin "orders" on "users".id = "orders".user_id',
+      {
+        schema: schema1,
+        explicit: true,
+        columnsGetter: (entity) => {
+          if (entity.name === "users") return ["u_col"]
+          if (entity.name === "orders") return ["o_col"]
+          return []
+        },
+      }
+    )
+    const result = await str(list)
+    ist(result.includes("u_col"))
+    ist(result.includes("o_col"))
+  })
 })


### PR DESCRIPTION
Resolves #3567: autocomplete did not suggest column names when the
table was specified with quoted/bracketed identifiers (e.g. `FROM
"film"`). The context-extraction regex in sqlContextComplete only
recognised unquoted identifiers, so loadColumnsFromQueryContext came
back empty and the columnsGetter was never asked for columns.

Other autocomplete fixes bundled in:
- Extract tables from JOIN clauses, not just FROM, so unaliased
  joined tables also produce column suggestions.
- Preserve the schema for schema-qualified tables that have no alias
  (e.g. `public.users.|`) when invoking columnsGetter, so consumers
  can disambiguate identically-named tables across schemas.
- Stop emitting column suggestions while the cursor is inside a
  table-name position (right after FROM/JOIN), where the user is
  typing a table identifier rather than a column.
- Vue wrapper now forwards the schema-qualified name to consumer
  columnsGetters when the schema is known. The studio's existing
  lookup already handles both forms.

Adds 12 regression tests covering double quotes, backticks, brackets,
case-insensitive FROM, joined tables, schema-qualified parents, and
the table-name cursor position.