### PR TITLE
Catch ident errors

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -131,7 +131,7 @@
     "source-map-support": "^0.5.21",
     "split.js": "^1.6.5",
     "sql-formatter": "15.7.3",
-    "sql-query-identifier": "^3.0.0",
+    "sql-query-identifier": "^3.0.1",
     "sqlanywhere": "beekeeper-studio/node-sqlanywhere#54d1ef2052ccdfe963f0956a3e4d024ee6f1fd8d",
     "ssh-config": "^5.1.0",
     "ssh2": "^1.14.0",

--- a/apps/studio/src-commercial/backend/lib/db/clients/anywhere.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/anywhere.ts
@@ -1254,14 +1254,6 @@ export class SQLAnywhereClient extends BasicDatabaseClient<SQLAnywhereResult> {
     }
   }
 
-  private identifyCommands(queryText: string) {
-    try {
-      return identify(queryText, { strict: false, dialect: 'mssql' });
-    } catch (err) {
-      return [];
-    }
-  }
-
   protected parseTableColumn(column: any): BksField {
     return {
       name: column.column_name,

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -592,14 +592,6 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     };
   }
 
-  private identifyCommands(queryText) {
-    try {
-      return identify(queryText);
-    } catch (err) {
-      return [];
-    }
-  }
-
   private parseFields(fields, _row) {
     return fields.map((field) => {
       field.dataType = dataTypesToMatchTypeCode[field?.type?.code] || 'user-defined'

--- a/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/duckdb.ts
@@ -682,7 +682,7 @@ export class DuckDBClient extends BasicDatabaseClient<DuckDBResult> {
     q: string,
     options: any
   ): Promise<DuckDBResult | DuckDBResult[]> {
-    const queries = identify(q, { strict: false });
+    const queries = this.identifyCommands(q);
     const params = options.params;
     const results: DuckDBResult[] = [];
     const conn: Connection = options.connection || this.connectionInstance;

--- a/apps/studio/src-commercial/backend/lib/db/clients/dynamodb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/dynamodb.ts
@@ -106,6 +106,7 @@ export class DynamoDBClient extends BasicDatabaseClient<DynamoQueryResult> {
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(null, dynamoContext, server, database);
     this.readOnlyMode = server?.config?.readOnlyMode;
+    this.dialect = 'dynamodb';
   }
 
   async applyChangesSql(_changes: TableChanges): Promise<string> {
@@ -631,7 +632,7 @@ export class DynamoDBClient extends BasicDatabaseClient<DynamoQueryResult> {
 
   async executeQuery(queryText: string, _options?: any): Promise<NgQueryResult[]> {
     // Use sql-query-identifier with native DynamoDB/PartiQL dialect support (v2.11.0+)
-    const identified = identify(queryText, { strict: false, dialect: 'dynamodb' });
+    const identified = this.identifyCommands(queryText);
     const results: NgQueryResult[] = [];
 
     for (const stmt of identified) {

--- a/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
@@ -126,15 +126,6 @@ const FIELD_TYPE_QUERY = (
   END
 `;
 
-function identifyCommands(queryText: string) {
-  try {
-    return identify(queryText, { strict: false, dialect: "generic" });
-  } catch (err) {
-    log.error(err);
-    return [];
-  }
-}
-
 function buildFilterString(filters: TableFilter[], columns = []) {
   let filterString = "";
   let filterParams = [];
@@ -1181,7 +1172,7 @@ export class FirebirdClient extends BasicDatabaseClient<FirebirdResult, Firebird
       tabId?: number;
     } = {}
   ): Promise<FirebirdResult | FirebirdResult[]> {
-    const queries = identifyCommands(queryText);
+    const queries = this.identifyCommands(queryText);
     const params = options.params ?? [];
 
     const results: FirebirdResult[] = [];

--- a/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
@@ -2,7 +2,6 @@ import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import { BasicDatabaseClient, ExecutionContext, QueryLogOptions } from "@/lib/db/clients/BasicDatabaseClient";
 import { DatabaseElement, IDbConnectionDatabase } from "@/lib/db/types";
 import { AggregationCursor, Collection, Db, Document, MongoClient, ObjectId } from 'mongodb';
-import { identify } from 'sql-query-identifier';
 import rawLog from '@bksLogger';
 import { BksField, BksFieldType, CancelableQuery, ExtendedTableColumn, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableDelete, TableFilter, TableIndex, TableInsert, TableOrView, TableProperties, TableResult, TableTrigger, TableUpdate, TableUpdateResult } from "@/lib/db/models";
 import { CreateTableSpec, IndexAlterations, TableKey } from "@/shared/lib/dialects/models";
@@ -46,6 +45,7 @@ export class MongoDBClient extends BasicDatabaseClient<QueryResult> {
 
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(knex, mongoContext, server, database);
+    this.dialect = 'psql';
   }
 
   async connect(): Promise<void> {
@@ -741,14 +741,6 @@ export class MongoDBClient extends BasicDatabaseClient<QueryResult> {
     }
 
     return results;
-  }
-
-  private identifyCommands(queryText: string) {
-    try {
-      return identify(queryText, { strict: false, dialect: 'psql' });
-    } catch (err) {
-      return [];
-    }
   }
 
   async executeCommand(commandText: string, _options?: any): Promise<NgQueryResult[]> {

--- a/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/oracle.ts
@@ -42,7 +42,6 @@ import {
 import rawLog from '@bksLogger'
 import { createCancelablePromise, joinFilters } from '@/common/utils';
 import { errors } from '@/lib/errors';
-import { identify as rawIdentify } from 'sql-query-identifier'
 import { IdentifyResult } from 'sql-query-identifier/lib/defines';
 import platformInfo from '@/common/platform_info';
 import { OracleCursor } from './oracle/OracleCursor';
@@ -84,6 +83,7 @@ export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Conne
     this.readOnlyMode = server?.config?.readOnlyMode || false
     // Typescript wasn't having it that createUpsertFunc could be either a function or null, so this ended up working
     this.createUpsertFunc = this.createUpsertSQL
+    this.dialect = 'oracle';
   }
 
   getBuilder(table: string, schema?: string): ChangeBuilderBase {
@@ -1102,7 +1102,7 @@ export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Conne
 
   protected async rawExecuteQuery(query: string, options: any): Promise<DriverResult | DriverResult[]> {
       const realQueries: string[] = _.isArray(query) ? query : [query]
-      const infos = _.flatMap(realQueries.map((q) => this.identify(q)))
+      const infos = _.flatMap(realQueries.map((q) => this.identifyCommands(q)))
       // TODO - use `executeMany` if no SELECT queries are present
       // const hasListing = !!infos.find((i) => ['LISTING', 'UNKNOWN'].includes(i.executionType))
       const hasReserved = this.reservedConnections.has(options?.tabId);
@@ -1162,10 +1162,6 @@ export class OracleClient extends BasicDatabaseClient<DriverResult, oracle.Conne
   async rollbackTransaction(tabId: number): Promise<void> {
     const conn = this.peekConnection(tabId);
     await conn.rollback();
-  }
-
-  private identify(query: string): IdentifyResult[] {
-    return rawIdentify(query, {strict: false, dialect: 'oracle'})
   }
 
   parseQueryResultColumns(qr: DriverResult): BksField[] {

--- a/apps/studio/src/assets/styles/app/_layout.scss
+++ b/apps/studio/src/assets/styles/app/_layout.scss
@@ -809,6 +809,18 @@ input[type=file] {
 .alert-success {
   color: color.adjust($brand-success, $lightness: 5%);
 }
+.alert-small {
+  align-items: center;
+  padding: 0.4rem 0.6rem;
+  margin: 0.25rem 0;
+  line-height: 1.1rem;
+  > i {
+    margin-right: 0.5rem;
+  }
+  .alert-body {
+    align-items: center;
+  }
+}
 
 // Dropdown
 // --------------------------

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -243,7 +243,7 @@
                 <hr>
                 <x-menuitem
                   @click.prevent="queryFunctions.primaryWrite"
-                  :disabled="disableRunToFile"
+                  :disabled="disableRunToFile || (primaryIsCurrent && runCurrentDisabled)"
                 >
                   <x-label>{{ runPrimaryText(true) }}</x-label>
                   <x-shortcut :value="displayShortcut('queryEditor.primaryQueryToFileAction')" />
@@ -256,7 +256,7 @@
                 </x-menuitem>
                 <x-menuitem
                   @click.prevent="queryFunctions.secondaryWrite"
-                  :disabled="disableRunToFile"
+                  :disabled="disableRunToFile || (primaryIsTab && runCurrentDisabled)"
                 >
                   <x-label>{{ runSecondaryText(true) }}</x-label>
                   <x-shortcut :value="displayShortcut('queryEditor.secondaryQueryToFileAction')" />

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -9,6 +9,25 @@
       class="top-panel"
       ref="topPanel"
     >
+      <div
+        v-if="querySelectionError"
+        class="query-parser-error"
+      >
+        <div class="alert alert-warning alert-small">
+          <i class="material-icons">error_outline</i>
+          <div class="alert-body">Run Current unavailable</div>
+          <div class="btn-group">
+            <a
+              @click.prevent="copyQuerySelectionError"
+              class="btn btn-flat btn-small"
+            >Copy error</a>
+            <a
+              @click.prevent="openTroubleshooting"
+              class="btn btn-flat btn-small"
+            >Report issue</a>
+          </div>
+        </div>
+      </div>
       <merge-manager
         v-if="query && query.id"
         :original-text="originalText"
@@ -196,7 +215,7 @@
               class="btn btn-primary btn-small"
               :v-tooltip="displayShortcut('queryEditor.primaryQueryAction')"
               @click.prevent="queryFunctions.primaryRead"
-              :disabled="runButtonDisabled"
+              :disabled="runButtonDisabled || (primaryIsCurrent && runCurrentDisabled)"
             >
               <x-label>{{ runPrimaryText() }}</x-label>
             </x-button>
@@ -207,11 +226,17 @@
             >
               <i class="material-icons">arrow_drop_down</i>
               <x-menu>
-                <x-menuitem @click.prevent="queryFunctions.primaryRead">
+                <x-menuitem
+                  @click.prevent="queryFunctions.primaryRead"
+                  :disabled="primaryIsCurrent && runCurrentDisabled"
+                >
                   <x-label>{{ runPrimaryText() }}</x-label>
                   <x-shortcut :value="displayShortcut('queryEditor.primaryQueryAction')" />
                 </x-menuitem>
-                <x-menuitem @click.prevent="queryFunctions.secondaryRead">
+                <x-menuitem
+                  @click.prevent="queryFunctions.secondaryRead"
+                  :disabled="primaryIsTab && runCurrentDisabled"
+                >
                   <x-label>{{ runSecondaryText() }}</x-label>
                   <x-shortcut :value="displayShortcut('queryEditor.secondaryQueryAction')" />
                 </x-menuitem>
@@ -528,7 +553,7 @@
   import { mapGetters, mapState } from 'vuex'
   import { identify } from 'sql-query-identifier'
 
-  import { canDeparameterize, convertParamsForReplacement, deparameterizeQuery } from '../lib/db/sql_tools'
+  import { canDeparameterize, convertParamsForReplacement, deparameterizeQuery, safelyIdentify } from '../lib/db/sql_tools'
   import { EditorMarker } from '@/lib/editor/utils'
   import ProgressBar from './editor/ProgressBar.vue'
   import ResultTable from './editor/ResultTable.vue'
@@ -623,6 +648,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
 
         individualQueries: [],
         currentlySelectedQuery: null,
+        querySelectionError: null,
+
         queryMagic: queryMagicExtension(),
         isManualCommit: false,
         hasActiveTransaction: false,
@@ -761,6 +788,11 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         return this.tab.isRunning ||
           this.running ||
           (this.editingResult && this.changesCount > 0);
+      },
+      runCurrentDisabled() {
+        // When the sql parser failed to detect multiple queries,
+        // "run current" becomes useless.
+        return !!this.querySelectionError && !this.hasSelectedText;
       },
       changesCount() {
         return this.$refs.table?.pendingChangesCount;
@@ -1463,6 +1495,7 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       },
       async submitCurrentQuery() {
         if(this.runButtonDisabled) return;
+        if (this.runCurrentDisabled) return;
         this.runningType = 'current'
 
         if (this.hasSelectedText && this.primaryIsCurrent) {
@@ -1535,7 +1568,11 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.selectedResult = 0
         let identification = []
         try {
-          identification = identify(rawQuery, { strict: false, dialect: this.identifyDialect, identifyTables: true, identifyColumns: true })
+          const { queries, error } = safelyIdentify(rawQuery, { strict: false, dialect: this.identifyDialect, identifyTables: true, identifyColumns: true })
+          if (error) {
+            log.error("Unable to identify query. Disabling run current.", error)
+          }
+          identification = queries
 
           if (this.canManageTransactions && identification.some((value: IdentifyResult) => value.executionType === "TRANSACTION")) {
             const startTransaction = identification.filter((value: IdentifyResult) => value.type === "BEGIN_TRANSACTION").length
@@ -1797,9 +1834,16 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
 
         return table?.columns.map((c) => c.columnName);
       },
-      handleQuerySelectionChange({ queries, selectedQuery }) {
+      handleQuerySelectionChange({ queries, selectedQuery, error }) {
         this.individualQueries = queries;
         this.currentlySelectedQuery = selectedQuery;
+        this.querySelectionError = error;
+      },
+      openTroubleshooting() {
+        window.main.openExternally('https://docs.beekeeperstudio.io/support/troubleshooting/')
+      },
+      copyQuerySelectionError() {
+        this.$native.clipboard.writeText(this.querySelectionError?.stack ?? this.querySelectionError?.message)
       },
       startTimer() {
         this.elapsedTime = 0;
@@ -2098,6 +2142,16 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
   // Hide the dot on the range highlight when not editing result
   .query-editor:not(.editing-result) ::v-deep .tabulator-range-active::after {
     visibility: hidden;
+  }
+
+  .query-parser-error {
+    margin-inline: 1rem;
+    margin-top: 0.5rem;
+    margin-bottom: -0.5rem;
+
+    .alert {
+      margin: 0;
+    }
   }
 </style>
 

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1494,7 +1494,7 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.trigger( AppEvent.beginExport, { query: query_sql, queryName: queryName });
       },
       async submitCurrentQuery() {
-        if(this.runButtonDisabled) return;
+        if (this.runButtonDisabled) return;
         if (this.runCurrentDisabled) return;
         this.runningType = 'current'
 
@@ -1507,7 +1507,16 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           return await this.submitQuery(this.currentlySelectedQuery.text)
         }
 
-        const queries = identify(this.unsavedText, { strict: false, dialect: this.identifierDialect, paramTypes: this.paramTypes })
+        const { queries, error } = safelyIdentify(this.unsavedText, { dialect: this.identifierDialect, paramTypes: this.paramTypes })
+
+        // this should not theoretically be possible as there probably would have been a queryselection error,
+        // but if we somehow manage to get here, we need to panic
+        if (error) {
+          log.error(error);
+          this.querySelectionError = error;
+          return;
+        }
+
         if (queries.length > 0) {
           this.individualQueries = queries
           this.currentlySelectedQuery = queries[0]
@@ -1568,11 +1577,10 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.selectedResult = 0
         let identification = []
         try {
-          const { queries, error } = safelyIdentify(rawQuery, { strict: false, dialect: this.identifyDialect, identifyTables: true, identifyColumns: true })
+          const { queries: identification, error } = safelyIdentify(rawQuery, { dialect: this.identifyDialect, identifyTables: true, identifyColumns: true })
           if (error) {
-            log.error("Unable to identify query. Disabling run current.", error)
+            log.error("Unable to identify query.", error)
           }
-          identification = queries
 
           if (this.canManageTransactions && identification.some((value: IdentifyResult) => value.executionType === "TRANSACTION")) {
             const startTransaction = identification.filter((value: IdentifyResult) => value.type === "BEGIN_TRANSACTION").length
@@ -1693,7 +1701,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         }
         const originalText = this.query?.text || this.tab.unsavedQueryText
         if (originalText) {
-          const queries = identify(originalText, { strict: false, dialect: this.identifierDialect, paramTypes: this.paramTypes })
+          // The run methods should catch any errors, so we don't need to do that here
+          const { queries } = safelyIdentify(originalText, { dialect: this.identifierDialect, paramTypes: this.paramTypes })
           if (queries.length > 0) {
             this.individualQueries = queries
             this.currentlySelectedQuery = queries[0]

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -4,16 +4,16 @@ import { buildInsertQueries, buildInsertQuery, errorMessages, isAllowedReadOnlyQ
 import { Knex } from 'knex';
 import _ from 'lodash'
 import { ChangeBuilderBase } from '@shared/lib/sql/change_builder/ChangeBuilderBase';
-import { identify } from 'sql-query-identifier';
 import { ConnectionType, DatabaseElement, IBasicDatabaseClient, IDbConnectionDatabase } from '../types';
 import rawLog from "@bksLogger";
 import connectTunnel from '../tunnel';
 import { IDbConnectionServer } from '../backendTypes';
 import platformInfo from '@/common/platform_info';
 import { LicenseKey } from '@/common/appdb/models/LicenseKey';
-import { IdentifyResult } from 'sql-query-identifier/lib/defines';
+import { Dialect as IdentifierDialect, IdentifyResult } from 'sql-query-identifier/lib/defines';
 import { Transcoder } from '../serialization/transcoders';
 import { ColumnReference, TableReference } from 'sql-query-identifier/lib/defines';
+import { safelyIdentify } from '../sql_tools';
 
 const log = rawLog.scope('BasicDatabaseClient');
 const logger = () => log;
@@ -71,7 +71,7 @@ export interface BaseQueryResult {
 export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult, Conn = null> implements IBasicDatabaseClient {
   knex: Knex | null;
   contextProvider: AppContextProvider;
-  dialect: "mssql" | "sqlite" | "mysql" | "oracle" | "psql" | "bigquery" | "generic";
+  dialect: IdentifierDialect;
   // TODO (@day): this can be cleaned up when we fix configuration
   readOnlyMode = false;
   server: IDbConnectionServer;
@@ -202,7 +202,14 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   async getResultEditData(queryText: string, fields: FieldDescriptor[]): Promise<FieldEditData[]> {
     if (!queryText) throw new Error('No query text to identify for this result')
 
-    const commands = identify(queryText, { identifyTables: true, identifyColumns: true, dialect: this.dialect });
+    const { queries: commands, error } = safelyIdentify(queryText, { identifyTables: true, identifyColumns: true, dialect: this.dialect });
+
+    if (error) {
+      // We can't do anything with the fallback identify result, so we panic
+      log.error(error.message);
+      throw new Error('Error identifying query, please file an issue');
+    }
+
     if (commands.length !== 1) return [];
 
     const command = commands[0];
@@ -638,8 +645,23 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
     return !isAllowedReadOnlyQuery(statements, this.readOnlyMode) && !options.overrideReadonly
   }
 
+  protected identifyCommands(queryText: string): IdentifyResult[] {
+    const { queries: commands, error } = safelyIdentify(queryText, { dialect: this.dialect });
+
+    if (error) {
+      log.error('Was not able to properly identify query: ', error.message);
+    }
+
+    return commands;
+  }
+
   async driverExecuteSingle(q: string, options: any = {}): Promise<RawResultType> {
-    const statements = identify(q, { strict: false, dialect: this.dialect });
+    const { queries: statements, error } = safelyIdentify(q, { dialect: this.dialect });
+
+    if (error) {
+      log.warn('Was not able to correctly identify query: ', error.message);
+    }
+
     if (await this.checkAllowReadOnly() && this.violatesReadOnly(statements, options)) {
       throw new Error(errorMessages.readOnly);
     }
@@ -673,7 +695,12 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   }
 
   async driverExecuteMultiple(q: string, options: any = {}): Promise<RawResultType[]> {
-    const statements = identify(q, { strict: false, dialect: this.dialect });
+    const { queries: statements, error } = safelyIdentify(q, { dialect: this.dialect });
+
+    if (error) {
+      log.warn('Was not able to correctly identify query: ', error.message);
+    }
+
     if (await this.checkAllowReadOnly() && this.violatesReadOnly(statements, options)) {
       throw new Error(errorMessages.readOnly);
     }

--- a/apps/studio/src/lib/db/clients/mysql.ts
+++ b/apps/studio/src/lib/db/clients/mysql.ts
@@ -220,14 +220,6 @@ async function configDatabase(
   return config;
 }
 
-function identifyCommands(queryText: string) {
-  try {
-    return identify(queryText);
-  } catch (err) {
-    return [];
-  }
-}
-
 function isMultipleQuery(fields: any[]) {
   if (!fields) {
     return false;
@@ -1182,7 +1174,7 @@ export class MysqlClient extends BasicDatabaseClient<ResultType, mysql.PoolConne
       return [];
     }
 
-    const commands = identifyCommands(queryText);
+    const commands = this.identifyCommands(queryText);
 
     if (!isMultipleQuery(fields)) {
       return [

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1789,14 +1789,6 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
     return data.rows[0].schema;
   }
 
-  private identifyCommands(queryText: string) {
-    try {
-      return identify(queryText);
-    } catch (err) {
-      return [];
-    }
-  }
-
   parseQueryResultColumns(qr: QueryResult): BksField[] {
     return qr.columns.map((column) => {
       let bksType: BksFieldType = 'UNKNOWN';

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -735,14 +735,6 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
     })
   }
 
-  private identifyCommands(queryText: string) {
-    try {
-      return identify(queryText, { strict: false, dialect: 'sqlite' });
-    } catch (err) {
-      return [];
-    }
-  }
-
   private async insertRows(cli: any, inserts: TableInsert[]) {
     for (const command of buildInsertQueries(knex, inserts)) {
       await this.driverExecuteSingle(command, cli);

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -36,6 +36,7 @@ import { AzureAuthService } from '../authentication/azure';
 import { IDbConnectionServer } from '../backendTypes';
 import { GenericBinaryTranscoder } from '../serialization/transcoders';
 import { IdentifyResult } from 'sql-query-identifier/lib/defines';
+import { safelyIdentify } from '../sql_tools';
 const log = logRaw.scope('sql-server')
 
 const D = SqlServerData
@@ -1233,14 +1234,6 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       rowCount: data.length,
       affectedRows: rowsAffected,
       text: command?.text
-    }
-  }
-
-  private identifyCommands(queryText: string) {
-    try {
-      return identify(queryText);
-    } catch (err) {
-      return [];
     }
   }
 

--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
 import { identify, Options } from 'sql-query-identifier'
+import { IdentifyResult } from 'sql-query-identifier/lib/defines'
 import { EntityFilter } from '@/store/models'
 import { RoutineTypeNames } from "./models"
 import { format } from 'sql-formatter'
@@ -12,6 +13,29 @@ export function splitQueries(queryText: string, dialect) {
   }
   const result = identify(queryText, { strict: false, dialect })
   return result
+}
+
+// Wraps identify so a parser failure is returned instead of thrown,
+// falling back to treating the whole text as a single query.
+export function safelyIdentify(
+  queryText: string,
+  options: Options
+): { queries: IdentifyResult[]; error: Error | null } {
+  try {
+    return { queries: identify(queryText, options), error: null }
+  } catch (error) {
+    const fallback: IdentifyResult = {
+      start: 0,
+      end: queryText.length - 1,
+      text: queryText,
+      type: "UNKNOWN",
+      executionType: "UNKNOWN",
+      parameters: [],
+      tables: [],
+      columns: [],
+    }
+    return { queries: [fallback], error: error as Error }
+  }
 }
 
 // can only have positional params OR non-positional

--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -3,15 +3,15 @@ import { identify, Options } from 'sql-query-identifier'
 import { IdentifyResult } from 'sql-query-identifier/lib/defines'
 import { EntityFilter } from '@/store/models'
 import { RoutineTypeNames } from "./models"
-import { format } from 'sql-formatter'
+import { format, ParamItems } from 'sql-formatter'
 import { Dialect, FormatterDialect } from '@/shared/lib/dialects/models'
-import { ParamItems } from 'sql-formatter/lib/src/formatter/Params'
 
 export function splitQueries(queryText: string, dialect) {
   if(_.isEmpty(queryText.trim())) {
     return []
   }
-  const result = identify(queryText, { strict: false, dialect })
+  safelyIdentify(queryText, { dialect });
+  const result = identify(queryText, { dialect })
   return result
 }
 
@@ -22,7 +22,8 @@ export function safelyIdentify(
   options: Options
 ): { queries: IdentifyResult[]; error: Error | null } {
   try {
-    return { queries: identify(queryText, options), error: null }
+    // We should really not be using strict mode anywhere, but I guess we can allow an override here just in case
+    return { queries: identify(queryText, { strict: false, ...options }), error: null }
   } catch (error) {
     const fallback: IdentifyResult = {
       start: 0,

--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -1,18 +1,17 @@
 import _ from 'lodash'
-import { identify, Options } from 'sql-query-identifier'
+import { identify, Options, Dialect as IdentifierDialect } from 'sql-query-identifier'
 import { IdentifyResult } from 'sql-query-identifier/lib/defines'
 import { EntityFilter } from '@/store/models'
 import { RoutineTypeNames } from "./models"
 import { format, ParamItems } from 'sql-formatter'
 import { Dialect, FormatterDialect } from '@/shared/lib/dialects/models'
 
-export function splitQueries(queryText: string, dialect) {
+export function splitQueries(queryText: string, dialect: IdentifierDialect): IdentifyResult[] {
   if(_.isEmpty(queryText.trim())) {
     return []
   }
-  safelyIdentify(queryText, { dialect });
-  const result = identify(queryText, { dialect })
-  return result
+  const { queries: result } = safelyIdentify(queryText, { dialect });
+  return result;
 }
 
 // Wraps identify so a parser failure is returned instead of thrown,

--- a/apps/studio/src/lib/db/sql_tools.ts
+++ b/apps/studio/src/lib/db/sql_tools.ts
@@ -108,7 +108,8 @@ export function removeQueryQuotes(possibleQuery: string, dialect: any): string {
   const unquotedQuery = possibleQuery.slice(1, possibleQuery.length - 1);
 
   // if the query is quoted and we can identify at least one valid sql statement, we'll unquote it.
-  if (isQuoted && identify(unquotedQuery, { strict: false, dialect })?.some((res) => res.type != 'UNKNOWN')) {
+  const { queries } = safelyIdentify(unquotedQuery, { dialect });
+  if (isQuoted && queries?.some((res) => res.type != 'UNKNOWN')) {
     return unquotedQuery;
   }
 

--- a/apps/studio/src/shared/lib/sql/SqlGenerator.ts
+++ b/apps/studio/src/shared/lib/sql/SqlGenerator.ts
@@ -10,6 +10,7 @@ import { Client_DuckDB } from '@shared/lib/knex-duckdb'
 import { ClickhouseKnexClient } from "@shared/lib/knex-clickhouse";
 import Client_Firebird from '@shared/lib/knex-firebird'
 import Client_Oracledb from '@shared/lib/knex-oracledb'
+import { safelyIdentify } from '@/lib/db/sql_tools'
 
 interface GeneratorConnection {
   dbConfig: any
@@ -83,7 +84,7 @@ export class SqlGenerator {
     // HACK: firebird knex includes the database path in the query which breaks
     // the sql syntax
     if (this.dialect === 'firebird') {
-      const queries = identify(sql, { strict: false, dialect: "generic" })
+      const { queries } = safelyIdentify(sql, { dialect: "generic" })
       sql = queries.reduce((prev, curr) => prev + curr.text.replace(`${this.connection.dbName}.`, ''), '')
     }
 

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
@@ -3,6 +3,7 @@ import { Extension, StateField, StateEffect } from "@codemirror/state";
 import { EditorView, Decoration, DecorationSet } from "@codemirror/view";
 import { identify, Options } from "sql-query-identifier";
 import { IdentifyResult, ParamTypes } from "sql-query-identifier/lib/defines";
+import { safelyIdentify } from "@/utils";
 // Utility function from entity-list/sql_tools
 function isTextSelected(
   textStart: number,
@@ -120,25 +121,8 @@ function splitQueries(
   if (_.isEmpty(queryText.trim())) {
     return { queries: [], error: null };
   }
-  try {
-    return {
-      queries: identify(queryText, { strict: false, dialect, paramTypes }),
-      error: null,
-    };
-  } catch (e) {
-    // identify can throw on unparseable input; treat the whole doc as one query
-    const fallback: IdentifyResult = {
-      start: 0,
-      end: queryText.length - 1,
-      text: queryText,
-      type: "UNKNOWN",
-      executionType: "UNKNOWN",
-      parameters: [],
-      tables: [],
-      columns: [],
-    };
-    return { queries: [fallback], error: e as Error };
-  }
+
+  return safelyIdentify(queryText, { dialect, paramTypes });
 }
 
 // State field that manages query selection

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { Extension, StateField, StateEffect } from "@codemirror/state";
 import { EditorView, Decoration, DecorationSet } from "@codemirror/view";
-import { identify, Options } from "sql-query-identifier";
+import { Options } from "sql-query-identifier";
 import { IdentifyResult, ParamTypes } from "sql-query-identifier/lib/defines";
 import { safelyIdentify } from "@/utils";
 // Utility function from entity-list/sql_tools

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
@@ -27,6 +27,7 @@ function isTextSelected(
 export interface QuerySelectionChangeParams {
   queries: IdentifyResult[];
   selectedQuery: IdentifyResult;
+  error: Error | null;
 }
 
 interface QuerySelectionState {
@@ -34,6 +35,7 @@ interface QuerySelectionState {
   selectedQueryIndex: number;
   selectedQueryPosition: { from: number; to: number } | null;
   decorations: DecorationSet;
+  error: Error | null;
 }
 
 // Effects for updating the state
@@ -107,12 +109,36 @@ function getSelectedQueryIndex(
   return -1;
 }
 
-function splitQueries(queryText: string, dialect: Options["dialect"], paramTypes: ParamTypes) {
+function splitQueries(
+  queryText: string,
+  dialect: Options["dialect"],
+  paramTypes: ParamTypes
+): {
+  queries: IdentifyResult[];
+  error: Error | null;
+} {
   if (_.isEmpty(queryText.trim())) {
-    return [];
+    return { queries: [], error: null };
   }
-  const result = identify(queryText, { strict: false, dialect, paramTypes });
-  return result;
+  try {
+    return {
+      queries: identify(queryText, { strict: false, dialect, paramTypes }),
+      error: null,
+    };
+  } catch (e) {
+    // identify can throw on unparseable input; treat the whole doc as one query
+    const fallback: IdentifyResult = {
+      start: 0,
+      end: queryText.length - 1,
+      text: queryText,
+      type: "UNKNOWN",
+      executionType: "UNKNOWN",
+      parameters: [],
+      tables: [],
+      columns: [],
+    };
+    return { queries: [fallback], error: e as Error };
+  }
 }
 
 // State field that manages query selection
@@ -122,6 +148,7 @@ const querySelectionState = StateField.define<QuerySelectionState>({
     selectedQueryIndex: -1,
     selectedQueryPosition: null,
     decorations: Decoration.none,
+    error: null,
   }),
 
   update: (state, tr) => {
@@ -134,7 +161,7 @@ const querySelectionState = StateField.define<QuerySelectionState>({
     const cursorIndexAnchor = cursor.anchor;
 
     // Split queries
-    const queries = splitQueries(tr.state.doc.toString(), dialect, paramTypes);
+    const { queries, error } = splitQueries(tr.state.doc.toString(), dialect, paramTypes);
     const selectedQueryIndex = getSelectedQueryIndex(
       queries,
       cursorIndex,
@@ -170,6 +197,7 @@ const querySelectionState = StateField.define<QuerySelectionState>({
       selectedQueryIndex,
       selectedQueryPosition,
       decorations,
+      error,
     };
   },
 
@@ -199,6 +227,7 @@ export function querySelection(
           onQuerySelectionChange({
             queries: currentState.queries,
             selectedQuery: currentState.queries[currentState.selectedQueryIndex],
+            error: currentState.error,
           });
         }
 

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
@@ -4,6 +4,7 @@ import { EditorView, Decoration, DecorationSet } from "@codemirror/view";
 import { Options } from "sql-query-identifier";
 import { IdentifyResult, ParamTypes } from "sql-query-identifier/lib/defines";
 import { safelyIdentify } from "@/utils";
+
 // Utility function from entity-list/sql_tools
 function isTextSelected(
   textStart: number,

--- a/apps/ui-kit/lib/utils/sql.ts
+++ b/apps/ui-kit/lib/utils/sql.ts
@@ -1,5 +1,26 @@
-import { identify } from 'sql-query-identifier'
-import { Dialect } from 'sql-query-identifier/lib/defines';
+import { identify, Options } from 'sql-query-identifier'
+import { Dialect, IdentifyResult } from 'sql-query-identifier/lib/defines';
+
+export function safelyIdentify(
+  queryText: string,
+  options: Options
+): { queries: IdentifyResult[]; error: Error | null } {
+  try {
+    return { queries: identify(queryText, { strict: false, ...options }), error: null }
+  } catch (error) {
+    const fallback: IdentifyResult = {
+      start: 0,
+      end: queryText.length - 1,
+      text: queryText,
+      type: "UNKNOWN",
+      executionType: "UNKNOWN",
+      parameters: [],
+      tables: [],
+      columns: [],
+    }
+    return { queries: [fallback], error: error as Error }
+  }
+}
 
 // a function that takes in a string and a dialect,
 // if the string is determined to be most likely a query and it is quoted, we remove the quotes,
@@ -14,7 +35,8 @@ export function removeQueryQuotes(possibleQuery: string, dialect: Dialect): stri
   const unquotedQuery = possibleQuery.slice(1, possibleQuery.length - 1);
 
   // if the query is quoted and we can identify at least one valid sql statement, we'll unquote it.
-  if (isQuoted && identify(unquotedQuery, { strict: false, dialect })?.some((res) => res.type != 'UNKNOWN')) {
+  const { queries } = safelyIdentify(unquotedQuery, { dialect });
+  if (isQuoted && queries?.some((res) => res.type != 'UNKNOWN')) {
     return unquotedQuery;
   }
 

--- a/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
@@ -1,6 +1,16 @@
 import { EditorSelection } from "@codemirror/state";
 import { SqlTextEditor } from "../../../lib/components/sql-text-editor/SqlTextEditor";
 import { vi } from "vitest";
+import * as sqlQueryIdentifier from "sql-query-identifier";
+
+// Wrap identify so individual tests can force it to throw via mockImplementationOnce
+vi.mock("sql-query-identifier", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof sqlQueryIdentifier;
+  return {
+    ...actual,
+    identify: vi.fn(actual.identify),
+  };
+});
 
 function initializeEditor(editor: SqlTextEditor, initialValue?: string) {
   const parent = document.createElement("div");
@@ -37,8 +47,6 @@ describe("querySelection", () => {
       new SqlTextEditor({ onQuerySelectionChange }),
       "SELECT 1;\nSELECT 2"
     );
-
-    onQuerySelectionChange.mockClear();
 
     // Move cursor to second query
     editor.view.dispatch({
@@ -110,6 +118,33 @@ describe("querySelection", () => {
         ]),
       })
     );
+
+    editor.destroy();
+  });
+
+  it("should fall back to a single whole-text query and report the error when identify throws", () => {
+    const onQuerySelectionChange = vi.fn();
+    const editor = initializeEditor(
+      new SqlTextEditor({ onQuerySelectionChange }),
+      "SELECT 1"
+    );
+
+    const error = new Error("parse failure");
+    vi.mocked(sqlQueryIdentifier.identify).mockImplementationOnce(() => {
+      throw error;
+    });
+
+    // Trigger a re-parse, which now throws and hits the fallback
+    editor.view.dispatch({
+      changes: { from: 8, insert: " WHERE" },
+    });
+
+    expect(onQuerySelectionChange).toHaveBeenCalledTimes(1);
+    const params = onQuerySelectionChange.mock.calls[0][0];
+    expect(params.error).toBe(error);
+    expect(params.queries).toHaveLength(1);
+    expect(params.queries[0].text).toBe("SELECT 1 WHERE");
+    expect(params.selectedQuery.text).toBe("SELECT 1 WHERE");
 
     editor.destroy();
   });

--- a/apps/ui-kit/vitest.config.js
+++ b/apps/ui-kit/vitest.config.js
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "./lib"),
+    },
+  },
   test: {
     globals: true,
     environment: "happy-dom",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13527,10 +13527,10 @@ sql-query-identifier@^2.10.0:
   resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-2.10.0.tgz#ee46e7ffb941a5f03a4f1b297d47d438dc6c14e1"
   integrity sha512-SBYnk1PPIDJ4M1+O3YXKfc4L++RyntcJAGhEWqBv0xrOzzp2k7lTeM7Ow//IfmDsfyh7dVas03UJWoL2P+nPEQ==
 
-sql-query-identifier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-3.0.0.tgz#33ff0974ece4138a810995709d1ef640fbc94031"
-  integrity sha512-XtAqC3MvrYz6ZCiTmSo6sBGaQRiQFLzraC824vApetKsoA+bDjSwNTBD/CAY1aOjEZY9uHc7XmJqrNrFW+pxaw==
+sql-query-identifier@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-3.0.1.tgz#d8568a8950ec5fe556b461b09168711ac801e2ad"
+  integrity sha512-qyEB/pXpI0rib0sAfbK4mN0lTlE0RasJL4Cb2FQcl6PLOF2OScab0RGQJbzpu0ELsS1efsVj/75TzCKo9lZqxg==
 
 sqlanywhere@beekeeper-studio/node-sqlanywhere#54d1ef2052ccdfe963f0956a3e4d024ee6f1fd8d:
   version "2.0.4"


### PR DESCRIPTION
fix #4350 
azmy added a new method `safelyIdentify` which just wraps identify and try catches the identification. If it succeeds it returns the queries, if it fails it generates a dummy result that is still useable to run. 

getResultEditData now throws if we get an error from `safelyIdentify` as if identify throws then the output won't be useable anyways.

The query editor disables run current if an error has occurred in the identify process:
<img width="877" height="889" alt="image" src="https://github.com/user-attachments/assets/57806c95-5d40-47cf-be41-d1f6572642f1" />
