### PR TITLE
Fix DuckDB TIMESTAMPTZ and UUID serialization to return strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ yarn-error.log
 cli.zip
 apps/studio/test-results
 *.db
+*.duckdb
 *.log
 *.orig
 surreal_data/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ yarn-error.log
 cli.zip
 apps/studio/test-results
 *.db
+*.duckdb
 *.log
 *.orig
 surreal_data/

--- a/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
@@ -50,7 +50,7 @@ import { DuckDBChangeBuilder } from "@shared/lib/sql/change_builder/DuckDBChange
 import { DuckDBData } from "@shared/lib/dialects/duckdb";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
 import { TableKey } from "@shared/lib/dialects/models";
-import { DuckDBBinaryTranscoder } from "@/lib/db/serialization/transcoders";
+import { DuckDBBinaryTranscoder, DuckDBTimestampTZTranscoder, DuckDBUUIDTranscoder } from "@/lib/db/serialization/transcoders";
 
 const log = rawLog.scope("duckdb");
 
@@ -205,7 +205,7 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
   // https://duckdb.org/docs/connect/concurrency#handling-concurrency
   connectionInstance: Connection;
   _defaultSchema: string = "main";
-  transcoders = [DuckDBBinaryTranscoder];
+  transcoders = [DuckDBBinaryTranscoder, DuckDBTimestampTZTranscoder, DuckDBUUIDTranscoder];
 
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(null, duckDBContext, server, database);
@@ -1049,10 +1049,13 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
   }
 
   protected parseQueryResultColumns(qr: DuckDBResult): BksField[] {
-    return qr.columns.map((c) => ({
-      name: c.name,
-      bksType: c.type.typeId === DuckDBTypeId.BLOB ? "BINARY" : "UNKNOWN",
-    }));
+    return qr.columns.map((c) => {
+      let bksType: BksFieldType = "UNKNOWN";
+      if (c.type.typeId === DuckDBTypeId.BLOB) bksType = "BINARY";
+      else if (c.type.typeId === DuckDBTypeId.TIMESTAMP_TZ) bksType = "DUCKDB_TIMESTAMP_TZ";
+      else if (c.type.typeId === DuckDBTypeId.UUID) bksType = "DUCKDB_UUID";
+      return { name: c.name, bksType };
+    });
   }
 
   async selectTopSql(

--- a/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
@@ -49,7 +49,7 @@ import { DuckDBChangeBuilder } from "@shared/lib/sql/change_builder/DuckDBChange
 import { DuckDBData } from "@shared/lib/dialects/duckdb";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
 import { TableKey } from "@shared/lib/dialects/models";
-import { DuckDBBinaryTranscoder } from "@/lib/db/serialization/transcoders";
+import { DuckDBBinaryTranscoder, DuckDBTimestampTZTranscoder, DuckDBUUIDTranscoder } from "@/lib/db/serialization/transcoders";
 
 const log = rawLog.scope("duckdb");
 
@@ -203,7 +203,7 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
   // We only use one connection to be able to read and write at the same time
   // https://duckdb.org/docs/connect/concurrency#handling-concurrency
   connectionInstance: Connection;
-  transcoders = [DuckDBBinaryTranscoder];
+  transcoders = [DuckDBBinaryTranscoder, DuckDBTimestampTZTranscoder, DuckDBUUIDTranscoder];
 
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(null, duckDBContext, server, database);
@@ -1052,10 +1052,13 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
   }
 
   protected parseQueryResultColumns(qr: DuckDBResult): BksField[] {
-    return qr.columns.map((c) => ({
-      name: c.name,
-      bksType: c.type.typeId === DuckDBTypeId.BLOB ? "BINARY" : "UNKNOWN",
-    }));
+    return qr.columns.map((c) => {
+      let bksType: BksFieldType = "UNKNOWN";
+      if (c.type.typeId === DuckDBTypeId.BLOB) bksType = "BINARY";
+      else if (c.type.typeId === DuckDBTypeId.TIMESTAMP_TZ) bksType = "DUCKDB_TIMESTAMP_TZ";
+      else if (c.type.typeId === DuckDBTypeId.UUID) bksType = "DUCKDB_UUID";
+      return { name: c.name, bksType };
+    });
   }
 
   async selectTopSql(

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -170,7 +170,7 @@ export interface BksField {
   bksType: BksFieldType;
 }
 
-export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID';
+export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID' | 'DUCKDB_TIMESTAMP_TZ' | 'DUCKDB_UUID';
 
 export interface TableChanges {
   inserts: TableInsert[];

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -167,7 +167,7 @@ export interface BksField {
   bksType: BksFieldType;
 }
 
-export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID';
+export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID' | 'DUCKDB_TIMESTAMP_TZ' | 'DUCKDB_UUID';
 
 export interface TableChanges {
   inserts: TableInsert[];

--- a/apps/studio/src/lib/db/serialization/transcoders.ts
+++ b/apps/studio/src/lib/db/serialization/transcoders.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { BksField } from "../models";
 import rawLog from "@bksLogger";
-import { DuckDBBlobValue } from "@duckdb/node-api";
+import { DuckDBBlobValue, DuckDBTimestampTZValue, DuckDBUUIDValue } from "@duckdb/node-api";
 import { ObjectId } from "mongodb";
 import { RecordId, StringRecordId } from "surrealdb";
 
@@ -109,6 +109,46 @@ export const LibSQLBinaryTranscoder: Transcoder<
   },
   deserializeCheckByValue(value): value is Uint8Array {
     return _.isTypedArray(value);
+  },
+};
+
+export const DuckDBTimestampTZTranscoder: Transcoder<DuckDBTimestampTZValue, string> = {
+  serialize(value) {
+    if (_.isNil(value)) return value;
+    if (!(value instanceof DuckDBTimestampTZValue)) {
+      log.warn("DuckDBTimestampTZTranscoder: unexpected value type");
+      return String(value);
+    }
+    return value.toString();
+  },
+  deserialize(value) {
+    return value as any;
+  },
+  serializeCheckByField(field): boolean {
+    return field.bksType === 'DUCKDB_TIMESTAMP_TZ';
+  },
+  deserializeCheckByValue(_value): _value is string {
+    return false;
+  },
+};
+
+export const DuckDBUUIDTranscoder: Transcoder<DuckDBUUIDValue, string> = {
+  serialize(value) {
+    if (_.isNil(value)) return value;
+    if (!(value instanceof DuckDBUUIDValue)) {
+      log.warn("DuckDBUUIDTranscoder: unexpected value type");
+      return String(value);
+    }
+    return value.toString();
+  },
+  deserialize(value) {
+    return value as any;
+  },
+  serializeCheckByField(field): boolean {
+    return field.bksType === 'DUCKDB_UUID';
+  },
+  deserializeCheckByValue(_value): _value is string {
+    return false;
   },
 };
 

--- a/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
@@ -204,6 +204,71 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
         await util.paramTest(['?']);
       })
     })
