### PR TITLE
Upgrade electron-builder to 26.11.1 and configure AppImage toolset

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -26,6 +26,9 @@ module.exports = {
     releaseNotesFile: "build/release-notes.md"
   },
   generateUpdatesFilesForAllChannels: true,
+  toolsets: {
+    appimage: "1.0.3"
+  },
   directories: {
     output: "dist_electron"
   },

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -198,7 +198,7 @@
     "cross-env": "^7.0.3",
     "dts-gen": "0.7.4",
     "electron": "39.8.5",
-    "electron-builder": "26.7.0",
+    "electron-builder": "26.11.1",
     "esbuild": "^0.25.12",
     "esbuild-node-externals": "^1.13.1",
     "eslint": "^8.57.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@
     minimist "^1.2.6"
     plist "^3.0.5"
 
-"@electron/rebuild@^4.0.3":
+"@electron/rebuild@4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@electron/rebuild/-/rebuild-4.0.3.tgz#f022f7e66874920fd16a4d802b8605885cb549d3"
   integrity sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==
@@ -5889,10 +5889,10 @@ app-builder-bin@5.0.0-alpha.12:
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz#2daf82f8badc698e0adcc95ba36af4ff0650dc80"
   integrity sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==
 
-app-builder-lib@26.7.0:
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.7.0.tgz#fffbd99ec6a1e6a2bd30a84f2cbd8c5e16c75f94"
-  integrity sha512-/UgCD8VrO79Wv8aBNpjMfsS1pIUfIPURoRn0Ik6tMe5avdZF+vQgl/juJgipcMmH3YS0BD573lCdCHyoi84USg==
+app-builder-lib@26.11.1:
+  version "26.11.1"
+  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-26.11.1.tgz#98a88daefdc4a5b012de225061eab5d43e68ffeb"
+  integrity sha512-KCZm58CifmTGbzw9PZOyDEecwjY3jY9cQ4uBRIDxZYhaJqqsz0RQFkryoV+EPhjVlkPql7Jsg6SNUkz837Bkhw==
   dependencies:
     "@develar/schema-utils" "~2.6.5"
     "@electron/asar" "3.4.1"
@@ -5900,20 +5900,20 @@ app-builder-lib@26.7.0:
     "@electron/get" "^3.0.0"
     "@electron/notarize" "2.5.0"
     "@electron/osx-sign" "1.3.3"
-    "@electron/rebuild" "^4.0.3"
+    "@electron/rebuild" "4.0.3"
     "@electron/universal" "2.0.3"
     "@malept/flatpak-bundler" "^0.4.0"
     "@types/fs-extra" "9.0.13"
     async-exit-hook "^2.0.1"
-    builder-util "26.4.1"
-    builder-util-runtime "9.5.1"
+    builder-util "26.11.1"
+    builder-util-runtime "9.6.1"
     chromium-pickle-js "^0.2.0"
     ci-info "4.3.1"
     debug "^4.3.4"
     dotenv "^16.4.5"
     dotenv-expand "^11.0.6"
     ejs "^3.1.8"
-    electron-publish "26.6.0"
+    electron-publish "26.11.1"
     fs-extra "^10.1.0"
     hosted-git-info "^4.1.0"
     isbinaryfile "^5.0.0"
@@ -5929,6 +5929,7 @@ app-builder-lib@26.7.0:
     tar "^7.5.7"
     temp-file "^3.4.0"
     tiny-async-pool "1.3.0"
+    unzipper "^0.12.3"
     which "^5.0.0"
 
 app-root-path@^3.1.0:
@@ -6356,7 +6357,7 @@ bl@^6.1.4:
     inherits "^2.0.4"
     readable-stream "^4.2.0"
 
-bluebird@^3.1.1, bluebird@^3.7.2:
+bluebird@^3.1.1, bluebird@^3.7.2, bluebird@~3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -6497,15 +6498,23 @@ builder-util-runtime@9.5.1, builder-util-runtime@^9.1.1:
     debug "^4.3.4"
     sax "^1.2.4"
 
-builder-util@26.4.1:
-  version "26.4.1"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-26.4.1.tgz#22a311fa68c976aa00f39686872799370f688225"
-  integrity sha512-FlgH43XZ50w3UtS1RVGDWOz8v9qMXPC7upMtKMtBEnYdt1OVoS61NYhKm/4x+cIaWqJTXua0+VVPI+fSPGXNIw==
+builder-util-runtime@9.6.1:
+  version "9.6.1"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-9.6.1.tgz#de85bca73bb89c7d7551d0e1e4d29fa665d286da"
+  integrity sha512-gnk+lN50T7TIRp4bHTVydSnWsNkYAxGiDDbed3U26Z82s1lr8em4E4fLs/EPfIEZIbfi4Zfo5NsdA9gHWbPmXg==
+  dependencies:
+    debug "^4.3.4"
+    sax "^1.2.4"
+
+builder-util@26.11.1:
+  version "26.11.1"
+  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-26.11.1.tgz#c90881567146db4c85bc82667244e13a5efeab5a"
+  integrity sha512-oWRbAjgN9RdVCLvNVN9ltZwaUkrH/FrH8wdggAwpz426PTdcbGEARp7J1HXad/QijURPxYL+BKykThaRjluPIQ==
   dependencies:
     "7zip-bin" "~5.2.0"
     "@types/debug" "^4.1.6"
     app-builder-bin "5.0.0-alpha.12"
-    builder-util-runtime "9.5.1"
+    builder-util-runtime "9.6.1"
     chalk "^4.1.2"
     cross-spawn "^7.0.6"
     debug "^4.3.4"
