### PR TITLE
Refactor cloud query audit API client

### DIFF
--- a/apps/studio/src/common/interfaces/IQueryAudit.ts
+++ b/apps/studio/src/common/interfaces/IQueryAudit.ts
@@ -7,7 +7,7 @@ export interface IQueryAuditUser {
 
 export interface IQueryAudit {
   id: number
-  version: number
+  revision: number
   action: 'create' | 'update' | 'destroy'
   createdAt: number
   user: IQueryAuditUser

--- a/apps/studio/src/components/editor/QueryEditHistory.vue
+++ b/apps/studio/src/components/editor/QueryEditHistory.vue
@@ -189,7 +189,7 @@ export default Vue.extend({
   },
   computed: {
     ...mapState(["connectionType", "tables"]),
-    ...mapGetters(["dialectData", "cloudClient", "workspaceEmail"]),
+    ...mapGetters(["dialectData"]),
     dirty(): boolean {
       return this.unsavedText !== null;
     },
@@ -345,11 +345,10 @@ export default Vue.extend({
       this.loadingList = true;
       this.error = null;
       try {
-        const cli = this.cloudClient;
-        if (!cli) {
-          throw new Error("You are not logged in");
-        }
-        const queryAudits: IQueryAudit[] = await cli.queryAudits.list(queryId);
+        const queryAudits: IQueryAudit[] = await this.$store.dispatch(
+          "data/queryAudits/list",
+          queryId
+        );
         this.queryAudits = queryAudits;
         if (queryAudits.length === 0) {
           this.previousAudit = null;
@@ -378,10 +377,6 @@ export default Vue.extend({
       this.loadingPreview = true;
       this.error = null;
       try {
-        const cli = this.cloudClient;
-        if (!cli) {
-          throw new Error("You are not logged in");
-        }
         if (auditId === "unsaved") {
           // Show editor text vs the latest saved snapshot. Reuse the
           // already-fetched detail when possible.
@@ -389,7 +384,10 @@ export default Vue.extend({
           const previous = latest
             ? this.previousAudit?.id === latest.id
               ? this.previousAudit
-              : await cli.queryAudits.get(queryId, latest.id)
+              : await this.$store.dispatch("data/queryAudits/get", {
+                  queryId,
+                  auditId: latest.id,
+                })
             : null;
           if (this.selectedAuditId === auditId) {
             this.selectedAudit = null;
@@ -397,10 +395,16 @@ export default Vue.extend({
           }
           return;
         }
-        const detail = await cli.queryAudits.get(queryId, auditId);
+        const detail: IQueryAuditDetail = await this.$store.dispatch(
+          "data/queryAudits/get",
+          { queryId, auditId }
+        );
         const previous =
           detail.previousAuditId != null
-            ? await cli.queryAudits.get(queryId, detail.previousAuditId)
+            ? await this.$store.dispatch("data/queryAudits/get", {
+                queryId,
+                auditId: detail.previousAuditId,
+              })
             : null;
         // Guard against a stale response if the user clicked another row in flight.
         if (this.selectedAuditId === auditId) {
@@ -430,13 +434,9 @@ export default Vue.extend({
       this.restoring = true;
       this.error = null;
       try {
-        const cli = this.cloudClient;
-        if (!cli) {
-          throw new Error("You are not logged in");
-        }
-        const restored: ISavedQuery = await cli.queryAudits.restore(
-          queryId,
-          auditId
+        const restored: ISavedQuery = await this.$store.dispatch(
+          "data/queryAudits/restore",
+          { queryId, auditId }
         );
         this.$store.commit("data/queries/upsert", restored);
         await this.loadAudits();

--- a/apps/studio/src/lib/cloud/controllers/QueryAuditsController.ts
+++ b/apps/studio/src/lib/cloud/controllers/QueryAuditsController.ts
@@ -6,18 +6,22 @@ import { res, url } from '@/lib/cloud/ClientHelpers'
 export class QueryAuditsController {
   constructor(protected axios: AxiosInstance) {}
 
+  name = 'audit'
+  plural = 'audits'
+  path = '/queries'
+
   async list(queryId: number): Promise<IQueryAudit[]> {
-    const response = await this.axios.get(url('/queries', queryId, 'audits'))
-    return res(response, 'audits')
+    const response = await this.axios.get(url(this.path, queryId, this.plural))
+    return res(response, this.plural)
   }
 
   async get(queryId: number, auditId: number): Promise<IQueryAuditDetail> {
-    const response = await this.axios.get(url('/queries', queryId, 'audits', auditId))
-    return res(response, 'audit')
+    const response = await this.axios.get(url(this.path, queryId, this.plural, auditId))
+    return res(response, this.name)
   }
 
   async restore(queryId: number, auditId: number): Promise<ISavedQuery> {
-    const response = await this.axios.post(url('/queries', queryId, 'audits', auditId, 'restore'), {})
+    const response = await this.axios.post(url(this.path, queryId, this.plural, auditId, 'restore'), {})
     return res(response, 'query')
   }
 }

--- a/apps/studio/src/store/DataModules.ts
+++ b/apps/studio/src/store/DataModules.ts
@@ -5,6 +5,8 @@ import { UtilConnectionModule } from "./modules/data/connection/UtilityConnectio
 import { CloudConnectionFolderModule } from "./modules/data/connection_folder/CloudConnectionFolderModule";
 import { CloudQueryModule } from "./modules/data/query/CloudQueryModule";
 import { UtilQueryModule } from "./modules/data/query/UtilityQueryModule";
+import { CloudQueryAuditModule } from "./modules/data/query_audit/CloudQueryAuditModule";
+import { LocalQueryAuditModule } from "./modules/data/query_audit/LocalQueryAuditModule";
 import { CloudQueryFolderModule } from "./modules/data/query_folder/CloudQueryFolderModule";
 import { UtilUsedConnectionModule } from "./modules/data/used_connection/UtilityUsedConnectionModule";
 import { CloudUsedQueryModule } from "./modules/data/used_query/CloudUsedQueryModule";
@@ -16,6 +18,11 @@ export const DataModules = [
     path: 'data/queries',
     local: UtilQueryModule,
     cloud: CloudQueryModule,
+  },
+  {
+    path: 'data/queryAudits',
+    local: LocalQueryAuditModule,
+    cloud: CloudQueryAuditModule,
   },
   {
     path: 'data/connections',

--- a/apps/studio/src/store/DataModules.ts
+++ b/apps/studio/src/store/DataModules.ts
@@ -6,7 +6,7 @@ import { CloudConnectionFolderModule } from "./modules/data/connection_folder/Cl
 import { CloudQueryModule } from "./modules/data/query/CloudQueryModule";
 import { UtilQueryModule } from "./modules/data/query/UtilityQueryModule";
 import { CloudQueryAuditModule } from "./modules/data/query_audit/CloudQueryAuditModule";
-import { LocalQueryAuditModule } from "./modules/data/query_audit/LocalQueryAuditModule";
+import { UtilQueryAuditModule } from "./modules/data/query_audit/UtilityQueryAuditModule";
 import { CloudQueryFolderModule } from "./modules/data/query_folder/CloudQueryFolderModule";
 import { UtilUsedConnectionModule } from "./modules/data/used_connection/UtilityUsedConnectionModule";
 import { CloudUsedQueryModule } from "./modules/data/used_query/CloudUsedQueryModule";
@@ -21,7 +21,7 @@ export const DataModules = [
   },
   {
     path: 'data/queryAudits',
-    local: LocalQueryAuditModule,
+    local: UtilQueryAuditModule,
     cloud: CloudQueryAuditModule,
   },
   {

--- a/apps/studio/src/store/modules/data/StoreHelpers.ts
+++ b/apps/studio/src/store/modules/data/StoreHelpers.ts
@@ -2,6 +2,7 @@ import { HasId } from "@/common/interfaces/IGeneric";
 import { having } from "@/common/utils";
 import _ from "lodash";
 import rawLog from '@bksLogger'
+import type { CloudClient } from "@/lib/cloud/CloudClient";
 
 const log = rawLog.scope('StoreHelpers')
 export type ClientError = Error | string | Error[] | string[] | null
@@ -17,11 +18,11 @@ interface BasicContext {
   commit(str: string, item: any)
 }
 
-export function havingCli<U>(context: BasicContext, f: (c: any) => Promise<U>) {
+export function havingCli<U>(context: BasicContext, f: (c: CloudClient) => Promise<U>) {
   return having(context.rootGetters.cloudClient, f, "You are not logged in")
 }
 
-export function safelyDo<U>(context: BasicContext, f: (c: any) => Promise<U>) {
+export function safelyDo<U>(context: BasicContext, f: (c: CloudClient) => Promise<U>) {
 
   const safeRunner = async (c: any) => {
     try {

--- a/apps/studio/src/store/modules/data/query_audit/CloudQueryAuditModule.ts
+++ b/apps/studio/src/store/modules/data/query_audit/CloudQueryAuditModule.ts
@@ -1,0 +1,46 @@
+import { Module } from "vuex";
+import { havingCli } from "../StoreHelpers";
+import { State as RootState } from "../../../index";
+import { IQueryAudit, IQueryAuditDetail } from "@/common/interfaces/IQueryAudit";
+import ISavedQuery from "@/common/interfaces/ISavedQuery";
+
+// Query audits are fetched on demand for a single query, not synced as a
+// global collection, so this module has no items/load/poll behaviour.
+interface State {
+  pollError: null;
+}
+
+export const CloudQueryAuditModule: Module<State, RootState> = {
+  namespaced: true,
+  state: {
+    pollError: null,
+  },
+  actions: {
+    async load() {},
+    async poll() {},
+    async list(context, queryId: number): Promise<IQueryAudit[]> {
+      return await havingCli(
+        context.rootGetters.cloudClient,
+        (cli) => cli.queryAudits.list(queryId),
+      );
+    },
+    async get(
+      context,
+      { queryId, auditId }: { queryId: number; auditId: number }
+    ): Promise<IQueryAuditDetail> {
+      return await havingCli(
+        context.rootGetters.cloudClient,
+        (cli) => cli.queryAudits.get(queryId, auditId),
+      );
+    },
+    async restore(
+      context,
+      { queryId, auditId }: { queryId: number; auditId: number }
+    ): Promise<ISavedQuery> {
+      return await havingCli(
+        context.rootGetters.cloudClient,
+        (cli) => cli.queryAudits.restore(queryId, auditId),
+      );
+    },
+  },
+};

--- a/apps/studio/src/store/modules/data/query_audit/LocalQueryAuditModule.ts
+++ b/apps/studio/src/store/modules/data/query_audit/LocalQueryAuditModule.ts
@@ -1,0 +1,28 @@
+import { Module } from "vuex";
+import { State as RootState } from "../../../index";
+import { IQueryAudit, IQueryAuditDetail } from "@/common/interfaces/IQueryAudit";
+import ISavedQuery from "@/common/interfaces/ISavedQuery";
+
+interface State {
+  pollError: null;
+}
+
+export const LocalQueryAuditModule: Module<State, RootState> = {
+  namespaced: true,
+  state: {
+    pollError: null,
+  },
+  actions: {
+    async load() {},
+    async poll() {},
+    async list(): Promise<IQueryAudit[]> {
+      return [];
+    },
+    async get(): Promise<IQueryAuditDetail | null> {
+      return null;
+    },
+    async restore(): Promise<ISavedQuery | null> {
+      return null;
+    },
+  },
+};

--- a/apps/studio/src/store/modules/data/query_audit/UtilityQueryAuditModule.ts
+++ b/apps/studio/src/store/modules/data/query_audit/UtilityQueryAuditModule.ts
@@ -7,7 +7,7 @@ interface State {
   pollError: null;
 }
 
-export const LocalQueryAuditModule: Module<State, RootState> = {
+export const UtilQueryAuditModule: Module<State, RootState> = {
   namespaced: true,
   state: {
     pollError: null,


### PR DESCRIPTION
- Rename `version` to `revision` so it doesn't conflict with ApplicationEntity's version
- Add stub local query audit
- Register cloud query audit as a DataModule