+
+    describe("TIMESTAMPTZ and UUID display tests", () => {
+      beforeAll(async () => {
+        await util.knex.raw(`
+          CREATE TABLE tz_uuid_types (
+            id INT PRIMARY KEY,
+            ts TIMESTAMPTZ,
+            uid UUID
+          )
+        `);
+        await util.knex.raw(`
+          INSERT INTO tz_uuid_types VALUES (
+            1,
+            TIMESTAMPTZ '2023-06-23 20:30:17.170+00',
+            UUID '550e8400-e29b-41d4-a716-446655440000'
+          )
+        `);
+      });
+
+      afterAll(async () => {
+        await util.knex.schema.dropTableIfExists("tz_uuid_types");
+      });
+
+      it("should return TIMESTAMPTZ as a readable string, not an object", async () => {
+        const { result: rows, fields } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const tsField = fields.find(f => f.name === 'ts');
+        expect(tsField?.bksType).toBe('DUCKDB_TIMESTAMP_TZ');
+
+        const row = rows[0];
+        expect(typeof row['ts']).toBe('string');
+        // Should look like a timestamp string, not {"micros":...}
+        expect(row['ts']).toMatch(/\d{4}-\d{2}-\d{2}/);
+        expect(row['ts']).not.toHaveProperty('micros');
+      });
+
+      it("should return UUID as a readable UUID string, not an object", async () => {
+        const { result: rows, fields } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const uuidField = fields.find(f => f.name === 'uid');
+        expect(uuidField?.bksType).toBe('DUCKDB_UUID');
+
+        const row = rows[0];
+        expect(typeof row['uid']).toBe('string');
+        // Should be formatted as a proper UUID
+        expect(row['uid']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+        expect(row['uid']).toBe('550e8400-e29b-41d4-a716-446655440000');
+      });
+
+      it("should handle NULL TIMESTAMPTZ and UUID values", async () => {
+        await util.knex.raw(`INSERT INTO tz_uuid_types VALUES (2, NULL, NULL)`);
+
+        const { result: rows } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const nullRow = rows.find((r: any) => r['id'] === 2);
+        expect(nullRow['ts']).toBeNull();
+        expect(nullRow['uid']).toBeNull();
+      });
+    });
   });
 }
 

