### PR TITLE
Feature: Show empty connection folders even when no connections exist

### DIFF
--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -426,7 +426,7 @@ export default {
       }
     },
     empty() {
-      return !this.filteredConnections?.length
+      return !this.filteredConnections?.length && !this.folders?.length
     },
     noPins() {
       return !this.pinnedConnections?.length;


### PR DESCRIPTION
# 🚀 Fix: Persistent Folder Visibility in Connection Sidebar

### 📋 Overview
Previously, the sidebar followed a "hide everything" logic if no connections were saved. This led to a confusing UX where existing folders vanished, despite still being part of the user's organizational structure.

### 🛠 Changes
- **ConnectionSidebar.vue**: Updated the `empty()` computed property to account for the existence of folders.
- **Logic Update**: The "No Saved Connections" state is now suppressed if at least one folder exists, ensuring the hierarchy remains visible.

### 📉 The Problem (UX Fail) 
- **Inconsistency**: Creating a new folder resulted in it immediately "disappearing" because it didn't contain a connection yet.
- **Confusing Errors**: Users would receive "duplicate folder" errors when trying to re-create a folder they couldn't see.
- **System Trust**: Hiding user-created data (folders) made the application appear broken or buggy.

### ✨ The Solution
- **Hierarchy Preservation**: Empty folders are now rendered in the sidebar, allowing users to see their planned structure.
- **Better Onboarding**: Provides a clear target for users to drag and drop future connections into their pre-defined categories.

### 📸 Visual Reference
| Before (Broken UX) | After (Fixed UX) |
| :--- | :--- |
| <img width="281" height="94" alt="Image2" src="https://github.com/user-attachments/assets/da93351b-f53a-4463-bd20-1148006a2176" /> | <img width="284" height="89" alt="Fixed" src="https://github.com/user-attachments/assets/0fa3fbf7-1ab0-4d51-bd69-6055ad5d903f" /> |
