### PR TITLE
Allow plugins to use the same style for menus

### DIFF
--- a/apps/studio/src/assets/styles/components/context-menu.scss
+++ b/apps/studio/src/assets/styles/components/context-menu.scss
@@ -12,7 +12,7 @@
   z-index: 1000000;
   padding: ($gutter-h * 0.75) 0;
   border-radius: 6px;
-  box-shadow: var(--elevation-5);
+  box-shadow: var(--menu-shadow);
   font-size: 0.85rem;
   text-transform: none;
   font-weight: 400;
@@ -74,7 +74,7 @@
 // ------ Theme Customization ------
 
 .BksContextMenu-list, .vue-simple-context-menu {
-  background: color.adjust($theme-bg, $lightness: 5%);
+  background: var(--menu-bg);
   color: $text;
 }
 

--- a/apps/studio/src/assets/styles/themes/scssvars-to-cssprops.scss
+++ b/apps/studio/src/assets/styles/themes/scssvars-to-cssprops.scss
@@ -29,6 +29,8 @@
   --input-highlight: #{$input-highlight};
 
   --query-editor-bg: #{$query-editor-bg};
+  --menu-bg: color-mix(in srgb, var(--theme-bg) 95%, #fff);
+  --menu-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.08), 0 6px 15px rgba(0, 0, 0, 0.12);
 
   --scrollbar-track: #{$scrollbar-track};
   --scrollbar-thumb: #{$scrollbar-thumb};

--- a/apps/studio/src/services/plugin/web/cssVars.ts
+++ b/apps/studio/src/services/plugin/web/cssVars.ts
@@ -31,6 +31,8 @@ export const cssVars = [
   "--input-highlight",
 
   "--query-editor-bg",
+  "--menu-bg",
+  "--menu-shadow",
 
   "--scrollbar-track",
   "--scrollbar-thumb",


### PR DESCRIPTION
New css props for plugins:

- `--menu-bg`
- `--menu-shadow`