### PR TITLE
Prevent calling persistence write function before the table is ready

### DIFF
--- a/apps/studio/src/common/tabulator.ts
+++ b/apps/studio/src/common/tabulator.ts
@@ -12,6 +12,9 @@ import {
 } from "@/lib/menu/tableMenu";
 import { rowHeaderField } from "@/common/utils";
 import _ from "lodash";
+import rawLog from "@bksLogger";
+
+const log = rawLog.scope("common/tabulator");
 
 interface Options extends TabulatorOptions {
   table?: string;
@@ -31,11 +34,24 @@ export function tabulatorForTableData(
   options: Options
 ): TabulatorFull {
   const { table, schema, ...tabulatorOptions } = options;
+  // Suppress the build-time save burst that clobbers persisted column
+  // widths on cold start.
+  let persistenceReady = false;
   const defaultOptions: Options = {
     persistence: {
       columns: ["width", "visible"],
     },
     persistenceMode: "local",
+    persistenceWriterFunc: (id: string, type: string, data: unknown) => {
+      if (!persistenceReady) {
+        return;
+      }
+      try {
+        localStorage.setItem(`${id}-${type}`, JSON.stringify(data));
+      } catch (e) {
+        log.warn(e);
+      }
+    },
     renderHorizontal: "virtual",
     autoResize: false,
     nestedFieldSeparator: false,
@@ -91,6 +107,13 @@ export function tabulatorForTableData(
   };
   const mergedOptions = _.merge(defaultOptions, tabulatorOptions);
   const tabulator = new TabulatorFull(el, mergedOptions);
+
+  const onFirstLayout = () => {
+    tabulator.off("layout-refreshed", onFirstLayout);
+    persistenceReady = true;
+  };
+  tabulator.on("layout-refreshed", onFirstLayout);
+
   if (options.onRangeChange) {
     function onRangeChange() {
       options.onRangeChange(tabulator.getRanges());

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -395,13 +395,6 @@ export default Vue.extend({
       selectedRowPosition: -1,
       selectedRowData: {},
       expandablePaths: [],
-
-      // Suppress tabulator's persistence writer until the initial layout
-      // settles. Tabulator fires save("columns") for every column-width
-      // assignment during firstRender; on cold start the container hasn't
-      // stabilized, so those saves clobber the persisted widths with bogus
-      // ones. See issue #4023.
-      persistenceReady: false,
     };
   },
   computed: {
@@ -750,14 +743,6 @@ export default Vue.extend({
     this.registerHandlers(this.rootBindings)
   },
   methods: {
-    persistenceWriter(id: string, type: string, data: unknown) {
-      if (!this.persistenceReady) return;
-      try {
-        localStorage.setItem(`${id}-${type}`, JSON.stringify(data));
-      } catch (e) {
-        log.warn("tabulator persistence write failed", e);
-      }
-    },
     createColumnFromProps(column) {
       // 1. add a column for a real column
       // if a FK, add another column with the link
@@ -1038,12 +1023,10 @@ export default Vue.extend({
       await this.$store.dispatch('updateTableColumns', this.table)
       await this.getTableKeys();
 
-      this.persistenceReady = false;
       this.tabulator = tabulatorForTableData(this.$refs.table, {
         table: this.table.name,
         schema: this.table.schema,
         persistenceID: this.tableId,
-        persistenceWriterFunc: this.persistenceWriter,
         rowHeader: {
           contextMenu: (_e, cell: CellComponent) => {
             const ranges = cell.getRanges();
@@ -1109,15 +1092,6 @@ export default Vue.extend({
       this.tabulator.on('tableBuilt', () => {
         this.tabulator.modules.selectRange.restoreFocus()
       })
-      // Open the persistence writer only after the initial layout pass
-      // has finished. layout-refreshed is the last event in that pass, so
-      // every save("columns") triggered during build (column-width events
-      // from setWidth, the layout-refreshed save itself, etc.) is dropped.
-      const onFirstLayout = () => {
-        this.tabulator.off('layout-refreshed', onFirstLayout)
-        this.$nextTick(() => { this.persistenceReady = true })
-      }
-      this.tabulator.on('layout-refreshed', onFirstLayout)
       this.tabulator.on('historyUndo', (action, component) => {
         if (action === "cellEdit") {
           this.cellEdited(component);

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -395,6 +395,13 @@ export default Vue.extend({
       selectedRowPosition: -1,
       selectedRowData: {},
       expandablePaths: [],
+
+      // Suppress tabulator's persistence writer until the initial layout
+      // settles. Tabulator fires save("columns") for every column-width
+      // assignment during firstRender; on cold start the container hasn't
+      // stabilized, so those saves clobber the persisted widths with bogus
+      // ones. See issue #4023.
+      persistenceReady: false,
     };
   },
   computed: {
@@ -743,6 +750,14 @@ export default Vue.extend({
     this.registerHandlers(this.rootBindings)
   },
   methods: {
+    persistenceWriter(id: string, type: string, data: unknown) {
+      if (!this.persistenceReady) return;
+      try {
+        localStorage.setItem(`${id}-${type}`, JSON.stringify(data));
+      } catch (e) {
+        log.warn("tabulator persistence write failed", e);
+      }
+    },
     createColumnFromProps(column) {
       // 1. add a column for a real column
       // if a FK, add another column with the link
@@ -1023,10 +1038,12 @@ export default Vue.extend({
       await this.$store.dispatch('updateTableColumns', this.table)
       await this.getTableKeys();
 
+      this.persistenceReady = false;
       this.tabulator = tabulatorForTableData(this.$refs.table, {
         table: this.table.name,
         schema: this.table.schema,
         persistenceID: this.tableId,
+        persistenceWriterFunc: this.persistenceWriter,
         rowHeader: {
           contextMenu: (_e, cell: CellComponent) => {
             const ranges = cell.getRanges();
@@ -1092,6 +1109,15 @@ export default Vue.extend({
       this.tabulator.on('tableBuilt', () => {
         this.tabulator.modules.selectRange.restoreFocus()
       })
+      // Open the persistence writer only after the initial layout pass
+      // has finished. layout-refreshed is the last event in that pass, so
+      // every save("columns") triggered during build (column-width events
+      // from setWidth, the layout-refreshed save itself, etc.) is dropped.
+      const onFirstLayout = () => {
+        this.tabulator.off('layout-refreshed', onFirstLayout)
+        this.$nextTick(() => { this.persistenceReady = true })
+      }
+      this.tabulator.on('layout-refreshed', onFirstLayout)
       this.tabulator.on('historyUndo', (action, component) => {
         if (action === "cellEdit") {
           this.cellEdited(component);


### PR DESCRIPTION
This probably fixes #4023

Tabulator calls persistence's save function so many times during table build. This prevents that.