### PR TITLE
Fix postgres query stream

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/anywhere.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/anywhere.ts
@@ -13,6 +13,7 @@ import { SqlAnywhereConn, SqlAnywherePool } from './anywhere/SqlAnywherePool';
 import _ from 'lodash';
 import { joinFilters } from '@/common/utils';
 import { SqlAnywhereChangeBuilder } from '@/shared/lib/sql/change_builder/SqlAnywhereChangeBuilder';
+import { SqlAnywhereCursor } from './anywhere/SqlAnywhereCursor';
 
 const D = SqlAnywhereData;
 const log = rawLog.scope('sql-anywhere');
@@ -1170,8 +1171,6 @@ export class SQLAnywhereClient extends BasicDatabaseClient<SQLAnywhereResult> {
 
     const conn = await this.pool.connect();
 
-    // Import SqlAnywhereCursor
-    const { SqlAnywhereCursor } = await import('./anywhere/SqlAnywhereCursor');
 
     return {
       totalRows: Number(rowCount),
@@ -1186,7 +1185,7 @@ export class SQLAnywhereClient extends BasicDatabaseClient<SQLAnywhereResult> {
     };
   }
 
-  queryStream(query: string, chunkSize: number): Promise<StreamResults> {
+  queryStream(_query: string, _chunkSize: number): Promise<StreamResults> {
     throw new Error('Method not implemented.');
   }
 

--- a/apps/studio/src-commercial/backend/lib/db/clients/anywhere/SqlAnywhereCursor.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/anywhere/SqlAnywhereCursor.ts
@@ -1,4 +1,4 @@
-import { BeeCursor, OrderBy, TableFilter } from "@/lib/db/models";
+import { BeeCursor, OrderBy, TableColumn, TableFilter } from "@/lib/db/models";
 import { SqlAnywhereConn } from "./SqlAnywherePool";
 import rawLog from '@bksLogger';
 import { SQLAnywhereClient } from "../anywhere";
@@ -28,6 +28,11 @@ export class SqlAnywhereCursor extends BeeCursor {
     this.client = client;
   }
 
+  // We don't support query streaming so we don't need the columns getter
+  get columns(): TableColumn[] | null {
+    return null;
+  }
+
   async start(): Promise<void> {
     log.info('Starting cursor');
     this.cursorPos = 0;
@@ -37,7 +42,7 @@ export class SqlAnywhereCursor extends BeeCursor {
     try {
       const offset = this.cursorPos * this.chunkSize;
       const limit = this.chunkSize;
-      
+
       // Generate SQL for paginated query
       const sql = await this.client.selectTopSql(
         this.options.table,
@@ -48,16 +53,16 @@ export class SqlAnywhereCursor extends BeeCursor {
         this.options.schema,
         ['*']
       );
-      
+
       // Execute the query
       const result = await this.conn.query(sql);
       this.cursorPos++;
-      
+
       // If no results, return empty array
       if (!result || result.length === 0) {
         return [];
       }
-      
+
       // Convert rows to array format expected by BeeCursor
       return result.map(row => Object.values(row));
     } catch (err) {

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/CassandraCursor.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/CassandraCursor.ts
@@ -1,4 +1,4 @@
-import { BeeCursor } from "@/lib/db/models";
+import { BeeCursor, TableColumn } from "@/lib/db/models";
 import rawLog from '@bksLogger'
 import { waitFor } from "@/lib/db/clients/base/wait"
 
@@ -20,6 +20,11 @@ export class CassandraCursor extends BeeCursor {
   ) {
     super(chunkSize)
 
+  }
+
+  // We don't support query streaming so we don't need the columns getter
+  get columns(): TableColumn[] | null {
+    return null;
   }
 
   start(): Promise<void> {

--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -1047,21 +1047,22 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
     return { totalRows, columns, cursor };
   }
 
-  async queryStream(query: string, chunkSize: number): Promise<StreamResults> {
-    const cursorOpts = {
-      query,
-      params: [],
-      client: this.client,
-      chunkSize
-    }
+  async queryStream(_query: string, _chunkSize: number): Promise<StreamResults> {
+    // const cursorOpts = {
+    //   query,
+    //   params: [],
+    //   client: this.client,
+    //   chunkSize
+    // }
 
-    const { columns, totalRows } = await this.getColumnsAndTotalRows(query);
+    // const { columns, totalRows } = await this.getColumnsAndTotalRows(query);
 
-    return {
-      totalRows,
-      columns,
-      cursor: new ClickHouseCursor(cursorOpts)
-    }
+    // return {
+    //   totalRows,
+    //   columns,
+    //   cursor: new ClickHouseCursor(cursorOpts)
+    // }
+    throw new Error("Query Streaming is not currently supported for clickhouse")
   }
 
   wrapIdentifier(value: string): string {

--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse/ClickHouseCursor.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse/ClickHouseCursor.ts
@@ -1,4 +1,4 @@
-import { BeeCursor } from "@/lib/db/models";
+import { BeeCursor, TableColumn } from "@/lib/db/models";
 import rawlog from "@bksLogger";
 import type { ClickHouseClient, Row, StreamReadable } from "@clickhouse/client";
 import { uuidv4 } from "@/lib/uuid";
@@ -27,6 +27,11 @@ export class ClickHouseCursor extends BeeCursor {
     super(options.chunkSize);
     this.options = options;
     this.client = options.client;
+  }
+
+  // We don't support query streaming so we don't need the columns getter
+  get columns(): TableColumn[] | null {
+    return null;
   }
 
   async start(): Promise<void> {

--- a/apps/studio/src-commercial/backend/lib/db/clients/firebird/FirebirdCursor.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/firebird/FirebirdCursor.ts
@@ -1,4 +1,4 @@
-import { BeeCursor, OrderBy, TableFilter } from "@/lib/db/models";
+import { BeeCursor, OrderBy, TableColumn, TableFilter } from "@/lib/db/models";
 import rawLog from "@bksLogger";
 import { Connection } from "./NodeFirebirdWrapper";
 import Firebird from "node-firebird";
@@ -22,6 +22,11 @@ export class FirebirdCursor extends BeeCursor {
   constructor(options: FirebirdCursorOptions) {
     super(options.chunkSize);
     this.init(options);
+  }
+
+  // We don't support query streaming so we don't need the columns getter
+  get columns(): TableColumn[] | null {
+    return null
   }
 
   async init(options: FirebirdCursorOptions) {

--- a/apps/studio/src/lib/db/clients/postgresql/PsqlCursor.ts
+++ b/apps/studio/src/lib/db/clients/postgresql/PsqlCursor.ts
@@ -33,7 +33,7 @@ export class PsqlCursor extends BeeCursor {
   }
 
   get columns(): TableColumn[] | null {
-    if (this.fields) return null;
+    if (!this.fields) return null;
     return this.fields.map((f) => ({
       columnName: f.name,
       dataType: this.options.dataTypes[f.dataTypeID] || 'user-defined'


### PR DESCRIPTION
A missing `!` in the psql cursor meant that we wouldn't be returning the columns properly for the headers of query exports. Also add empty methods for cursors that don't support query streaming to satisfy typescript