### PR TITLE
fix team subfolder name

### DIFF
--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -205,7 +205,7 @@
                 <sidebar-folder
                   v-for="{ folder: subfolder, connections: subConnections } in subfolders"
                   :key="`${subfolder.id}-${subConnections.length}`"
-                  :name="folder.name"
+                  :name="subfolder.name"
                   :children-count="connections.length"
                   :rename="renamingFolderId === subfolder.id"
                   placeholder="No Items"


### PR DESCRIPTION
All subfolders in the team folder shows "Team".

<img width="259" height="155" alt="image" src="https://github.com/user-attachments/assets/67f87de5-12f0-4f63-be7a-d6733b2e404d" />
