### PR TITLE
fix: two silent bugs in SQL change builders (Cassandra rename + DuckDB column type quoting)

### DIFF
--- a/apps/studio/.gitignore
+++ b/apps/studio/.gitignore
@@ -1,1 +1,2 @@
 *.db
+*.duckdb

--- a/apps/studio/src/shared/lib/sql/change_builder/CassandraChangeBuilder.ts
+++ b/apps/studio/src/shared/lib/sql/change_builder/CassandraChangeBuilder.ts
@@ -113,7 +113,7 @@ export class CassandraChangeBuilder extends ChangeBuilderBase {
         You cannot rename a column if an index has been created on it.
         You cannot rename a static column, since you cannot use a static column in the table's primary key.
     */
-    const renameColumnAlterations = spec.alterations?.filter(v => { v.changeType === 'columnName' })
+    const renameColumnAlterations = spec.alterations?.filter(v => v.changeType === 'columnName') ?? []
     const alterations = [
       ...spec.adds?.map(v => this.addColumn(v)),
       ...spec.drops?.map(v => this.dropColumn(v))

--- a/apps/studio/src/shared/lib/sql/change_builder/DuckDBChangeBuilder.ts
+++ b/apps/studio/src/shared/lib/sql/change_builder/DuckDBChangeBuilder.ts
@@ -16,7 +16,7 @@ export class DuckDBChangeBuilder extends ChangeBuilderBase {
     return [
       'ADD COLUMN',
       this.wrapIdentifier(item.columnName),
-      this.wrapIdentifier(item.dataType),
+      item.dataType,
       item.defaultValue ? `DEFAULT ${this.wrapLiteral(item.defaultValue)}` : null,
       item.nullable ? 'NULL' : 'NOT NULL',
       item.extra,

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -46,6 +46,53 @@ describe("Cassandra Tests", () => {
     }
   })
 
+  // Regression test: the filter callback in CassandraChangeBuilder.alterTable used a
+  // block body without a return statement, so renameColumnAlterations was always empty
+  // and ALTER TABLE … RENAME … SQL was never generated.
+  describe("Column rename via alterTable", () => {
+    const KEYSPACE = 'alter_rename_test_ks'
+    let renameConnection
+
+    beforeAll(async () => {
+      await connection.executeQuery(
+        `CREATE KEYSPACE IF NOT EXISTS ${KEYSPACE} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+      )
+      await connection.executeQuery(`
+        CREATE TABLE IF NOT EXISTS ${KEYSPACE}.cluster_rename_test (
+          bucket uuid,
+          ts timeuuid,
+          value text,
+          PRIMARY KEY (bucket, ts)
+        )
+      `)
+
+      // Create a second connection targeting this keyspace so that
+      // alterTable generates unqualified SQL that Cassandra can resolve.
+      renameConnection = server.createConnection(KEYSPACE)
+      await renameConnection.connect()
+    })
+
+    afterAll(async () => {
+      if (renameConnection) await renameConnection.disconnect()
+      await connection.executeQuery(`DROP KEYSPACE IF EXISTS ${KEYSPACE}`)
+    })
+
+    it("should rename a clustering column end-to-end", async () => {
+      await renameConnection.alterTable({
+        table: 'cluster_rename_test',
+        adds: [],
+        drops: [],
+        alterations: [
+          { columnName: 'ts', changeType: 'columnName', newValue: 'event_time' }
+        ]
+      })
+
+      const columns = await renameConnection.listTableColumns('cluster_rename_test')
+      expect(columns.find((c) => c.columnName === 'event_time')).toBeTruthy()
+      expect(columns.find((c) => c.columnName === 'ts')).toBeFalsy()
+    })
+  })
+
   it("Should connect to Cassandra", async () => {
     const version = await connection.versionString()
     expect(version).toBeTruthy()

--- a/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/duckdb.spec.ts
@@ -204,6 +204,45 @@ function testWith(options: typeof TEST_VERSIONS[number]) {
         await util.paramTest(['?']);
       })
     })
+
+    // Regression test: wrapIdentifier was used for the data type in addColumn,
+    // producing "DOUBLE" (quoted identifier) instead of DOUBLE (type name).
+    // DuckDB rejects a quoted identifier as a type name, so the column was never added.
+    describe("addColumn type regression", () => {
+      beforeAll(async () => {
+        await util.knex.schema.raw(`CREATE TABLE IF NOT EXISTS add_col_type_test (id INTEGER PRIMARY KEY)`)
+      })
+
+      afterAll(async () => {
+        await util.knex.schema.dropTableIfExists('add_col_type_test')
+      })
+
+      it("should add a DOUBLE column without quoting the type name", async () => {
+        await util.connection.alterTable({
+          table: 'add_col_type_test',
+          schema: util.defaultSchema,
+          adds: [{ columnName: 'score', dataType: 'DOUBLE', nullable: true }]
+        })
+
+        const columns = await util.connection.listTableColumns('add_col_type_test', util.defaultSchema)
+        const col = columns.find((c) => c.columnName.toLowerCase() === 'score')
+        expect(col).toBeTruthy()
+        expect(col.dataType.toLowerCase()).toContain('double')
+      })
+
+      it("should add a VARCHAR column without quoting the type name", async () => {
+        await util.connection.alterTable({
+          table: 'add_col_type_test',
+          schema: util.defaultSchema,
+          adds: [{ columnName: 'label', dataType: 'VARCHAR', nullable: true }]
+        })
+
+        const columns = await util.connection.listTableColumns('add_col_type_test', util.defaultSchema)
+        const col = columns.find((c) => c.columnName.toLowerCase() === 'label')
+        expect(col).toBeTruthy()
+        expect(col.dataType.toLowerCase()).toContain('varchar')
+      })
+    })
   });
 }
 

--- a/apps/studio/tests/unit/lib/db/clients/cassandra.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandra.spec.ts
@@ -1,0 +1,39 @@
+import { CassandraChangeBuilder } from "@shared/lib/sql/change_builder/CassandraChangeBuilder"
+
+describe("CassandraChangeBuilder", () => {
+  describe("alterTable - column rename", () => {
+    it("generates RENAME SQL for a clustering column rename", () => {
+      const builder = new CassandraChangeBuilder("my_table", [])
+      const sql = builder.alterTable({
+        table: "my_table",
+        adds: [],
+        drops: [],
+        alterations: [
+          { columnName: "old_col", changeType: "columnName", newValue: "new_col" }
+        ]
+      })
+      expect(sql).not.toBeNull()
+      expect(sql).toContain("RENAME")
+      expect(sql).toContain('"old_col"')
+      expect(sql).toContain('"new_col"')
+    })
+
+    it("does not silently drop multiple column renames", () => {
+      const builder = new CassandraChangeBuilder("my_table", [])
+      const sql = builder.alterTable({
+        table: "my_table",
+        adds: [],
+        drops: [],
+        alterations: [
+          { columnName: "col_a", changeType: "columnName", newValue: "col_a_new" },
+          { columnName: "col_b", changeType: "columnName", newValue: "col_b_new" },
+        ]
+      })
+      expect(sql).not.toBeNull()
+      expect(sql).toContain('"col_a"')
+      expect(sql).toContain('"col_a_new"')
+      expect(sql).toContain('"col_b"')
+      expect(sql).toContain('"col_b_new"')
+    })
+  })
+})

--- a/apps/studio/tests/unit/lib/db/clients/duckdb_change_builder.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/duckdb_change_builder.spec.ts
@@ -1,0 +1,29 @@
+import { DuckDBChangeBuilder } from "@shared/lib/sql/change_builder/DuckDBChangeBuilder"
+
+describe("DuckDBChangeBuilder", () => {
+  describe("addColumn", () => {
+    it("does not double-quote the data type", () => {
+      const builder = new DuckDBChangeBuilder("my_table")
+      const sql = builder.addColumn({
+        columnName: "my_col",
+        dataType: "INTEGER",
+        nullable: false,
+      })
+      // data type must NOT be wrapped in quotes like "INTEGER"
+      expect(sql).not.toContain('"INTEGER"')
+      expect(sql).toContain("INTEGER")
+    })
+
+    it("generates valid ADD COLUMN syntax", () => {
+      const builder = new DuckDBChangeBuilder("my_table")
+      const sql = builder.alterTable({
+        table: "my_table",
+        adds: [{ columnName: "score", dataType: "DOUBLE", nullable: true }]
+      })
+      expect(sql).toContain("ADD COLUMN")
+      expect(sql).toContain('"score"')
+      expect(sql).toContain("DOUBLE")
+      expect(sql).not.toContain('"DOUBLE"')
+    })
+  })
+})


### PR DESCRIPTION
## Bugs fixed

### 1. CassandraChangeBuilder — column renames silently produce no SQL

**File:** `apps/studio/src/shared/lib/sql/change_builder/CassandraChangeBuilder.ts` line 116

The `.filter()` callback used a block body without a `return` statement:

```typescript
// before — always returns undefined (falsy) → every item is dropped
const renameColumnAlterations = spec.alterations?.filter(v => { v.changeType === 'columnName' })

// after — expression body returns the boolean correctly
const renameColumnAlterations = spec.alterations?.filter(v => v.changeType === 'columnName') ?? []
```

Because the callback always returned `undefined`, the filter produced an empty array for every input.  This meant that **any `ALTER TABLE … RENAME COLUMN` call in Cassandra generated no SQL at all** — the call appeared to succeed but the column was never renamed in the database.

The `?? []` guard also ensures the variable is always an array even when `spec.alterations` is omitted, preventing a later crash from spreading `undefined`.

---

### 2. DuckDBChangeBuilder — data type wrapped as a quoted identifier

**File:** `apps/studio/src/shared/lib/sql/change_builder/DuckDBChangeBuilder.ts` line 19

`addColumn` passed `item.dataType` through `wrapIdentifier()`, which wraps the value in double-quotes:

```typescript
// before — produces "INTEGER" (quoted identifier, invalid as a type name)
this.wrapIdentifier(item.dataType),

// after — bare type name, consistent with every other change builder
item.dataType,
```

This generated DDL like:

```sql
ALTER TABLE t ADD COLUMN score "DOUBLE" NULL
```

`"DOUBLE"` is interpreted as a user-defined type identifier, not the built-in numeric type.  Adding a column with any standard DuckDB type would either fail or silently create a column with the wrong type.

---

## Tests

Two new unit test files verify both fixes and will catch regressions:

- `tests/unit/lib/db/clients/cassandra.spec.ts` — checks that column renames produce `RENAME … TO …` SQL
- `tests/unit/lib/db/clients/duckdb_change_builder.spec.ts` — checks that `ADD COLUMN` does not double-quote the data type

Both tests fail against the original code and pass after the fix.

https://claude.ai/code/session_01WjbNk58XcEshqPkgAnMEst

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjbNk58XcEshqPkgAnMEst)_