### PR TITLE
Trim e2e PR trigger, add concurrency, bump old checkout actions

### DIFF
--- a/.github/workflows/delete-draft-releases.yml
+++ b/.github/workflows/delete-draft-releases.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Delete all draft releases
         uses: actions/github-script@v7

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,10 +10,11 @@ on:
       - master
     paths-ignore:
       - docs/**
-  pull_request:
-    paths-ignore:
-      - apps/sqltools/**
-      - docs/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   prep:

--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Download DEB artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What

Three small CI cleanups bundled.

### 1. e2e-tests.yml: drop the pull_request trigger

The cross-platform smoke workflow already runs on every PR (Linux + macOS + Windows). The full Linux e2e suite running on PRs too was largely redundant for catching early regressions and was eating ~20 minutes of CI time per PR push.

Now the full suite runs only on:
- `push` to master (catches anything smoke missed before it lands)
- `workflow_dispatch` (manual trigger when needed for a specific PR)

If we ever want it back on PRs, easy to revert. **Flagging this as a policy call** - if you'd rather keep PR coverage, just say and I'll back it out.

### 2. e2e-tests.yml: concurrency cancellation

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Same pattern as `studio-test.yml` and `e2e-smoke-test.yml`. A new master push (or new manual dispatch) cancels the in-progress run instead of letting two stack.

### 3. Bump `actions/checkout` to v4

Brought the stragglers up to current:
- `delete-draft-releases.yml`: v3 → v4
- `docs-deploy.yml`: v2 → v4
- `studio-build-non-production.yml`: v1 → v4 (×2)

**Not bumped on purpose:** `studio-publish.yml` and `ui-kit-publish.yml` - those are the release path, leaving for a separate, focused bump.

## Test plan

- [x] YAML syntax check on all four touched files
- [ ] CI: verify the full e2e workflow no longer runs on this PR (only smoke should)
- [ ] CI: verify the workflow_dispatch trigger appears in the Actions UI for `e2e-tests.yml`