### PR TITLE
feat: Add tables overview dashboard

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -1,6 +1,6 @@
 import { UserSetting } from "@/common/appdb/models/user_setting";
 import { IConnection } from "@/common/interfaces/IConnection";
-import { DatabaseFilterOptions, ExtendedTableColumn, FieldDescriptor, FieldEditData, FilterOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableFilter, TableIndex, TableInsert, TableOrView, TablePartition, TableProperties, TableResult, TableTrigger, TableUpdateResult } from "@/lib/db/models";
+import { DatabaseFilterOptions, ExtendedTableColumn, FieldDescriptor, FieldEditData, FilterOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableFilter, TableIndex, TableInsert, TableOrView, TablePartition, TableProperties, TableResult, TableTrigger, TableUpdateResult, TableOverview, TablesOverview } from "@/lib/db/models";
 import { DatabaseElement, IDbConnectionServerConfig } from "@/lib/db/types";
 import { AlterPartitionsSpec, AlterTableSpec, CreateTableSpec, dialectFor, IndexAlterations, RelationAlterations, TableKey } from "@shared/lib/dialects/models";
 import { checkConnection, errorMessages, getDriverHandler, state } from "@/handlers/handlerState";
@@ -58,6 +58,9 @@ export interface IConnectionHandlers {
   'conn/executeQuery': ({ queryText, options, sId }: { queryText: string, options: any, sId: string }) => Promise<NgQueryResult[]>,
   'conn/listDatabases': ({ filter, sId }: { filter?: DatabaseFilterOptions, sId: string }) => Promise<string[]>,
   'conn/getTableProperties': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<TableProperties | null>,
+  'conn/getTableOverview': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<TableOverview | null>,
+  'conn/getTablesOverview': ({ schema, sId }: { schema?: string, sId: string }) => Promise<TablesOverview>,
+  'conn/optimizeTable': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<void>,
   'conn/getQuerySelectTop': ({ table, limit, schema, sId }: { table: string, limit: number, schema?: string, sId: string }) => Promise<string>,
   'conn/listMaterializedViews': ({ filter, sId }: { filter?: FilterOptions, sId: string }) => Promise<TableOrView[]>,
   'conn/getPrimaryKey': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<string | null>,
@@ -379,6 +382,21 @@ export const ConnHandlers: IConnectionHandlers = {
   'conn/getTableProperties': async function({ table, schema, sId }: { table: string, schema?: string, sId: string}) {
     checkConnection(sId);
     return await state(sId).connection.getTableProperties(table, schema);
+  },
+
+  'conn/getTableOverview': async function({ table, schema, sId }: { table: string, schema?: string, sId: string }) {
+    checkConnection(sId);
+    return await state(sId).connection.getTableOverview(table, schema);
+  },
+
+  'conn/getTablesOverview': async function({ schema, sId }: { schema?: string, sId: string }) {
+    checkConnection(sId);
+    return await state(sId).connection.getTablesOverview(schema);
+  },
+
+  'conn/optimizeTable': async function({ table, schema, sId }: { table: string, schema?: string, sId: string }) {
+    checkConnection(sId);
+    return await state(sId).connection.optimizeTable(table, schema);
   },
 
   'conn/getQuerySelectTop': async function({ table, limit, schema, sId }: { table: string, limit: number, schema?: string, sId: string }) {

--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -6,7 +6,7 @@ import { JsonValue } from "@/types";
 import { LoadViewParams } from "@beekeeperstudio/plugin";
 
 export type PluginTabType = 'plugin-base' | 'plugin-shell';
-export type CoreTabType = 'query' | 'table' | 'table-properties' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
+export type CoreTabType = 'query' | 'table' | 'table-properties' | 'tables-overview' | 'settings' | 'table-builder' | 'backup' | 'import-export-database' | 'restore' | 'import-table' | 'shell'
 export type TabType = CoreTabType | PluginTabType
 
 const pickable = ['title', 'tabType', 'unsavedChanges', 'unsavedQueryText', 'tableName', 'schemaName', 'context']
@@ -167,6 +167,8 @@ export function matches(obj: TransportOpenTab, other: TransportOpenTab): boolean
       return obj.tableName === other.tableName &&
         (obj.schemaName || null) === (other.schemaName || null) &&
         (obj.entityType || null) === (other.entityType || null);
+    case 'tables-overview':
+      return obj.tabType === 'tables-overview';
     case 'import-export-database':
       // we store export state in the store, so don't want multiple open
       // at a time.

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -131,6 +131,12 @@
             />
           </template>
         </tab-with-table>
+        <TablesOverview
+          v-if="tab.tabType === 'tables-overview'"
+          :active="activeTab?.id === tab.id"
+          :tab="tab"
+          :tab-id="tab.id"
+        />
         <TableBuilder
           v-if="tab.tabType === 'table-builder'"
           :active="activeTab?.id === tab.id"
@@ -300,6 +306,7 @@ import Statusbar from './common/StatusBar.vue'
 import CoreTabHeader from './CoreTabHeader.vue'
 import TableTable from './tableview/TableTable.vue'
 import TableProperties from './TabTableProperties.vue'
+import TablesOverview from './TabTablesOverview.vue'
 import TableBuilder from './TabTableBuilder.vue'
 import ImportExportDatabase from './importexportdatabase/ImportExportDatabase.vue'
 import ImportTable from './TabImportTable.vue'
@@ -337,6 +344,7 @@ export default Vue.extend({
     CoreTabHeader,
     TableTable,
     TableProperties,
+    TablesOverview,
     ImportExportDatabase,
     ImportTable,
     Draggable,
@@ -670,6 +678,8 @@ export default Vue.extend({
     async createTab(config: TabTypeConfig.Config) {
       if (config.type === "query") {
         this.createQuery()
+      } else if (config.type === "tables-overview") {
+        this.openTablesOverview()
       } else if (config.type === "shell") {
         this.createShell()
       } else if (config.type === "plugin-shell" || config.type === "plugin-base") {
@@ -1015,6 +1025,16 @@ export default Vue.extend({
       const existing = this.tabItems.find((tab) => matches(tab, t))
       if (existing) return this.$store.dispatch('tabs/setActive', existing)
       this.addTab(t)
+    },
+    openTablesOverview() {
+      const tab = {} as TransportOpenTab;
+      tab.tabType = 'tables-overview';
+      tab.title = 'Tables Overview';
+      tab.entityType = 'table';
+      tab.unsavedChanges = false;
+      const existing = this.tabItems.find((t) => matches(t, tab))
+      if (existing) return this.$store.dispatch('tabs/setActive', existing)
+      this.addTab(tab)
     },
     async openTable({ table, filters }) {
       let tab = {} as TransportOpenTab;

--- a/apps/studio/src/components/TabTablesOverview.vue
+++ b/apps/studio/src/components/TabTablesOverview.vue
@@ -1,0 +1,329 @@
+<template>
+  <div class="table-properties">
+    <div
+      v-if="error"
+      class="alert-wrapper"
+    >
+      <div class="alert alert-danger">
+        {{ error.message }}
+      </div>
+    </div>
+
+    <template v-else>
+      <div class="table-properties-header tables-overview-header" />
+
+      <div
+        v-if="loading"
+        class="table-properties-loading"
+      >
+        <x-progressbar />
+      </div>
+
+      <div
+        class="table-properties-wrap"
+        v-if="!loading"
+      >
+        <div class="table-info-table">
+          <div class="table-info-table-wrap">
+            <div class="center-wrap">
+              <div class="table-subheader">
+                <div class="table-title">
+                  <h2>Tables Overview</h2>
+                </div>
+                <span class="expand" />
+                <div class="actions">
+                  <x-button
+                    v-if="hasDatabaseOptimization"
+                    class="btn btn-sm btn-flat"
+                    title="Optimize database"
+                    @click.prevent="optimizeDatabase"
+                  >
+                    Optimize Database
+                  </x-button>
+                  <a
+                    @click.prevent="refresh"
+                    class="btn btn-link btn-fab"
+                    title="Refresh"
+                  >
+                    <i class="material-icons">refresh</i>
+                  </a>
+                </div>
+              </div>
+
+              <div
+                v-if="!supportedFeatures.tableOverview"
+                class="alert alert-info"
+              >
+                Tables overview is not supported for this database engine.
+              </div>
+
+              <div
+                v-else-if="!rows.length"
+                class="alert alert-info"
+              >
+                No tables overview data available.
+              </div>
+
+              <table
+                v-else
+                class="table table-condensed table-hover tables-overview-table"
+              >
+                <thead>
+                  <tr>
+                    <th @click="sortBy('tableName')">Table</th>
+                    <th @click="sortBy('rowCount')">Rows</th>
+                    <th @click="sortBy('totalSize')">Total Size</th>
+                    <th @click="sortBy('tableSize')">Table Size</th>
+                    <th @click="sortBy('indexSize')">Index Size</th>
+                    <th v-if="hasFreeSpace" @click="sortBy('freeSpace')">Free Space</th>
+                    <th v-if="hasFragmentation" @click="sortBy('fragmentation')">Fragmentation</th>
+                    <th v-if="hasOptimizableRows">Action</th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  <tr
+                    v-for="row in sortedRows"
+                    :key="`${row.schemaName || 'default'}.${row.tableName}`"
+                  >
+                    <td>
+                      <span v-if="row.schemaName">{{ row.schemaName }}.</span>{{ row.tableName }}
+                    </td>
+                    <td>{{ formatNumber(row.rowCount) }}</td>
+                    <td>{{ formatBytes(row.totalSize) }}</td>
+                    <td>{{ formatBytes(row.tableSize) }}</td>
+                    <td>{{ formatBytes(row.indexSize) }}</td>
+                    <td v-if="hasFreeSpace">{{ formatNullableBytes(row.freeSpace) }}</td>
+                    <td v-if="hasFragmentation">{{ formatFragmentation(row.fragmentation) }}</td>
+                    <td v-if="hasOptimizableRows">
+                      <x-button
+                        v-if="row.canOptimize"
+                        class="btn btn-sm btn-flat"
+                        :title="row.optimizationNote || 'Optimize table'"
+                        @click.prevent="optimize(row)"
+                      >
+                        Optimize
+                      </x-button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="expand" />
+
+          <status-bar
+            class="tabulator-footer"
+            :active="active"
+          >
+            <div class="flex flex-middle statusbar-actions">
+              <span class="statusbar-info col flex expand">
+                <span class="statusbar-item">
+                  {{ rows.length }} tables
+                </span>
+                <span class="statusbar-item">
+                  {{ formatNumber(totalRows) }} rows
+                </span>
+                <span class="statusbar-item">
+                  {{ formatBytes(totalSize) }} total size
+                </span>
+                <span 
+                  v-if="overview.freeSpace !== null && overview.freeSpace !== undefined"
+                  class="statusbar-item"
+                >
+                  {{ formatBytes(overview.freeSpace) }} free space
+                </span>
+              </span>
+            </div>
+          </status-bar>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import _ from 'lodash'
+import { mapState } from 'vuex'
+import { format as humanBytes } from 'bytes'
+import rawLog from '@bksLogger'
+import StatusBar from './common/StatusBar.vue'
+
+const log = rawLog.scope('TabTablesOverview')
+
+const emptyOverview = { tables: [], freeSpace: null, canOptimize: false, optimizationNote: null }
+
+export default {
+  props: ["tabId", "active", "tab"],
+
+  components: {
+    StatusBar
+  },
+
+  data() {
+    return {
+      initialized: false,
+      loading: true,
+      error: null,
+      overview: emptyOverview,
+      sortField: 'totalSize',
+      sortDirection: 'desc'
+    }
+  },
+
+  watch: {
+    active() {
+      if (this.active && !this.initialized) {
+        this.initialize()
+      }
+    }
+  },
+
+  computed: {
+    ...mapState(['connection', 'supportedFeatures']),
+
+    rows() {
+      return this.overview.tables
+    },
+
+    totalRows() {
+      return this.rows.reduce((sum, row) => sum + Number(row.rowCount || 0), 0)
+    },
+
+    totalSize() {
+      return this.rows.reduce((sum, row) => sum + Number(row.totalSize || 0), 0)
+    },
+
+    hasOptimizableRows() {
+      return this.supportedFeatures.tableOptimization && this.rows.some((row) => row.canOptimize)
+    },
+
+    hasDatabaseOptimization() {
+      return this.supportedFeatures.tableOptimization && this.overview.canOptimize
+    },
+
+    hasFragmentation() {
+      return this.rows.some((row) => row.fragmentation !== null)
+    },
+
+    hasFreeSpace() {
+      return this.rows.some((row) => row.freeSpace !== null)
+    },
+
+    sortedRows() {
+      return _.orderBy(this.rows, [this.sortField], [this.sortDirection])
+    }
+  },
+
+  methods: {
+    async initialize() {
+      log.info("initializing")
+      this.initialized = true
+      await this.refresh()
+    },
+
+    async refresh() {
+      log.info("refresh")
+      this.loading = true
+      this.error = null
+
+      try {
+        if (!this.supportedFeatures.tableOverview) {
+          this.overview = emptyOverview
+          return
+        }
+        this.overview = await this.connection.getTablesOverview()
+      } catch (ex) {
+        this.error = ex
+        this.overview = emptyOverview
+      } finally {
+        log.info("setting loaded = false")
+        this.loading = false
+      }
+    },
+
+    sortBy(field) {
+      if (this.sortField === field) {
+        this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc'
+      } else {
+        this.sortField = field
+        this.sortDirection = field === 'tableName' ? 'asc' : 'desc'
+      }
+    },
+
+    formatBytes(value) {
+      return humanBytes(value || 0)
+    },
+
+    formatNullableBytes(value) {
+      if (value === null || value === undefined) return 'N/A'
+      return humanBytes(value)
+    },
+
+    formatNumber(value) {
+      return Number(value || 0).toLocaleString()
+    },
+
+    formatFragmentation(value) {
+      if (value === null || value === undefined) return 'N/A'
+      return `${Math.round(value * 100)}%`
+    },
+
+    async optimizeDatabase() {
+      const confirmed = await this.$confirm(
+        'Optimize database?',
+        this.overview.optimizationNote || 'This operation may take time on large databases.'
+      )
+
+      if (!confirmed) return
+
+      try {
+        await this.connection.optimizeTable(null, null)
+        this.$noty.success('Database optimized successfully')
+        await this.refresh()
+      } catch (ex) {
+        this.$noty.error(`Error optimizing database: ${ex.message}`)
+      }
+    },
+
+    async optimize(row) {
+      const confirmed = await this.$confirm(
+        `Optimize ${row.tableName}?`,
+        row.optimizationNote || 'This operation may take time on large tables.'
+      )
+
+      if (!confirmed) return
+
+      try {
+        await this.connection.optimizeTable(row.tableName, row.schemaName)
+        this.$noty.success(`${row.tableName} optimized successfully`)
+        await this.refresh()
+      } catch (ex) {
+        this.$noty.error(`Error optimizing ${row.tableName}: ${ex.message}`)
+      }
+    }
+  },
+
+
+
+  async mounted() {
+    if (this.active) {
+      await this.initialize()
+    }
+  }
+}
+</script>
+
+<style scoped>
+.tables-overview-table th,
+.tables-overview-table td {
+  padding-right: 2rem;
+  white-space: nowrap;
+}
+
+.tables-overview-table th:last-child,
+.tables-overview-table td:last-child {
+  padding-right: 0;
+}
+</style>

--- a/apps/studio/src/components/tab/TabIcon.vue
+++ b/apps/studio/src/components/tab/TabIcon.vue
@@ -23,6 +23,11 @@
     :class="iconClass"
   >construction</i>
   <i
+    v-else-if="tab.tabType === 'tables-overview'"
+    class="material-icons item-icon icon-table-properties"
+    :class="iconClass"
+  >construction</i>
+  <i
     v-else-if="tab.tabType === 'settings'"
     class="material-icons item-icon settings"
   >settings</i>

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -1,4 +1,4 @@
-import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, SchemaFilterOptions, DatabaseFilterOptions, TableChanges, OrderBy, TableFilter, TableResult, StreamResults, CancelableQuery, ExtendedTableColumn, PrimaryKeyColumn, TableProperties, TableIndex, TableTrigger, TableInsert, NgQueryResult, TablePartition, TableUpdateResult, ImportFuncOptions, DatabaseEntity, BksField, FieldDescriptor, FieldReadOnlyReason, ServerStatistics, FieldEditData } from '../models';
+import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, SchemaFilterOptions, DatabaseFilterOptions, TableChanges, OrderBy, TableFilter, TableResult, StreamResults, CancelableQuery, ExtendedTableColumn, PrimaryKeyColumn, TableProperties, TableIndex, TableTrigger, TableInsert, NgQueryResult, TablePartition, TableUpdateResult, ImportFuncOptions, DatabaseEntity, BksField, FieldDescriptor, FieldReadOnlyReason, ServerStatistics, FieldEditData, TableOverview, TablesOverview } from '../models';
 import { AlterPartitionsSpec, AlterTableSpec, CreateTableSpec, IndexAlterations, RelationAlterations, TableKey } from '@shared/lib/dialects/models';
 import { buildInsertQueries, buildInsertQuery, errorMessages, isAllowedReadOnlyQuery, joinQueries, applyChangesSql } from './utils';
 import { Knex } from 'knex';
@@ -302,6 +302,8 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   abstract executeQuery(queryText: string, options?: any): Promise<NgQueryResult[]>;
   abstract listDatabases(filter?: DatabaseFilterOptions): Promise<string[]>;
   abstract getTableProperties(table: string, schema?: string): Promise<TableProperties | null>;
+  abstract getTableOverview(table: string, schema?: string): Promise<TableOverview | null>;
+  abstract getTablesOverview(schema?: string): Promise<TablesOverview>;
   abstract getQuerySelectTop(table: string, limit: number, schema?: string): Promise<string>;
   abstract listMaterializedViews(filter?: FilterOptions): Promise<TableOrView[]>;
   abstract getPrimaryKey(table: string, schema?: string): Promise<string | null>;
@@ -426,6 +428,7 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   }
 
   abstract truncateAllTables(schema?: string): Promise<void>;
+  abstract optimizeTable(table: string, schema?: string): Promise<void>;
   // ****************************************************************************
 
   // ****************************************************************************

--- a/apps/studio/src/lib/db/clients/bedrock.ts
+++ b/apps/studio/src/lib/db/clients/bedrock.ts
@@ -19,6 +19,8 @@ import {
   PrimaryKeyColumn,
   TableProperties,
   TableChanges,
+  TableOverview,
+  TablesOverview
 } from "../models";
 import {
   IndexColumn,
@@ -212,6 +214,18 @@ export class BedrockClient extends MysqlClient {
       triggers,
       partitions: [],
     };
+  }
+
+  async getTableOverview(table: string, _schema?: string): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(_schema?: string): Promise<TablesOverview> {
+    return []
+  }
+
+  async optimizeTable(_table: string, _schema?: string): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   // TODO transactions?

--- a/apps/studio/src/lib/db/clients/bigquery.ts
+++ b/apps/studio/src/lib/db/clients/bigquery.ts
@@ -1,7 +1,7 @@
 import * as bq from '@google-cloud/bigquery';
 import { TableKey } from "@shared/lib/dialects/models";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
-import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, ExtendedTableColumn, TableTrigger, TableIndex, SchemaFilterOptions, CancelableQuery, NgQueryResult, DatabaseFilterOptions, TableChanges, TableProperties, PrimaryKeyColumn, OrderBy, TableFilter, TableResult, StreamResults, TableInsert, TableUpdate, TableDelete, BksField } from "../models";
+import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, ExtendedTableColumn, TableTrigger, TableIndex, SchemaFilterOptions, CancelableQuery, NgQueryResult, DatabaseFilterOptions, TableChanges, TableProperties, PrimaryKeyColumn, OrderBy, TableFilter, TableResult, StreamResults, TableInsert, TableUpdate, TableDelete, BksField, TableOverview, TablesOverview } from "../models";
 import { DatabaseElement, IDbConnectionDatabase } from "../types";
 import { BasicDatabaseClient, ExecutionContext, QueryLogOptions } from "./BasicDatabaseClient";
 import knexlib from 'knex';
@@ -387,6 +387,18 @@ export class BigQueryClient extends BasicDatabaseClient<BigQueryResult> {
     const data = await this.driverExecuteSingle(sql);
 
     return data.rows.map((row) => row.createtable)[0];
+  }
+
+  async getTableOverview(_table: string, _schema?: string): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(_schema?: string): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(_table: string, _schema?: string): Promise<void> {
+    throw new Error('BigQuery manages table optimization automatically')
   }
 
   async getViewCreateScript(_view: string, _schema?: string): Promise<string[]> {

--- a/apps/studio/src/lib/db/clients/cockroach.ts
+++ b/apps/studio/src/lib/db/clients/cockroach.ts
@@ -1,5 +1,5 @@
 import pg, { PoolConfig } from "pg";
-import { FilterOptions, SupportedFeatures, TableIndex, TableOrView, TablePartition, TableProperties, TableTrigger, ExtendedTableColumn, BksField } from "../models";
+import { FilterOptions, SupportedFeatures, TableIndex, TableOrView, TablePartition, TableProperties, TableTrigger, ExtendedTableColumn, BksField, TableOverview, TablesOverview } from "../models";
 import { PostgresClient, STQOptions } from "./postgresql";
 import _ from 'lodash';
 import { defaultCreateScript } from "./postgresql/scripts";
@@ -152,6 +152,18 @@ export class CockroachClient extends PostgresClient {
       partitions,
       owner
     };
+  }
+
+  async getTableOverview(_table: string, _schema: string = this._defaultSchema): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(_schema: string = this._defaultSchema): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(_table: string, _schema: string = this._defaultSchema): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   async createDatabase(databaseName: string, charset: string, _collation: string): Promise<string> {

--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -59,6 +59,8 @@ import {
   TableResult,
   TableTrigger,
   TableUpdate,
+  TableOverview,
+  TablesOverview
 } from "../models";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
 import BksConfig from "@/common/bksConfig";
@@ -902,6 +904,18 @@ export class MysqlClient extends BasicDatabaseClient<ResultType, mysql.PoolConne
       triggers,
       partitions: []
     };
+  }
+
+  async getTableOverview(_table: string, _schema?: string): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(_schema?: string): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(_table: string, _schema?: string): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   async createDatabase(

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -9,7 +9,7 @@ import knexlib from 'knex'
 import logRaw from '@bksLogger'
 
 import { DatabaseElement, IDbConnectionDatabase } from '../types'
-import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, CancelableQuery, SupportedFeatures, TableColumn, TableOrView, TableProperties, TableTrigger, TablePartition, ImportFuncOptions, BksField, BksFieldType } from "../models";
+import { FilterOptions, OrderBy, TableFilter, TableUpdateResult, TableResult, Routine, TableChanges, TableInsert, TableUpdate, TableDelete, DatabaseFilterOptions, SchemaFilterOptions, NgQueryResult, StreamResults, ExtendedTableColumn, PrimaryKeyColumn, TableIndex, CancelableQuery, SupportedFeatures, TableColumn, TableOrView, TableProperties, TableOverview, TablesOverview, TableTrigger, TablePartition, ImportFuncOptions, BksField, BksFieldType } from "../models";
 import { buildDatabaseFilter, buildDeleteQueries, buildInsertQueries, buildSchemaFilter, buildSelectQueriesFromUpdates, buildUpdateQueries, escapeString, refreshTokenIfNeeded, joinQueries, errorMessages } from './utils';
 import { createCancelablePromise, joinFilters } from '../../../common/utils';
 import { errors } from '../../errors';
@@ -125,7 +125,11 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
       restore: true,
       indexNullsNotDistinct: this.version.number >= 150_000,
       transactions: true,
-      filterTypes: ['standard', 'ilike']
+      filterTypes: ['standard', 'ilike'],
+      tableOverview: true,
+      tablesOverview: true,
+      tableOptimization: true,
+      fragmentationStats: true
     };
   }
 
@@ -935,6 +939,172 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
       partitions,
       owner,
       permissionWarnings: permissionWarnings.length > 0 ? permissionWarnings : undefined
+    }
+  }
+
+  async getTableOverview(table: string, schema: string = this._defaultSchema): Promise<TableOverview | null> {
+    const identifier = this.wrapTable(table, schema)
+    const permissionWarnings: string[] = []
+
+    const statements = [
+      `'${escapeString(schema)}' as schema_name`,
+      `'${escapeString(table)}' as table_name`,
+      `COALESCE(s.n_live_tup, 0) as row_count`,
+      `COALESCE(s.n_dead_tup, 0) as dead_tuples`,
+      `pg_total_relation_size(c.oid) as total_size`,
+      `pg_relation_size('${identifier}') as table_size`,
+      `pg_indexes_size('${identifier}') as index_size`,
+      `NULL as free_space`,
+      `CASE
+        WHEN COALESCE(s.n_live_tup, 0) + COALESCE(s.n_dead_tup, 0) > 0
+        THEN COALESCE(s.n_dead_tup, 0)::float / (COALESCE(s.n_live_tup, 0) + COALESCE(s.n_dead_tup, 0))
+        ELSE NULL
+      END as fragmentation`
+    ]
+
+    if (this.version.number < 90000) {
+      statements[6] = `0 as index_size`
+    }
+
+    const sql = `
+      SELECT ${statements.join(",")}
+      FROM pg_class c
+      JOIN pg_namespace n
+        ON n.oid = c.relnamespace
+      LEFT JOIN pg_stat_user_tables s
+        ON s.relid = c.oid
+      WHERE c.relname = $1
+        AND n.nspname = $2
+        AND c.relkind IN ('r', 'p')
+      LIMIT 1
+    `
+
+    const result = await this.driverExecuteSingle(sql, { params: [table, schema] }).catch(err => {
+      log.warn('Unable to fetch table overview (likely due to insufficient permissions):', err.message)
+      permissionWarnings.push('Unable to retrieve table overview due to insufficient permissions')
+      return { rows: [{ schema_name: schema, table_name: table, row_count: 0, total_size: 0, table_size: 0, index_size: 0, free_space: null, fragmentation: null }] }
+    })
+
+    const props = result.rows.length > 0 ? result.rows[0] : {}
+
+    const rowCount = Number(props.row_count || 0)
+    const deadTuples = Number(props.dead_tuples || 0)
+    const fragmentation = props.fragmentation === null || props.fragmentation === undefined
+      ? null
+      : Number(props.fragmentation)
+
+    const canOptimize = deadTuples > 1000 || (fragmentation !== null && fragmentation > 0.2)
+
+    return {
+      schemaName: props.schema_name || schema,
+      tableName: props.table_name || table,
+      rowCount,
+      totalSize: Number(props.total_size || 0),
+      indexSize: Number(props.index_size || 0),
+      tableSize: Number(props.table_size || 0),
+      freeSpace: null,
+      fragmentation,
+      canOptimize,
+      optimizationNote: canOptimize
+        ? "VACUUM ANALYZE can reclaim space from dead tuples and update planner statistics."
+        : null,
+      permissionWarnings: permissionWarnings.length > 0 ? permissionWarnings : undefined
+    }
+  }
+
+  async getTablesOverview(schema?: string): Promise<TablesOverview> {
+    const permissionWarnings: string[] = []
+
+    const statements = [
+      `n.nspname as schema_name`,
+      `c.relname as table_name`,
+      `COALESCE(s.n_live_tup, 0) as row_count`,
+      `COALESCE(s.n_dead_tup, 0) as dead_tuples`,
+      `pg_total_relation_size(c.oid) as total_size`,
+      `pg_relation_size(c.oid) as table_size`,
+      `pg_indexes_size(c.oid) as index_size`,
+      `NULL as free_space`,
+      `CASE
+        WHEN COALESCE(s.n_live_tup, 0) + COALESCE(s.n_dead_tup, 0) > 0
+        THEN COALESCE(s.n_dead_tup, 0)::float / (COALESCE(s.n_live_tup, 0) + COALESCE(s.n_dead_tup, 0))
+        ELSE NULL
+      END as fragmentation`
+    ]
+
+    if (this.version.number < 90000) {
+      statements[6] = `0 as index_size`
+    }
+
+    const schemaFilter = schema
+      ? `AND n.nspname = $1`
+      : `
+        AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+        AND n.nspname NOT LIKE 'pg_toast%'
+      `
+
+    const sql = `
+      SELECT ${statements.join(",")}
+      FROM pg_class c
+      JOIN pg_namespace n
+        ON n.oid = c.relnamespace
+      LEFT JOIN pg_stat_user_tables s
+        ON s.relid = c.oid
+      WHERE c.relkind IN ('r', 'p')
+        ${schemaFilter}
+      ORDER BY pg_total_relation_size(c.oid) DESC
+    `
+
+    const result = await this.driverExecuteSingle(sql, schema ? { params: [schema] } : {})
+      .catch(err => {
+        log.warn('Unable to fetch tables overview (likely due to insufficient permissions):', err.message)
+        permissionWarnings.push('Unable to retrieve tables overview due to insufficient permissions')
+        return { rows: [] }
+      })
+
+    const tables: TableOverview[] = result.rows.map((props: any) => {
+      const deadTuples = Number(props.dead_tuples || 0)
+      const fragmentation = props.fragmentation === null || props.fragmentation === undefined
+        ? null
+        : Number(props.fragmentation)
+
+      const canOptimize = deadTuples > 1000 || (fragmentation !== null && fragmentation > 0.2)
+
+      return {
+        schemaName: props.schema_name || schema || this._defaultSchema,
+        tableName: props.table_name,
+        rowCount: Number(props.row_count || 0),
+        totalSize: Number(props.total_size || 0),
+        tableSize: Number(props.table_size || 0),
+        indexSize: Number(props.index_size || 0),
+        freeSpace: props.free_space === null || props.free_space === undefined
+          ? null
+          : Number(props.free_space),
+        fragmentation,
+        canOptimize,
+        optimizationNote: canOptimize
+          ? "VACUUM ANALYZE can reclaim space from dead tuples and update planner statistics."
+          : null,
+        permissionWarnings: permissionWarnings.length > 0 ? permissionWarnings : undefined
+      }
+    })
+
+    return {
+      tables,
+      freeSpace: null,
+      canOptimize: tables.some((t) => t.canOptimize),
+      optimizationNote: tables.some((t) => t.canOptimize)
+        ? "VACUUM ANALYZE will process all tables that need optimization."
+        : null,
+    }
+
+  }
+
+  async optimizeTable(table: string, schema: string): Promise<void> {
+    if (!table) {
+      await this.driverExecuteSingle(`VACUUM ANALYZE`);
+    } else {
+      const identifier = this.wrapTable(table, schema ?? this._defaultSchema)
+      await this.driverExecuteSingle(`VACUUM ANALYZE ${identifier}`)
     }
   }
 

--- a/apps/studio/src/lib/db/clients/redis.ts
+++ b/apps/studio/src/lib/db/clients/redis.ts
@@ -12,6 +12,8 @@ import {
   TableUpdateResult,
   TableUpdate,
   TableDelete,
+  TableOverview,
+  TablesOverview
 } from "../models";
 import {
   AppContextProvider,
@@ -563,6 +565,18 @@ export class RedisClient extends BasicDatabaseClient<RedisQueryResult> {
 
   async getTableProperties() {
     return null;
+  }
+
+  async getTableOverview(table: string, _schema?: string): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(_table: string, _schema?: string): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   async getQuerySelectTop(_table: string, limit: number) {

--- a/apps/studio/src/lib/db/clients/redshift.ts
+++ b/apps/studio/src/lib/db/clients/redshift.ts
@@ -1,7 +1,7 @@
 import { PoolConfig } from "pg";
 import { AWSCredentials, ClusterCredentialConfiguration, RedshiftCredentialResolver } from "../authentication/amazon-redshift";
 import { DatabaseElement } from "../types";
-import { FilterOptions, PrimaryKeyColumn, SupportedFeatures, TableOrView, TableProperties, ExtendedTableColumn, TableIndex } from "../models";
+import { FilterOptions, PrimaryKeyColumn, SupportedFeatures, TableOrView, TableProperties, ExtendedTableColumn, TableIndex, TableOverview, TablesOverview } from "../models";
 import { PostgresClient, STQOptions } from "./postgresql";
 import {escapeString, resolveAWSCredentials} from "./utils";
 import pg from 'pg';
@@ -150,6 +150,18 @@ export class RedshiftClient extends PostgresClient {
 
   async getTableProperties(_table: string, _schema?: string): Promise<TableProperties> {
     return null;
+  }
+
+  async getTableOverview(table: string, schema: string = this._defaultSchema): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(schema: string = this._defaultSchema): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(table: string, schema: string = this._defaultSchema): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   async getPrimaryKeys(table: string, schema?: string): Promise<PrimaryKeyColumn[]> {

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -4,7 +4,7 @@ import { SqliteData } from "@shared/lib/dialects/sqlite";
 import { ChangeBuilderBase } from "@shared/lib/sql/change_builder/ChangeBuilderBase";
 import { SqliteChangeBuilder } from "@shared/lib/sql/change_builder/SqliteChangeBuilder";
 import Database from "better-sqlite3";
-import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, ExtendedTableColumn, TableTrigger, TableIndex, SchemaFilterOptions, CancelableQuery, NgQueryResult, DatabaseFilterOptions, TableChanges, TableProperties, PrimaryKeyColumn, OrderBy, TableFilter, TableResult, StreamResults, QueryResult, TableInsert, TableUpdate, TableDelete, ImportFuncOptions, BksField, BksFieldType } from "../models";
+import { SupportedFeatures, FilterOptions, TableOrView, Routine, TableColumn, ExtendedTableColumn, TableTrigger, TableIndex, SchemaFilterOptions, CancelableQuery, NgQueryResult, DatabaseFilterOptions, TableChanges, TableProperties, PrimaryKeyColumn, OrderBy, TableFilter, TableResult, StreamResults, QueryResult, TableInsert, TableUpdate, TableDelete, ImportFuncOptions, BksField, BksFieldType, TableOverview, TablesOverview } from "../models";
 import { DatabaseElement, IDbConnectionDatabase } from "../types";
 import { ClientError } from "./utils";
 import { BasicDatabaseClient, ExecutionContext, QueryLogOptions } from "./BasicDatabaseClient"; import { buildInsertQueries, buildDeleteQueries, buildSelectTopQuery } from './utils';
@@ -75,6 +75,10 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
       customRoutines: false,
       comments: false,
       properties: true,
+      tableOverview: true,
+      tablesOverview: true,
+      tableOptimization: true,
+      fragmentationStats: false,
       partitions: false,
       editPartitions: false,
       backups: true,
@@ -418,6 +422,115 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
       triggers,
       partitions: []
     }
+  }
+
+  async getTableOverview(table: string, _schema?: string): Promise<TableOverview | null> {
+    try {
+      const exists = await this.driverExecuteSingle(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name = ?
+        LIMIT 1
+      `, { params: [table] });
+
+      if (!exists.rows.length) return null;
+
+      const safeTableName = table.replace(/`/g, "``");
+
+      const rowResult = await this.driverExecuteSingle(`
+        SELECT COUNT(*) as count FROM \`${safeTableName}\`
+      `);
+      const rowCount = Number(rowResult.rows?.[0]?.count || 0);
+
+      let tableSize = 0;
+      let indexSize = 0;
+
+      try {
+        const tableSizeResult = await this.driverExecuteSingle(`
+          SELECT COALESCE(SUM(pgsize), 0) as size
+          FROM dbstat WHERE name = ?
+        `, { params: [table] });
+
+        const indexSizeResult = await this.driverExecuteSingle(`
+          SELECT COALESCE(SUM(s.pgsize), 0) as size
+          FROM dbstat s
+          WHERE s.name IN (
+            SELECT name FROM sqlite_master
+            WHERE type = 'index' AND tbl_name = ?
+          )
+        `, { params: [table] });
+
+        tableSize = Number(tableSizeResult.rows?.[0]?.size || 0);
+        indexSize = Number(indexSizeResult.rows?.[0]?.size || 0);
+      } catch {
+        tableSize = 0;
+        indexSize = 0;
+      }
+
+      return {
+        schemaName: "main",
+        tableName: table,
+        rowCount,
+        tableSize,
+        indexSize,
+        totalSize: tableSize + indexSize,
+        freeSpace: null,
+        fragmentation: null,
+        canOptimize: false,      // decidided on getTablesOverview because
+        optimizationNote: null,  // SQlite optimization is database-wide
+      };
+    } catch (err: any) {
+      log.warn("Unable to fetch table overview:", err.message);
+      return {
+        schemaName: "main",
+        tableName: table,
+        rowCount: 0,
+        totalSize: 0,
+        tableSize: 0,
+        indexSize: 0,
+        freeSpace: null,
+        fragmentation: null,
+        canOptimize: false,
+        optimizationNote: null,
+        permissionWarnings: [err.message],
+      };
+    }
+  }
+
+  async getTablesOverview(_schema?: string): Promise<TablesOverview> {
+    try {
+      const tables = await this.driverExecuteSingle(`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+      `);
+
+      const promises = tables.rows.map((row: any) => this.getTableOverview(row.name));
+      const results = await Promise.all(promises);
+      const overviews = results.filter((o): o is TableOverview => o !== null);
+
+      const freelistResult = await this.driverExecuteSingle('PRAGMA freelist_count;');
+      const pageSizeResult = await this.driverExecuteSingle('PRAGMA page_size;');
+      const freelist = Number(freelistResult.rows?.[0]?.freelist_count || 0);
+      const pageSize = Number(pageSizeResult.rows?.[0]?.page_size || 0);
+      const freeSpace = freelist * pageSize;
+      const canOptimize = freeSpace > 1024 * 1024;
+
+      return {
+        tables: overviews,
+        freeSpace,
+        canOptimize,
+        optimizationNote: canOptimize
+          ? "SQLite optimization is database-wide (VACUUM). It cannot be applied per table."
+          : null,
+      };
+    } catch (err: any) {
+      log.warn("Unable to fetch tables overview:", err.message);
+      return { tables: [], freeSpace: null, canOptimize: false, optimizationNote: null };
+    }
+  }
+
+  async optimizeTable(_table: string): Promise<void> {
+    await this.driverExecuteSingle(`VACUUM`);
   }
 
   async getTableCreateScript(table: string, _schema?: string): Promise<string> {

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -30,7 +30,7 @@ import {
   ExecutionContext,
   QueryLogOptions
 } from './BasicDatabaseClient'
-import { FilterOptions, OrderBy, TableFilter, ExtendedTableColumn, TableIndex, TableProperties, TableResult, StreamResults, Routine, TableOrView, NgQueryResult, DatabaseFilterOptions, TableChanges, ImportFuncOptions, DatabaseEntity, BksFieldType, BksField } from '../models';
+import { FilterOptions, OrderBy, TableFilter, ExtendedTableColumn, TableIndex, TableProperties, TableResult, StreamResults, Routine, TableOrView, NgQueryResult, DatabaseFilterOptions, TableChanges, ImportFuncOptions, DatabaseEntity, BksFieldType, BksField, TableOverview, TablesOverview } from '../models';
 import { AlterTableSpec, IndexAlterations, RelationAlterations } from '@shared/lib/dialects/models';
 import { AzureAuthService } from '../authentication/azure';
 import { IDbConnectionServer } from '../backendTypes';
@@ -385,6 +385,18 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       description,
       relations
     }
+  }
+
+  async getTableOverview(table: string, schema?: string): Promise<TableOverview | null> {
+    return null;
+  }
+
+  async getTablesOverview(schema?: string): Promise<TablesOverview> {
+    return [];
+  }
+
+  async optimizeTable(table: string, schema?: string): Promise<void> {
+    throw new Error('Table optimization is not supported for this database')
   }
 
   async getOutgoingKeys(table: string, schema?: string) {

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -87,6 +87,27 @@ export interface TableProperties {
   permissionWarnings?: string[]
 }
 
+export interface TableOverview {
+  schemaName?: string
+  tableName: string
+  rowCount: number
+  totalSize: number
+  tableSize: number
+  indexSize: number
+  freeSpace?: number | null
+  fragmentation?: number | null
+  canOptimize: boolean              // table
+  optimizationNote: string | null
+  permissionWarnings?: string[]
+}
+
+export interface TablesOverview {
+  tables: TableOverview[]
+  freeSpace?: number | null
+  canOptimize: boolean             // database-wide
+  optimizationNote: string | null
+}
+
 export interface TableColumn {
   columnName: string
   dataType: string
@@ -252,6 +273,11 @@ export interface SupportedFeatures {
   indexNullsNotDistinct: boolean; // for postgres 15 and above
   transactions: boolean;
   filterTypes: IncludedFilterTypes[];
+
+  tableOverview: boolean;
+  tablesOverview: boolean;
+  tableOptimization: boolean;
+  fragmentationStats: boolean;
 }
 
 export enum FieldReadOnlyReason {

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -1,4 +1,4 @@
-import { CancelableQuery, DatabaseFilterOptions, ExtendedTableColumn, FieldDescriptor, FieldEditData, FilterOptions, ImportFuncOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, ServerStatistics, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableFilter, TableIndex, TableInsert, TableOrView, TablePartition, TableProperties, TableResult, TableTrigger, TableUpdateResult } from './models';
+import { CancelableQuery, DatabaseFilterOptions, ExtendedTableColumn, FieldDescriptor, FieldEditData, FilterOptions, ImportFuncOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, ServerStatistics, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableFilter, TableIndex, TableInsert, TableOrView, TablePartition, TableProperties, TableResult, TableTrigger, TableUpdateResult, TableOverview, TablesOverview } from './models';
 import { AlterPartitionsSpec, AlterTableSpec, CreateTableSpec, IndexAlterations, RelationAlterations, TableKey } from '@shared/lib/dialects/models';
 import type { SshMode } from '@/common/interfaces/IConnection';
 
@@ -267,6 +267,9 @@ export interface IBasicDatabaseClient {
   executeQuery(queryText: string, options?: any): Promise<NgQueryResult[]>,
   listDatabases(filter?: DatabaseFilterOptions): Promise<string[]>,
   getTableProperties(table: string, schema?: string): Promise<TableProperties | null>,
+  getTableOverview(table: string, schema?: string): Promise<TableOverview | null>,
+  getTablesOverview(schema?: string): Promise<TablesOverview>,
+  optimizeTable(table: string, schema?: string): Promise<void>,
   getQuerySelectTop(table: string, limit: number, schema?: string): Promise<string>,
   listMaterializedViews(filter?: FilterOptions): Promise<TableOrView[]>,
   getPrimaryKey(table: string, schema?: string): Promise<string | null>,

--- a/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
+++ b/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
@@ -1,6 +1,6 @@
 import { DatabaseElement, IBasicDatabaseClient } from "../db/types";
 import Vue from 'vue';
-import { CancelableQuery, DatabaseFilterOptions, ExtendedTableColumn, FilterOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, SupportedFeatures, TableChanges, TableFilter, TableColumn, TableIndex, TableOrView, TablePartition, TableResult, TableProperties, StreamResults, TableInsert, TableTrigger, ImportFuncOptions, FieldDescriptor, FieldEditData, ServerStatistics } from "../db/models";
+import { CancelableQuery, DatabaseFilterOptions, ExtendedTableColumn, FilterOptions, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, SupportedFeatures, TableChanges, TableFilter, TableColumn, TableIndex, TableOrView, TablePartition, TableResult, TableProperties, StreamResults, TableInsert, TableTrigger, ImportFuncOptions, FieldDescriptor, FieldEditData, ServerStatistics, TableOverview, TablesOverview } from "../db/models";
 import { AlterPartitionsSpec, AlterTableSpec, CreateTableSpec, IndexAlterations, RelationAlterations, TableKey } from "@shared/lib/dialects/models";
 import { IConnection } from "@/common/interfaces/IConnection";
 
@@ -120,6 +120,18 @@ export class ElectronUtilityConnectionClient implements IBasicDatabaseClient {
 
   async getTableProperties(table: string, schema?: string): Promise<TableProperties> {
     return await Vue.prototype.$util.send('conn/getTableProperties', { table, schema });
+  }
+
+  async getTableOverview(table: string, schema?: string): Promise<TableOverview | null> {
+    return await Vue.prototype.$util.send('conn/getTableOverview', { table, schema });
+  }
+
+  async getTablesOverview(schema?: string): Promise<TablesOverview> {
+    return await Vue.prototype.$util.send('conn/getTablesOverview', { schema });
+  }
+
+  async optimizeTable(table: string, schema?: string): Promise<void> {
+    return await Vue.prototype.$util.send('conn/optimizeTable', { table, schema });
   }
 
   async getQuerySelectTop(table: string, limit: number, schema?: string): Promise<string> {

--- a/apps/studio/src/store/modules/TabModule.ts
+++ b/apps/studio/src/store/modules/TabModule.ts
@@ -29,6 +29,11 @@ export const TabModule: Module<State, RootState> = {
         menuItem: { label: 'Add Query', shortcut: 'Control+T' },
       },
       {
+        type: 'tables-overview',
+        name: "Tables Overview",
+        menuItem: { label: 'Tables Overview' },
+      },
+      {
         type: 'shell',
         name: "Shell",
         menuItem: { label: 'Add Shell' },

--- a/apps/studio/tests/unit/components/TabTablesOverview.spec.ts
+++ b/apps/studio/tests/unit/components/TabTablesOverview.spec.ts
@@ -1,0 +1,128 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuex from "vuex";
+import TabTablesOverview from "@/components/TabTablesOverview.vue";
+
+Vue.use(Vuex);
+
+describe("TabTablesOverview.vue", () => {
+  const overview = {
+    tables: [
+      {
+        schemaName: "public",
+        tableName: "events",
+        rowCount: 10000,
+        totalSize: 4096,
+        tableSize: 3072,
+        indexSize: 1024,
+        freeSpace: null,
+        fragmentation: 0.25,
+        canOptimize: true,
+        optimizationNote: "VACUUM ANALYZE can reclaim space.",
+      },
+      {
+        schemaName: "public",
+        tableName: "users",
+        rowCount: 20,
+        totalSize: 512,
+        tableSize: 512,
+        indexSize: 0,
+        freeSpace: null,
+        fragmentation: null,
+        canOptimize: false,
+        optimizationNote: null,
+      },
+    ],
+    freeSpace: null,
+    canOptimize: true,
+    optimizationNote: "VACUUM ANALYZE will process all tables that need optimization.",
+  };
+
+  function mountComponent({
+    supportedFeatures = {
+      tableOverview: true,
+      tableOptimization: true,
+    },
+    connection = {
+      getTablesOverview: jest.fn().mockResolvedValue(overview),
+      optimizeTable: jest.fn().mockResolvedValue(undefined),
+    },
+  } = {}) {
+    const store = new Vuex.Store({
+      state: {
+        connection,
+        supportedFeatures,
+      },
+    });
+
+    const wrapper = shallowMount(TabTablesOverview, {
+      store,
+      propsData: {
+        tabId: 1,
+        active: false,
+        tab: {},
+      },
+      mocks: {
+        $confirm: jest.fn().mockResolvedValue(true),
+        $noty: {
+          success: jest.fn(),
+          error: jest.fn(),
+        },
+      },
+      stubs: {
+        "x-progressbar": true,
+        "x-button": true,
+        "status-bar": true,
+      },
+    });
+
+    return { wrapper, connection };
+  }
+
+  it("loads the tables overview when initialized", async () => {
+    const { wrapper, connection } = mountComponent();
+
+    await wrapper.vm.initialize();
+
+    expect(connection.getTablesOverview).toHaveBeenCalled();
+    expect(wrapper.vm.loading).toBe(false);
+    expect(wrapper.vm.rows).toEqual(overview.tables);
+    expect(wrapper.vm.totalRows).toBe(10020);
+    expect(wrapper.vm.totalSize).toBe(4608);
+    expect(wrapper.vm.hasOptimizableRows).toBe(true);
+    expect(wrapper.vm.hasDatabaseOptimization).toBe(true);
+    expect(wrapper.vm.hasFragmentation).toBe(true);
+  });
+
+  it("optimizes one table and refreshes the overview", async () => {
+    const { wrapper, connection } = mountComponent();
+    wrapper.setData({ overview });
+    wrapper.vm.refresh = jest.fn().mockResolvedValue(undefined);
+
+    await wrapper.vm.optimize(overview.tables[0]);
+
+    expect(wrapper.vm.$confirm).toHaveBeenCalledWith(
+      "Optimize events?",
+      "VACUUM ANALYZE can reclaim space."
+    );
+    expect(connection.optimizeTable).toHaveBeenCalledWith("events", "public");
+    expect(wrapper.vm.$noty.success).toHaveBeenCalledWith("events optimized successfully");
+    expect(wrapper.vm.refresh).toHaveBeenCalled();
+  });
+
+  it("optimizes the database and refreshes the overview", async () => {
+    const { wrapper, connection } = mountComponent();
+    wrapper.setData({ overview });
+    wrapper.vm.refresh = jest.fn().mockResolvedValue(undefined);
+
+    await wrapper.vm.optimizeDatabase();
+
+    expect(wrapper.vm.$confirm).toHaveBeenCalledWith(
+      "Optimize database?",
+      "VACUUM ANALYZE will process all tables that need optimization."
+    );
+    expect(connection.optimizeTable).toHaveBeenCalledWith(null, null);
+    expect(wrapper.vm.$noty.success).toHaveBeenCalledWith("Database optimized successfully");
+    expect(wrapper.vm.refresh).toHaveBeenCalled();
+  });
+});

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -190,4 +190,149 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(client.getTableOwner).toHaveBeenCalledWith('test_table', 'public');
   })
 
+  it("Should build a table overview from PostgreSQL stats", async () => {
+    client._defaultSchema = 'public';
+    client.version = { number: 150000 };
+    client.wrapTable = jest.fn().mockReturnValue('"public"."events"');
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({
+      rows: [{
+        schema_name: 'public',
+        table_name: 'events',
+        row_count: '10000',
+        dead_tuples: '2500',
+        total_size: '4096',
+        table_size: '3072',
+        index_size: '1024',
+        free_space: null,
+        fragmentation: '0.25',
+      }]
+    });
+
+    const result = await client.getTableOverview('events', 'public');
+
+    expect(result).toEqual({
+      schemaName: 'public',
+      tableName: 'events',
+      rowCount: 10000,
+      totalSize: 4096,
+      indexSize: 1024,
+      tableSize: 3072,
+      freeSpace: null,
+      fragmentation: 0.25,
+      canOptimize: true,
+      optimizationNote: 'VACUUM ANALYZE can reclaim space from dead tuples and update planner statistics.',
+      permissionWarnings: undefined,
+    });
+    expect(client.driverExecuteSingle).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE c.relname = $1'),
+      { params: ['events', 'public'] }
+    );
+  })
+
+  it("Should return a safe table overview when PostgreSQL stats are not accessible", async () => {
+    client._defaultSchema = 'public';
+    client.version = { number: 150000 };
+    client.wrapTable = jest.fn().mockReturnValue('"public"."private_table"');
+    client.driverExecuteSingle = jest.fn().mockRejectedValue(new Error('permission denied'));
+
+    const result = await client.getTableOverview('private_table', 'public');
+
+    expect(result).toEqual({
+      schemaName: 'public',
+      tableName: 'private_table',
+      rowCount: 0,
+      totalSize: 0,
+      indexSize: 0,
+      tableSize: 0,
+      freeSpace: null,
+      fragmentation: null,
+      canOptimize: false,
+      optimizationNote: null,
+      permissionWarnings: ['Unable to retrieve table overview due to insufficient permissions'],
+    });
+  })
+
+  it("Should build a database tables overview and mark optimizable PostgreSQL tables", async () => {
+    client._defaultSchema = 'public';
+    client.version = { number: 150000 };
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          schema_name: 'public',
+          table_name: 'events',
+          row_count: '10000',
+          dead_tuples: '2500',
+          total_size: '4096',
+          table_size: '3072',
+          index_size: '1024',
+          free_space: null,
+          fragmentation: '0.25',
+        },
+        {
+          schema_name: 'public',
+          table_name: 'users',
+          row_count: '20',
+          dead_tuples: '0',
+          total_size: '512',
+          table_size: '512',
+          index_size: '0',
+          free_space: null,
+          fragmentation: null,
+        },
+      ]
+    });
+
+    const result = await client.getTablesOverview('public');
+
+    expect(result).toEqual({
+      tables: [
+        {
+          schemaName: 'public',
+          tableName: 'events',
+          rowCount: 10000,
+          totalSize: 4096,
+          tableSize: 3072,
+          indexSize: 1024,
+          freeSpace: null,
+          fragmentation: 0.25,
+          canOptimize: true,
+          optimizationNote: 'VACUUM ANALYZE can reclaim space from dead tuples and update planner statistics.',
+          permissionWarnings: undefined,
+        },
+        {
+          schemaName: 'public',
+          tableName: 'users',
+          rowCount: 20,
+          totalSize: 512,
+          tableSize: 512,
+          indexSize: 0,
+          freeSpace: null,
+          fragmentation: null,
+          canOptimize: false,
+          optimizationNote: null,
+          permissionWarnings: undefined,
+        },
+      ],
+      freeSpace: null,
+      canOptimize: true,
+      optimizationNote: 'VACUUM ANALYZE will process all tables that need optimization.',
+    });
+    expect(client.driverExecuteSingle).toHaveBeenCalledWith(
+      expect.stringContaining('AND n.nspname = $1'),
+      { params: ['public'] }
+    );
+  })
+
+  it("Should optimize either the whole PostgreSQL database or a single table", async () => {
+    client._defaultSchema = 'public';
+    client.wrapTable = jest.fn().mockReturnValue('"public"."events"');
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({ rows: [] });
+
+    await client.optimizeTable(null, null);
+    await client.optimizeTable('events', 'public');
+
+    expect(client.driverExecuteSingle).toHaveBeenNthCalledWith(1, 'VACUUM ANALYZE');
+    expect(client.driverExecuteSingle).toHaveBeenNthCalledWith(2, 'VACUUM ANALYZE "public"."events"');
+  })
+
 })

