### PR TITLE
Fix alert margins and link placement breaking the layout

### DIFF
--- a/apps/studio/src/components/connection/CommonAdvanced.vue
+++ b/apps/studio/src/components/connection/CommonAdvanced.vue
@@ -10,7 +10,7 @@
       />
     </template>
     <template>
-      <div class="row gutter alert-row ssh-tunnel-info">
+      <div class="row alert-row">
         <div class="alert alert-info">
           <i class="material-icons-outlined">info</i>
           <div>For the SSH tunnel to work, AllowTcpForwarding must be set to "yes" in your ssh server config.</div>
@@ -373,10 +373,6 @@ export default {
   padding-left: 0.25rem;
   opacity: 0.6;
   vertical-align: middle;
-}
-
-.ssh-tunnel-info {
-  margin-inline: 0;
 }
 
 body.theme-dark .bastion-host {

--- a/apps/studio/src/components/connection/CommonIam.vue
+++ b/apps/studio/src/components/connection/CommonIam.vue
@@ -4,7 +4,7 @@
       <span class="expand">IAM Authentication</span>
     </h4>
     <div class="advanced-body">
-      <div class="row gutter">
+      <div class="row">
         <div class="alert alert-info">
           <i class="material-icons-outlined">info</i>
           <div>

--- a/apps/studio/src/components/connection/CommonSsl.vue
+++ b/apps/studio/src/components/connection/CommonSsl.vue
@@ -12,7 +12,7 @@
       </template>
 
       <template #default>
-        <div class="row gutter">
+        <div class="row">
           <div class="alert alert-info">
             <i class="material-icons-outlined">info</i>
             <div>

--- a/apps/studio/src/components/connection/SqliteForm.vue
+++ b/apps/studio/src/components/connection/SqliteForm.vue
@@ -7,7 +7,7 @@
             for="Database"
             required
           >Database File</label>
-          <file-picker 
+          <file-picker
             v-model="config.defaultDatabase"
             input-id="Database"
             editable
@@ -25,8 +25,8 @@
                 <span class="flex">
                   <span class="expand">
                     This is a global setting that affects all SQLite connections.
+                    <a href="https://docs.beekeeperstudio.io/docs/sqlite#runtime-extensions">Learn more</a>
                   </span>
-                  <a href="https://docs.beekeeperstudio.io/docs/sqlite#runtime-extensions">Learn more</a>
                 </span>
               </div>
 
@@ -39,8 +39,8 @@
                   <span class="expand">
                     Runtime extensions are disabled. Configured extensions will be ignored until you set
                     <code>allowRuntimeExtensions = true</code> under <code>[security]</code> in your user config file.
+                    <a href="https://docs.beekeeperstudio.io/docs/sqlite#runtime-extensions">Learn more</a>
                   </span>
-                  <a href="https://docs.beekeeperstudio.io/docs/sqlite#runtime-extensions">Learn more</a>
                 </span>
               </div>
 


### PR DESCRIPTION
- Alerts in connection form are now aligned with the elements around it. Making it look tidier.

<img width="474" height="206" alt="Screenshot 2026-06-02 at 09 01 18" src="https://github.com/user-attachments/assets/d9f97898-5896-4213-83f7-51fe080f271a" />

<img width="500" height="202" alt="Screenshot 2026-06-02 at 09 01 33" src="https://github.com/user-attachments/assets/2393c725-1c87-4585-a0a2-168a77f64d59" />

- Links (`<a>` tags) should not break the layout when the area is too small.

https://github.com/user-attachments/assets/2926b9b0-1d4a-4001-aca2-1ea4118fc5c4

