### PR TITLE
Better range actions

### DIFF
--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -280,7 +280,7 @@ import { stringToTypedArray } from '@/common/utils'
             contextMenu: (_e, cell) => {
               return [
                 ...copyActionsMenu({
-                  ranges: cell.getRanges(),
+                  ranges: cell.getTable().getRanges(),
                   table: this.result.tableName || "mytable",
                   schema: this.result.schema,
                 }),
@@ -332,14 +332,14 @@ import { stringToTypedArray } from '@/common/utils'
           element.classList.add(classToAdd);
         }
       },
-      setAsNullMenuItem(range: RangeComponent) {
-        const areAllCellsReadOnly = range
-          .getColumns()
+      setAsNullMenuItem(ranges: RangeComponent[]) {
+        const areAllCellsReadOnly = ranges
+          .flatMap((range) => range.getColumns())
           .every((col) => !this.cellEditCheck(col));
         return {
           label: createMenuItem("Set as NULL"),
           action: () => {
-            const targets = range.getCells().flat().map((cell) => ({
+            const targets = ranges.flatMap((range) => range.getCells().flat()).map((cell) => ({
               row: cell.getRow(),
               field: cell.getField()
             }));
@@ -399,7 +399,7 @@ import { stringToTypedArray } from '@/common/utils'
         }
 
         const cellMenu = (_e, cell: CellComponent) => {
-          const ranges = cell.getRanges();
+          const ranges = cell.getTable().getRanges();
           const range = _.last(ranges);
 
           return [
@@ -407,7 +407,7 @@ import { stringToTypedArray } from '@/common/utils'
             this.setAsNullMenuItem(range),
             { separator: true },
             ...copyActionsMenu({
-              ranges: cell.getRanges(),
+              ranges: cell.getTable().getRanges(),
               table: this.result.tableName,
               schema: this.defaultSchema,
             }),
@@ -427,7 +427,7 @@ import { stringToTypedArray } from '@/common/utils'
         const columnMenu = (_e, column) => {
           return [
             ...copyActionsMenu({
-              ranges: column.getRanges(),
+              ranges: column.getTable().getRanges(),
               table: this.result.tableName,
               schema: this.defaultSchema,
             }),

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -824,11 +824,11 @@ export default Vue.extend({
       // to the FK table.
       const cellMenu = (keyDatas?: any[]) => {
         return (_e, cell: CellComponent) => {
-          const ranges = cell.getRanges();
+          const ranges = cell.getTable().getRanges()
           const range = _.last(ranges)
           const menu = [
             this.openEditorMenu(cell),
-            this.setAsNullMenuItem(range),
+            this.setAsNullMenuItem(ranges),
             { separator: true },
             this.quickFilterMenuItem(cell),
             ...copyActionsMenu({
@@ -839,7 +839,7 @@ export default Vue.extend({
             { separator: true },
             ...pasteActionsMenu(range),
             { separator: true },
-            ...this.rowActionsMenu(range),
+            ...this.rowActionsMenu(ranges),
             ...this.getExtraPopupMenu('tableTable.cell', { transform: "tabulator" }),
           ]
 
@@ -862,8 +862,7 @@ export default Vue.extend({
       }
 
       const columnMenu = (_e, column: ColumnComponent) => {
-        const ranges = (column as any).getRanges();
-        const range = _.last(ranges) as RangeComponent;
+        const ranges = column.getTable().getRanges();
         let hideColumnLabel = `Hide ${column.getDefinition().title}`
 
         if (hideColumnLabel.length > 33) {
@@ -871,7 +870,7 @@ export default Vue.extend({
         }
 
         return [
-          this.setAsNullMenuItem(range),
+          this.setAsNullMenuItem(ranges),
           { separator: true },
           ...copyActionsMenu({
             ranges,
@@ -1113,10 +1112,9 @@ export default Vue.extend({
         persistenceWriterFunc: this.persistenceWriter,
         rowHeader: {
           contextMenu: (_e, cell: CellComponent) => {
-            const ranges = cell.getRanges();
-            const range = _.last(ranges);
+            const ranges = cell.getTable().getRanges();
             return [
-              this.setAsNullMenuItem(range),
+              this.setAsNullMenuItem(ranges),
               { separator: true },
               ...copyActionsMenu({
                 ranges,
@@ -1124,15 +1122,14 @@ export default Vue.extend({
                 schema: this.table.schema,
               }),
               { separator: true },
-              ...this.rowActionsMenu(range),
+              ...this.rowActionsMenu(ranges),
               ...this.getExtraPopupMenu('tableTable.rowHeader', { transform: "tabulator" }),
             ]
           },
           headerContextMenu: () => {
             const ranges = this.tabulator.getRanges();
-            const range: RangeComponent = _.last(ranges)
             return [
-              this.setAsNullMenuItem(range),
+              this.setAsNullMenuItem(ranges),
               { separator: true },
               ...copyActionsMenu({
                 ranges,
@@ -1190,28 +1187,29 @@ export default Vue.extend({
       this.tableFilters = getFilters(this.tab) || [createTableFilter(this.table.columns?.[0]?.columnName)]
       this.filters = normalizeFilters(this.tableFilters || [])
     },
-    rowActionsMenu(range: RangeComponent) {
-      const rowRangeLabel = `${range.getTopEdge() + 1} - ${range.getBottomEdge() + 1}`
+    rowActionsMenu(ranges: RangeComponent[]) {
       const selectedRowsCount = this.getSelectedRows().length
+      let rowRangeLabel = "";
+      if (selectedRowsCount === 1) {
+        rowRangeLabel = "row";
+      } else if (ranges.length === 1) {
+        const top = ranges[0].getTopEdge() + 1;
+        const bottom = ranges[0].getBottomEdge() + 1;
+        rowRangeLabel = `rows ${top} - ${bottom}`;
+      } else {
+        rowRangeLabel = `${selectedRowsCount} selected rows`;
+      }
       return [
         {
-          label:
-            range.getTopEdge() === range.getBottomEdge()
-              ? createMenuItem("Clone row", "Control+D")
-              : createMenuItem(`Clone rows ${rowRangeLabel}`, "Control+D"),
+          label: createMenuItem(`Clone ${rowRangeLabel}`, "Control+D"),
           action: this.cellCloneRow.bind(this),
           disabled: !this.editable,
         },
         {
-          label:
-            selectedRowsCount > 1
-              ? createMenuItem(`Delete ${selectedRowsCount} selected rows`, "Delete")
-              : range.getTopEdge() === range.getBottomEdge()
-              ? createMenuItem("Delete row", "Delete")
-              : createMenuItem(`Delete rows ${rowRangeLabel}`, "Delete"),
+          label: createMenuItem(`Delete ${rowRangeLabel} selected rows`, "Delete"),
           action: () => {
             this.tabulator.rowManager.element.focus()
-            this.deleteTableSelection(undefined, range)
+            this.deleteTableSelection(undefined)
           },
           disabled: !this.editable,
         },
@@ -1227,18 +1225,18 @@ export default Vue.extend({
           action: () => {
             this.trigger(AppEvent.selectSecondarySidebarTab, 'json-viewer')
             this.trigger(AppEvent.toggleSecondarySidebar, true)
-            this.updateJsonViewer({ range })
+            this.updateJsonViewer({ range: _.last(ranges) })
           },
         },
       ]
     },
-    setAsNullMenuItem(range: RangeComponent) {
-      const areAllCellsPrimarykey = range
-        .getColumns()
+    setAsNullMenuItem(ranges: RangeComponent[]) {
+      const areAllCellsPrimarykey = ranges
+        .flatMap((range) => range.getColumns())
         .every((col) => this.isPrimaryKey(col.getField()));
       return {
         label: createMenuItem("Set as NULL"),
-        action: () => range.getCells().flat().forEach((cell) => {
+        action: () => ranges.flatMap((range) => range.getCells().flat()).forEach((cell) => {
           if (!this.isPrimaryKey(cell.getField())) cell.setValue(null);
         }),
         disabled: areAllCellsPrimarykey || !this.editable,
@@ -1253,7 +1251,7 @@ export default Vue.extend({
       switch(s) {
         case 'in': {
           const ranges = cell.getRanges();
-          const selectedCells = ranges.flatMap(range => range.getCells()).flat();
+          const selectedCells = ranges.flatMap(range => range.getCells().flat());
           const selectedValues = selectedCells
             .filter(c => c.getField() === cell.getField())
             .map(c => c.getValue())
@@ -1536,7 +1534,7 @@ export default Vue.extend({
       })
     },
     cellCloneRow(_e, cell: CellComponent) {
-      this.cloneSelection(_.last(cell.getRanges()))
+      this.cloneSelection()
     },
     cellAddCol(_e, field) {
       if (this.dialectData.disabledFeatures?.tableTable) {


### PR DESCRIPTION
**Before**

Range actions are limited to a single range. So operations like cloning, copying, setting as `NULL`, etc. are limited to a single range even though users have selected multiple ranges.

**Now**

No limitation! Users can now select multiple ranges and do range operations to those ranges, except **pasting**.

Resolves #4319 