### PR TITLE
fix double encoded jsonb values when inserting a new row from table view

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1339,7 +1339,8 @@ export default Vue.extend({
           } else {
             result[columnName] = d
             // HACK (azmi): we should handle this from backend with tests instead
-            if (this.dialect === 'postgresql' && dataType === 'jsonb') {
+            // _.isObject guard: if it's already a string don't stringify it (would double-encode)
+            if (this.dialect === 'postgresql' && dataType === 'jsonb' && _.isObject(d)) {
               result[columnName] = JSON.stringify(d)
             }
           }

--- a/apps/studio/tests/unit/components/tableview/TableTable.spec.ts
+++ b/apps/studio/tests/unit/components/tableview/TableTable.spec.ts
@@ -1,0 +1,95 @@
+import TableTable from "@/components/tableview/TableTable.vue";
+
+// Regression coverage for #4222.
+// `buildPendingInserts` used to JSON.stringify every postgres jsonb cell, even
+// when the user typed a string (which Tabulator hands back unparsed). That
+// double-encoded the value before it ever left the renderer.
+describe("TableTable.vue — buildPendingInserts", () => {
+  const buildPendingInserts = (TableTable as any).options.methods.buildPendingInserts;
+
+  function makeContext({
+    columns,
+    rowData,
+    dialect = "postgresql",
+  }: {
+    columns: { columnName: string; dataType: string; generated?: boolean }[];
+    rowData: Record<string, unknown>;
+    dialect?: string;
+  }) {
+    return {
+      table: {
+        name: "jsontest",
+        schema: "public",
+        columns,
+      },
+      dialect,
+      dialectData: { requireDataset: false },
+      database: "banana",
+      pendingChanges: {
+        inserts: [{ row: { getData: () => rowData } }],
+        updates: [],
+        deletes: [],
+      },
+      isPrimaryKey(col: string) {
+        return col === "id";
+      },
+    };
+  }
+
+  it("does not JSON.stringify a jsonb cell that is already a string (issue-4222)", () => {
+    const ctx = makeContext({
+      columns: [
+        { columnName: "id", dataType: "integer" },
+        { columnName: "data", dataType: "jsonb" },
+      ],
+      rowData: { id: 1, data: '{"hello":"world"}' },
+    });
+
+    const [insert] = buildPendingInserts.call(ctx);
+
+    expect(insert.data[0].data).toBe('{"hello":"world"}');
+  });
+
+  it("JSON.stringifies a jsonb cell when the value is an object", () => {
+    const ctx = makeContext({
+      columns: [
+        { columnName: "id", dataType: "integer" },
+        { columnName: "data", dataType: "jsonb" },
+      ],
+      rowData: { id: 2, data: { hello: "world" } },
+    });
+
+    const [insert] = buildPendingInserts.call(ctx);
+
+    expect(insert.data[0].data).toBe('{"hello":"world"}');
+  });
+
+  it("leaves a JSON scalar string for a jsonb cell untouched (issue-4222)", () => {
+    const ctx = makeContext({
+      columns: [
+        { columnName: "id", dataType: "integer" },
+        { columnName: "data", dataType: "jsonb" },
+      ],
+      rowData: { id: 3, data: '"plain"' },
+    });
+
+    const [insert] = buildPendingInserts.call(ctx);
+
+    expect(insert.data[0].data).toBe('"plain"');
+  });
+
+  it("does not touch jsonb cells on non-postgres dialects", () => {
+    const ctx = makeContext({
+      columns: [
+        { columnName: "id", dataType: "integer" },
+        { columnName: "data", dataType: "jsonb" },
+      ],
+      rowData: { id: 4, data: { hello: "world" } },
+      dialect: "mysql",
+    });
+
+    const [insert] = buildPendingInserts.call(ctx);
+
+    expect(insert.data[0].data).toEqual({ hello: "world" });
+  });
+});


### PR DESCRIPTION
  1. Add a new row, insert jsonb value
<img width="135" height="73" alt="Screenshot 2026-05-08 at 08 20 54" src="https://github.com/user-attachments/assets/86d1475c-f34c-4bc0-b15f-9fcf525527a1" />
  2. The value is a string
<img width="727" height="84" alt="Screenshot 2026-05-08 at 08 21 12" src="https://github.com/user-attachments/assets/4c95f45d-ab29-43bb-a69a-d55fa0fe381c" />
  3. It gets `JSON.stringify`-ed even though it's a string. That's why there are extra \ characters in jsonb values.
<img width="346" height="38" alt="Screenshot 2026-05-08 at 08 20 50" src="https://github.com/user-attachments/assets/8c9c18f3-bcf4-4715-a93e-fe6b0da1d035" />
