### PR TITLE
upgrade bundled ai shell v3.1.0

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -41,7 +41,7 @@
     "@azure/msal-node": "^2.12.0",
     "@babel/core": "^7.29.0",
     "@babel/plugin-transform-class-static-block": "^7.26.0",
-    "@beekeeperstudio/bks-ai-shell": "^3.0.9",
+    "@beekeeperstudio/bks-ai-shell": "^3.1.0",
     "@beekeeperstudio/bks-er-diagram": "^1.0.9",
     "@beekeeperstudio/plugin": "^1.6.0",
     "@cleverbrush/async": "^1.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2149,10 +2149,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@beekeeperstudio/bks-ai-shell@^3.0.9":
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@beekeeperstudio/bks-ai-shell/-/bks-ai-shell-3.0.9.tgz#298bbeaab0578b4a164f4777f3e27edc5379c583"
-  integrity sha512-YhQ5VjqNlv359VfUdYuOPK1bhHgu6GgCRD6FBBomFeDK6CrHI15Z7ZxFMXEYf1LGW4oJOVELfaR0q25+uNgbZA==
+"@beekeeperstudio/bks-ai-shell@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@beekeeperstudio/bks-ai-shell/-/bks-ai-shell-3.1.0.tgz#492ac7dda65cd22ba93b7143dfd05ea1acede777"
+  integrity sha512-6dWgXdr5PDerNs1UthaZG6UQLN2Dztst8SzWNqjRm9XRgph/5cqfg8Z2vk8SngdycUePBEuuBBhTVksGzBfUzg==
 
 "@beekeeperstudio/bks-er-diagram@^1.0.9":
   version "1.0.9"


### PR DESCRIPTION
Contains 2 new providers and some fixes!

- Z.AI GLM provider by @GreenWormsClt
- DeepSeek provider by @GreenWormsClt
- Updated Gemini model list by @GreenWormsClt

Full notes in the [v3.1.0](https://github.com/beekeeper-studio/bks-ai-shell/releases/tag/v3.1.0) release page.