### PR TITLE
perf: lazy-load xlsx (SheetJS) out of the renderer entry bundle

### DIFF
--- a/apps/studio/src-commercial/entrypoints/renderer.ts
+++ b/apps/studio/src-commercial/entrypoints/renderer.ts
@@ -20,7 +20,6 @@ import store from '@/store/index'
 import ConfigPlugin from '@/plugins/ConfigPlugin'
 import { VueElectronPlugin } from '@/lib/NativeWrapper'
 import AppEventHandler from '@/lib/events/AppEventHandler'
-import xlsx from 'xlsx'
 import TimeAgo from 'javascript-time-ago'
 import en from 'javascript-time-ago/locale/en'
 import VueClipboard from 'vue-clipboard2'
@@ -112,7 +111,6 @@ import ProductTourPlugin from '@/plugins/ProductTourPlugin'
     // (window as any).sql = SQL;
     // (window as any).hint = Hint;
     // (window as any).SQLHint = SQLHint;
-    (window as any).XLSX = xlsx;
     Vue.config.devtools = window.platformInfo.isDevelopment;
     // @ts-ignore
     // window.platformInfo = window.main.platformInfo

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -71,7 +71,6 @@
   import { tabulatorForTableData } from '@/common/tabulator';
   import EditorModal from '../tableview/EditorModal.vue'
   import { AppEvent } from "@/common/AppEvent";
-  import XLSX from 'xlsx';
   import { parseRowDataForJsonViewer } from '@/lib/data/jsonViewer'
   import { vueEditor } from '@shared/lib/tabulator/helpers';
   import NullableInputEditorVue from '@shared/components/tabulator/NullableInputEditor.vue';
@@ -955,7 +954,7 @@ import { stringToTypedArray } from '@/common/utils'
           // forceRedraw??
         }
       },
-      download(format) {
+      async download(format) {
         let formatter = format;
         const dateString = dateFormat(new Date(), 'yyyy-mm-dd_hMMss');
         const title = this.query.title ? _.snakeCase(this.query.title) : 'query_results';
@@ -978,6 +977,9 @@ import { stringToTypedArray } from '@/common/utils'
 
         // Fix Issue #2863 replacing null values with empty string
         if(format === 'xlsx'){
+          // Lazy-load SheetJS only when exporting to Excel; keeps it out of the entry bundle.
+          const xlsxModule = await import('xlsx');
+          const XLSX = xlsxModule.default || xlsxModule;
           formatter = (rows, options, setFileContents) => {
              const values = rows.map(row => row.columns.map(col => {
                if(col.value === null){


### PR DESCRIPTION
## What

SheetJS (`xlsx`) was eagerly loaded into the renderer **entry** bundle, so it
parsed/evaluated on every cold app start even though it is only needed when a
user exports query results to Excel. This moves it behind a dynamic `import()`
so it is fetched on demand.

## Changes

- **`renderer.ts`** — removed the eager `import xlsx from 'xlsx'` and the
  `(window as any).XLSX = xlsx` global assignment. Nothing in the app reads
  `window.XLSX`: Excel *import* runs in the utility process via
  `$util.send('import/excel/...')`, and Excel *export* (in `ResultTable.vue`)
  is the only renderer consumer — now lazy.
- **`ResultTable.vue`** — `download()` is now `async` and loads SheetJS via
  `await import('xlsx')` inside the `xlsx` branch only. All three callers
  (`TabQueryEditor`, `TabShell`, `TabPluginShell`) are fire-and-forget, so the
  async signature change is safe.

## Impact

Verified with `yarn build:vite`:

- `xlsx` is now emitted as a separate on-demand chunk
  (`xlsx-*.js`, ~500 kB / **~163 kB gzipped**).
- The SheetJS code is **no longer present in the entry chunk** — 0 `SheetJS`
  signature matches in `index-*.js`, 7 in the lazy chunk; the entry only holds
  the code-split reference to the xlsx chunk filename.

Net: ~163 kB gzipped of JS no longer loads at startup; it is fetched only when
exporting to Excel.

## Note for reviewers

Removing `(window as any).XLSX` drops an undocumented global. No code in the
repo reads it, and it sat alongside already-commented-out globals
(`window.sql`, `window.SQLHint`), so it appears vestigial. If any third-party
plugin relied on `window.XLSX`, that would need a separate lazy shim — flagging
in case maintainers know of such usage.

## Testing

- `yarn build:vite` succeeds; chunk split confirmed as above.
- `bin/check-lodash.sh` passes (lodash imports untouched).
- Excel export path is functionally unchanged — same `XLSX.utils.*` / `XLSX.write`
  calls, just loaded lazily.
