### PR TITLE
fixes: saved query no longer gets removed from its folder when saved from the query editor tab.

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1357,6 +1357,13 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
             const payload = _.clone(this.query)
             payload.text = this.unsavedText
             payload.excerpt = payload.text.substr(0, 250)
+            if (payload.id) {
+              const latest = this.savedQueries.find(q => q.id === payload.id)
+              if (latest) {
+                payload.queryFolderId = latest.queryFolderId
+                payload.position = latest.position
+              }
+            }
             this.$modal.hide(`save-modal-${this.tab.id}`)
             const id = await this.$store.dispatch('data/queries/save', payload)
             this.tab.queryId = id


### PR DESCRIPTION
 The tab keeps a local snapshot of the saved query that never resyncs with the `data/queries` store. After moving the query into a folder via the
  sidebar, the snapshot's `queryFolderId` (and `position`) are stale, so the next save dispatches the stale values and the backend merge overwrites
   the real ones.

  ## Fixes #4329

  In `TabQueryEditor.saveQuery`, override the payload's `queryFolderId` and `position` from the live `savedQueries` store before dispatching the
  save.