### PR TITLE
feat: unixtime query magic

### DIFF
--- a/apps/studio/src/lib/magic/magics/format_magics/UnixTimeMagic.ts
+++ b/apps/studio/src/lib/magic/magics/format_magics/UnixTimeMagic.ts
@@ -1,0 +1,116 @@
+import { CellComponent } from 'tabulator-tables';
+import { Magic } from '../../Magic';
+import { MagicColumn } from '../../MagicColumn';
+
+/**
+ * UnixTimeMagic - Formats Unix timestamps as readable dates.
+ *
+ * Flags:
+ * - Timezone: utc (default: local)
+ * - Scale: s, ms, us, ns (default: s)
+ * - Format: iso (default: locale string)
+ *
+ * Example usage:
+ * - created_at__format__unixtime
+ * - timestamp__format__unixtime__utc__ms__iso
+ * - time__format__unixtime__ns__utc
+ *
+ * Flags can be provided in any order. When multiple flags of the same category
+ * are present, the last one wins.
+ */
+
+const SCALES = ['s', 'ms', 'us', 'ns'];
+
+function parseFlags(args: string[]): {
+  useUtc: boolean;
+  scale: string;
+  useIso: boolean;
+} {
+  const flags = args.slice(3).map((arg) => arg.toLowerCase());
+
+  let useUtc = false;
+  let scale = 's';
+  let useIso = false;
+
+  for (const flag of flags) {
+    if (flag === 'utc') {
+      useUtc = true;
+    } else if (flag === 'iso') {
+      useIso = true;
+    } else if (SCALES.includes(flag)) {
+      scale = flag;
+    }
+  }
+
+  return { useUtc, scale, useIso };
+}
+
+function convertToMs(value: number, scale: string): number {
+  switch (scale) {
+    case 's':
+      return value * 1000;
+    case 'ms':
+      return value;
+    case 'us':
+      return Math.floor(value / 1000);
+    case 'ns':
+      return Math.floor(value / 1000000);
+    default:
+      return value * 1000;
+  }
+}
+
+function formatDate(value: number, useUtc: boolean, useIso: boolean): string {
+  try {
+    const date = new Date(value);
+
+    if (isNaN(date.getTime())) {
+      return 'NaN';
+    }
+
+    if (useIso) {
+      return date.toISOString();
+    } else {
+      const locale = window.platformInfo?.locale || 'en-US';
+      const formatterOptions: Intl.DateTimeFormatOptions = {
+        dateStyle: 'short',
+        timeStyle: 'short'
+      };
+
+      if (useUtc) {
+        formatterOptions.timeZone = 'UTC';
+      }
+      const format = new Intl.DateTimeFormat(locale, formatterOptions);
+
+      return format.format(date);
+    }
+  } catch {
+    return 'NaN';
+  }
+}
+
+const UnixTimeMagic: Magic = {
+  name: 'UnixTimeMagic',
+  initializers: ['unixtime', 'unix', 'timestamp'],
+  autocompleteHints: [...SCALES, 'utc', 'iso'],
+  render: function (args: string[]): MagicColumn {
+    const { useUtc, scale, useIso } = parseFlags(args);
+
+    return {
+      title: args[0],
+      formatter: (cell: CellComponent) => {
+        const value = cell.getValue();
+        const numValue = Number(value);
+
+        if (isNaN(numValue)) {
+          return 'NaN';
+        }
+
+        const msValue = convertToMs(numValue, scale);
+        return formatDate(msValue, useUtc, useIso);
+      },
+    };
+  },
+};
+
+export default UnixTimeMagic;

--- a/apps/studio/src/lib/magic/magics/format_magics/UnixTimeMagic.ts
+++ b/apps/studio/src/lib/magic/magics/format_magics/UnixTimeMagic.ts
@@ -74,7 +74,7 @@ function formatDate(value: number, useUtc: boolean, useIso: boolean): string {
       const locale = window.platformInfo?.locale || 'en-US';
       const formatterOptions: Intl.DateTimeFormatOptions = {
         dateStyle: 'short',
-        timeStyle: 'short'
+        timeStyle: 'medium'
       };
 
       if (useUtc) {

--- a/apps/studio/src/lib/magic/magics/format_magics/index.ts
+++ b/apps/studio/src/lib/magic/magics/format_magics/index.ts
@@ -6,6 +6,7 @@ import LinkMagic from "./LinkMagic";
 import MoneyMagic from "./MoneyMagic";
 import ProgressMagic from "./ProgressMagic";
 import StarsMagic from "./StarsMagic";
+import UnixTimeMagic from "./UnixTimeMagic";
 
 export default [
   LinkMagic,
@@ -15,5 +16,6 @@ export default [
   MoneyMagic,
   ProgressMagic,
   EmailMagic,
-  EnumMagic
+  EnumMagic,
+  UnixTimeMagic
 ]

--- a/docs/user_guide/query-magics.md
+++ b/docs/user_guide/query-magics.md
@@ -24,6 +24,7 @@ Here's a quick walkthrough on how to use Query Magics.
 - Display a number as a star rating
 - Display a number as a progress bar
 - Display a number as localized money
+- Display a unix timestamp as a readable date string
 
 ## How To Use Query Magics
 
@@ -176,6 +177,20 @@ columname__format__stars[__max]
 --examples
 columname__format__stars__10 -- 0-10 stars
 
+```
+
+### Format as Unix Timestamp
+
+Converts a Unix timestamp (in seconds, milliseconds, microseconds, or nanoseconds) to a readable date string. Defaults to local timezone and locale format.
+
+```sql
+-- Valid scales: s (default), ms, us, ns
+columnname__format__unixtime[__scale][__utc][__iso]
+
+-- examples
+columnname__format__unixtime              -- 12/12/25, 12:12:12 PM
+columnname__format__unixtime__ms__utc     -- 12/12/25, 6:12:12 PM
+columnname__format__unixtime__ns__iso     -- 2025-12-12T18:12:12.000Z
 ```
 
 ### Link to another table (goto)


### PR DESCRIPTION
<img width="902" height="532" alt="image" src="https://github.com/user-attachments/assets/7ff574fb-ef26-4e40-9a9a-f6e78373f121" />

This pr is similar to the accepted issue: https://github.com/beekeeper-studio/beekeeper-studio/issues/3327 

Some design decisions:
- Multiple flags can be present last one wins
- defaults to US locale if not present (I found the same pattern in the money formatter)
- I truncate anything below ms since Date only supports ms
- I am using, dateStyle: 'short', timeStyle: 'short' . It might be applicable to more people to have timeStyle: 'medium' the more I think about it, but not sure.