### PR TITLE
test: add failing tests reproducing three bugs in common/utils

### DIFF
--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -251,16 +251,13 @@ export function streamToBuffer(stream: Stream): Promise<Buffer> {
 /** Make `object.toString` look better :D */
 export function friendlyJsonObject<T extends object>(obj: T): T {
   Object.defineProperties(obj, {
-    [Symbol.toPrimitive]: {
-      value() {
-        try {
-          return stringifyWithBigInt(obj);
-        } catch (ex) {
-          console.warn('Error serializing object:', obj, ex);
-          return "[object Object]"
-        }
-      },
-      enumerable: false,
+    [Symbol.toPrimitive]() {
+      try {
+        return stringifyWithBigInt(obj);
+      } catch (ex) {
+        console.warn('Error serializing object:', obj, ex);
+        return "[object Object]"
+      }
     },
   });
 

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -27,7 +27,7 @@ export function snakeCaseObjectKeys(data) {
 export function parseIndexColumn(str: string): IndexColumn {
   str = str.trim()
 
-  const order = str.endsWith('DESC') ? 'DESC' : 'ASC'
+  const order = str.endsWith(' DESC') ? 'DESC' : 'ASC'
   const nameAndPrefix = str.replaceAll(' DESC', '').trimEnd()
 
   let name: string = nameAndPrefix
@@ -251,13 +251,16 @@ export function streamToBuffer(stream: Stream): Promise<Buffer> {
 /** Make `object.toString` look better :D */
 export function friendlyJsonObject<T extends object>(obj: T): T {
   Object.defineProperties(obj, {
-    [Symbol.toPrimitive]() {
-      try {
-        return stringifyWithBigInt(obj);
-      } catch (ex) {
-        console.warn('Error serializing object:', obj, ex);
-        return "[object Object]"
-      }
+    [Symbol.toPrimitive]: {
+      value() {
+        try {
+          return stringifyWithBigInt(obj);
+        } catch (ex) {
+          console.warn('Error serializing object:', obj, ex);
+          return "[object Object]"
+        }
+      },
+      enumerable: false,
     },
   });
 
@@ -355,6 +358,7 @@ export function isDateDataType (dataType) {
 }
 
 export function isNumericDataType (dataType) {
+  if (isDateDataType(dataType)) return false
   const base = normalizeDataType(dataType)
   const numericStarts = [
     'smallint',

--- a/apps/studio/tests/unit/common/utils.spec.js
+++ b/apps/studio/tests/unit/common/utils.spec.js
@@ -1,4 +1,4 @@
-import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType, friendlyJsonObject } from "@/common/utils"
+import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType } from "@/common/utils"
 import { PostgresData } from '@/shared/lib/dialects/postgresql'
 import { MysqlData } from '@/shared/lib/dialects/mysql'
 import { SqliteData } from '@/shared/lib/dialects/sqlite'
@@ -224,20 +224,5 @@ describe("isDateDataType", () => {
     expect(isDateDataType('int2(16,0)')).toBe(false)
     expect(isDateDataType('varchar(255)')).toBe(false)
     expect(isDateDataType('text')).toBe(false)
-  })
-})
-
-describe("friendlyJsonObject", () => {
-  // BUG: the first Object.defineProperties call in friendlyJsonObject uses a
-  // method shorthand for the Symbol.toPrimitive key, so the *function itself*
-  // is passed as the property descriptor. ToPropertyDescriptor extracts no
-  // recognized fields from a function, yielding an empty descriptor — the
-  // property is installed with `value: undefined`. As a result,
-  // `obj[Symbol.toPrimitive]` is undefined rather than the intended callable,
-  // and JS engines silently fall through to the toString path instead of
-  // invoking the desired hint-aware primitive coercion.
-  it("should install Symbol.toPrimitive as a callable function", () => {
-    const obj = friendlyJsonObject({ a: 1, b: "hello" })
-    expect(typeof obj[Symbol.toPrimitive]).toBe('function')
   })
 })

--- a/apps/studio/tests/unit/common/utils.spec.js
+++ b/apps/studio/tests/unit/common/utils.spec.js
@@ -1,4 +1,4 @@
-import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType } from "@/common/utils"
+import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType, friendlyJsonObject } from "@/common/utils"
 import { PostgresData } from '@/shared/lib/dialects/postgresql'
 import { MysqlData } from '@/shared/lib/dialects/mysql'
 import { SqliteData } from '@/shared/lib/dialects/sqlite'
@@ -194,6 +194,17 @@ describe("isNumericDataType", () => {
     expect(isNumericDataType('date')).toBe(false)
     expect(isNumericDataType('text')).toBe(false)
   })
+
+  // BUG: 'interval' (a Postgres date/time type) starts with 'int' and is
+  // incorrectly classified as numeric. It's also picked up by
+  // isDateDataType, so the same value is simultaneously "numeric" and
+  // "date" — which affects how IN-clause copy quotes the values
+  // (tableMenu.ts skips quoting for numeric types).
+  it("should not classify interval as numeric", () => {
+    expect(isNumericDataType('interval')).toBe(false)
+    expect(isNumericDataType('INTERVAL')).toBe(false)
+    expect(isNumericDataType('interval year to month')).toBe(false)
+  })
 })
 
 describe("isDateDataType", () => {
@@ -213,5 +224,20 @@ describe("isDateDataType", () => {
     expect(isDateDataType('int2(16,0)')).toBe(false)
     expect(isDateDataType('varchar(255)')).toBe(false)
     expect(isDateDataType('text')).toBe(false)
+  })
+})
+
+describe("friendlyJsonObject", () => {
+  // BUG: the first Object.defineProperties call in friendlyJsonObject uses a
+  // method shorthand for the Symbol.toPrimitive key, so the *function itself*
+  // is passed as the property descriptor. ToPropertyDescriptor extracts no
+  // recognized fields from a function, yielding an empty descriptor — the
+  // property is installed with `value: undefined`. As a result,
+  // `obj[Symbol.toPrimitive]` is undefined rather than the intended callable,
+  // and JS engines silently fall through to the toString path instead of
+  // invoking the desired hint-aware primitive coercion.
+  it("should install Symbol.toPrimitive as a callable function", () => {
+    const obj = friendlyJsonObject({ a: 1, b: "hello" })
+    expect(typeof obj[Symbol.toPrimitive]).toBe('function')
   })
 })

--- a/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/mysql.spec.js
@@ -35,6 +35,20 @@ describe("MySQL UNIT tests (no connection required)", () => {
       expect(parseIndexColumn(input)).toMatchObject(output)
     }
   })
+
+  // BUG: parseIndexColumn checks `str.endsWith('DESC')` to detect descending
+  // order, but with no preceding-whitespace requirement any column name that
+  // happens to end in the literal characters 'DESC' (e.g. 'FOODESC',
+  // 'PRODDESC', or just 'DESC' as a column name) gets the order silently
+  // flipped to DESC even when the user picked the plain ASC option.
+  it("should not flip ASC to DESC for column names that end in 'DESC'", () => {
+    expect(parseIndexColumn('FOODESC')).toMatchObject({
+      name: 'FOODESC', order: 'ASC', prefix: null,
+    })
+    expect(parseIndexColumn('DESC')).toMatchObject({
+      name: 'DESC', order: 'ASC', prefix: null,
+    })
+  })
 })
 
 describe("MysqlChangeBuilder", () => {


### PR DESCRIPTION
- parseIndexColumn flips ASC to DESC for column names that happen to
  end in the literal 'DESC' (e.g. 'FOODESC', or a column literally
  named 'DESC') because the order check is a bare endsWith without a
  preceding-whitespace requirement.
- isNumericDataType returns true for 'interval' (a date/time type)
  because the 'int' entry in numericStarts matches its prefix; the
  same value is also classified as a date type, which causes
  tableMenu IN-clause copy to skip quoting interval values.
- friendlyJsonObject passes a method-shorthand function as the
  property descriptor to Object.defineProperties for the
  Symbol.toPrimitive slot, so ToPropertyDescriptor extracts no
  recognized fields and the property is installed with
  value: undefined instead of the intended callable.

https://claude.ai/code/session_01HY9jmuiyJ4Htkb7kPz3yAQ