### PR TITLE
Cache playwright browsers in e2e workflows

### DIFF
--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Python 3.11 (non-Mac)
         uses: actions/setup-python@v5
@@ -69,8 +69,23 @@ jobs:
       - name: Install xvfb-maybe
         run: npm install -g xvfb-maybe
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+
       - name: Install Playwright browsers
-        run: yarn playwright install --with-deps chromium
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        run: yarn playwright install chromium
+
+      - name: Install Playwright system dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: yarn playwright install-deps chromium
 
       - name: Build UI Kit
         run: yarn lib:build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,6 +2,7 @@ name: E2E Tests
 
 permissions:
   contents: read
+  actions: write
 
 on:
   push:
@@ -15,24 +16,15 @@ on:
       - docs/**
 
 jobs:
-  e2e-tests:
-    name: E2E Tests
+  prep:
     runs-on: ubuntu-24.04
-
     steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v2
-
-      - name: Install Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
+      - uses: actions/checkout@v4
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
 
       - name: Cache node_modules
         id: cache-nm
@@ -56,8 +48,56 @@ jobs:
           HUSKY: "0"
           npm_config_node_gyp: ${{ github.workspace }}/node_modules/node-gyp/bin/node-gyp.js
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+
       - name: Install Playwright browsers
-        run: yarn playwright install --with-deps chromium
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        run: yarn playwright install chromium
+
+  e2e-tests:
+    name: E2E Tests
+    runs-on: ubuntu-24.04
+    needs: [prep]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            apps/studio/node_modules
+            apps/ui-kit/node_modules
+            apps/sqltools/node_modules
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          fail-on-cache-miss: true
+
+      - name: Restore Playwright browsers cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          fail-on-cache-miss: true
+
+      - name: Install Playwright system dependencies
+        run: yarn playwright install-deps chromium
 
       - name: Build UI Kit
         run: yarn lib:build


### PR DESCRIPTION
## What

Both e2e workflows reinstall Playwright browsers from scratch on every run (~2-3 minutes of download). The unit/integration workflow already caches `node_modules` via a prep -> test job pattern; this brings the same approach to e2e and adds Playwright browsers alongside.

## Changes

### `e2e-tests.yml` (Linux, full e2e suite)

Restructured to match `studio-test.yml`:

- **`prep` job**: primes both caches
  - `node_modules` keyed on `yarn.lock` (existing key)
  - `~/.cache/ms-playwright` keyed on `yarn.lock`
- **`e2e-tests` job** (depends on prep): `cache/restore@v4` with `fail-on-cache-miss: true` for both caches, runs `playwright install-deps chromium` (apt packages aren't cached), then builds + tests.

### `e2e-smoke-test.yml` (cross-platform matrix)

Each OS has its own cache, so no benefit from a shared prep job - just added the Playwright cache inline alongside the existing `node_modules` one. Multi-path entry handles per-OS browser locations:

```yaml
path: |
  ~/.cache/ms-playwright              # Linux
  ~/Library/Caches/ms-playwright       # macOS
  ~/AppData/Local/ms-playwright        # Windows
```

Browser download skipped on cache hit. Linux still runs `playwright install-deps` unconditionally (apt packages).

## Why this should be safe

- Same cache key strategy as the existing node_modules cache (`hashFiles('yarn.lock')`), so invalidation tracks together.
- Browser binaries don't include apt packages - those still install on every run.
- `playwright install chromium` is a no-op when binaries are already in the cache dir, so the cache-hit path doesn't risk stale installs.

## Expected savings

Per run, ballpark:
- Cache hit: ~2-3 min saved on browser download
- Cache miss: same as before (full install)

For PRs that don't touch `yarn.lock`, every e2e + smoke run should hit the cache.