### PR TITLE
feat: Enable custom SSL certificate support in ClickHouse client

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -63,6 +63,9 @@ import { errors } from "@/lib/errors";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
 import { ClickHouseCursor } from "./clickhouse/ClickHouseCursor";
+import { readFileSync } from 'fs';
+import { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config";
+import https from 'https'
 
 interface JSONResult {
   statement: IdentifyResult;
@@ -148,7 +151,7 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
       url = urlObj.toString();
     }
 
-    this.client = createClient({
+    const config: NodeClickHouseClientConfigOptions = {
       url,
       username: this.server.config.user,
       password: this.server.config.password,
@@ -158,7 +161,34 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
         default_format: "JSONCompact",
       },
       request_timeout: 120_000, // 2 minutes
-    });
+    };
+    if (this.server.config.ssl) {
+      let hasCerts = false;
+      // ClickHouse client supports both one-way and mutual TLS authentication. If sslCertFile and sslKeyFile are provided, we will use mutual TLS, otherwise we will use one-way TLS.
+      if (this.server.config.sslCaFile) {
+        hasCerts = true;
+        if (this.server.config.sslCertFile && this.server.config.sslKeyFile) {
+          config.tls = {
+            ca_cert: readFileSync(this.server.config.sslCaFile),
+            cert: readFileSync(this.server.config.sslCertFile),
+            key: readFileSync(this.server.config.sslKeyFile),
+          };
+        } else {
+          config.tls = {
+            ca_cert: readFileSync(this.server.config.sslCaFile),
+          };
+        }
+      }
+
+      // Beekeeper's default behavior is to disable verification unless certificates are provided.
+      if (!hasCerts || !this.server.config.sslRejectUnauthorized) {
+        config.http_agent = new https.Agent({
+          rejectUnauthorized: false
+        });
+      }
+    }
+
+    this.client = createClient(config);
     const result = await this.driverExecuteSingle(
       "SELECT version() AS version"
     );

--- a/apps/studio/src/components/connection/ClickHouseForm.vue
+++ b/apps/studio/src/components/connection/ClickHouseForm.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="with-connection-type">
-    <!-- FIXME Clickhouse client supports custom SSL certificates -->
-    <common-server-inputs :config="config" :support-complex-s-s-l="false" />
+    <common-server-inputs :config="config" :support-complex-s-s-l="true" />
     <common-advanced :config="config" />
   </div>
 </template>


### PR DESCRIPTION
This pull request adds support for custom SSL certificates when connecting to ClickHouse databases, and updates the frontend to reflect this new capability in the connection form.

**Backend: Enhanced SSL/TLS Support for ClickHouse Connections**
- Added support for custom SSL certificates in the `ClickHouseClient` by conditionally setting the `tls` configuration based on the presence of certificate files (`sslCaFile`, `sslCertFile`, `sslKeyFile`). If certificates are not provided, or if `sslRejectUnauthorized` is not set, the client will not verify the server certificate, to be consistent with behavior elsewhere.

**Frontend: Updated Connection Form**
- Enabled support for complex SSL options in the ClickHouse connection form by setting `support-complex-s-s-l` to `true` in `ClickHouseForm.vue`, allowing users to provide custom certificates via the UI.