### PR TITLE
Add DynamoDB beta support documentation and update status

### DIFF
--- a/docs/includes/supported_databases.es.md
+++ b/docs/includes/supported_databases.es.md
@@ -22,8 +22,8 @@
 | [MongoDB](https://www.mongodb.com/)                      | ⭐ Soporte Completo          |           |    ✅    |     [Caracteristicas](https://www.beekeeperstudio.io/db/mongodb-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/mongodb) |
 | [Trino](https://trino.io/) / [Presto](https://prestodb.io/) | ⭐ Soporte Completo       |           |    ✅    |    [Caracteristicas](https://www.beekeeperstudio.io/db/trino-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/trino/) |
 | [SurrealDB](https://surrealdb.com/)                      | ⭐ Soporte Completo          |           |    ✅    |      [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/surrealdb) |
+| [DynamoDB](https://aws.amazon.com/dynamodb/)             | 🧪 Soporte Beta             |           |    ✅    |      [Caracteristicas](https://www.beekeeperstudio.io/db/dynamodb-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/dynamodb) |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Proximamente              |           |    ✅    |   -- |
-| [DynamoDB](https://aws.amazon.com/dynamodb/)             | 🗓️ Planificado              |           |    ✅    |       -- |
 
 
 

--- a/docs/includes/supported_databases.md
+++ b/docs/includes/supported_databases.md
@@ -23,8 +23,8 @@
 | [MongoDB](https://www.mongodb.com/)                      | ⭐ Full Support               |          |    ✅    |     [Features](https://www.beekeeperstudio.io/db/mongodb-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/mongodb) |
 | [Trino](https://trino.io/) / [Presto](https://prestodb.io/) | ⭐ Full Support                |           |    ✅    |    [Features](https://www.beekeeperstudio.io/db/trino-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/trino/) |
 | [SurrealDB](https://surrealdb.com/)                      | ⭐ Full Support               |           |    ✅    |      [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/surrealdb) |
+| [DynamoDB](https://aws.amazon.com/dynamodb/)             | 🧪 Beta Support               |           |    ✅    |      [Features](https://www.beekeeperstudio.io/db/dynamodb-client/), [Docs](https://docs.beekeeperstudio.io/user_guide/connecting/dynamodb) |
 | [Snowflake](https://www.snowflake.com/)                  | ⏳ Coming Soon                |           |    ✅    |   -- |
-| [DynamoDB](https://aws.amazon.com/dynamodb/)             | 🗓️ Planned               |           |    ✅    |       -- |
 
 
 

--- a/docs/user_guide/connecting/dynamodb.md
+++ b/docs/user_guide/connecting/dynamodb.md
@@ -7,6 +7,23 @@ description: "Browse tables, run PartiQL queries, and edit data in DynamoDB usin
 
 # DynamoDB Support
 
+!!! note "Beta feature"
+    DynamoDB support is currently in beta. It works well, but you may run into the occasional rough edge — please [report any issues](https://github.com/beekeeper-studio/beekeeper-studio/issues/new/choose).
+
+## Connecting to DynamoDB
+
+DynamoDB is a managed AWS service, so there's no host or port to enter. Select **DynamoDB** as the connection type, then choose how to authenticate:
+
+- **IAM Access Key and Secret Key** — enter an access key ID and secret access key directly.
+- **IAM Credentials File** — use a named profile from the shared AWS credentials file (`~/.aws/credentials`).
+- **AWS CLI Authentication** — reuse the credentials from an existing AWS CLI configuration.
+
+Set the **AWS Region** your tables live in (for example, `us-east-1`).
+
+### Connecting to DynamoDB Local
+
+To connect to [DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) or another DynamoDB-compatible endpoint, enter its address in the **Custom Endpoint** field (for example, `http://localhost:8000`). Any non-empty credentials work against a local endpoint.
+
 ## Supported Features
 
 - Table data view (Scan-based)


### PR DESCRIPTION
## Summary
Updates documentation to reflect DynamoDB's transition from "Planned" to "Beta Support" status, and adds comprehensive connection and feature documentation for users.

## Changes Made

- **Added DynamoDB connection guide** (`docs/user_guide/connecting/dynamodb.md`):
  - Beta feature notice with link to issue reporting
  - Authentication methods (IAM Access Key, IAM Credentials File, AWS CLI)
  - AWS Region configuration
  - DynamoDB Local connection instructions with custom endpoint support

- **Updated database support tables** (`docs/includes/supported_databases.md` and `.es.md`):
  - Changed DynamoDB status from "🗓️ Planned" to "🧪 Beta Support"
  - Reordered table to place DynamoDB before Snowflake (coming soon)
  - Added feature and documentation links for DynamoDB

## Implementation Details

The documentation follows the existing structure and conventions:
- Uses MkDocs Material admonition syntax for the beta notice
- Maintains consistent formatting with other database connection guides
- Provides clear authentication options for different AWS credential scenarios
- Includes practical example for local development (DynamoDB Local)
- Translations updated in both English and Spanish support tables

https://claude.ai/code/session_019strjgkd4FfUStQvLVb6de