@@ -7487,13 +7496,13 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
-dmg-builder@26.7.0:
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.7.0.tgz#3f1d2ef65c4a6087daf63a9b94621bd465993297"
-  integrity sha512-uOOBA3f+kW3o4KpSoMQ6SNpdXU7WtxlJRb9vCZgOvqhTz4b3GjcoWKstdisizNZLsylhTMv8TLHFPFW0Uxsj/g==
+dmg-builder@26.11.1:
+  version "26.11.1"
+  resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-26.11.1.tgz#26ab321dc38f23bd7b68c34909fbff7a09fa5b29"
+  integrity sha512-uFE7wiNn/GJ/MCtHz9ZIYj8w+27WTKush6PX6a1rt7RWJ5Ua4WgK6PAgErSBQXk0Q8UM4YMTXUBNFhN1gR+1qw==
   dependencies:
-    app-builder-lib "26.7.0"
-    builder-util "26.4.1"
+    app-builder-lib "26.11.1"
+    builder-util "26.11.1"
     fs-extra "^10.1.0"
     iconv-lite "^0.6.2"
     js-yaml "^4.1.0"
@@ -7611,6 +7620,13 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexify@^4.0.0, duplexify@^4.1.1:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-4.1.3.tgz#a07e1c0d0a2c001158563d32592ba58bddb0236f"
@@ -7655,17 +7671,17 @@ ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-builder@26.7.0:
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.7.0.tgz#e1f5b4434b453c19bceb0ccac859c3104e3c26d8"
-  integrity sha512-LoXbCvSFxLesPneQ/fM7FB4OheIDA2tjqCdUkKlObV5ZKGhYgi5VHPHO/6UUOUodAlg7SrkPx7BZJPby+Vrtbg==
+electron-builder@26.11.1:
+  version "26.11.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-26.11.1.tgz#57739ad92763a1e585249ad682db6a9774cf94ce"
+  integrity sha512-CMG8PQAnUBWIx9THpwWysrHfJQs9Q1E1VDayK+ZkNqvih+ao8mywMP5v2ohLkzlg1ZeVyvkQP6oICJGzyeCAUQ==
   dependencies:
-    app-builder-lib "26.7.0"
-    builder-util "26.4.1"
-    builder-util-runtime "9.5.1"
+    app-builder-lib "26.11.1"
+    builder-util "26.11.1"
+    builder-util-runtime "9.6.1"
     chalk "^4.1.2"
     ci-info "^4.2.0"
-    dmg-builder "26.7.0"
+    dmg-builder "26.11.1"
     fs-extra "^10.1.0"
     lazy-val "^1.0.5"
     simple-update-notifier "2.0.0"
@@ -7691,14 +7707,14 @@ electron-log@^5.1.5:
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-5.4.3.tgz#02a90baf4256950ca416095db6e5745268584d20"
   integrity sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==
 
-electron-publish@26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-26.6.0.tgz#94e8f00c163376ebb6b296544c11b61d3afc027d"
-  integrity sha512-LsyHMMqbvJ2vsOvuWJ19OezgF2ANdCiHpIucDHNiLhuI+/F3eW98ouzWSRmXXi82ZOPZXC07jnIravY4YYwCLQ==
+electron-publish@26.11.1:
+  version "26.11.1"
+  resolved "https://registry.yarnpkg.com/electron-publish/-/electron-publish-26.11.1.tgz#590e8c896092631d3cb5c48088a6725723747df4"
+  integrity sha512-aMugkYS7QZtS/PjbyOSh0MlymxoWppj7+lEcqmsO1jM6igedcgAdFtmWms3g/DdMPpCZDVKxzkC4a3UK6HGlmA==
   dependencies:
     "@types/fs-extra" "^9.0.11"
-    builder-util "26.4.1"
-    builder-util-runtime "9.5.1"
+    builder-util "26.11.1"
+    builder-util-runtime "9.6.1"
     chalk "^4.1.2"
     form-data "^4.0.5"
     fs-extra "^10.1.0"
@@ -8597,6 +8613,15 @@ fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.2.0:
+  version "11.3.5"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.5.tgz#07a44eff40bea53e719909a532f91a23bf0769ff"
+  integrity sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -8983,7 +9008,7 @@ got@^11.7.0, got@^11.8.5:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.11, graceful-fs@^4.2.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -12489,7 +12514,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.5, readable-stream@~2.3.6:
+readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -14558,6 +14583,17 @@ unzip-crx-3@^0.2.0:
     jszip "^3.1.0"
     mkdirp "^0.5.1"
     yaku "^0.16.6"
+
+unzipper@^0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.12.3.tgz#31958f5eed7368ed8f57deae547e5a673e984f87"
+  integrity sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==
+  dependencies:
+    bluebird "~3.7.2"
+    duplexer2 "~0.1.4"
+    fs-extra "^11.2.0"
+    graceful-fs "^4.2.2"
+    node-int64 "^0.4.0"
 
 update-browserslist-db@^1.2.0:
   version "1.2.3"


### PR DESCRIPTION
## Summary
Updates electron-builder to version 26.11.1 and adds explicit AppImage toolset configuration to the Electron builder configuration.

## Changes
- **Dependency upgrade**: electron-builder `26.7.0` → `26.11.1`
- **Build configuration**: Added `toolsets` configuration specifying AppImage toolset version `1.0.3` in `electron-builder-config.js`

## Details
The AppImage toolset configuration ensures consistent and explicit control over the AppImage generation tool version used during the build process. This upgrade to electron-builder 26.11.1 includes bug fixes and improvements from the intermediate releases (26.7.1 through 26.11.1).

https://claude.ai/code/session_01D8g2mHFAmKAtpGJajGemED