### PR TITLE
Rename openTab table/structure `table` prop to `name`

### DIFF
--- a/apps/studio/src/services/plugin/web/PluginStoreService.ts
+++ b/apps/studio/src/services/plugin/web/PluginStoreService.ts
@@ -324,13 +324,13 @@ export default class PluginStoreService {
     }
 
     if (options.type === "tableStructure") {
-      const table = this.findTableOrThrow(options.table, options.schema);
+      const table = this.findTableOrThrow(options.name, options.schema);
       this.appEventBus.emit(AppEvent.openTableProperties, { table });
       return;
     }
 
     if (options.type === "tableTable") {
-      const table = this.findTableOrThrow(options.table, options.schema);
+      const table = this.findTableOrThrow(options.name, options.schema);
       this.appEventBus.emit(AppEvent.loadTable, {
         table,
         filters: options.filters,

--- a/docs/plugin_development/api-reference.md
+++ b/docs/plugin_development/api-reference.md
@@ -634,7 +634,7 @@ await openTab('query', { query: 'SELECT * FROM users' });
 
 // Open a table data tab
 await openTab('tableTable', {
-  table: 'users',
+  name: 'users',
   schema: 'public',
   filters: [
     { field: 'active', type: '=', value: 'true' }
@@ -643,7 +643,7 @@ await openTab('tableTable', {
 
 // Open a table structure tab
 await openTab('tableStructure', {
-  table: 'users',
+  name: 'users',
   schema: 'public'
 });
 ```
@@ -1217,7 +1217,7 @@ Represents the currently selected range in a data table.
 
 | Property   | Type            | Description |
 |------------|-----------------|-------------|
-| `table`    | `string`        | Table name |
+| `name`     | `string`        | Table name |
 | `schema`   | `string`        | Schema name (optional) |
 | `filters`  | `TableFilter[]` | Filters to apply (optional) |
 | `database` | `string`        | Database name (optional) |
@@ -1226,7 +1226,7 @@ Represents the currently selected range in a data table.
 
 | Property   | Type     | Description |
 |------------|----------|-------------|
-| `table`    | `string` | Table name |
+| `name`     | `string` | Table name |
 | `schema`   | `string` | Schema name (optional) |
 | `database` | `string` | Database name (optional) |
 


### PR DESCRIPTION
## What

Rename the `table` option to `name` for the plugin `openTab` API:

```ts
openTab("tableTable", { name: "customer", schema: "public" });
openTab("tableStructure", { name: "customer", schema: "public" });
```

## Why

So the options match the `Table` type signature, which uses `{ name: string; schema: string }`. Previously these used `table` while everything else referring to a table uses `name`, which was inconsistent.

## Breaking change

This is a breaking change to the `openTab("tableTable" | "tableStructure", ...)` options, but it's fine — no plugins currently use these APIs.

## Scope / follow-up

This PR covers the in-repo side only:
- `PluginStoreService.openTab` reads `options.name` (and the param type now points at `RequestMap["openTab"]["args"]`).
- Plugin API reference docs updated.

The `@beekeeperstudio/plugin` package (separate repo) still needs the matching `table` → `name` rename in `OpenTableTableTabOptions` / `OpenTableStructureTabOptions`, then a version bump in `apps/studio/package.json`, for this to work end-to-end and type-check cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)