### PR TITLE
Add redaction utility to prevent sensitive data in logs

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
@@ -1,4 +1,5 @@
 import electronLog from "@bksLogger";
+import { redact } from "@/lib/log/redact";
 import knexlib, { Knex } from "knex";
 import Client_Firebird from "@shared/lib/knex-firebird";
 import Firebird from "node-firebird";
@@ -278,7 +279,7 @@ export class FirebirdClient extends BasicDatabaseClient<FirebirdResult, Firebird
 
     this.firebirdOptions = config;
 
-    log.debug("create driver client for firebird with config %j", config);
+    log.debug("create driver client for firebird with config %j", redact(config));
 
     this.pool =  new Pool(BksConfig.db.firebird.maxConnections, config);
 

--- a/apps/studio/src/backend/lib/OfflineLicense.ts
+++ b/apps/studio/src/backend/lib/OfflineLicense.ts
@@ -77,7 +77,10 @@ export class OfflineLicense {
         log.info("Public key does not exist", this.publicKeyPath)
       }
       this.validateSignature()
-      log.info("Validated license - ", this.payload)
+      log.info("Validated license", {
+        licenseType: this.payload?.license_key?.license_type,
+        validUntil: this.payload?.license_key?.valid_until,
+      })
     } catch (ex) {
       log.error("Unable to validate license -", ex)
       this.isValid = false

--- a/apps/studio/src/common/appdb/models/LicenseKey.ts
+++ b/apps/studio/src/common/appdb/models/LicenseKey.ts
@@ -69,7 +69,6 @@ export function keysToStatus(licenses: LicenseKey[]): LicenseStatus {
 export class LicenseKey extends ApplicationEntity {
 
   withProps(props: any) {
-    console.log("merging props into me:", props)
     if (props) LicenseKey.merge(this, props);
     return this;
   }

--- a/apps/studio/src/common/bksConfig/mainBksConfig.ts
+++ b/apps/studio/src/common/bksConfig/mainBksConfig.ts
@@ -1,4 +1,5 @@
 import rawLog from "@bksLogger";
+import { redact } from "@/lib/log/redact";
 import platformInfo from "@/common/platform_info";
 import * as path from "path";
 import _ from "lodash";
@@ -311,9 +312,9 @@ export function mainBksConfig(): BksConfig {
   if (warnings.length > 0) {
     log.warn("Warnings:", warnings);
   }
-  log.info(`Default config: ${JSON.stringify(defaultConfig, null, 2)}`);
-  log.info(`System config: ${JSON.stringify(systemConfig, null, 2)}`);
-  log.info(`User config: ${JSON.stringify(userConfig, null, 2)}`);
+  log.info(`Default config: ${JSON.stringify(redact(defaultConfig), null, 2)}`);
+  log.info(`System config: ${JSON.stringify(redact(systemConfig), null, 2)}`);
+  log.info(`User config: ${JSON.stringify(redact(userConfig), null, 2)}`);
 
   return BksConfigProvider.create(source, platformInfo);
 }

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -90,7 +90,7 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
         } else if (!dbObj) {
           dbObj = new cls().withProps(obj);
         }
-        log.info(`Saving ${name}: `, dbObj);
+        log.info(`Saving ${name}`, { id: (dbObj as any)?.id });
         await niceValidateOrReject(dbObj);
         await dbObj.save();
         return await transform(dbObj, cls);
@@ -105,7 +105,7 @@ function handlersFor<T extends Transport>(name: string, cls: any, transform: (ob
         await cls.remove(dbEntities)
       } else {
         const dbObj = await cls.findOneBy({ id: obj.id });
-        log.info(`Removing ${name}: `, dbObj);
+        log.info(`Removing ${name}`, { id: (dbObj as any)?.id });
         await dbObj?.remove();
       }
     },

--- a/apps/studio/src/lib/cloud/CloudClient.ts
+++ b/apps/studio/src/lib/cloud/CloudClient.ts
@@ -102,12 +102,14 @@ export class CloudClient {
     this.usedQueries = new UsedQueriesController(this.axios)
 
     this.axios.interceptors.request.use(request => {
-      log.debug('REQ', JSON.stringify(request, null, 2))
+      // Don't log the full request — headers contain auth tokens and the
+      // body may contain credentials.
+      log.debug('REQ', request.method?.toUpperCase(), request.url)
       return request
     })
 
     this.axios.interceptors.response.use(response => {
-      log.debug('RES:', JSON.stringify(response, null, 2))
+      log.debug('RES', response.status, response.config?.method?.toUpperCase(), response.config?.url)
       return response
     })
 

--- a/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
+++ b/apps/studio/src/lib/cloud/controllers/LicenseKeyController.ts
@@ -48,7 +48,7 @@ export class LicenseKeyController {
       headers['X-Installation-Id'] = encodedInstallationInfo;
       log.info("made headers")
     }
-    log.debug("making request for license", key, installationId, headers)
+    log.debug("making request for license", { installationId, hasKey: !!key })
 
     const response = await this.axios.get(url(this.path, key), {
       params,

--- a/apps/studio/src/lib/db/clients/bigquery.ts
+++ b/apps/studio/src/lib/db/clients/bigquery.ts
@@ -10,6 +10,7 @@ import { BigQueryClient as BigQueryKnexClient } from '@shared/lib/knex-bigquery'
 import { BigQueryChangeBuilder } from "@shared/lib/sql/change_builder/BigQueryChangeBuilder";
 import platformInfo from "@/common/platform_info";
 import rawLog from '@bksLogger';
+import { redact } from '@/lib/log/redact';
 import { applyChangesSql, buildDeleteQueries, buildInsertQuery, buildSelectQueriesFromUpdates, buildSelectTopQuery, buildUpdateQueries, escapeString } from './utils';
 import { createCancelablePromise } from '@/common/utils';
 import { errors } from '@/lib/errors';
@@ -85,7 +86,7 @@ export class BigQueryClient extends BasicDatabaseClient<BigQueryResult> {
     // For testing purposes
     this.config.apiEndpoint = this.bigQueryEndpoint(this.server.config)
 
-    log.debug("configDatabase config: ", this.config)
+    log.debug("configDatabase config: ", redact(this.config))
 
 
     this.knex = knexlib({

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -7,6 +7,7 @@ import { identify } from 'sql-query-identifier';
 import _ from 'lodash'
 import knexlib from 'knex'
 import logRaw from '@bksLogger'
+import { redact } from '@/lib/log/redact';
 
 import { DatabaseElement, IDbConnectionDatabase } from '../types'
 import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, CancelableQuery, SupportedFeatures, TableColumn, TableOrView, TableProperties, TableTrigger, TablePartition, ImportFuncOptions, BksField, BksFieldType } from "../models";
@@ -138,7 +139,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
 
     const dbConfig = await this.configDatabase(this.server, this.database);
 
-    log.info("CONFIG: ", dbConfig)
+    log.info("CONFIG: ", redact(dbConfig))
 
     this.conn = {
       pool: new pg.Pool(dbConfig)

--- a/apps/studio/src/lib/log/redact.ts
+++ b/apps/studio/src/lib/log/redact.ts
@@ -1,0 +1,121 @@
+// Redact sensitive values before logging. Walks plain objects and arrays,
+// replacing the value of any key matching the sensitive-key pattern with
+// '[REDACTED]'. Buffers are always replaced (they're usually private key
+// material). Class instances, Errors, Dates, RegExps, primitives, and
+// functions are returned as-is so we don't strip useful debug context.
+
+const SENSITIVE_KEY = new RegExp(
+  [
+    'password',
+    'passphrase',
+    'privatekey',
+    'private_key',
+    'bastion_?key',
+    '^key$',
+    '^keys$',
+    '^secret$',
+    'apisecret',
+    'api_?secret',
+    'client_?secret',
+    '^token$',
+    'accesstoken',
+    'access_?token',
+    'refreshtoken',
+    'refresh_?token',
+    'idtoken',
+    'id_?token',
+    'authtoken',
+    'auth_?token',
+    'sessiontoken',
+    'session_?token',
+    'apikey',
+    'api_?key',
+    'license_?key',
+    'licensekey',
+    '^credentials?$',
+    '^authorization$',
+    '^cookie$',
+    'session_?id',
+    'sessionid',
+    'key_?file',
+    'keyfilename',
+    'service_?account',
+  ].join('|'),
+  'i'
+);
+
+const REDACTED = '[REDACTED]';
+const DEFAULT_MAX_DEPTH = 8;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function isBuffer(value: unknown): boolean {
+  return (
+    typeof Buffer !== 'undefined' &&
+    typeof Buffer.isBuffer === 'function' &&
+    Buffer.isBuffer(value)
+  );
+}
+
+function isSpecialObject(value: object): boolean {
+  return (
+    value instanceof Error ||
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof Map ||
+    value instanceof Set ||
+    ArrayBuffer.isView(value as ArrayBufferView)
+  );
+}
+
+/**
+ * Returns whether a property name should have its value redacted.
+ * Exported for tests; prefer redact() at call sites.
+ */
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY.test(key);
+}
+
+/**
+ * Returns a safe-to-log copy of `value` with sensitive fields replaced.
+ * - Primitives, functions, Errors, Dates, RegExps, Maps, Sets, and typed
+ *   arrays are returned unchanged.
+ * - Buffers are replaced with '[REDACTED]' (treated as key material).
+ * - Plain objects and arrays are deep-cloned; values under sensitive keys
+ *   are replaced with '[REDACTED]'. Non-plain objects (class instances)
+ *   are returned as-is to avoid breaking on getters / circular refs.
+ */
+export function redact<T>(value: T, maxDepth = DEFAULT_MAX_DEPTH): T {
+  return redactInternal(value, maxDepth, new WeakSet()) as T;
+}
+
+function redactInternal(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value !== 'object') return value;
+  if (isBuffer(value)) return REDACTED;
+  if (isSpecialObject(value as object)) return value;
+  if (depth <= 0) return value;
+  if (seen.has(value as object)) return '[Circular]';
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return value.map((v) => redactInternal(v, depth - 1, seen));
+  }
+
+  if (!isPlainObject(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(value)) {
+    const child = (value as Record<string, unknown>)[key];
+    if (isSensitiveKey(key)) {
+      out[key] = child === null || child === undefined ? child : REDACTED;
+    } else {
+      out[key] = redactInternal(child, depth - 1, seen);
+    }
+  }
+  return out;
+}

--- a/apps/studio/src/plugins/SettingsPlugin.ts
+++ b/apps/studio/src/plugins/SettingsPlugin.ts
@@ -7,7 +7,7 @@ export const SettingsPlugin = {
 
   async get(key, defaultValue) {
     const result = await Vue.prototype.$util.send('appdb/setting/get', { key });
-    log.info("get", JSON.stringify(result));
+    log.debug("get", key, { found: result?.value !== undefined });
     if (result && result.value !== undefined) {
       return result.value
     }
@@ -15,7 +15,7 @@ export const SettingsPlugin = {
   },
 
   async set(key: string, value: string) {
-    log.info("set", key, value)
+    log.debug("set", key);
     await Vue.prototype.$util.send('appdb/setting/set', { key, value });
   }
 }

--- a/apps/studio/src/store/modules/PinModule.ts
+++ b/apps/studio/src/store/modules/PinModule.ts
@@ -85,7 +85,6 @@ export const PinModule: Module<State, RootState> = {
       if (existing) return
 
       if (database && usedConfig) {
-        console.log('GETTING NEW PIN: ', item, database, usedConfig)
         let newPin = await Vue.prototype.$util.send('appdb/pins/new', {
           init: {
             table: item,
@@ -93,7 +92,6 @@ export const PinModule: Module<State, RootState> = {
             saved: usedConfig
           }
         });
-        console.log('RECEIVED NEW PIN: ', newPin)
         newPin.position = (context.getters.orderedPins.reverse()[0]?.position || 0) + 1
         if(usedConfig.id) {
           newPin = await Vue.prototype.$util.send('appdb/pins/save', { obj: newPin });

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -2,6 +2,7 @@ import { IConnection } from "@/common/interfaces/IConnection";
 import { DataState, DataStore, mutationsFor, utilActionsFor } from "@/store/modules/data/DataModuleBase";
 import _ from "lodash";
 import rawLog from "@bksLogger";
+import { redact } from "@/lib/log/redact";
 import { safely } from "../StoreHelpers";
 import Vue from "vue";
 
@@ -21,7 +22,7 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
   mutations: mutationsFor<IConnection>(),
   actions: utilActionsFor<IConnection>('used', {
     async recordUsed(context, config: IConnection) {
-      log.debug("Recording used config for: ", config)
+      log.debug("Recording used config for: ", redact(config))
       const lastUsedConnection = context.state.items.find(c => {
         return config.id &&
           config.workspaceId &&
@@ -29,7 +30,7 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
             (c.connectionId && c.connectionId === config.id)) &&
           c.workspaceId === config.workspaceId;
       });
-      log.debug("Found used config", lastUsedConnection);
+      log.debug("Found used config", redact(lastUsedConnection));
       if (lastUsedConnection) {
         // Overlay the latest connection details from `config` (which is the
         // saved connection the user is connecting to) onto the existing

--- a/apps/studio/src/vendor/node-ssh-forward/index.ts
+++ b/apps/studio/src/vendor/node-ssh-forward/index.ts
@@ -21,6 +21,7 @@ import * as net from 'net'
 import * as fs from 'fs'
 import * as os from 'os'
 import rawLog from '@bksLogger'
+import { redact } from '@/lib/log/redact'
 import _ from 'lodash'
 
 import ElectronFriendlyPageantAgent from '@/vendor/ssh2/ElectronFriendlyPageantAgent'
@@ -150,7 +151,7 @@ class SSHConnection {
 
   private async establish() {
     let connection: Client
-    this.debug("establish with options", this.options)
+    this.debug("establish with options", redact(this.options))
     if (this.options.bastionHost) {
       connection = await this.connectViaBastion()
     } else {

--- a/apps/studio/tests/unit/lib/log/redact.spec.ts
+++ b/apps/studio/tests/unit/lib/log/redact.spec.ts
@@ -1,0 +1,204 @@
+import { redact, isSensitiveKey } from "@/lib/log/redact";
+
+describe("isSensitiveKey", () => {
+  it.each([
+    "password",
+    "Password",
+    "passphrase",
+    "privateKey",
+    "private_key",
+    "bastionPassword",
+    "bastionPassphrase",
+    "bastionPrivateKey",
+    "token",
+    "accessToken",
+    "access_token",
+    "refreshToken",
+    "refresh_token",
+    "idToken",
+    "authToken",
+    "apiKey",
+    "api_key",
+    "clientSecret",
+    "client_secret",
+    "secret",
+    "credentials",
+    "credential",
+    "authorization",
+    "Authorization",
+    "cookie",
+    "sessionId",
+    "session_id",
+    "licenseKey",
+    "license_key",
+    "keyFilename",
+    "keyFile",
+    "serviceAccount",
+    "service_account",
+  ])("treats %s as sensitive", (key) => {
+    expect(isSensitiveKey(key)).toBe(true);
+  });
+
+  it.each([
+    "host",
+    "port",
+    "user",
+    "username",
+    "database",
+    "id",
+    "name",
+    "url",
+    "method",
+    "status",
+    "publicKey",
+    "primaryKey",
+    "keyboard",
+    "keystroke",
+  ])("treats %s as non-sensitive", (key) => {
+    expect(isSensitiveKey(key)).toBe(false);
+  });
+});
+
+describe("redact", () => {
+  it("returns primitives unchanged", () => {
+    expect(redact("hello")).toBe("hello");
+    expect(redact(42)).toBe(42);
+    expect(redact(true)).toBe(true);
+    expect(redact(null)).toBe(null);
+    expect(redact(undefined)).toBe(undefined);
+  });
+
+  it("redacts sensitive top-level fields", () => {
+    const input = {
+      host: "db.example.com",
+      port: 5432,
+      user: "alice",
+      password: "hunter2",
+    };
+    expect(redact(input)).toEqual({
+      host: "db.example.com",
+      port: 5432,
+      user: "alice",
+      password: "[REDACTED]",
+    });
+  });
+
+  it("does not mutate the input object", () => {
+    const input = { password: "hunter2", user: "alice" };
+    redact(input);
+    expect(input.password).toBe("hunter2");
+  });
+
+  it("redacts SSH options with passphrase and Buffer privateKey", () => {
+    const input = {
+      endHost: "10.0.0.1",
+      endPort: 22,
+      username: "root",
+      passphrase: "supersecret",
+      privateKey: Buffer.from("-----BEGIN OPENSSH PRIVATE KEY-----..."),
+      keepaliveInterval: 60,
+    };
+    const out = redact(input) as Record<string, unknown>;
+    expect(out.endHost).toBe("10.0.0.1");
+    expect(out.username).toBe("root");
+    expect(out.passphrase).toBe("[REDACTED]");
+    expect(out.privateKey).toBe("[REDACTED]");
+  });
+
+  it("redacts nested objects", () => {
+    const input = {
+      server: {
+        config: {
+          host: "example.com",
+          password: "shh",
+          ssh: {
+            user: "root",
+            privateKey: "ABCDEF",
+            passphrase: "yo",
+          },
+        },
+      },
+    };
+    expect(redact(input)).toEqual({
+      server: {
+        config: {
+          host: "example.com",
+          password: "[REDACTED]",
+          ssh: {
+            user: "root",
+            privateKey: "[REDACTED]",
+            passphrase: "[REDACTED]",
+          },
+        },
+      },
+    });
+  });
+
+  it("redacts arrays of objects", () => {
+    const input = [
+      { name: "a", token: "t1" },
+      { name: "b", token: "t2" },
+    ];
+    expect(redact(input)).toEqual([
+      { name: "a", token: "[REDACTED]" },
+      { name: "b", token: "[REDACTED]" },
+    ]);
+  });
+
+  it("replaces raw Buffer with [REDACTED]", () => {
+    expect(redact(Buffer.from("secret"))).toBe("[REDACTED]");
+  });
+
+  it("handles circular references without crashing", () => {
+    const input: any = { name: "a", password: "p" };
+    input.self = input;
+    const out = redact(input) as any;
+    expect(out.name).toBe("a");
+    expect(out.password).toBe("[REDACTED]");
+    expect(out.self).toBe("[Circular]");
+  });
+
+  it("preserves Error instances", () => {
+    const err = new Error("boom");
+    expect(redact(err)).toBe(err);
+  });
+
+  it("preserves Date and RegExp", () => {
+    const d = new Date();
+    const r = /foo/;
+    expect(redact(d)).toBe(d);
+    expect(redact(r)).toBe(r);
+  });
+
+  it("preserves class instances rather than traversing them", () => {
+    class Thing {
+      password = "secret";
+      name = "thing";
+    }
+    const t = new Thing();
+    // Class instance is returned as-is (we don't deep-clone arbitrary classes).
+    expect(redact(t)).toBe(t);
+  });
+
+  it("preserves null values for sensitive keys", () => {
+    expect(redact({ password: null, token: undefined })).toEqual({
+      password: null,
+      token: undefined,
+    });
+  });
+
+  it("redacts axios-style request headers (plain object input)", () => {
+    const headers = {
+      email: "u@example.com",
+      token: "abc123",
+      authorization: "Bearer xyz",
+      app: "beekeeper",
+    };
+    expect(redact(headers)).toEqual({
+      email: "u@example.com",
+      token: "[REDACTED]",
+      authorization: "[REDACTED]",
+      app: "beekeeper",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds a new `redact()` utility function to safely sanitize sensitive data before logging. This prevents credentials, tokens, passwords, and other sensitive information from being exposed in application logs.

## Key Changes
- **New module**: `src/lib/log/redact.ts` with `redact()` and `isSensitiveKey()` functions
  - Recursively walks plain objects and arrays, replacing values under sensitive keys with `[REDACTED]`
  - Handles edge cases: circular references, Buffers, class instances, special objects (Error, Date, RegExp, etc.)
  - Comprehensive sensitive key detection via regex pattern (passwords, tokens, API keys, credentials, etc.)
  - Includes depth limiting to prevent infinite recursion

- **Comprehensive test coverage**: `tests/unit/lib/log/redact.spec.ts` with 204 lines of tests covering:
  - Sensitive vs. non-sensitive key classification
  - Nested object and array redaction
  - Buffer handling
  - Circular reference detection
  - Preservation of special object types
  - Edge cases (null/undefined values, class instances)

- **Applied redaction to existing logs**:
  - `mainBksConfig.ts`: Redact config objects before logging
  - `CloudClient.ts`: Removed full request/response logging (contained auth headers); now logs only method/URL/status
  - `OfflineLicense.ts`: Log only license metadata instead of full payload
  - `UtilityUsedConnectionModule.ts`: Redact connection objects before logging
  - `appDbHandlers.ts`: Log only object ID instead of full object
  - `SettingsPlugin.ts`: Changed from logging full result to logging only key and found status
  - `firebird.ts`, `bigquery.ts`, `postgresql.ts`: Redact connection configs before logging
  - `node-ssh-forward/index.ts`: Redact SSH connection options before logging
  - `LicenseKeyController.ts`: Redact sensitive request parameters
  - Removed unnecessary `console.log()` statements from `PinModule.ts` and `LicenseKey.ts`

## Implementation Details
- Uses `WeakSet` to track visited objects and detect circular references
- Distinguishes between plain objects (which are cloned and traversed) and class instances (returned as-is)
- Buffers are always redacted as they typically contain key material
- Sensitive key matching is case-insensitive and handles both camelCase and snake_case variants
- Preserves `null` and `undefined` values for sensitive keys rather than replacing them

https://claude.ai/code/session_01Huooy49LfZ4JDDVy5VtivQ