### PR TITLE
Add font packages to snap stagePackages for better text rendering

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -219,7 +219,14 @@ module.exports = {
     environment: {
       "ELECTRON_SNAP": "true"
     },
-    plugs: ["default", "ssh-keys", "removable-media", "mount-observe"]
+    plugs: ["default", "ssh-keys", "removable-media", "mount-observe"],
+    stagePackages: [
+      "default",
+      "fonts-noto",
+      "fonts-noto-cjk",
+      "fonts-noto-color-emoji",
+      "fonts-liberation",
+    ],
   },
   win: {
     icon: './public/icons/png/512x512.png',


### PR DESCRIPTION
## Summary
Added font packages to the snap configuration's `stagePackages` to ensure proper text rendering in the Snap distribution of Beekeeper Studio.

## Changes
- Added `stagePackages` array to the snap configuration in `electron-builder-config.js`
- Included the following font packages:
  - `fonts-noto` - Comprehensive Unicode font coverage
  - `fonts-noto-cjk` - CJK (Chinese, Japanese, Korean) character support
  - `fonts-noto-color-emoji` - Color emoji rendering
  - `fonts-liberation` - Liberation font family for better compatibility

## Details
The snap package was missing font dependencies, which could result in missing glyphs or poor text rendering for users with non-Latin characters or emoji. By explicitly including these fonts in `stagePackages`, we ensure they are bundled with the snap distribution and available at runtime.

https://claude.ai/code/session_01W3sgTxzgMs1rL2XDEVVsmn