### PR TITLE
feat(editor): split view for query results (#3626)

### DIFF
--- a/apps/studio/src/assets/styles/app/query-editor.scss
+++ b/apps/studio/src/assets/styles/app/query-editor.scss
@@ -129,6 +129,155 @@
       margin: 0 auto;
     }
 
+    .split-results-container {
+      display: flex;
+      flex: 1 1 100%;
+      min-height: 0;
+      overflow: hidden;
+
+      &.orientation-horizontal {
+        flex-direction: column;
+      }
+
+      &.orientation-vertical {
+        flex-direction: row;
+      }
+
+      &.is-maximized {
+        .split-results-pane {
+          flex: 1 1 100% !important;
+          flex-basis: 100% !important;
+        }
+      }
+    }
+
+    .split-results-pane {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .result-panel {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 100%;
+      min-width: 0;
+      min-height: 0;
+      overflow: hidden;
+      background: $query-editor-bg;
+
+      &.has-header {
+        .result-panel-header {
+          display: flex;
+          align-items: center;
+          gap: $gutter-h;
+          padding: ($gutter-h * 0.5) ($gutter-w * 0.75);
+          background: color.adjust($query-editor-bg, $lightness: 2%);
+          border-bottom: 1px solid $border-color;
+          font-size: 0.78rem;
+          line-height: 1;
+          user-select: none;
+          cursor: default;
+        }
+      }
+
+      &.is-focused.has-header .result-panel-header {
+        box-shadow: inset 2px 0 0 $brand-info;
+      }
+
+      .result-panel-label {
+        font-weight: 600;
+        color: $text;
+        white-space: nowrap;
+
+        .result-panel-label-total {
+          color: $text-lighter;
+          font-weight: 400;
+          margin-left: 2px;
+        }
+      }
+
+      .result-panel-meta {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        color: $text-lighter;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        i.material-icons,
+        i.material-icons-outlined {
+          font-size: 14px;
+          line-height: 1;
+        }
+
+        .truncated-rows {
+          color: $brand-warning;
+        }
+      }
+
+      .expand {
+        flex: 1 1 auto;
+      }
+
+      .result-panel-maximize {
+        padding: 0 ($gutter-h * 0.5);
+        min-width: auto;
+        height: auto;
+
+        i.material-icons {
+          font-size: 14px;
+        }
+      }
+
+      .result-panel-body {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 100%;
+        min-height: 0;
+        overflow: hidden;
+
+        .result-table {
+          flex: 1 1 100%;
+          min-height: 0;
+        }
+
+        .message {
+          flex: 1 1 100%;
+        }
+      }
+    }
+  }
+
+  // Layout toggle inside the query status bar
+  .results-view-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 1px;
+
+    .btn.btn-flat.btn-icon {
+      padding: 0 ($gutter-h * 0.5);
+      min-width: auto;
+      opacity: 0.55;
+
+      i.material-icons {
+        font-size: 15px;
+      }
+
+      &:hover {
+        opacity: 0.9;
+      }
+
+      &.active {
+        opacity: 1;
+        background: rgba($theme-base, 0.12);
+        color: $brand-info;
+      }
+    }
   }
 
   .BksSqlTextEditor {
@@ -174,8 +323,6 @@
   > div {
     display: table-cell;
     padding: $gutter-h;
-    padding-right: ($gutter-h - .2);
-    padding-bottom: ($gutter-h + .2);
   }
   .new {
     margin-right: $gutter-h;

--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -52,6 +52,27 @@ export type TransportOpenTabInit<Context = {}> = Omit<
 export type TransportPluginShellTab = TransportOpenTab<PluginTabContext>;
 export type TransportPluginTab = TransportOpenTab<PluginTabContext>;
 
+/** How the multiple result sets of a query are rendered. */
+export type QueryResultsViewMode = 'tabbed' | 'split';
+/** Orientation of the gutter when `QueryResultsViewMode === 'split'`.
+ * `horizontal` = split BY a horizontal line = panels stacked top-to-bottom.
+ * `vertical` = split BY a vertical line = panels side-by-side. */
+export type QueryResultsSplitOrientation = 'horizontal' | 'vertical';
+
+/** Persisted layout state for a query tab. Stored in `context`. */
+export type QueryTabContext = {
+  /** How the multiple result sets of a query are rendered. */
+  resultsViewMode?: QueryResultsViewMode;
+  /** When `resultsViewMode === 'split'`, the split.js direction.
+   * `horizontal` = split BY a horizontal line = panels stacked top-to-bottom.
+   * `vertical` = split BY a vertical line = panels side-by-side. */
+  resultsSplitOrientation?: QueryResultsSplitOrientation;
+  /** When non-null, only this result index is rendered (others hidden). */
+  resultsMaximizedIndex?: number | null;
+};
+
+export type TransportQueryTab = TransportOpenTab<QueryTabContext>;
+
 export type PluginTabContext = {
   pluginId: string;
   pluginTabTypeId: string;

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -265,6 +265,20 @@
         :message="runningText"
         v-if="running"
       />
+      <split-results-container
+        v-else-if="showSplitResults"
+        ref="splitResults"
+        :results="results"
+        :orientation="resultsSplitOrientation"
+        :query="query"
+        :tab="tab"
+        :active="active"
+        :focused-index="selectedResult"
+        :maximized-index="resultsMaximizedIndex"
+        :binary-encoding="$bksConfig.ui.general.binaryEncoding"
+        @focus-panel="onFocusPanel"
+        @toggle-maximize="onToggleMaximize"
+      />
       <result-table
         ref="table"
         v-else-if="showResultTable"
@@ -320,6 +334,8 @@
         :changes-count="$refs.table?.pendingChangesCount"
         :changes-string="$refs.table?.pendingChangesString"
         :result-editable="resultEditable"
+        :view-mode="resultsViewMode"
+        :split-orientation="resultsSplitOrientation"
         @editResults="editResults"
         @stopEditing="stopEditing"
         @saveChanges="saveChanges"
@@ -331,6 +347,7 @@
         @clipboardMarkdown="clipboardMarkdown"
         @submitCurrentQueryToFile="submitCurrentQueryToFile"
         @wrap-text="wrapText = !wrapText"
+        @layout-change="onLayoutChange"
         :execute-time="executeTime"
         :elapsed-time="elapsedTime"
         :active="active"
@@ -532,6 +549,7 @@
   import { EditorMarker } from '@/lib/editor/utils'
   import ProgressBar from './editor/ProgressBar.vue'
   import ResultTable from './editor/ResultTable.vue'
+  import SplitResultsContainer from './editor/SplitResultsContainer.vue'
   import ShortcutHints from './editor/ShortcutHints.vue'
   import SqlTextEditor from "@beekeeperstudio/ui-kit/vue/sql-text-editor"
   import BksSuperFormatter from "@beekeeperstudio/ui-kit/vue/super-formatter"
@@ -545,7 +563,7 @@
   import MergeManager from '@/components/editor/MergeManager.vue'
   import { AppEvent } from '@/common/AppEvent'
   import { PropType } from 'vue'
-  import { TransportOpenTab, findQuery } from '@/common/transport/TransportOpenTab'
+  import { TransportOpenTab, findQuery, QueryTabContext, QueryResultsViewMode, QueryResultsSplitOrientation } from '@/common/transport/TransportOpenTab'
   import { blankFavoriteQuery } from '@/common/transport'
   import { FieldEditData, TableOrView } from "@/lib/db/models";
   import { FormatterDialect, dialectFor, formatOptionsFor } from "@shared/lib/dialects/models"
@@ -565,7 +583,7 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
 
   export default {
     // this.queryText holds the current editor value, always
-    components: { ResultTable, ProgressBar, ShortcutHints, QueryEditorStatusBar, ErrorAlert, MergeManager, SqlTextEditor, SurrealTextEditor, BksSuperFormatter, QueryEditHistory },
+    components: { ResultTable, ProgressBar, ShortcutHints, QueryEditorStatusBar, ErrorAlert, MergeManager, SqlTextEditor, SurrealTextEditor, BksSuperFormatter, QueryEditHistory, SplitResultsContainer },
     props: {
       tab: Object as PropType<TransportOpenTab>,
       active: Boolean
@@ -640,7 +658,11 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         },
         editingResult: false,
         resultsEditData: [],
-        resultEditableMap: []
+        resultEditableMap: [],
+
+        resultsViewMode: 'tabbed' as QueryResultsViewMode,
+        resultsSplitOrientation: 'horizontal' as QueryResultsSplitOrientation,
+        resultsMaximizedIndex: null as number | null,
       }
     },
     computed: {
@@ -891,6 +913,16 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       showResultTable() {
         return this.rowCount > 0
       },
+      /** Tabbed mode shows one ResultTable at a time. Split mode renders all
+       * results via SplitResultsContainer. Downgrades to tabbed when there is
+       * only one result. */
+      effectiveViewMode(): QueryResultsViewMode {
+        if (this.resultsViewMode === 'split' && this.results.length > 1) return 'split'
+        return 'tabbed'
+      },
+      showSplitResults() {
+        return this.effectiveViewMode === 'split' && this.results.length > 0
+      },
       entities() {
         return this.tables.map((t: TableOrView) => ({
           schema: t.schema,
@@ -953,6 +985,14 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
     watch: {
       selectedResult() {
         this.editingResult = false
+      },
+      'results.length'(newLength: number) {
+        if (
+          this.resultsMaximizedIndex !== null &&
+          this.resultsMaximizedIndex >= newLength
+        ) {
+          this.resultsMaximizedIndex = null
+        }
       },
       error() {
         this.errorMarker = null
@@ -1669,11 +1709,80 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       async switchPaneFocus(_event?: KeyboardEvent, target?: 'text-editor' | 'table') {
         if (target) {
           this.focusElement = target
-        } else {
-          this.focusElement = this.focusElement === 'text-editor'
-            ? 'table'
-            : 'text-editor'
+          return
         }
+
+        const inSplit = this.effectiveViewMode === 'split'
+
+        if (inSplit) {
+          // Cycle: editor -> panel 0 -> panel 1 -> ... -> editor
+          if (this.focusElement === 'text-editor') {
+            this.focusElement = 'table'
+            this.selectedResult = 0
+            this.$nextTick(() => {
+              (this.$refs.splitResults as any)?.focusPanel?.(this.selectedResult)
+            })
+            return
+          }
+
+          const visibleCount = this.resultsMaximizedIndex !== null ? 1 : this.results.length
+          const next = this.selectedResult + 1
+          if (next >= visibleCount) {
+            this.focusElement = 'text-editor'
+          } else {
+            this.selectedResult = next
+            this.$nextTick(() => {
+              (this.$refs.splitResults as any)?.focusPanel?.(this.selectedResult)
+            })
+          }
+          return
+        }
+
+        this.focusElement = this.focusElement === 'text-editor'
+          ? 'table'
+          : 'text-editor'
+      },
+      /** Status bar emits this when the user clicks a layout toggle button. */
+      onLayoutChange({ mode, orientation }: { mode: QueryResultsViewMode; orientation: QueryResultsSplitOrientation }) {
+        this.resultsViewMode = mode
+        this.resultsSplitOrientation = orientation
+        // Leaving split clears any maximized state.
+        if (mode !== 'split') this.resultsMaximizedIndex = null
+        this.persistLayoutState()
+      },
+      onFocusPanel(index: number) {
+        this.selectedResult = index
+        this.focusElement = 'table'
+      },
+      onToggleMaximize(maximizedIndex: number | null) {
+        this.resultsMaximizedIndex = maximizedIndex
+        if (maximizedIndex !== null) {
+          this.selectedResult = maximizedIndex
+        }
+        this.persistLayoutState()
+      },
+      restoreLayoutState() {
+        const ctx = (this.tab?.context || {}) as QueryTabContext
+        if (ctx.resultsViewMode === 'split' || ctx.resultsViewMode === 'tabbed') {
+          this.resultsViewMode = ctx.resultsViewMode
+        }
+        if (ctx.resultsSplitOrientation === 'horizontal' || ctx.resultsSplitOrientation === 'vertical') {
+          this.resultsSplitOrientation = ctx.resultsSplitOrientation
+        }
+        if (typeof ctx.resultsMaximizedIndex === 'number' || ctx.resultsMaximizedIndex === null) {
+          this.resultsMaximizedIndex = ctx.resultsMaximizedIndex ?? null
+        }
+      },
+      persistLayoutState() {
+        if (!this.tab) return
+        const next: QueryTabContext = {
+          ...(this.tab.context || {}),
+          resultsViewMode: this.resultsViewMode,
+          resultsSplitOrientation: this.resultsSplitOrientation,
+          resultsMaximizedIndex: this.resultsMaximizedIndex,
+        }
+        this.tab.context = next
+        this.$store.dispatch('tabs/save', this.tab)
       },
       blurTextEditor() {
         let timedOut = false
@@ -1910,6 +2019,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       this.registerHandlers(this.rootBindings)
     },
     async mounted() {
+      this.restoreLayoutState()
+
       const {
         primaryFunc,
         secondaryFunc,

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -11,7 +11,7 @@
         v-hotkey="keymap"
       >
         <span
-          v-show="results?.length > 1"
+          v-show="results?.length > 1 && viewMode !== 'split'"
           class="statusbar-item result-selector"
           :title="'Results'"
         >
@@ -39,6 +39,43 @@
               </option>
             </select>
           </div>
+        </span>
+        <span
+          v-show="results?.length > 1 && !!viewMode"
+          class="statusbar-item results-view-toggle"
+          role="group"
+          aria-label="Results layout"
+        >
+          <button
+            type="button"
+            class="btn btn-flat btn-icon"
+            :class="{ active: viewMode === 'tabbed' }"
+            v-tooltip="'Tabbed view — one result at a time'"
+            aria-label="Tabbed view"
+            @click="setLayout('tabbed', splitOrientation)"
+          >
+            <i class="material-icons">tab</i>
+          </button>
+          <button
+            type="button"
+            class="btn btn-flat btn-icon"
+            :class="{ active: viewMode === 'split' && splitOrientation === 'horizontal' }"
+            v-tooltip="'Split — stacked (top to bottom)'"
+            aria-label="Split stacked"
+            @click="setLayout('split', 'horizontal')"
+          >
+            <i class="material-icons">horizontal_split</i>
+          </button>
+          <button
+            type="button"
+            class="btn btn-flat btn-icon"
+            :class="{ active: viewMode === 'split' && splitOrientation === 'vertical' }"
+            v-tooltip="'Split — side by side'"
+            aria-label="Split side by side"
+            @click="setLayout('split', 'vertical')"
+          >
+            <i class="material-icons">vertical_split</i>
+          </button>
         </span>
         <div
           class="statusbar-item row-counts"
@@ -251,7 +288,21 @@ const shortEnglishHumanizer = humanizeDuration.humanizer({
 });
 
 export default {
-  props: ['results', 'running', 'value', 'executeTime', 'wrapText', 'active', 'elapsedTime', 'editing', 'changesCount', 'changesString', 'resultEditable'],
+  props: [
+    'results',
+    'running',
+    'value',
+    'executeTime',
+    'wrapText',
+    'active',
+    'elapsedTime',
+    'editing',
+    'changesCount',
+    'changesString',
+    'resultEditable',
+    'viewMode',
+    'splitOrientation',
+  ],
   components: { Statusbar },
   data() {
     return {
@@ -415,6 +466,9 @@ export default {
     },
     submitCurrentQueryToFile() {
       this.$emit('submitCurrentQueryToFile')
+    },
+    setLayout(mode, orientation) {
+      this.$emit('layout-change', { mode, orientation })
     },
   }
 }

--- a/apps/studio/src/components/editor/ResultPanel.vue
+++ b/apps/studio/src/components/editor/ResultPanel.vue
@@ -1,0 +1,176 @@
+<template>
+  <div
+    class="result-panel"
+    :class="{
+      'has-header': showHeader,
+      'is-maximized': maximized,
+      'is-focused': focused,
+    }"
+  >
+    <div
+      v-if="showHeader"
+      class="result-panel-header"
+      @mousedown="$emit('focus')"
+    >
+      <span class="result-panel-label">
+        Result {{ resultIndex + 1 }}<span
+          v-if="totalResults > 1"
+          class="result-panel-label-total"
+        >/{{ totalResults }}</span>
+      </span>
+      <span class="result-panel-meta">
+        <template v-if="hasRows">
+          <i class="material-icons">list_alt</i>
+          <span>{{ rowCount }} {{ pluralize('row', rowCount, false) }}</span>
+          <span
+            v-if="result.truncated"
+            class="truncated-rows"
+            v-tooltip="'Truncated — use Download to get the full resultset'"
+          >/&nbsp;{{ result.totalRowCount }}</span>
+        </template>
+        <template v-else>
+          <i class="material-icons">info</i>
+          <span>No rows · {{ result.affectedRows || 0 }} affected</span>
+        </template>
+      </span>
+      <span class="expand" />
+      <button
+        v-if="canMaximize"
+        type="button"
+        class="btn btn-flat btn-icon result-panel-maximize"
+        :title="maximized ? 'Restore split view' : 'Maximize this result'"
+        @click="$emit('toggle-maximize')"
+      >
+        <i class="material-icons">{{
+          maximized ? 'close_fullscreen' : 'open_in_full'
+        }}</i>
+      </button>
+    </div>
+    <div
+      class="result-panel-body"
+      ref="body"
+    >
+      <result-table
+        v-if="hasRows"
+        ref="resultTable"
+        :result="result"
+        :table-height="bodyHeight"
+        :query="query"
+        :active="active"
+        :tab="tab"
+        :focus="focused"
+        :binary-encoding="binaryEncoding"
+      />
+      <div
+        v-else
+        class="message"
+      >
+        <div class="alert alert-info">
+          <i class="material-icons-outlined">info</i>
+          <span>No Results. {{ result.affectedRows || 0 }} rows affected.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import _ from 'lodash';
+import ResultTable from './ResultTable.vue';
+
+export default Vue.extend({
+  name: 'ResultPanel',
+  components: { ResultTable },
+  props: {
+    result: {
+      type: Object,
+      required: true,
+    },
+    resultIndex: {
+      type: Number,
+      required: true,
+    },
+    totalResults: {
+      type: Number,
+      required: true,
+    },
+    query: {
+      type: Object as PropType<any>,
+      default: null,
+    },
+    tab: {
+      type: Object as PropType<any>,
+      required: true,
+    },
+    active: {
+      type: Boolean,
+      default: false,
+    },
+    focused: {
+      type: Boolean,
+      default: false,
+    },
+    binaryEncoding: {
+      type: String,
+      default: 'hex',
+    },
+    showHeader: {
+      type: Boolean,
+      default: true,
+    },
+    canMaximize: {
+      type: Boolean,
+      default: true,
+    },
+    maximized: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      bodyHeight: 0,
+      resizeObserver: null as ResizeObserver | null,
+    };
+  },
+  computed: {
+    hasRows(): boolean {
+      return !!this.result?.rows?.length;
+    },
+    rowCount(): number {
+      return this.result?.rows?.length || 0;
+    },
+  },
+  mounted() {
+    this.measure();
+    if (typeof ResizeObserver !== 'undefined') {
+      this.resizeObserver = new ResizeObserver(
+        _.throttle(() => this.measure(), 100, { trailing: true })
+      );
+      this.resizeObserver.observe(this.$refs.body as Element);
+    }
+  },
+  beforeDestroy() {
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+  },
+  methods: {
+    measure() {
+      const el = this.$refs.body as HTMLElement | undefined;
+      if (!el) return;
+      this.bodyHeight = el.clientHeight;
+    },
+    pluralize(word: string, amount: number, flag: boolean): string {
+      return (window as any).main.pluralize(word, amount, flag);
+    },
+    /** Forwards focus into the underlying tabulator instance. */
+    focusTable() {
+      const rt = this.$refs.resultTable as any;
+      rt?.triggerFocus?.();
+    },
+  },
+});
+</script>

--- a/apps/studio/src/components/editor/SplitResultsContainer.vue
+++ b/apps/studio/src/components/editor/SplitResultsContainer.vue
@@ -1,0 +1,177 @@
+<template>
+  <div
+    class="split-results-container"
+    :class="[`orientation-${orientation}`, { 'is-maximized': isMaximized }]"
+    ref="container"
+  >
+    <result-panel
+      v-for="(result, index) in results"
+      :key="index"
+      :ref="`panel-${index}`"
+      v-show="isPanelVisible(index)"
+      class="split-results-pane"
+      :data-pane-index="index"
+      :result="result"
+      :result-index="index"
+      :total-results="results.length"
+      :query="query"
+      :tab="tab"
+      :active="active"
+      :focused="focusedIndex === index"
+      :binary-encoding="binaryEncoding"
+      :can-maximize="results.length > 1"
+      :maximized="maximizedIndex === index"
+      @toggle-maximize="onToggleMaximize(index)"
+      @focus="$emit('focus-panel', index)"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from "vue";
+import _ from "lodash";
+import Split from "split.js";
+import ResultPanel from "./ResultPanel.vue";
+import type { QueryResultsSplitOrientation } from "@/common/transport/TransportOpenTab";
+
+type SplitInstance = ReturnType<typeof Split>;
+
+export default Vue.extend({
+  name: "SplitResultsContainer",
+  components: { ResultPanel },
+  props: {
+    results: {
+      type: Array as PropType<any[]>,
+      required: true,
+    },
+    orientation: {
+      type: String as PropType<QueryResultsSplitOrientation>,
+      default: "horizontal",
+    },
+    query: {
+      type: Object as PropType<any>,
+      default: null,
+    },
+    tab: {
+      type: Object as PropType<any>,
+      required: true,
+    },
+    active: {
+      type: Boolean,
+      default: false,
+    },
+    focusedIndex: {
+      type: Number,
+      default: 0,
+    },
+    binaryEncoding: {
+      type: String,
+      default: "hex",
+    },
+    maximizedIndex: {
+      type: Number as PropType<number | null>,
+      default: null,
+    },
+  },
+  data() {
+    return {
+      split: null as SplitInstance | null,
+    };
+  },
+  computed: {
+    isMaximized(): boolean {
+      return this.maximizedIndex !== null && this.maximizedIndex !== undefined;
+    },
+    /** Direction passed to split.js. The orientation names are inverted relative
+     * to split.js: a "horizontal split" stacks panels (gutter is horizontal) so
+     * split.js calls that `vertical` direction. */
+    splitDirection(): "horizontal" | "vertical" {
+      return this.orientation === "horizontal" ? "vertical" : "horizontal";
+    },
+  },
+  watch: {
+    orientation() {
+      this.rebuildSplit();
+    },
+    "results.length"() {
+      this.rebuildSplit();
+    },
+    maximizedIndex() {
+      this.rebuildSplit();
+    },
+  },
+  mounted() {
+    this.$nextTick(() => this.rebuildSplit());
+  },
+  beforeDestroy() {
+    this.destroySplit();
+  },
+  methods: {
+    isPanelVisible(index: number): boolean {
+      if (!this.isMaximized) return true;
+      return this.maximizedIndex === index;
+    },
+    visiblePanelElements(): HTMLElement[] {
+      const elements: HTMLElement[] = [];
+      for (let i = 0; i < this.results.length; i++) {
+        if (!this.isPanelVisible(i)) continue;
+        const refs = this.$refs[`panel-${i}`] as Vue[] | undefined;
+        const refInstance = Array.isArray(refs) ? refs[0] : refs;
+        const el = refInstance?.$el as HTMLElement | undefined;
+        if (el) elements.push(el);
+      }
+      return elements;
+    },
+    destroySplit() {
+      if (this.split) {
+        try {
+          this.split.destroy();
+        } catch (e) {
+          // split.js can throw on destroy if elements were already removed
+        }
+        this.split = null;
+      }
+    },
+    rebuildSplit() {
+      this.$nextTick(() => {
+        this.destroySplit();
+        const elements = this.visiblePanelElements();
+
+        // Reset any flex-basis left over from a previous split.js instance.
+        for (let i = 0; i < this.results.length; i++) {
+          const refs = this.$refs[`panel-${i}`] as Vue[] | undefined;
+          const refInstance = Array.isArray(refs) ? refs[0] : refs;
+          const el = refInstance?.$el as HTMLElement | undefined;
+          if (el) el.style.flexBasis = "";
+        }
+
+        if (elements.length < 2) return;
+
+        const sizes = elements.map(() => 100 / elements.length);
+        this.split = Split(elements, {
+          sizes,
+          direction: this.splitDirection,
+          gutterSize: 6,
+          minSize: 80,
+          elementStyle: (_dimension, size) => ({
+            "flex-basis": `calc(${size}%)`,
+          }),
+          onDragEnd: _.debounce(() => {
+            this.$emit("panels-resized");
+          }, 50),
+        });
+      });
+    },
+    onToggleMaximize(index: number) {
+      const next = this.maximizedIndex === index ? null : index;
+      this.$emit("toggle-maximize", next);
+    },
+    /** Programmatically focus a particular panel's table. */
+    focusPanel(index: number) {
+      const refs = this.$refs[`panel-${index}`] as Vue[] | undefined;
+      const refInstance = Array.isArray(refs) ? refs[0] : refs;
+      (refInstance as any)?.focusTable?.();
+    },
+  },
+});
+</script>

--- a/apps/studio/tests/unit/components/editor/QueryEditorStatusBar.spec.ts
+++ b/apps/studio/tests/unit/components/editor/QueryEditorStatusBar.spec.ts
@@ -1,0 +1,148 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuex from "vuex";
+import QueryEditorStatusBar from "@/components/editor/QueryEditorStatusBar.vue";
+
+Vue.use(Vuex);
+
+(global as any).window.main = {
+  pluralize: (word: string, count: number) =>
+    count === 1 ? word : `${word}s`,
+};
+
+function makeStore() {
+  return new Vuex.Store({
+    state: {
+      connection: {},
+      usedConfig: { readOnlyMode: false },
+    },
+    getters: { dialect: () => "postgresql", isCommunity: () => false },
+    modules: {
+      settings: {
+        namespaced: true,
+        state: {
+          settings: {
+            keymap: { value: "default" },
+            hideResultsDropdown: { value: false },
+          },
+        },
+        actions: { save: jest.fn() },
+      },
+    },
+  });
+}
+
+const stubs = {
+  statusbar: { template: "<div><slot /></div>" },
+  "x-buttons": { template: "<div><slot /></div>" },
+  "x-button": { template: "<div><slot /></div>" },
+  "x-menu": { template: "<div><slot /></div>" },
+  "x-menuitem": { template: "<div><slot /></div>" },
+  "x-label": { template: "<div><slot /></div>" },
+};
+
+const mocks = {
+  $config: { defaults: { keymapTypes: [{ name: "Default", value: "default" }] } },
+  $bksConfig: {},
+  $vHotkeyKeymap: () => ({}),
+  $store: makeStore(),
+};
+
+function mount(propsData: any) {
+  return shallowMount(QueryEditorStatusBar, {
+    propsData: {
+      results: [],
+      running: false,
+      value: 0,
+      executeTime: 0,
+      elapsedTime: 0,
+      active: true,
+      wrapText: false,
+      viewMode: "tabbed",
+      splitOrientation: "horizontal",
+      ...propsData,
+    },
+    store: makeStore(),
+    stubs,
+    mocks,
+  });
+}
+
+describe("QueryEditorStatusBar layout toggle", () => {
+  it("emits layout-change with tabbed mode when the tabbed button is clicked", () => {
+    const wrapper = mount({
+      results: [
+        { rows: [{ a: 1 }], affectedRows: 0 },
+        { rows: [{ b: 2 }], affectedRows: 0 },
+      ],
+      viewMode: "split",
+      splitOrientation: "horizontal",
+    });
+
+    (wrapper.vm as any).setLayout("tabbed", "horizontal");
+    expect(wrapper.emitted("layout-change")[0]).toEqual([
+      { mode: "tabbed", orientation: "horizontal" },
+    ]);
+  });
+
+  it("emits layout-change with split horizontal", () => {
+    const wrapper = mount({
+      results: [
+        { rows: [{ a: 1 }], affectedRows: 0 },
+        { rows: [{ b: 2 }], affectedRows: 0 },
+      ],
+    });
+
+    (wrapper.vm as any).setLayout("split", "horizontal");
+    expect(wrapper.emitted("layout-change")[0]).toEqual([
+      { mode: "split", orientation: "horizontal" },
+    ]);
+  });
+
+  it("emits layout-change with split vertical", () => {
+    const wrapper = mount({
+      results: [
+        { rows: [{ a: 1 }], affectedRows: 0 },
+        { rows: [{ b: 2 }], affectedRows: 0 },
+      ],
+    });
+
+    (wrapper.vm as any).setLayout("split", "vertical");
+    expect(wrapper.emitted("layout-change")[0]).toEqual([
+      { mode: "split", orientation: "vertical" },
+    ]);
+  });
+
+  it("renders three toggle buttons when there are 2+ results", () => {
+    const wrapper = mount({
+      results: [
+        { rows: [{ a: 1 }], affectedRows: 0 },
+        { rows: [{ b: 2 }], affectedRows: 0 },
+      ],
+    });
+
+    const toggle = wrapper.find(".results-view-toggle");
+    expect(toggle.exists()).toBe(true);
+    // tabbed, stacked, side-by-side
+    expect(toggle.findAll("button").length).toBe(3);
+  });
+
+  it("marks the matching toggle button as active", () => {
+    const wrapper = mount({
+      results: [
+        { rows: [{ a: 1 }], affectedRows: 0 },
+        { rows: [{ b: 2 }], affectedRows: 0 },
+      ],
+      viewMode: "split",
+      splitOrientation: "vertical",
+    });
+
+    const activeButtons = wrapper
+      .find(".results-view-toggle")
+      .findAll("button.active");
+    expect(activeButtons.length).toBe(1);
+    expect(activeButtons.at(0).attributes("aria-label")).toBe(
+      "Split side by side"
+    );
+  });
+});

--- a/apps/studio/tests/unit/components/editor/ResultPanel.spec.ts
+++ b/apps/studio/tests/unit/components/editor/ResultPanel.spec.ts
@@ -1,0 +1,95 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import ResultPanel from "@/components/editor/ResultPanel.vue";
+
+// jsdom doesn't have ResizeObserver
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// pluralize is reached via window.main.pluralize in the component
+(global as any).window.main = {
+  pluralize: (word: string, count: number) =>
+    count === 1 ? word : `${word}s`,
+};
+
+const baseProps = {
+  result: { rows: [], fields: [], affectedRows: 0 },
+  resultIndex: 0,
+  totalResults: 3,
+  tab: { id: 1, title: "Untitled Query" },
+};
+
+describe("ResultPanel.vue", () => {
+  it("shows the no-rows message when result has no rows", () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: {
+        ...baseProps,
+        result: { rows: [], fields: [], affectedRows: 5 },
+      },
+      stubs: { "result-table": true },
+    });
+
+    expect(wrapper.text()).toContain("No Results");
+    expect(wrapper.text()).toContain("5");
+  });
+
+  it("renders the row count in the header", async () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: {
+        ...baseProps,
+        result: {
+          rows: [{ a: 1 }, { a: 2 }, { a: 3 }],
+          fields: [{ name: "a", id: "a" }],
+          affectedRows: 0,
+        },
+      },
+      stubs: { "result-table": true },
+    });
+
+    await Vue.nextTick();
+    expect(wrapper.find(".result-panel-label").text()).toContain("Result 1");
+    expect(wrapper.find(".result-panel-meta").text()).toContain("3");
+  });
+
+  it("hides the header when showHeader=false", () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: { ...baseProps, showHeader: false },
+      stubs: { "result-table": true },
+    });
+
+    expect(wrapper.find(".result-panel-header").exists()).toBe(false);
+  });
+
+  it("hides the maximize button when canMaximize=false", () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: { ...baseProps, canMaximize: false },
+      stubs: { "result-table": true },
+    });
+
+    expect(wrapper.find(".result-panel-maximize").exists()).toBe(false);
+  });
+
+  it("emits toggle-maximize when the maximize button is clicked", async () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: { ...baseProps, canMaximize: true },
+      stubs: { "result-table": true },
+    });
+
+    await wrapper.find(".result-panel-maximize").trigger("click");
+    expect(wrapper.emitted("toggle-maximize")).toBeTruthy();
+    expect(wrapper.emitted("toggle-maximize")).toHaveLength(1);
+  });
+
+  it("emits focus when the header is mousedown'd", async () => {
+    const wrapper = shallowMount(ResultPanel, {
+      propsData: baseProps,
+      stubs: { "result-table": true },
+    });
+
+    await wrapper.find(".result-panel-header").trigger("mousedown");
+    expect(wrapper.emitted("focus")).toBeTruthy();
+  });
+});