--- a/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
@@ -272,6 +272,110 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
         await util.queryStreamDoubleExecutionTest()
       })
     })
+
+    describe("TIMESTAMPTZ and UUID display tests", () => {
+      beforeAll(async () => {
+        await util.knex.raw(`
+          CREATE TABLE tz_uuid_types (
+            id INT PRIMARY KEY,
+            ts TIMESTAMPTZ,
+            uid UUID
+          )
+        `);
+        await util.knex.raw(`
+          INSERT INTO tz_uuid_types VALUES (
+            1,
+            TIMESTAMPTZ '2023-06-23 20:30:17.170+00',
+            UUID '550e8400-e29b-41d4-a716-446655440000'
+          )
+        `);
+      });
+
+      afterAll(async () => {
+        await util.knex.schema.dropTableIfExists("tz_uuid_types");
+      });
+
+      it("should return TIMESTAMPTZ as a readable string, not an object", async () => {
+        const { result: rows, fields } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const tsField = fields.find(f => f.name === 'ts');
+        expect(tsField?.bksType).toBe('DUCKDB_TIMESTAMP_TZ');
+
+        const row = rows[0];
+        expect(typeof row['ts']).toBe('string');
+        expect(row['ts']).toMatch(/\d{4}-\d{2}-\d{2}/);
+        expect(row['ts']).not.toHaveProperty('micros');
+      });
+
+      it("should return UUID as a readable UUID string, not an object", async () => {
+        const { result: rows, fields } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const uuidField = fields.find(f => f.name === 'uid');
+        expect(uuidField?.bksType).toBe('DUCKDB_UUID');
+
+        const row = rows[0];
+        expect(typeof row['uid']).toBe('string');
+        expect(row['uid']).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+        expect(row['uid']).toBe('550e8400-e29b-41d4-a716-446655440000');
+      });
+
+      it("should handle NULL TIMESTAMPTZ and UUID values", async () => {
+        await util.knex.raw(`INSERT INTO tz_uuid_types VALUES (2, NULL, NULL)`);
+
+        const { result: rows } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+
+        const nullRow = rows.find((r: any) => r['id'] === 2);
+        expect(nullRow['ts']).toBeNull();
+        expect(nullRow['uid']).toBeNull();
+      });
+
+      it("should round-trip TIMESTAMPTZ and UUID values through applyChanges", async () => {
+        const { result: rows } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+        const originalRow = rows.find((r: any) => r['id'] === 1);
+        const tsString = originalRow['ts'] as string;
+        const uuidString = originalRow['uid'] as string;
+
+        expect(typeof tsString).toBe('string');
+        expect(typeof uuidString).toBe('string');
+
+        await util.connection.applyChanges({
+          inserts: [],
+          updates: [
+            {
+              table: 'tz_uuid_types',
+              schema: util.defaultSchema,
+              primaryKeys: [{ column: 'id', value: 1 }],
+              column: 'ts',
+              value: tsString,
+            },
+            {
+              table: 'tz_uuid_types',
+              schema: util.defaultSchema,
+              primaryKeys: [{ column: 'id', value: 1 }],
+              column: 'uid',
+              value: uuidString,
+            },
+          ],
+          deletes: [],
+        });
+
+        const { result: updated } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+        const updatedRow = updated.find((r: any) => r['id'] === 1);
+        expect(typeof updatedRow['ts']).toBe('string');
+        expect(typeof updatedRow['uid']).toBe('string');
+        expect(updatedRow['uid']).toBe('550e8400-e29b-41d4-a716-446655440000');
+      });
+    });
   });
 }
 

