### PR TITLE
Fix trial license support date expiration condition

### DIFF
--- a/apps/studio/src/common/appdb/models/LicenseKey.ts
+++ b/apps/studio/src/common/appdb/models/LicenseKey.ts
@@ -26,7 +26,14 @@ export function keysToStatus(licenses: LicenseKey[]): LicenseStatus {
     const currentLicense = _.orderBy(licenses, ["validUntil"], ["desc"])[0];
     status.license = currentLicense;
 
-    if (currentDate > currentLicense.supportUntil) {
+    // "Expired support date" indicates a paid lifetime license whose
+    // support window has ended but is still valid for the version it was
+    // sold against. Trial licenses are time-limited previews, not lifetime
+    // licenses, so this condition does not apply to them.
+    if (
+      currentLicense.licenseType !== "TrialLicense" &&
+      currentDate > currentLicense.supportUntil
+    ) {
       status.condition.push("Expired support date");
     }
 

--- a/apps/studio/tests/unit/common/appdb/models/license.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/license.spec.ts
@@ -94,6 +94,26 @@ describe("License", () => {
       });
     });
 
+    it("Community - Trial expired (no 'Expired support date')", async () => {
+      currentTime("18-Sep-2024");
+      currentVersion(ANY_VERSION);
+
+      await LicenseKey.clear();
+      const license = new LicenseKey();
+      license.validUntil = new Date("17-Sep-2024");
+      license.supportUntil = new Date("17-Sep-2024");
+      license.licenseType = "TrialLicense";
+      license.email = "trial_user";
+      license.key = "fake";
+      license.maxAllowedAppRelease = { tagName: ANY_VERSION_TAG };
+      await license.save();
+
+      expectStatus().toEqual({
+        edition: "community",
+        condition: ["Expired valid date"],
+      });
+    });
+
     it("Community - License expired", async () => {
       currentTime("18-Sep-2024");
       currentVersion(ANY_VERSION);


### PR DESCRIPTION
## Summary
Fixes the license status logic to prevent trial licenses from showing an "Expired support date" condition. Trial licenses are time-limited previews, not lifetime licenses, so they should not trigger the support date expiration message.

## Changes
- **LicenseKey.ts**: Updated `keysToStatus()` to exclude trial licenses from the "Expired support date" condition check
  - Added type guard to only apply support date expiration logic to non-trial licenses
  - Added clarifying comment explaining the distinction between trial and paid lifetime licenses
- **license.spec.ts**: Added test case "Community - Trial expired (no 'Expired support date')" to verify trial licenses don't show the support date expiration message

## Implementation Details
The fix distinguishes between two license types:
- **Trial licenses**: Time-limited previews that expire completely (show "Expired valid date")
- **Paid lifetime licenses**: Remain valid for their version but may have expired support windows (show "Expired support date")

This ensures the UI correctly communicates the license status to users based on the license type.

https://claude.ai/code/session_01AkowmzFK1xhxkea1U4RNWk