--- a/apps/studio/tests/unit/components/editor/SplitResultsContainer.spec.ts
+++ b/apps/studio/tests/unit/components/editor/SplitResultsContainer.spec.ts
@@ -1,0 +1,144 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+
+jest.mock("split.js", () => {
+  const splitMock: any = jest.fn(() => ({
+    destroy: jest.fn(),
+    getSizes: jest.fn(() => [50, 50]),
+    setSizes: jest.fn(),
+  }));
+  return { __esModule: true, default: splitMock };
+});
+
+import SplitResultsContainer from "@/components/editor/SplitResultsContainer.vue";
+
+(global as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+(global as any).window.main = {
+  pluralize: (word: string, count: number) =>
+    count === 1 ? word : `${word}s`,
+};
+
+function makeResults(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    rows: [{ a: i }],
+    fields: [{ name: "a", id: "a" }],
+    affectedRows: 0,
+  }));
+}
+
+const baseProps = {
+  query: null,
+  tab: { id: 1, title: "Untitled Query" },
+  active: true,
+  binaryEncoding: "hex",
+};
+
+describe("SplitResultsContainer.vue", () => {
+  it("renders one ResultPanel per result", () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(3),
+        orientation: "horizontal",
+      },
+    });
+
+    expect(wrapper.findAllComponents({ name: "ResultPanel" })).toHaveLength(3);
+  });
+
+  it("applies orientation class to the container", () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(2),
+        orientation: "vertical",
+      },
+    });
+
+    expect(wrapper.classes()).toContain("orientation-vertical");
+  });
+
+  it("re-applies class when orientation prop changes", async () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(2),
+        orientation: "horizontal",
+      },
+    });
+
+    await wrapper.setProps({ orientation: "vertical" });
+    expect(wrapper.classes()).toContain("orientation-vertical");
+    expect(wrapper.classes()).not.toContain("orientation-horizontal");
+  });
+
+  it("marks container as maximized when a panel is maximized", () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(3),
+        orientation: "horizontal",
+        maximizedIndex: 1,
+      },
+    });
+
+    expect(wrapper.classes()).toContain("is-maximized");
+  });
+
+  it("emits toggle-maximize with the new index when child fires the event", async () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(2),
+        orientation: "horizontal",
+        maximizedIndex: null,
+      },
+    });
+
+    const panels = wrapper.findAllComponents({ name: "ResultPanel" });
+    panels.at(1).vm.$emit("toggle-maximize");
+
+    await Vue.nextTick();
+    const emitted = wrapper.emitted("toggle-maximize");
+    expect(emitted).toBeTruthy();
+    expect(emitted[0]).toEqual([1]);
+  });
+
+  it("emits toggle-maximize with null when the currently maximized panel is toggled off", async () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(2),
+        orientation: "horizontal",
+        maximizedIndex: 0,
+      },
+    });
+
+    const panels = wrapper.findAllComponents({ name: "ResultPanel" });
+    panels.at(0).vm.$emit("toggle-maximize");
+
+    await Vue.nextTick();
+    expect(wrapper.emitted("toggle-maximize")[0]).toEqual([null]);
+  });
+
+  it("forwards focus-panel events from children with the panel index", async () => {
+    const wrapper = shallowMount(SplitResultsContainer, {
+      propsData: {
+        ...baseProps,
+        results: makeResults(2),
+        orientation: "horizontal",
+      },
+    });
+
+    const panels = wrapper.findAllComponents({ name: "ResultPanel" });
+    panels.at(1).vm.$emit("focus");
+
+    await Vue.nextTick();
+    expect(wrapper.emitted("focus-panel")[0]).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Description
Fixes #3626

This PR introduces a split pane query result view, allowing users to inspect and compare multiple result sets simultaneously. It expands the UI with a flexible layout system supporting tabbed, stacked (horizontal split), and side-by-side (vertical split) views.

**Changes:**
- Added **SplitResultsContainer.vue** and **ResultPanel.vue** components to manage the multi-pane layout using split.js.
- Updated **TabQueryEditor.vue** to integrate the new split container alongside the existing single-result table functionality.
- Modified **QueryEditorStatusBar.vue** to include layout toggle buttons and drive pane visibility.
- Implemented layout state persistence via the **tab.context**, ensuring user preferences (view mode and split orientation) are saved per tab.
- Added comprehensive unit tests to verify pane resizing, layout transitions, and state persistence.

## Testing

- [x] Added unit tests for result-state logic, layout transitions, and tab context persistence.
- [x] Added component tests for pane resizing and layout calculations across all three modes.

## Screenshot and Video

**Before**
<img width="1919" height="1079" alt="before" src="https://github.com/user-attachments/assets/62898d2c-979e-47b0-8dee-6d8bc4c04373" />

**After**
<img width="1919" height="1079" alt="After1" src="https://github.com/user-attachments/assets/8e3a561b-ea76-4103-b2a3-a7862060cd25" />
<img width="1919" height="1079" alt="After2" src="https://github.com/user-attachments/assets/749b8c0d-c5bc-47d1-8169-1c35f565b77a" />
<img width="1919" height="1079" alt="After3" src="https://github.com/user-attachments/assets/f4600dd1-5cb4-4829-9da1-6c34ef63dc8a" />


## Authors
Signed-off-by: Martim Borges <martim.borges@tecnico.ulisboa.pt>
Co-authored-by: António Mello <antonio.mello@tecnico.ulisboa.pt>