--- a/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
@@ -268,6 +268,50 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
         expect(nullRow['ts']).toBeNull();
         expect(nullRow['uid']).toBeNull();
       });
+
+      it("should round-trip TIMESTAMPTZ and UUID values through applyChanges", async () => {
+        // Read the serialised strings from the DB
+        const { result: rows } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+        const originalRow = rows.find((r: any) => r['id'] === 1);
+        const tsString = originalRow['ts'] as string;
+        const uuidString = originalRow['uid'] as string;
+
+        expect(typeof tsString).toBe('string');
+        expect(typeof uuidString).toBe('string');
+
+        // Write the strings back via applyChanges (simulates what the UI does)
+        await util.connection.applyChanges({
+          inserts: [],
+          updates: [
+            {
+              table: 'tz_uuid_types',
+              schema: util.defaultSchema,
+              primaryKeys: [{ column: 'id', value: 1 }],
+              column: 'ts',
+              value: tsString,
+            },
+            {
+              table: 'tz_uuid_types',
+              schema: util.defaultSchema,
+              primaryKeys: [{ column: 'id', value: 1 }],
+              column: 'uid',
+              value: uuidString,
+            },
+          ],
+          deletes: [],
+        });
+
+        // Re-read and verify values survived the round-trip
+        const { result: updated } = await util.connection.selectTop(
+          'tz_uuid_types', 0, 10, [], [], util.defaultSchema, ["*"]
+        );
+        const updatedRow = updated.find((r: any) => r['id'] === 1);
+        expect(typeof updatedRow['ts']).toBe('string');
+        expect(typeof updatedRow['uid']).toBe('string');
+        expect(updatedRow['uid']).toBe('550e8400-e29b-41d4-a716-446655440000');
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
This PR fixes the serialization of DuckDB's `TIMESTAMPTZ` and `UUID` types to return readable string representations instead of internal object structures.

## Key Changes
- **Added transcoders** for `TIMESTAMPTZ` and `UUID` types in `transcoders.ts`:
  - `DuckDBTimestampTZTranscoder`: Converts `DuckDBTimestampTZValue` objects to ISO 8601 timestamp strings
  - `DuckDBUUIDTranscoder`: Converts `DuckDBUUIDValue` objects to standard UUID string format
  
- **Updated DuckDB client** (`duckdb.ts`):
  - Registered the new transcoders in the client's transcoder list
  - Enhanced `parseQueryResultColumns()` to properly identify and tag `TIMESTAMP_TZ` and `UUID` column types
  
- **Extended type definitions** (`models.ts`):
  - Added `'DUCKDB_TIMESTAMP_TZ'` and `'DUCKDB_UUID'` to the `BksFieldType` union type
  
- **Added comprehensive tests** (`duckdb.spec.ts`):
  - Verify `TIMESTAMPTZ` values are returned as readable timestamp strings
  - Verify `UUID` values are returned in proper UUID format
  - Ensure NULL values are handled correctly for both types

- **Updated .gitignore**: Added `*.duckdb` to ignore DuckDB database files

## Implementation Details
The transcoders follow the existing pattern used for other DuckDB types (like BLOB), leveraging the `toString()` method on DuckDB's native value objects to produce human-readable output. This ensures consistency with how other database types are serialized in the application.

https://claude.ai/code/session_01XdsrVobV5HHeW4YuZ4tmEG