### PR TITLE
test(mysql): failing repro for caching_sha2_password sign-in regression

### DIFF
--- a/apps/studio/tests/integration/lib/db/clients/mysql-8-auth.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/mysql-8-auth.spec.js
@@ -1,0 +1,70 @@
+import { GenericContainer } from 'testcontainers'
+import { dbtimeout } from '../../../../lib/db'
+import { createServer } from '@commercial/backend/lib/db/server'
+import { TestOrmConnection } from '../../../../lib/TestOrmConnection'
+import { LicenseKey } from '@/common/appdb/models/LicenseKey'
+
+// Regression test for the symptom: "I can sign in to my MySQL 8 server with
+// MySQL Workbench / the mysql CLI, but Beekeeper Studio fails to connect."
+//
+// Reproduction:
+//   - MySQL 8 server, user authenticated with caching_sha2_password
+//   - FLUSH PRIVILEGES so the fast-auth cache is empty (same state as after
+//     a server restart, before any successful login)
+//   - Non-TLS TCP connection
+//
+// In that state the server requires the RSA public-key dance to negotiate
+// caching_sha2_password. Workbench and the mysql CLI do this transparently.
+// This test asks Beekeeper's MySQL client (used directly, not via knex) to
+// do the same.
+
+describe("MySQL 8 caching_sha2_password (uncached user, non-TLS)", () => {
+  jest.setTimeout(dbtimeout)
+
+  let container
+  let server
+
+  beforeAll(async () => {
+    await TestOrmConnection.connect()
+    await LicenseKey.createTrialLicense()
+
+    container = await new GenericContainer('mysql:8')
+      .withName("testmysql-sha2-auth")
+      .withEnvironment({
+        "MYSQL_ROOT_PASSWORD": "rootpass",
+        "MYSQL_DATABASE": "test",
+      })
+      .withExposedPorts(3306)
+      .withStartupTimeout(dbtimeout)
+      .start()
+
+    await container.exec([
+      'mysql', '-u', 'root', '-prootpass', '-e',
+      `
+        CREATE USER 'sha2user'@'%' IDENTIFIED WITH caching_sha2_password BY 'pw';
+        GRANT ALL PRIVILEGES ON test.* TO 'sha2user'@'%';
+        FLUSH PRIVILEGES;
+      `,
+    ])
+  })
+
+  afterAll(async () => {
+    if (server) await server.disconnect()
+    if (container) await container.stop()
+    await TestOrmConnection.disconnect()
+  })
+
+  it("connects without TLS when the user is not yet in the fast-auth cache", async () => {
+    const config = {
+      client: 'mysql',
+      host: container.getHost(),
+      port: container.getMappedPort(3306),
+      user: 'sha2user',
+      password: 'pw',
+      ssl: false,
+    }
+    server = createServer(config)
+    const connection = server.createConnection('test')
+    await expect(connection.connect()).resolves.not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

A user reported they could sign in to their MySQL server with MySQL Workbench but not with Beekeeper Studio. Suspected cause: a MySQL 8 user authenticated with `caching_sha2_password` whose credentials are not in the server's fast-auth cache (the state right after a server restart, or after `FLUSH PRIVILEGES`). Under those conditions, a non-TLS connection needs an RSA public-key dance to encrypt the password before sending it. Workbench and the `mysql` CLI handle that transparently. Beekeeper's `mysql2`-based client doesn't appear to.

This PR adds a single failing integration test that reproduces the scenario as cleanly as possible:

- Fresh MySQL 8 container, dedicated to this spec
- A new user created with `IDENTIFIED WITH caching_sha2_password`
- `FLUSH PRIVILEGES` to evict the fast-auth cache
- Exercises Beekeeper's MySQL client via `createServer` directly (no knex wrapper), so the failure surface is the Beekeeper client, not the test harness

Lives in its own spec file (`mysql-8-auth.spec.js`) so the dedicated server setup (sha2 user, empty cache) doesn't collide with the existing `mysql.spec.js` fixtures, which use `root` and a different auth path.

## What this PR is **not**

- Not a fix. The fix is more involved than the `allowPublicKeyRetrieval` flag I initially suggested in chat — that's a JDBC option, not a `mysql2` one. The real options in `mysql2` are: enable TLS, or wire a `caching_sha2_password` entry in `authPlugins` with a `serverPublicKey`/`onServerPublicKey` callback.
- Not run locally. The sandbox has no Docker, so I couldn't actually watch this fail. CI should confirm.

## Test plan

- [ ] CI runs `mysql-8-auth.spec.js` and the new test fails with an auth-related error (expected: `ER_ACCESS_DENIED_ERROR` or a sha2/public-key message)
- [ ] If the test unexpectedly passes, my diagnosis is wrong and we need a different repro (probably involving the exact server version and `default_authentication_plugin` setting the reporter is using)
- [ ] Once we have a confirmed repro, follow up with a fix PR that wires `authPlugins.caching_sha2_password` in `apps/studio/src/lib/db/clients/mysql.ts:145`

https://claude.ai/code/session_013BegFJQidnBH9N5ToATvHj

---
_Generated by [Claude Code](https://claude.ai/code/session_013BegFJQidnBH9N5ToATvHj)_