### PR TITLE
Backup tests

### DIFF
--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -153,6 +153,10 @@ jobs:
       - name: Symlink libaio v1 (for oracle)
         run: sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
 
+      - name: Install PostgreSQL 15 (for postgres-backup)
+        if: matrix.chunk[0] == 'postgres-backup.spec.ts'
+        run: sudo bash bin/get-postgres-15.sh
+
       - name: Test
         uses: nick-fields/retry@v2
         with:

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -148,9 +148,11 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Install libaio (for oracle)
+        if: matrix.chunk[0] == 'oracle.spec.js'
         run: sudo apt install libaio-dev
 
       - name: Symlink libaio v1 (for oracle)
+        if: matrix.chunk[0] == 'oracle.spec.js'
         run: sudo ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
 
       - name: Install PostgreSQL 15 (for postgres-backup)

--- a/apps/studio/src-commercial/backend/handlers/backupHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/backupHandlers.ts
@@ -3,7 +3,7 @@ import { spawn } from "child_process";
 import { state } from "@/handlers/handlerState";
 import platformInfo from "@/common/platform_info";
 
-const errorMessages = {
+export const errorMessages = {
   nonZero: 'Command returned non-zero exit code'
 }
 

--- a/apps/studio/src-commercial/entrypoints/utility.ts
+++ b/apps/studio/src-commercial/entrypoints/utility.ts
@@ -130,7 +130,7 @@ process.parentPort.on('message', async ({ data, ports }) => {
     case 'close':
       log.info('REMOVING STATE FOR: ', sId);
       state(sId).port.close();
-      removeState(sId);
+      await removeState(sId);
       break;
     default:
       log.error('UNRECOGNIZED MESSAGE TYPE RECEIVED FROM MAIN PROCESS');

--- a/apps/studio/src/components/backup/BackupSettings.vue
+++ b/apps/studio/src/components/backup/BackupSettings.vue
@@ -128,6 +128,7 @@
                     <label :for="control.settingName">{{ control.settingDesc + (control.required ? '*' : '') }}</label>
                     <div class="input-group">
                       <input
+                        class="form-control"
                         type="text"
                         :name="control.settingName"
                         :id="control.settingName"

--- a/apps/studio/src/handlers/handlerState.ts
+++ b/apps/studio/src/handlers/handlerState.ts
@@ -57,7 +57,21 @@ export function newState(id: string): void {
   states.set(id, new State());
 }
 
-export function removeState(id: string): void {
+export async function removeState(id: string): Promise<void> {
+  const state = states.get(id);
+  if (!state) return;
+  for (const file of state.tempFiles.values()) {
+    if (file.fileHandle) {
+      await file.fileHandle.close().catch();
+    }
+
+    if (file.fileObject) {
+      try {
+        file.fileObject.removeCallback()
+      } catch {}
+    }
+  }
+  state.tempFiles.clear();
   states.delete(id);
 }
 

--- a/apps/studio/src/handlers/tempHandlers.ts
+++ b/apps/studio/src/handlers/tempHandlers.ts
@@ -45,6 +45,9 @@ export const TempHandlers: ITempHandlers = {
     const file = state(sId).tempFiles.get(id);
 
     if (!file) throw new Error("Could not find file");
+    if (file.fileHandle) {
+      await file.fileHandle.close().catch();
+    }
     file.fileObject.removeCallback();
     state(sId).tempFiles.delete(id);
   }

--- a/apps/studio/src/lib/db/BaseCommandClient.ts
+++ b/apps/studio/src/lib/db/BaseCommandClient.ts
@@ -52,16 +52,32 @@ export abstract class BaseCommandClient {
   // deprecated their password env variable :(
   static get quotedPassword() {
     const password = BaseCommandClient._password || '';
+    return this.quoteValue(password);
+  }
+
+  get quotedOutputFilePath() {
+    let filepath = '';
+    if (this._config.outputPath && this._config.outputPath.trim() !== '') {
+      filepath += `${this._config.outputPath}${this.pathSep}`;
+    }
+    if (this.filename && this._config.format !== 'd') {
+      filepath += this.filename;
+    }
+    return BaseCommandClient.quoteValue(filepath);
+  }
+
+  protected static quoteValue(value: string): string {
     if (window.platformInfo.isWindows) {
-      const escaped = password
+      const escaped = value
         .replace(/%/g, '%%')
         .replace(/"/g, '""')
         .replace(/([&|<>^])/g, '^$1');
       return `"${escaped}"`;
     } else {
-      const escaped = password.replace(/'/g, `'\\''`);
+      const escaped = value.replace(/'/g, `'\\''`);
       return `'${escaped}'`;
     }
+
   }
 
   set connConfig(value: IConnection) {

--- a/apps/studio/src/lib/db/BaseCommandClient.ts
+++ b/apps/studio/src/lib/db/BaseCommandClient.ts
@@ -66,6 +66,10 @@ export abstract class BaseCommandClient {
     return BaseCommandClient.quoteValue(filepath);
   }
 
+  get quotedInputFilePath() {
+    return BaseCommandClient.quoteValue(this._config.inputPath);
+  }
+
   protected static quoteValue(value: string): string {
     if (window.platformInfo.isWindows) {
       const escaped = value

--- a/apps/studio/src/lib/db/backup-clients/mysql.ts
+++ b/apps/studio/src/lib/db/backup-clients/mysql.ts
@@ -150,7 +150,7 @@ export class MySqlBackupClient extends BaseCommandClient {
       }
     }
 
-    command.options.push(`--result-file=${this._config.outputPath}${this.pathSep}${this.filename}`);
+    command.options.push(`--result-file=${this.quotedOutputFilePath}`);
 
     if (this._config.insertIgnore) {
       command.options.push(`--insert-ignore`);

--- a/apps/studio/src/lib/db/backup-clients/postgresql.ts
+++ b/apps/studio/src/lib/db/backup-clients/postgresql.ts
@@ -169,7 +169,7 @@ export class PostgresBackupClient extends BaseCommandClient {
         `--verbose`,
         `--username=${BaseCommandClient.username}`,
         `--format=${this._config.format}`,
-        `--file=${this._config.outputPath}${this.pathSep}${this._config.format != 'd' ? this.filename : ''}`
+        `--file=${this.quotedOutputFilePath}`
       ]
     });
 

--- a/apps/studio/src/lib/db/backup-clients/sqlite.ts
+++ b/apps/studio/src/lib/db/backup-clients/sqlite.ts
@@ -70,7 +70,7 @@ export class SqliteBackupClient extends BaseCommandClient {
       mainCommand: this._config.dumpToolPath,
       options: [
         BaseCommandClient.databaseName,
-        `".output ${this._config.outputPath}${this.pathSep}${this.filename}"`,
+        `".output ${this.quotedOutputFilePath}"`,
         `".trace stdout"`
       ]
     });

--- a/apps/studio/src/lib/db/restore-clients/mysql.ts
+++ b/apps/studio/src/lib/db/restore-clients/mysql.ts
@@ -61,7 +61,7 @@ export class MySqlRestoreClient extends BaseCommandClient {
   buildCommand(): Command {
     /* use the SQL command variant for sql-format and mysqlimport for the delimited-text format
       SQL format:
-      `source dump.sql` 
+      `source dump.sql`
 
       Delimited-text:
       **ACTUALLY** it may be easier to use mysqlimport as the SQL statement seems to only allow single table imports.
@@ -110,13 +110,13 @@ export class MySqlRestoreClient extends BaseCommandClient {
       command.options.push(BaseCommandClient.connectionType == 'mariadb' ? '--skip-ssl' : '--ssl-mode=DISABLED');
     }
 
-    command.options.push(`--execute="SOURCE ${this._config.inputPath}"`);
+    command.options.push(`--execute="SOURCE ${this.quotedInputFilePath}"`);
 
     return command;
   }
 
 
-  // NOTE (@day): this is for if we want to support the delimited-text format in the future. It will require more work though. 
+  // NOTE (@day): this is for if we want to support the delimited-text format in the future. It will require more work though.
   buildToolCommand(): Command {
     const command = new Command({
       isSql: false,

--- a/apps/studio/src/lib/db/restore-clients/mysql.ts
+++ b/apps/studio/src/lib/db/restore-clients/mysql.ts
@@ -110,7 +110,7 @@ export class MySqlRestoreClient extends BaseCommandClient {
       command.options.push(BaseCommandClient.connectionType == 'mariadb' ? '--skip-ssl' : '--ssl-mode=DISABLED');
     }
 
-    command.options.push(`--execute="SOURCE ${this.quotedInputFilePath}"`);
+    command.options.push(`--execute="SOURCE ${this._config.inputPath}"`);
 
     return command;
   }

--- a/apps/studio/src/lib/db/restore-clients/postgresql.ts
+++ b/apps/studio/src/lib/db/restore-clients/postgresql.ts
@@ -176,7 +176,7 @@ export class PostgresRestoreClient extends BaseCommandClient {
 
     command.options.push(`--dbname=${BaseCommandClient.databaseName}`)
 
-    command.options.push(`${this._config.inputPath}`);
+    command.options.push(`${this.quotedInputFilePath}`);
 
     return command;
   }

--- a/apps/studio/src/lib/db/restore-clients/sqlite.ts
+++ b/apps/studio/src/lib/db/restore-clients/sqlite.ts
@@ -31,7 +31,7 @@ export class SqliteRestoreClient extends BaseCommandClient {
       mainCommand: this.mainCommand,
       options: [
         BaseCommandClient.databaseName,
-        `".read ${this._config.inputPath}"`
+        `".read ${this.quotedInputFilePath}"`
       ]
     });
 

--- a/apps/studio/tests/integration/lib/db/backup-clients/all.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/all.ts
@@ -14,6 +14,9 @@ type backupParams = {
   backupConfig: Partial<BackupConfig>,
   restoreConfig: Partial<BackupConfig>,
   outputDirSuffix?: string,
+  beforeRestore?: () => Promise<void>,
+  verifyRestore?: () => Promise<void>,
+  skipRestoreRun?: boolean,
 }
 
 export type BackupTestConfig = {
@@ -31,17 +34,23 @@ export function runBackupTests(getParams: () => backupParams) {
   let backupConfig: Partial<BackupConfig>;
   let restoreConfig: Partial<BackupConfig>;
   let outputDirSuffix: string | undefined;
+  let beforeRestore: (() => Promise<void>) | undefined;
+  let verifyRestore: (() => Promise<void>) | undefined;
+  let skipRestoreRun: boolean;
 
   beforeAll(() => {
     // TODO (@day): look into this further
     // I hate this with a burning passion, but just doesn't like me just passing to the function...
-    const {dialect: d, backup: b, restore: r, backupConfig: bc, restoreConfig: rc, outputDirSuffix: ods} = getParams();
-    dialect = d;
-    backup = b;
-    restore = r;
-    backupConfig = bc;
-    restoreConfig = rc;
-    outputDirSuffix = ods;
+    const params = getParams();
+    dialect = params.dialect;
+    backup = params.backup;
+    restore = params.restore;
+    backupConfig = params.backupConfig;
+    restoreConfig = params.restoreConfig;
+    outputDirSuffix = params.outputDirSuffix;
+    beforeRestore = params.beforeRestore;
+    verifyRestore = params.verifyRestore;
+    skipRestoreRun = params.skipRestoreRun ?? false;
   })
 
   it("Should be able to find the backup dump tool", async () => {
@@ -134,12 +143,24 @@ export function runBackupTests(getParams: () => backupParams) {
   })
 
   it("Should be able to run a restore", async () => {
+    if (skipRestoreRun) {
+      return;
+    }
+
+    if (beforeRestore) {
+      await beforeRestore();
+    }
+
     try {
       await restore.runCommand();
     } catch (e) {
       // this may reject even if the command actually succeeds (don't blame me, blame pg_restore)
       // so we need to check if it succeeds in other ways
       expect(e).toBe(errorMessages.nonZero)
+    }
+
+    if (verifyRestore) {
+      await verifyRestore();
     }
   })
 }

--- a/apps/studio/tests/integration/lib/db/backup-clients/all.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/all.ts
@@ -91,7 +91,7 @@ export function runBackupTests(getParams: () => backupParams) {
     if (backupConfig.format != 'd') {
       const backupPath = path.join(backupDir, backup.filename);
       expect(fs.existsSync(backupPath)).toBe(true);
-      if (backupConfig.format != 't' && !backupConfig.compression) {
+      if (!['t', 'c'].includes(backupConfig.format) && !backupConfig.compression) {
         // read 3 kb of the file just to see if it actually contains sql
         const data = await readFile(backupPath);
 

--- a/apps/studio/tests/integration/lib/db/backup-clients/all.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/all.ts
@@ -12,13 +12,15 @@ type backupParams = {
   backup: BaseCommandClient,
   restore: BaseCommandClient,
   backupConfig: Partial<BackupConfig>,
-  restoreConfig: Partial<BackupConfig>
+  restoreConfig: Partial<BackupConfig>,
+  outputDirSuffix?: string,
 }
 
 export type BackupTestConfig = {
   description: string,
   backup: Partial<BackupConfig>,
-  restore: Partial<BackupConfig>
+  restore: Partial<BackupConfig>,
+  outputDirSuffix?: string,
 }
 
 export function runBackupTests(getParams: () => backupParams) {
@@ -28,16 +30,18 @@ export function runBackupTests(getParams: () => backupParams) {
   let restore: BaseCommandClient;
   let backupConfig: Partial<BackupConfig>;
   let restoreConfig: Partial<BackupConfig>;
+  let outputDirSuffix: string | undefined;
 
   beforeAll(() => {
     // TODO (@day): look into this further
     // I hate this with a burning passion, but just doesn't like me just passing to the function...
-    const {dialect: d, backup: b, restore: r, backupConfig: bc, restoreConfig: rc} = getParams();
+    const {dialect: d, backup: b, restore: r, backupConfig: bc, restoreConfig: rc, outputDirSuffix: ods} = getParams();
     dialect = d;
     backup = b;
     restore = r;
     backupConfig = bc;
     restoreConfig = rc;
+    outputDirSuffix = ods;
   })
 
   it("Should be able to find the backup dump tool", async () => {
@@ -46,6 +50,10 @@ export function runBackupTests(getParams: () => backupParams) {
 
   it("Should create a backup command", () => {
     backupDir = fs.mkdtempSync(path.join(os.tmpdir(), `${dialect}-backup-`));
+    if (outputDirSuffix) {
+      backupDir = path.join(backupDir, outputDirSuffix);
+      fs.mkdirSync(backupDir, { recursive: true });
+    }
     if (backupConfig.format == 'd') {
       backupDir = fs.mkdtempSync(path.join(backupDir, `${dialect}-dir-backup-`));
     }

--- a/apps/studio/tests/integration/lib/db/backup-clients/all.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/all.ts
@@ -1,0 +1,153 @@
+import { BaseCommandClient } from "@/lib/db/BaseCommandClient";
+import { errorMessages } from "@commercial/backend/handlers/backupHandlers";
+import { Command } from "@/lib/db/models";
+import { BackupConfig } from "@/lib/db/models/BackupConfig";
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { Dialect, identify } from 'sql-query-identifier'
+
+type backupParams = {
+  dialect: Dialect,
+  backup: BaseCommandClient,
+  restore: BaseCommandClient,
+  backupConfig: Partial<BackupConfig>,
+  restoreConfig: Partial<BackupConfig>
+}
+
+export type BackupTestConfig = {
+  description: string,
+  backup: Partial<BackupConfig>,
+  restore: Partial<BackupConfig>
+}
+
+export function runBackupTests(getParams: () => backupParams) {
+  let backupDir: string;
+  let dialect: Dialect;
+  let backup: BaseCommandClient;
+  let restore: BaseCommandClient;
+  let backupConfig: Partial<BackupConfig>;
+  let restoreConfig: Partial<BackupConfig>;
+
+  beforeAll(() => {
+    // TODO (@day): look into this further
+    // I hate this with a burning passion, but just doesn't like me just passing to the function...
+    const {dialect: d, backup: b, restore: r, backupConfig: bc, restoreConfig: rc} = getParams();
+    dialect = d;
+    backup = b;
+    restore = r;
+    backupConfig = bc;
+    restoreConfig = rc;
+  })
+
+  it("Should be able to find the backup dump tool", async () => {
+    await expect(backup.findDumpTool()).resolves.not.toThrow();
+  })
+
+  it("Should create a backup command", () => {
+    backupDir = fs.mkdtempSync(path.join(os.tmpdir(), `${dialect}-backup-`));
+    if (backupConfig.format == 'd') {
+      backupDir = fs.mkdtempSync(path.join(backupDir, `${dialect}-dir-backup-`));
+    }
+    backupConfig.outputPath = backupDir;
+    backup.config = backupConfig;
+    backup.initLogFile();
+    backup.addLogCallback = (log: string) => {
+      backup.writeToLog(log);
+    }
+    backup.notificationCallback = (_notif) => {
+      return;
+    }
+
+    let command: Command = backup.buildCommand();
+    expect(command).not.toBeNull();
+
+    const commands: string[] = [`${command.mainCommand} ${command.options ? command.options.join(' ') : ''}`];
+
+    while (command.postCommand) {
+      command = command.postCommand;
+
+      commands.push(`${command.mainCommand} ${command.options ? command.options.join(' ') : ''}`);
+    }
+  })
+
+  it("Should be able to run a backup", async () => {
+    try {
+      await backup.runCommand();
+    } catch (e) {
+      // this may reject even if the command actually succeeds (don't blame me, blame pg_dump)
+      // so we need to check if it succeeds in other ways
+      expect(e).toBe(errorMessages.nonZero)
+    }
+
+    if (backupConfig.format != 'd') {
+      const backupPath = path.join(backupDir, backup.filename);
+      expect(fs.existsSync(backupPath)).toBe(true);
+      if (backupConfig.format != 't' && !backupConfig.compression) {
+        // read 3 kb of the file just to see if it actually contains sql
+        const data = await readFile(backupPath);
+
+        const identification = identify(data, { strict: false, dialect });
+        expect(identification.some((value) => value.executionType != 'UNKNOWN')).toBe(true);
+      }
+    } else {
+      expect(fs.existsSync(backupDir)).toBe(true)
+    }
+  })
+
+  it("Should be able to find the restore tool", async () => {
+    await expect(restore.findDumpTool()).resolves.not.toThrow();
+  })
+
+  it("Should create a restore command", () => {
+    const inputPath = restoreConfig.isDir ? backupDir : path.join(backupDir, backup.filename);
+    restoreConfig.inputPath = inputPath;
+    restore.config = restoreConfig;
+
+    restore.initLogFile();
+    restore.addLogCallback = (log: string) => {
+      restore.writeToLog(log);
+    }
+    restore.notificationCallback = (_notif) => {
+      return;
+    }
+
+    let command: Command = restore.buildCommand();
+    expect(command).not.toBeNull();
+
+    // TODO (@day): any way to validate the command?
+    const commands: string[] = [`${command.mainCommand} ${command.options ? command.options.join(' ') : ''}`];
+
+    while (command.postCommand) {
+      command = command.postCommand;
+
+      commands.push(`${command.mainCommand} ${command.options ? command.options.join(' ') : ''}`);
+    }
+  })
+
+  it("Should be able to run a restore", async () => {
+    try {
+      await restore.runCommand();
+    } catch (e) {
+      // this may reject even if the command actually succeeds (don't blame me, blame pg_restore)
+      // so we need to check if it succeeds in other ways
+      expect(e).toBe(errorMessages.nonZero)
+    }
+  })
+}
+
+async function readFile(path: string): Promise<string> {
+  const s = fs.createReadStream(path, { end: 3000 });
+  let data = '';
+
+  s.on('data', (chunk) => {
+    data += chunk;
+  })
+
+  const close = new Promise<void>((resolve) => {
+    s.on('close', () => { resolve() })
+  });
+
+  await close;
+  return data;
+}

--- a/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
@@ -111,9 +111,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
     })
 
     afterAll(async () => {
-      if (util?.connection) {
-        await util.connection.disconnect();
-      }
+      await util.disconnect();
       if (container) {
         await container.stop()
       }

--- a/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
@@ -125,13 +125,21 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
 
     describe("Common Tests", () => {
       runBackupTests(() => {
+        const skipDataChecks = backupConfig.schemaOnly;
         return {
           dialect: 'mysql',
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
           restoreConfig,
-          outputDirSuffix
+          outputDirSuffix,
+          beforeRestore: skipDataChecks ? undefined : async () => {
+            await util.knex.raw('DELETE FROM `test`.`test_param`');
+          },
+          verifyRestore: skipDataChecks ? undefined : async () => {
+            const rows = await util.knex.raw("SELECT data FROM `test`.`test_param` WHERE data = 'River Song'");
+            expect((rows[0] as any[]).length).toBeGreaterThan(0);
+          },
         }
       })
     })

--- a/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
@@ -1,0 +1,117 @@
+import { CommandClients, commandClientsFor } from "@/lib/db/CommandClient";
+import { BackupConfig } from "@/lib/db/models/BackupConfig";
+import { IDbConnectionServerConfig } from "@/lib/db/types";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { DBTestUtil, dbtimeout } from "../../../../lib/db";
+import { IConnection } from "@/common/interfaces/IConnection";
+import { BackupTestConfig, runBackupTests } from "./all";
+import { installUtilStub, UtilStub } from "./setup";
+
+const TEST_CONFIGS: Array<BackupTestConfig> = [
+  {
+    description: "Plain text backup",
+    backup: {
+      dropDatabase: true,
+      insertIgnore: true,
+      sqlInsert: true
+    },
+    restore: {}
+  }
+]
+
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+  describe(`MySQL: Can Create and restore backups: ${description}`, () => {
+    let container: StartedTestContainer;
+    let config: IDbConnectionServerConfig;
+    let util: DBTestUtil;
+    let clients: CommandClients;
+    let stub: UtilStub;
+    jest.setTimeout(dbtimeout)
+
+    beforeAll(async () => {
+      const timeoutDefault = 10000;
+      stub = installUtilStub();
+      const temp = fs.mkdtempSync(path.join(os.tmpdir(), `mysql-`));
+      fs.chmodSync(temp, "777")
+      container = await new GenericContainer('mysql:8')
+        .withName("testbackupmysql")
+        .withEnvironment({
+          "MYSQL_ROOT_PASSWORD": "test",
+          "MYSQL_DATABASE": "test"
+        })
+        .withExposedPorts(3306)
+        .withStartupTimeout(dbtimeout)
+        .withBindMounts([{
+          source: temp,
+          target: '/var/run/mysqld',
+          mode: 'rw'
+        }])
+        .start();
+      config = {
+        client: 'mysql',
+        host: container.getHost(),
+        port: container.getMappedPort(3306),
+        user: 'root',
+        password: 'test',
+        osUser: 'foo',
+        ssh: null,
+        sslCaFile: null,
+        sslCertFile: null,
+        sslKeyFile: null,
+        sslRejectUnauthorized: false,
+        ssl: false,
+        domain: null,
+        socketPath: null,
+        socketPathEnabled: false,
+        readOnlyMode: false
+      };
+
+      util = new DBTestUtil(config, "test", { dialect: 'mysql' });
+      await util.setupdb();
+
+      clients = commandClientsFor('mysql');
+
+      clients.backup.serverConfig = config;
+      clients.restore.serverConfig = config;
+
+      const iConn: IConnection = {
+        defaultDatabase: 'test',
+        username: config.user,
+        password: config.password,
+        host: config.host,
+        port: config.port
+      } as IConnection;
+
+      clients.backup.connConfig = iConn;
+      clients.restore.connConfig = iConn;
+      jest.setTimeout(timeoutDefault);
+    })
+
+    describe("Common Tests", () => {
+      runBackupTests(() => {
+        return {
+          dialect: 'mysql',
+          backup: clients.backup,
+          restore: clients.restore,
+          backupConfig,
+          restoreConfig
+        }
+      })
+    })
+
+    afterAll(async () => {
+      if (util?.connection) {
+        await util.connection.disconnect();
+      }
+      if (container) {
+        await container.stop()
+      }
+      stub?.dispose();
+    })
+  })
+}
+
+TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))

--- a/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
@@ -27,10 +27,35 @@ const TEST_CONFIGS: Array<BackupTestConfig> = [
       filename: 'Dumb name with spaces'
     },
     restore: {}
+  },
+  {
+    description: "Backup with parens & brackets in filename",
+    backup: {
+      dropDatabase: true,
+      filename: 'backup (mysql) [2026-05-19]'
+    },
+    restore: {}
+  },
+  {
+    description: "Backup with spaces in output directory and filename",
+    backup: {
+      dropDatabase: true,
+      filename: 'Dumb name with spaces'
+    },
+    restore: {},
+    outputDirSuffix: 'my backups (mysql)'
+  },
+  {
+    description: "Backup with spaces in output directory only",
+    backup: {
+      dropDatabase: true,
+    },
+    restore: {},
+    outputDirSuffix: 'backup dir with spaces'
   }
 ]
 
-function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>, outputDirSuffix?: string) {
   describe(`MySQL: Can Create and restore backups: ${description}`, () => {
     let container: StartedTestContainer;
     let config: IDbConnectionServerConfig;
@@ -105,7 +130,8 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
-          restoreConfig
+          restoreConfig,
+          outputDirSuffix
         }
       })
     })
@@ -120,4 +146,4 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
   })
 }
 
-TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))
+TEST_CONFIGS.forEach(({description, backup, restore, outputDirSuffix}) => testWith(description, backup, restore, outputDirSuffix))

--- a/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/mysql-backup.spec.ts
@@ -19,6 +19,14 @@ const TEST_CONFIGS: Array<BackupTestConfig> = [
       sqlInsert: true
     },
     restore: {}
+  },
+  {
+    description: "Backup with spaces in filename",
+    backup: {
+      dropDatabase: true,
+      filename: 'Dumb name with spaces'
+    },
+    restore: {}
   }
 ]
 
@@ -109,7 +117,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
       if (container) {
         await container.stop()
       }
-      stub?.dispose();
+      await stub?.dispose();
     })
   })
 }

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -66,10 +66,16 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
       const temp = fs.mkdtempSync(path.join(os.tmpdir(), `psql-`));
       fs.chmodSync(temp, "777")
       container = await new GenericContainer(`postgres:latest`)
-        .withEnv("POSTGRES_PASSWORD", "example")
-        .withEnv("POSTGRES_DB", "banana")
+        .withEnvironment({
+          "POSTGRES_PASSWORD": "example",
+          "POSTGRES_DB": "banana"
+        })
         .withExposedPorts(5432)
-        .withBindMount(path.join(temp, "postgresql"), "/var/run/postgresql", "rw")
+        .withBindMounts([{
+          source: path.join(temp, "postgresql"),
+          target: "/var/run/postgresql",
+          mode: "rw"
+        }])
         .withStartupTimeout(dbtimeout)
         .start();
       jest.setTimeout(timeoutDefault);
@@ -132,7 +138,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
       if (container) {
         await container.stop()
       }
-      stub?.dispose();
+      await stub?.dispose();
     })
   })
 }

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -48,10 +48,53 @@ const TEST_CONFIGS: Array<BackupTestConfig> = [
       compression: "9"
     },
     restore: {}
+  },
+  {
+    description: "Plain text backup with spaces in filename",
+    backup: {
+      format: "p",
+      filename: "Postgres dump with spaces"
+    },
+    restore: {}
+  },
+  {
+    description: "Custom backup with spaces in filename",
+    backup: {
+      format: "c",
+      filename: "Postgres custom (compressed)"
+    },
+    restore: {}
+  },
+  {
+    description: "Tar backup with spaces in filename",
+    backup: {
+      format: "t",
+      filename: "Postgres tar dump"
+    },
+    restore: {}
+  },
+  {
+    description: "Plain text backup with spaces in output directory",
+    backup: {
+      format: "p",
+      filename: "dump with spaces"
+    },
+    restore: {},
+    outputDirSuffix: "psql backups (test)"
+  },
+  {
+    description: "Directory backup with spaces in output directory",
+    backup: {
+      format: "d",
+    },
+    restore: {
+      isDir: true,
+    },
+    outputDirSuffix: "psql dir backups (test)"
   }
 ]
 
-function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>, outputDirSuffix?: string) {
   describe(`Postgresql: Can Create and restore backups: ${description}`, () => {
 
     let container: StartedTestContainer;
@@ -126,7 +169,8 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
-          restoreConfig
+          restoreConfig,
+          outputDirSuffix
         }
       })
     })
@@ -143,4 +187,4 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
 }
 
 
-TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))
+TEST_CONFIGS.forEach(({description, backup, restore, outputDirSuffix}) => testWith(description, backup, restore, outputDirSuffix))

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -132,9 +132,8 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
     })
 
     afterAll(async () => {
-      if (util?.connection) {
-        await util.connection.disconnect();
-      }
+      await util.disconnect();
+
       if (container) {
         await container.stop()
       }

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -165,13 +165,23 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
 
     describe("Common Tests", () => {
       runBackupTests(() => {
+        const skipRestoreRun = backupConfig.format === 'p';
+        const skipDataChecks = backupConfig.schemaOnly;
         return {
           dialect: 'psql',
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
           restoreConfig,
-          outputDirSuffix
+          outputDirSuffix,
+          skipRestoreRun,
+          beforeRestore: skipRestoreRun || skipDataChecks ? undefined : async () => {
+            await util.knex.raw('DELETE FROM test_param');
+          },
+          verifyRestore: skipRestoreRun || skipDataChecks ? undefined : async () => {
+            const rows = await util.knex('test_param').where({ data: 'River Song' });
+            expect(rows.length).toBeGreaterThan(0);
+          },
         }
       })
     })

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -1,0 +1,141 @@
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import { DBTestUtil, dbtimeout } from "../../../../lib/db";
+import fs from 'fs'
+import os from 'os'
+import path from 'path'
+import { IDbConnectionServerConfig } from "@/lib/db/types";
+import { CommandClients, commandClientsFor } from "@/lib/db/CommandClient";
+import { IConnection } from "@/common/interfaces/IConnection";
+import { BackupConfig } from "@/lib/db/models/BackupConfig";
+import { BackupTestConfig, runBackupTests } from "./all";
+import { installUtilStub, UtilStub } from "./setup";
+
+const TEST_CONFIGS: Array<BackupTestConfig> = [
+  {
+    description: "Plain text backup, create/drop database",
+    backup: {
+      createDatabase: true,
+      dropDatabase: true,
+      format: "p",
+    },
+    restore: {}
+  },
+  {
+    description: "Directory backup, discard owners, schema only",
+    backup: {
+      discardOwners: true,
+      format: "d",
+      schemaOnly: true,
+    },
+    restore: {
+      isDir: true,
+    }
+  },
+  {
+    description: "Tar backup, no privileges, insert rows",
+    backup: {
+      format: "t",
+      noBackupPrivileges: true,
+      sqlInsert: true
+    },
+    restore: {}
+  },
+  {
+    description: "Custom backup, data only, compressed",
+    backup: {
+      dataOnly: true,
+      format: "c",
+      compression: "9"
+    },
+    restore: {}
+  }
+]
+
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+  describe(`Postgresql: Can Create and restore backups: ${description}`, () => {
+
+    let container: StartedTestContainer;
+    let config: IDbConnectionServerConfig;
+    let util: DBTestUtil;
+    let clients: CommandClients;
+    let stub: UtilStub;
+
+    beforeAll(async () => {
+      stub = installUtilStub();
+      const timeoutDefault = 10000;
+      const temp = fs.mkdtempSync(path.join(os.tmpdir(), `psql-`));
+      fs.chmodSync(temp, "777")
+      container = await new GenericContainer(`postgres:latest`)
+        .withEnv("POSTGRES_PASSWORD", "example")
+        .withEnv("POSTGRES_DB", "banana")
+        .withExposedPorts(5432)
+        .withBindMount(path.join(temp, "postgresql"), "/var/run/postgresql", "rw")
+        .withStartupTimeout(dbtimeout)
+        .start();
+      jest.setTimeout(timeoutDefault);
+
+      config = {
+        client: 'postgresql',
+        host: container.getHost(),
+        port: container.getMappedPort(5432),
+        user: 'postgres',
+        password: 'example',
+        osUser: 'foo',
+        ssh: null,
+        sslCaFile: null,
+        sslCertFile: null,
+        sslKeyFile: null,
+        sslRejectUnauthorized: false,
+        ssl: false,
+        domain: null,
+        socketPath: null,
+        socketPathEnabled: false,
+        readOnlyMode: false
+      };
+
+      util = new DBTestUtil(config, "banana", { dialect: 'postgresql', defaultSchema: 'public' });
+      await util.setupdb();
+
+      clients = commandClientsFor('postgresql');
+
+      clients.backup.serverConfig = config;
+      clients.restore.serverConfig = config;
+
+      const iConn: IConnection = {
+        defaultDatabase: 'banana',
+        username: config.user,
+        password: config.password,
+        host: config.host,
+        port: config.port,
+      } as IConnection;
+
+      clients.backup.connConfig = iConn;
+      clients.restore.connConfig = iConn;
+    })
+
+    describe("Common Tests", () => {
+      runBackupTests(() => {
+        return {
+          dialect: 'psql',
+          backup: clients.backup,
+          restore: clients.restore,
+          backupConfig,
+          restoreConfig
+        }
+      })
+    })
+
+    afterAll(async () => {
+      if (util?.connection) {
+        await util.connection.disconnect();
+      }
+      if (container) {
+        await container.stop()
+      }
+      stub?.dispose();
+    })
+  })
+}
+
+
+TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))

--- a/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/postgres-backup.spec.ts
@@ -102,6 +102,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
     let util: DBTestUtil;
     let clients: CommandClients;
     let stub: UtilStub;
+    jest.setTimeout(dbtimeout)
 
     beforeAll(async () => {
       stub = installUtilStub();
@@ -121,7 +122,6 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
         }])
         .withStartupTimeout(dbtimeout)
         .start();
-      jest.setTimeout(timeoutDefault);
 
       config = {
         client: 'postgresql',
@@ -160,6 +160,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
 
       clients.backup.connConfig = iConn;
       clients.restore.connConfig = iConn;
+      jest.setTimeout(timeoutDefault);
     })
 
     describe("Common Tests", () => {

--- a/apps/studio/tests/integration/lib/db/backup-clients/setup.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/setup.ts
@@ -13,7 +13,7 @@ const handlers: Record<string, (args: any) => Promise<any>> = {
 
 export interface UtilStub {
   sId: string;
-  dispose(): void;
+  dispose(): Promise<void>;
 }
 
 // Install a stub for Vue.prototype.$util that routes calls into the real
@@ -68,10 +68,10 @@ export function installUtilStub(): UtilStub {
 
   return {
     sId,
-    dispose: () => {
+    dispose: async () => {
       emitter.removeAllListeners();
       tokens.clear();
-      removeState(sId);
+      await removeState(sId);
     },
   };
 }

--- a/apps/studio/tests/integration/lib/db/backup-clients/setup.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/setup.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from "events";
+import Vue from "vue";
+import { newState, removeState, state } from "@/handlers/handlerState";
+import { BackupHandlers } from "@commercial/backend/handlers/backupHandlers";
+import { TempHandlers } from "@/handlers/tempHandlers";
+import { uuidv4 } from "@/lib/uuid";
+import os from "os";
+
+const handlers: Record<string, (args: any) => Promise<any>> = {
+  ...BackupHandlers,
+  ...TempHandlers,
+};
+
+export interface UtilStub {
+  sId: string;
+  dispose(): void;
+}
+
+// Install a stub for Vue.prototype.$util that routes calls into the real
+// backend handlers (BackupHandlers, TempHandlers) instead of going through the
+// utility-process IPC. This lets us exercise BaseCommandClient and the
+// backup-clients end-to-end from a Node-side jest test without spinning up
+// Electron.
+export function installUtilStub(): UtilStub {
+  ensurePlatformInfo();
+
+  const sId = uuidv4();
+  newState(sId);
+
+  // The real handler code calls `state(sId).port.postMessage({ type, input })`
+  // to emit notifications and log chunks. We route those through an
+  // EventEmitter so $util.addListener can subscribe to them.
+  const emitter = new EventEmitter();
+  emitter.setMaxListeners(0);
+  (state(sId) as any).port = {
+    postMessage: ({ type, input }: { type: string; input: unknown }) => {
+      emitter.emit(type, input);
+    },
+    close: () => undefined,
+    on: () => undefined,
+    start: () => undefined,
+  };
+
+  const tokens = new Map<symbol, { event: string; fn: (...args: any[]) => void }>();
+
+  Vue.prototype.$util = {
+    send: async (name: string, args: Record<string, unknown> = {}) => {
+      const handler = handlers[name];
+      if (!handler) {
+        throw new Error(`installUtilStub: no handler registered for "${name}"`);
+      }
+      // `this` is referenced by BackupHandlers (recursive postCommand calls)
+      return handler.call(handlers, { ...args, sId });
+    },
+    addListener: (event: string, fn: (...args: any[]) => void) => {
+      const token = Symbol(event);
+      tokens.set(token, { event, fn });
+      emitter.on(event, fn);
+      return token;
+    },
+    removeListener: (token: symbol) => {
+      const entry = tokens.get(token);
+      if (!entry) return;
+      emitter.off(entry.event, entry.fn);
+      tokens.delete(token);
+    },
+  };
+
+  return {
+    sId,
+    dispose: () => {
+      emitter.removeAllListeners();
+      tokens.clear();
+      removeState(sId);
+    },
+  };
+}
+
+function ensurePlatformInfo() {
+  const g = globalThis as any;
+  // BaseCommandClient reads `window.platformInfo.*`. Under the `node` test
+  // environment there is no `window`, so alias it to globalThis. (In jsdom,
+  // `window === globalThis` already, so this is a no-op.)
+  if (typeof g.window === "undefined") {
+    g.window = g;
+  }
+  if (g.platformInfo && typeof g.platformInfo.isWindows === "boolean") return;
+  g.platformInfo = {
+    ...(g.platformInfo ?? {}),
+    isWindows: process.platform === "win32",
+    isMac: process.platform === "darwin",
+    isLinux: process.platform === "linux",
+    downloadsDirectory: os.tmpdir(),
+  };
+}

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -23,10 +23,32 @@ const TEST_CONFIGS: Array<BackupTestConfig> = [
       preserveRowIds: true
     },
     restore: {}
+  },
+  {
+    description: "Backup with spaces in filename",
+    backup: {
+      filename: "sqlite dump with spaces"
+    },
+    restore: {}
+  },
+  {
+    description: "Backup with parens & brackets in filename",
+    backup: {
+      filename: "backup (sqlite) [2026-05-19]"
+    },
+    restore: {}
+  },
+  {
+    description: "Backup with spaces in output directory and filename",
+    backup: {
+      filename: "sqlite dump"
+    },
+    restore: {},
+    outputDirSuffix: "sqlite backups (test)"
   }
 ]
 
-function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>, outputDirSuffix?: string) {
   describe(`SQLite: Can Create and restore backups: ${description}`, () => {
     let config: IDbConnectionServerConfig;
     let util: DBTestUtil;
@@ -63,7 +85,8 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
-          restoreConfig
+          restoreConfig,
+          outputDirSuffix
         }
       })
     })
@@ -75,4 +98,4 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
   })
 }
 
-TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))
+TEST_CONFIGS.forEach(({description, backup, restore, outputDirSuffix}) => testWith(description, backup, restore, outputDirSuffix))

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -72,7 +72,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
       if (util?.connection) {
         await util.connection.disconnect();
       }
-      stub?.dispose();
+      await stub?.dispose();
     })
   })
 }

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -75,7 +75,9 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
       } as IConnection;
 
       clients.backup.connConfig = iConn;
+      clients.backup.database = iConn.defaultDatabase;
       clients.restore.connConfig = iConn;
+      clients.restore.database = iConn.defaultDatabase;
     })
 
     describe("Common Tests", () => {

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -69,9 +69,7 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
     })
 
     afterAll(async () => {
-      if (util?.connection) {
-        await util.connection.disconnect();
-      }
+      await util?.disconnect();
       await stub?.dispose();
     })
   })

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -1,0 +1,80 @@
+import { IConnection } from "@/common/interfaces/IConnection";
+import { CommandClients, commandClientsFor } from "@/lib/db/CommandClient";
+import { BackupConfig } from "@/lib/db/models/BackupConfig";
+import { IDbConnectionServerConfig } from "@/lib/db/types";
+import tmp from 'tmp';
+import { DBTestUtil } from "../../../../lib/db";
+import { BackupTestConfig, runBackupTests } from "./all";
+import { installUtilStub, UtilStub } from "./setup";
+
+const TEST_CONFIGS: Array<BackupTestConfig> = [
+  {
+    description: "Plain text backup, no system tables",
+    backup: {
+      nosys: true,
+    },
+    restore: {}
+  },
+  {
+    description: "Plain text backup, data only, newlines, with row-ids",
+    backup: {
+      dataOnly: true,
+      newlines: true,
+      preserveRowIds: true
+    },
+    restore: {}
+  }
+]
+
+function testWith(description: string, backupConfig: Partial<BackupConfig>, restoreConfig: Partial<BackupConfig>) {
+  describe(`SQLite: Can Create and restore backups: ${description}`, () => {
+    let config: IDbConnectionServerConfig;
+    let util: DBTestUtil;
+    let clients: CommandClients;
+    let stub: UtilStub;
+
+    beforeAll(async () => {
+      stub = installUtilStub();
+      const dbfile = tmp.fileSync();
+
+      config = {
+        client: 'sqlite'
+      } as IDbConnectionServerConfig;
+      util = new DBTestUtil(config, dbfile.name, { dialect: 'sqlite' });
+      await util.setupdb();
+
+      clients = commandClientsFor('sqlite');
+
+      clients.backup.serverConfig = config;
+      clients.restore.serverConfig = config;
+
+      const iConn: IConnection = {
+        defaultDatabase: dbfile.name
+      } as IConnection;
+
+      clients.backup.connConfig = iConn;
+      clients.restore.connConfig = iConn;
+    })
+
+    describe("Common Tests", () => {
+      runBackupTests(() => {
+        return {
+          dialect: 'sqlite',
+          backup: clients.backup,
+          restore: clients.restore,
+          backupConfig,
+          restoreConfig
+        }
+      })
+    })
+
+    afterAll(async () => {
+      if (util?.connection) {
+        await util.connection.disconnect();
+      }
+      stub?.dispose();
+    })
+  })
+}
+
+TEST_CONFIGS.forEach(({description, backup, restore}) => testWith(description, backup, restore))

--- a/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
+++ b/apps/studio/tests/integration/lib/db/backup-clients/sqlite-backup.spec.ts
@@ -80,13 +80,25 @@ function testWith(description: string, backupConfig: Partial<BackupConfig>, rest
 
     describe("Common Tests", () => {
       runBackupTests(() => {
+        const skipDataChecks = backupConfig.schemaOnly;
         return {
           dialect: 'sqlite',
           backup: clients.backup,
           restore: clients.restore,
           backupConfig,
           restoreConfig,
-          outputDirSuffix
+          outputDirSuffix,
+          beforeRestore: skipDataChecks ? undefined : async () => {
+            if (backupConfig.dataOnly) {
+              await util.knex.raw('DELETE FROM test_param');
+            } else {
+              await util.knex.raw('DROP TABLE IF EXISTS test_param');
+            }
+          },
+          verifyRestore: skipDataChecks ? undefined : async () => {
+            const rows = await util.knex('test_param').where({ data: 'River Song' });
+            expect(rows.length).toBeGreaterThan(0);
+          },
         }
       })
     })

--- a/bin/get-postgres-15.sh
+++ b/bin/get-postgres-15.sh
@@ -1,0 +1,4 @@
+sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+apt-get update
+apt-get -y install postgresql


### PR DESCRIPTION
Apparently these got lost in the move to one repo. Added them and added a stub that acts as the port communication between the frontend/backend so we can still test everything.

Also updated the output path handling so that it is properly quoted and escaped.