### PR TITLE
Use icon buttons in query editor toolbar to save space

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -184,12 +184,19 @@
               v-model="dryRun"
             >
           </x-button>
-          <x-button
-            @click.prevent="triggerSave"
-            class="btn btn-flat btn-small"
+          <button
+            class="btn btn-fab btn-flat"
+            style="background: transparent;"
           >
-            Save
-          </x-button>
+            <i class="material-icons">history</i>
+          </button>
+          <button
+            @click.prevent="triggerSave"
+            class="btn btn-fab btn-flat"
+            style="background: transparent;"
+          >
+            <i class="material-icons">save</i>
+          </button>
 
           <x-buttons class="" v-tooltip="runButtonTooltip">
             <x-button
@@ -198,7 +205,10 @@
               @click.prevent="queryFunctions.primaryRead"
               :disabled="runButtonDisabled"
             >
-              <x-label>{{ runPrimaryText() }}</x-label>
+              <x-label style="display: flex; align-items: center;">
+                <i class="material-icons">play_arrow</i>
+                {{ runPrimaryText() }}
+              </x-label>
             </x-button>
             <x-button
               class="btn btn-primary btn-small"


### PR DESCRIPTION
<img width="207" height="79" alt="Screenshot 2026-05-20 at 20 05 59" src="https://github.com/user-attachments/assets/a576e26a-ce4b-4f1c-a8c0-422a1ae4d3e0" />

Frees up horizontal space in the query editor toolbar by leaning on icons instead of text labels.

Why? Reduce toolbar width so more of it stays usable in narrower windows.