--- a/apps/studio/tests/unit/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/sqlite.spec.js
@@ -24,4 +24,89 @@ describe("SQLite UNIT test (no connection)", () => {
     expect(result).toBe(expected);
     await client.disconnect()
   })
+
+  it("Should build a table overview for an existing SQLite table", async () => {
+    const client = new SqliteClient(null, null);
+    client.driverExecuteSingle = jest.fn()
+      .mockResolvedValueOnce({ rows: [{ name: 'users' }] })
+      .mockResolvedValueOnce({ rows: [{ count: '42' }] })
+      .mockResolvedValueOnce({ rows: [{ size: '2048' }] })
+      .mockResolvedValueOnce({ rows: [{ size: '512' }] });
+
+    const result = await client.getTableOverview('users');
+
+    expect(result).toEqual({
+      schemaName: 'main',
+      tableName: 'users',
+      rowCount: 42,
+      tableSize: 2048,
+      indexSize: 512,
+      totalSize: 2560,
+      freeSpace: null,
+      fragmentation: null,
+      canOptimize: false,
+      optimizationNote: null,
+    });
+    expect(client.driverExecuteSingle).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('WHERE type = \'table\' AND name = ?'),
+      { params: ['users'] }
+    );
+    expect(client.driverExecuteSingle).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('SELECT COUNT(*) as count FROM `users`')
+    );
+  })
+
+  it("Should return null when a SQLite table overview is requested for a missing table", async () => {
+    const client = new SqliteClient(null, null);
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({ rows: [] });
+
+    const result = await client.getTableOverview('missing');
+
+    expect(result).toBeNull();
+  })
+
+  it("Should build a SQLite database overview and detect database-wide optimization", async () => {
+    const client = new SqliteClient(null, null);
+    const userOverview = {
+      schemaName: 'main',
+      tableName: 'users',
+      rowCount: 42,
+      tableSize: 2048,
+      indexSize: 512,
+      totalSize: 2560,
+      freeSpace: null,
+      fragmentation: null,
+      canOptimize: false,
+      optimizationNote: null,
+    };
+    client.driverExecuteSingle = jest.fn()
+      .mockResolvedValueOnce({ rows: [{ name: 'users' }, { name: 'orders' }] })
+      .mockResolvedValueOnce({ rows: [{ freelist_count: 300 }] })
+      .mockResolvedValueOnce({ rows: [{ page_size: 4096 }] });
+    client.getTableOverview = jest.fn()
+      .mockResolvedValueOnce(userOverview)
+      .mockResolvedValueOnce(null);
+
+    const result = await client.getTablesOverview();
+
+    expect(result).toEqual({
+      tables: [userOverview],
+      freeSpace: 1228800,
+      canOptimize: true,
+      optimizationNote: 'SQLite optimization is database-wide (VACUUM). It cannot be applied per table.',
+    });
+    expect(client.getTableOverview).toHaveBeenCalledWith('users');
+    expect(client.getTableOverview).toHaveBeenCalledWith('orders');
+  })
+
+  it("Should run VACUUM when optimizing SQLite", async () => {
+    const client = new SqliteClient(null, null);
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({ rows: [] });
+
+    await client.optimizeTable('ignored');
+
+    expect(client.driverExecuteSingle).toHaveBeenCalledWith('VACUUM');
+  })
 })


### PR DESCRIPTION
Add a new Tables Overview tab to inspect table-level metrics across a database, including row count, total size, table size, index size, and fragmentation indicators when supported.

The feature introduces a shared overview model and database client contract, with engine-specific implementations for PostgreSQL and SQLite. Other clients expose the same contract but return unsupported or empty behaviour until proper engine-specific support is added.

Add unit tests for the overview component and database client behaviour.

Closes #4055

Demonstration video:
https://github.com/user-attachments/assets/25bf1bd9-79b2-4310-b900-3bf65364787d