### PR TITLE
Fix bastion host background for system dark theme

### DIFF
--- a/apps/studio/src/components/connection/CommonAdvanced.vue
+++ b/apps/studio/src/components/connection/CommonAdvanced.vue
@@ -10,7 +10,7 @@
       />
     </template>
     <template>
-      <div class="row gutter alert-row">
+      <div class="row gutter alert-row ssh-tunnel-info">
         <div class="alert alert-info">
           <i class="material-icons-outlined">info</i>
           <div>For the SSH tunnel to work, AllowTcpForwarding must be set to "yes" in your ssh server config.</div>
@@ -373,6 +373,10 @@ export default {
   padding-left: 0.25rem;
   opacity: 0.6;
   vertical-align: middle;
+}
+
+.ssh-tunnel-info {
+  margin-inline: 0;
 }
 
 body.theme-dark .bastion-host {

--- a/apps/studio/src/components/connection/CommonAdvanced.vue
+++ b/apps/studio/src/components/connection/CommonAdvanced.vue
@@ -378,4 +378,10 @@ export default {
 body.theme-dark .bastion-host {
   background-color: rgb(from var(--theme-base) r g b / 3.5%);
 }
+
+@media (prefers-color-scheme: dark) {
+  body.theme-system .bastion-host {
+    background-color: rgb(from var(--theme-base) r g b / 3.5%);
+  }
+}
 </style>


### PR DESCRIPTION
- The existing `body.theme-dark .bastion-host` rule only applies when the theme is explicitly set to dark
- When using the system theme with a dark OS preference, the tint was missing

Bug:

<img width="439" height="397" alt="Screenshot 2026-05-28 at 20 17 00" src="https://github.com/user-attachments/assets/3460e441-b5a6-437e-bce0-7ae6707eef2a" />

Patch:

<img width="439" height="405" alt="Screenshot 2026-05-28 at 20 17 13" src="https://github.com/user-attachments/assets/b658da11-18ec-4ce5-b012-c98ec6b171c2" />


