### PR TITLE
fix: always allow selecting local workspace on connection screen

### DIFF
--- a/apps/studio/src/components/sidebar/WorkspaceSidebar.vue
+++ b/apps/studio/src/components/sidebar/WorkspaceSidebar.vue
@@ -42,7 +42,7 @@
 </template>
 
 <script lang="ts">
-import { IWorkspace } from '@/common/interfaces/IWorkspace'
+import { IWorkspace, LocalWorkspace } from '@/common/interfaces/IWorkspace'
 import ContentPlaceholder from '@/components/common/loading/ContentPlaceholder.vue'
 import ContentPlaceholderImg from '@/components/common/loading/ContentPlaceholderImg.vue'
 import WorkspaceAvatar from '@/components/common/WorkspaceAvatar.vue'
@@ -110,7 +110,8 @@ components: { NewWorkspaceButton, WorkspaceAvatar, AccountStatusButton, ContentP
       this.$store.dispatch('credentials/load')
     },
     click(blob: { workspace: IWorkspace, client: CloudClient}) {
-      if (this.$store.getters.isCommunity) {
+      const isLocal = blob.workspace.id === LocalWorkspace.id
+      if (!isLocal && this.$store.getters.isCommunity) {
         this.$root.$emit(AppEvent.upgradeModal)
         return
       }

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -222,6 +222,9 @@ export const LicenseModule: Module<State, RootState>  = {
     async remove(context, license) {
       await Vue.prototype.$util.send('license/remove', { id: license.id })
       await context.dispatch('sync')
+      if (context.getters.isCommunity && context.rootState.workspaceId !== -1) {
+        context.commit('workspaceId', -1, { root: true })
+      }
     },
     async sync(context) {
       const status = await Vue.prototype.$util.send('license/getStatus')


### PR DESCRIPTION
If the user removed their license while a cloud workspace was selected,
clicking the local workspace opened the upgrade modal instead of switching
to it, leaving them stuck. Allow the local workspace click regardless of
license, and reset to the local workspace when a license is removed and
the user drops back to community.