### PR TITLE
Add back none ssh method

### DIFF
--- a/apps/studio/src/lib/db/tunnel.ts
+++ b/apps/studio/src/lib/db/tunnel.ts
@@ -34,7 +34,7 @@ function findDefaultIdentityFile(): string | undefined {
 }
 
 function buildAuthHandler(opts: { useAgent: boolean; hasPrivateKey: boolean; hasPassword: boolean }): AuthenticationType[] {
-  const methods: AuthenticationType[] = [];
+  const methods: AuthenticationType[] = ['none'];// always add none as a fallback for things like tailscale, #4358
   if (opts.useAgent) methods.push('agent');
   if (opts.hasPrivateKey) methods.push('publickey');
   if (opts.hasPassword) methods.push('password');


### PR DESCRIPTION
Services like Tailscale take over port 22 and require the `none` ssh authentication method. The changes made for the automatic authentication method overrode the defaults from `ssh2`, which meant that `none` was never tried