### PR TITLE
Add SQL Server integrated (Windows/Kerberos) authentication support

### DIFF
--- a/.github/workflows/windows-login-tests.yaml
+++ b/.github/workflows/windows-login-tests.yaml
@@ -1,0 +1,143 @@
+name: SQL Server Integrated Auth integration test
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'apps/studio/src/lib/db/clients/sqlserver.ts'
+      - 'apps/studio/src/lib/db/types.ts'
+      - 'apps/studio/package.json'
+      - 'apps/studio/tests/integration/lib/db/clients/sqlserver-winauth.spec.ts'
+      - '.github/workflows/windows-login-tests.yaml'
+  workflow_dispatch:
+
+jobs:
+  sqlserver-winauth:
+    runs-on: windows-2022
+    # Tight enough that a stall surfaces in minutes, not in an hour of
+    # wall-clock. Bump it if install+test growth ever gets close.
+    timeout-minutes: 25
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Ensure SQL Server Express is installed
+        run: |
+          # Skip if a SQL Server instance is already installed on the runner.
+          # windows-2022 has historically shipped with SQL Server Express 2019
+          # pre-installed; relying on that when it's there sidesteps chocolatey
+          # flakes entirely.
+          $existing = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server' -ErrorAction SilentlyContinue |
+            Where-Object {
+              $_.Name -match 'MSSQL\d+\.' -and
+              (Test-Path (Join-Path $_.PSPath 'MSSQLServer\SuperSocketNetLib\Tcp'))
+            } | Select-Object -First 1
+          if ($existing) {
+            Write-Host "Using pre-installed SQL Server instance: $($existing.Name)"
+            exit 0
+          }
+
+          Write-Host 'No pre-installed SQL Server found. Installing via chocolatey with retry.'
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "::group::chocolatey install attempt $attempt of $maxAttempts"
+            # --limit-output dropped on purpose: we want full logs when it fails.
+            choco install sql-server-express -y --no-progress --ignore-checksums
+            $exit = $LASTEXITCODE
+            Write-Host '::endgroup::'
+            if ($exit -eq 0) { exit 0 }
+            if ($attempt -lt $maxAttempts) {
+              Write-Host "Chocolatey exit $exit. Backing off before retry."
+              Start-Sleep -Seconds 30
+            }
+          }
+          throw "Failed to install SQL Server Express after $maxAttempts chocolatey attempts."
+
+      - name: Enable TCP/IP on port 1433 and restart the instance
+        run: |
+          $base = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server' |
+            Where-Object {
+              $_.Name -like '*SQLEXPRESS*' -and
+              (Test-Path (Join-Path $_.PSPath 'MSSQLServer\SuperSocketNetLib\Tcp'))
+            } | Select-Object -First 1
+          if (-not $base) { throw 'Could not locate the SQLEXPRESS registry key.' }
+
+          $tcp = Join-Path $base.PSPath 'MSSQLServer\SuperSocketNetLib\Tcp'
+          Set-ItemProperty -Path $tcp -Name 'Enabled' -Value 1
+
+          # Wipe dynamic ports and pin TcpPort=1433 on every IP stanza so the
+          # probe (Server=localhost,1433) reliably lands on this instance.
+          Get-ChildItem $tcp | ForEach-Object {
+            Set-ItemProperty -Path $_.PSPath -Name 'TcpDynamicPorts' -Value ''
+            Set-ItemProperty -Path $_.PSPath -Name 'TcpPort' -Value '1433'
+          }
+
+          Restart-Service 'MSSQL$SQLEXPRESS' -Force
+
+          $deadline = (Get-Date).AddSeconds(90)
+          while ((Get-Date) -lt $deadline) {
+            if (Test-NetConnection -ComputerName localhost -Port 1433 -InformationLevel Quiet -WarningAction SilentlyContinue) {
+              Write-Host 'SQL Server is listening on 1433.'
+              break
+            }
+            Start-Sleep -Seconds 2
+          }
+
+      - name: Open Windows Firewall for TCP/1433
+        run: |
+          # Connections by hostname (vs localhost) traverse the NIC and are
+          # subject to firewall rules. Loopback bypasses the firewall, so the
+          # localhost case works without this rule, but the hostname case in
+          # the Jest spec needs it.
+          New-NetFirewallRule -DisplayName 'SQL Server TCP 1433 (CI)' `
+            -Direction Inbound -Action Allow -Protocol TCP -LocalPort 1433 | Out-Null
+
+      - name: Verify integrated auth reaches SQL Server (pre-flight)
+        run: |
+          # The chocolatey package adds the installing user (runneradmin) as a
+          # sysadmin, so integrated auth over TCP should succeed without any
+          # further GRANT. If this step fails the Jest step will too, so fail
+          # early with a cleaner diagnostic. Exercise both hostnames the Jest
+          # spec will try.
+          sqlcmd -S "localhost,1433" -E -Q "SELECT SUSER_SNAME() AS loginName, @@VERSION AS v;"
+          if ($LASTEXITCODE -ne 0) { throw "Integrated auth pre-flight (localhost) failed (exit $LASTEXITCODE)." }
+
+          $hn = [System.Net.Dns]::GetHostName()
+          Write-Host "Pre-flighting hostname connection to $hn,1433"
+          sqlcmd -S "$hn,1433" -E -Q "SELECT SUSER_SNAME() AS loginName, @@SERVERNAME AS server;"
+          if ($LASTEXITCODE -ne 0) { throw "Integrated auth pre-flight (hostname=$hn) failed (exit $LASTEXITCODE)." }
+
+      - name: Install workspace dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run SQL Server integrated auth Jest spec
+        working-directory: apps/studio
+        env:
+          TEST_MODE: '1'
+          ELECTRON_RUN_AS_NODE: '1'
+        # --forceExit: msnodesqlv8 pool teardown can leave a native ODBC handle
+        # owned by the driver, which can keep Node from exiting cleanly even after
+        # all tests pass. --forceExit tells Jest to call process.exit() once the
+        # run completes.
+        # --testTimeout: global per-test ceiling so any legitimate hang fails in
+        # 90s instead of consuming the whole job budget.
+        run: yarn internal:integration --testPathPattern sqlserver-winauth --runInBand --ci --forceExit --testTimeout=90000
+
+      - name: Collect SQL Server ERRORLOGs on failure
+        if: failure()
+        run: |
+          Get-ChildItem 'C:\Program Files\Microsoft SQL Server\*\MSSQL\Log\ERRORLOG*' -ErrorAction SilentlyContinue |
+            ForEach-Object {
+              Write-Host "===== $($_.FullName) ====="
+              Get-Content $_.FullName -Tail 200
+            }

--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -40,7 +40,11 @@ module.exports = {
   ],
   afterPack: "./build/afterPack.js",
   asarUnpack: [
-    'package.json'
+    'package.json',
+    // msnodesqlv8 ships a native ODBC addon used for SQL Server integrated
+    // (SSPI/Kerberos) auth. prebuild-install drops the binary under build/Release
+    // and/or prebuilds depending on platform, so unpack both.
+    '**/msnodesqlv8/**/*.node'
   ],
   extraResources: [
     {

--- a/apps/studio/esbuild.mjs
+++ b/apps/studio/esbuild.mjs
@@ -35,7 +35,7 @@ const externals = ['better-sqlite3', 'sqlite3',
         'oracledb', '@electron/remote', "@google-cloud/bigquery",
         'pg-query-stream', 'electron', '@duckdb/node-api',
         '@mongosh/browser-runtime-electron', '@mongosh/service-provider-node-driver',
-        'mongodb-client-encryption', 'sqlanywhere', 'ws', 'kerberos',
+        'mongodb-client-encryption', 'sqlanywhere', 'ws', 'kerberos', 'msnodesqlv8',
         ...ensureInstalled,
       ]
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -161,6 +161,9 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "yargs-parser": "^21.0.0"
   },
+  "optionalDependencies": {
+    "msnodesqlv8": "^5.1.5"
+  },
   "devDependencies": {
     "@aws-sdk/types": "^3.127.0",
     "@babel/core": "^7.29.0",

--- a/apps/studio/src-commercial/backend/lib/connection-provider.ts
+++ b/apps/studio/src-commercial/backend/lib/connection-provider.ts
@@ -91,6 +91,7 @@ export default {
       sslKeyFile: config.sslKeyFile,
       sslRejectUnauthorized: config.sslRejectUnauthorized,
       trustServerCertificate: config.trustServerCertificate,
+      windowsAuthEnabled: config.windowsAuthEnabled,
       instantClientLocation: settings?.oracleInstantClient?.stringValue || undefined,
       oracleConfigLocation: settings?.oracleConfigLocation?.stringValue || undefined,
       options: config.options,

--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -260,6 +260,10 @@ export class DbConnectionBase extends ApplicationEntity {
   @Column({ type: 'boolean', nullable: false })
   trustServerCertificate = false
 
+  // SQL Server only. Integrated authentication (SSPI/Kerberos/NTLM) via msnodesqlv8.
+  @Column({ type: 'boolean', nullable: false })
+  windowsAuthEnabled = false
+
   // oracle only.
   @Column({type: 'varchar', nullable: true})
   serviceName: Nullable<string> = null

--- a/apps/studio/src/common/appdb/models/used_connection.ts
+++ b/apps/studio/src/common/appdb/models/used_connection.ts
@@ -33,6 +33,7 @@ export class UsedConnection extends DbConnectionBase implements ISimpleConnectio
       }
       this.options = other.options
       this.trustServerCertificate = other.trustServerCertificate
+      this.windowsAuthEnabled = other.windowsAuthEnabled
       this.redshiftOptions = other.redshiftOptions
       this.cassandraOptions = other.cassandraOptions
       this.socketPath = other.socketPath

--- a/apps/studio/src/common/interfaces/IConnection.ts
+++ b/apps/studio/src/common/interfaces/IConnection.ts
@@ -53,6 +53,7 @@ export interface ISimpleConnection extends Transport {
   readOnlyMode: boolean
   labelColor?: Nullable<string>
   trustServerCertificate?: boolean
+  windowsAuthEnabled?: boolean
   serviceName: Nullable<string>
   options?: any
   redshiftOptions?: RedshiftOptions

--- a/apps/studio/src/components/connection/CommonServerInputs.vue
+++ b/apps/studio/src/components/connection/CommonServerInputs.vue
@@ -71,7 +71,7 @@
       :support-complex-s-s-l="supportComplexSSL"
     />
 
-    <div class="row gutter">
+    <div v-if="!hideCredentials" class="row gutter">
       <div class="col form-group" :class="[showPasswordForm ? 's6' : 's12']">
         <label for="user">User</label>
         <masked-input
@@ -120,6 +120,11 @@ export default {
     showPasswordForm: {
       type: Boolean,
       default: true
+    },
+    // Used by SqlServerForm to hide user/password when integrated auth is selected.
+    hideCredentials: {
+      type: Boolean,
+      default: false
     },
     passwordLabel: {
       type: String,

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -21,7 +21,7 @@
           SQL Server Options
         </h4>
         <div class="advanced-body">
-          <div class="form-group">
+          <div class="form-group" v-show="!windowsAuthEnabled">
             <label for="domain">
               Domain
               <i

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -15,6 +15,15 @@
         </option>
       </select>
     </div>
+    <div v-show="windowsAuthEnabled" class="alert alert-info">
+      <i class="material-icons-outlined">info</i>
+      <div>
+        Integrated authentication uses the current OS login &mdash; no username or
+        password. On Linux and macOS it also requires unixODBC, the Microsoft ODBC
+        Driver 18 for SQL Server, and a valid Kerberos ticket (kinit).
+        <a href="https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/">Setup guide</a>
+      </div>
+    </div>
     <common-server-inputs v-show="!azureAuthEnabled" :config="config" :hide-credentials="windowsAuthEnabled">
       <div class="advanced-connection-settings">
         <h4 class="advanced-heading">

--- a/apps/studio/src/components/connection/SqlServerForm.vue
+++ b/apps/studio/src/components/connection/SqlServerForm.vue
@@ -7,12 +7,15 @@
         <option value="default">
           Username / Password
         </option>
+        <option value="windows">
+          Windows / Kerberos (Integrated)
+        </option>
         <option :key="`${t.value}-${t.name}`" v-for="t in authTypes" :value="t.value">
           {{ t.name }}
         </option>
       </select>
     </div>
-    <common-server-inputs v-show="!azureAuthEnabled" :config="config">
+    <common-server-inputs v-show="!azureAuthEnabled" :config="config" :hide-credentials="windowsAuthEnabled">
       <div class="advanced-connection-settings">
         <h4 class="advanced-heading">
           SQL Server Options
@@ -71,12 +74,18 @@
     components: {CommonEntraId, CommonServerInputs, CommonAdvanced },
     props: ['config'],
     mounted() {
-      this.authType = this.config?.azureAuthOptions?.azureAuthType || 'default'
-      this.azureAuthEnabled = this.config?.azureAuthOptions?.azureAuthEnabled || false
+      if (this.config?.windowsAuthEnabled) {
+        this.authType = 'windows'
+        this.windowsAuthEnabled = true
+      } else {
+        this.authType = this.config?.azureAuthOptions?.azureAuthType || 'default'
+        this.azureAuthEnabled = this.config?.azureAuthOptions?.azureAuthEnabled || false
+      }
     },
     data() {
       return {
         azureAuthEnabled: false,
+        windowsAuthEnabled: false,
         authType: 'default',
         authTypes: AzureAuthTypes,
       }
@@ -85,25 +94,47 @@
       async authType() {
         if (this.authType === 'default') {
           this.azureAuthEnabled = false
+          this.windowsAuthEnabled = false
+          this.config.windowsAuthEnabled = false
+          this.config.azureAuthOptions.azureAuthType = undefined
+          return
+        }
+
+        // Integrated (Windows/Kerberos) and Azure auth are both paid features.
+        if (this.$store.getters.isCommunity) {
+          this.$root.$emit(AppEvent.upgradeModal, "Enterprise Authentication");
+          this.authType = 'default'
+          return
+        }
+
+        if (this.authType === 'windows') {
+          this.azureAuthEnabled = false
+          this.windowsAuthEnabled = true
+          this.config.windowsAuthEnabled = true
           this.config.azureAuthOptions.azureAuthType = undefined
         } else {
-          if (this.$store.getters.isCommunity) {
-            this.$root.$emit(AppEvent.upgradeModal, "Enterprise Authentication");
-            this.authType = 'default'
-          } else {
-            this.azureAuthEnabled = true
-            this.config.azureAuthOptions.azureAuthType = this.authType
-          }
+          this.azureAuthEnabled = true
+          this.windowsAuthEnabled = false
+          this.config.windowsAuthEnabled = false
+          this.config.azureAuthOptions.azureAuthType = this.authType
         }
       },
       azureAuthEnabled() {
         this.config.azureAuthOptions.azureAuthEnabled = this.azureAuthEnabled
       },
       config() {
-        if (this.config.azureAuthOptions.azureAuthEnabled) {
-          this.authType = this.config.azureAuthOptions.azureAuthType;
+        if (this.config.windowsAuthEnabled) {
+          this.authType = 'windows'
+          this.windowsAuthEnabled = true
+          this.azureAuthEnabled = false
+        } else if (this.config.azureAuthOptions?.azureAuthEnabled) {
+          this.authType = this.config.azureAuthOptions.azureAuthType
+          this.windowsAuthEnabled = false
+          this.azureAuthEnabled = true
         } else {
-          this.authType = 'default';
+          this.authType = 'default'
+          this.windowsAuthEnabled = false
+          this.azureAuthEnabled = false
         }
       },
     },

--- a/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
+++ b/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
@@ -15,6 +15,29 @@ const errorMappings = {
     {
       pattern: 'self signed certificate',
       help: "You might need to check 'Trust Server Certificate'"
+    },
+    {
+      // Integrated auth: the ODBC driver (and unixODBC on Linux/macOS) is missing.
+      pattern: 'odbc driver',
+      help: "Integrated authentication needs the Microsoft ODBC Driver 18 for SQL Server installed (plus unixODBC on Linux/macOS).",
+      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+    },
+    {
+      // Integrated auth: the native driver module failed to load.
+      pattern: 'msnodesqlv8',
+      help: "The native driver for integrated authentication could not load. On Linux/macOS install unixODBC and the Microsoft ODBC Driver 18 for SQL Server.",
+      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+    },
+    {
+      // Integrated auth: SSPI/Kerberos handshake failed or timed out.
+      pattern: 'sspi',
+      help: "Integrated (Kerberos/NTLM) authentication failed. Check for a valid Kerberos ticket (kinit) and that the server's SPN is registered. Connect by hostname/FQDN so Kerberos can match the SPN.",
+      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+    },
+    {
+      pattern: 'kerberos',
+      help: "Kerberos authentication failed. Check for a valid ticket (kinit), a registered server SPN, and a client clock in sync with the KDC.",
+      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
     }
   ],
   'oracle': [

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -1278,112 +1278,103 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       )
     }
 
-    const { driver, legacy } = await this.findWindowsAuthDriver()
-    if (legacy) {
-      log.warn('Integrated authentication is using the legacy "{SQL Server}" ODBC driver, ' +
-        'which does not support TLS 1.2. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft for secure connections.')
-    }
-
     const trustCert = this.dbConfig.options?.trustServerCertificate
     const server = this.dbConfig.server
     const port = this.dbConfig.port || 1433
     const CONNECT_TIMEOUT_S = 15
 
-    // Patch mssql's generated connection string before msnodesqlv8 uses it: mssql
-    // ignores the driver name, emits Trusted_Connection as a boolean (must be
-    // yes/no), and omits TrustServerCertificate.
-    const connecting = new sqlWindows.ConnectionPool({
-      ...this.dbConfig,
-      connectionTimeout: CONNECT_TIMEOUT_S * 1000,
-      beforeConnect: (cfg: any) => {
-        cfg.conn_str = cfg.conn_str
-          .replace(/Driver=[^;]*/i, `Driver={${driver}}`)
-          .replace(/Trusted_Connection=[^;]*/i, 'Trusted_Connection=yes')
-        if (trustCert) cfg.conn_str += ';TrustServerCertificate=yes'
-        cfg.conn_timeout = CONNECT_TIMEOUT_S
-      }
-    }).connect()
-
-    return await withDeadline(
-      connecting,
-      CONNECT_TIMEOUT_S * 1000,
-      `Integrated authentication timed out after ${CONNECT_TIMEOUT_S}s connecting to ${server},${port} with Driver={${driver}}. ` +
-      `The server is reachable but the SSPI/Kerberos login handshake did not complete in time. ` +
-      `Check the SQL Server SPN registration and that the current user's Kerberos ticket (kinit) or NTLM fallback can reach a domain controller.`
-    )
-  }
-
-  // Probe directly via msnodesqlv8 to (a) discover which ODBC driver is installed
-  // and (b) surface real connection errors -- mssql wraps native msnodesqlv8 errors
-  // into opaque strings. Prefers modern ODBC drivers (TLS 1.2 support).
-  private async findWindowsAuthDriver(): Promise<{ driver: string, legacy: boolean }> {
-    let rawSql: any
-    try {
-      rawSql = require('msnodesqlv8')
-    } catch {
-      throw new Error('Integrated authentication requires the msnodesqlv8 native module, which failed to load.')
-    }
-    const server = this.dbConfig.server
-    const port = this.dbConfig.port || 1433
-    const database = this.dbConfig.database || 'master'
-    const trustCert = this.dbConfig.options?.trustServerCertificate ? 'yes' : 'no'
-
+    // Driver discovery is folded into the real connect: try each candidate ODBC
+    // driver with the actual connection and keep the first that opens. A missing
+    // driver fails immediately at the ODBC driver-manager level (IM002, before any
+    // network or auth), so only the driver that is present completes a single SSPI/
+    // Kerberos handshake -- no throwaway probe connection, and the string that is
+    // validated IS the string used. Modern drivers first (TLS 1.2 support); the
+    // legacy built-in driver only exists on Windows and is a last resort.
     const candidates: { driver: string, legacy: boolean }[] = [
       { driver: 'ODBC Driver 18 for SQL Server', legacy: false },
       { driver: 'ODBC Driver 17 for SQL Server', legacy: false },
     ]
-    // The legacy built-in driver only exists on Windows; it's a last resort.
     if (process.platform === 'win32') {
       candidates.push({ driver: 'SQL Server', legacy: true })
     }
 
-    const PROBE_TIMEOUT_S = 10
-
-    for (const candidate of candidates) {
-      const connStr =
-        `Driver={${candidate.driver}};Server=${server},${port};Database=${database};` +
-        `Trusted_Connection=yes;TrustServerCertificate=${trustCert};`
-      const result: { ok: boolean, error?: string } = await new Promise((resolve) => {
-        let settled = false
-        const done = (r: { ok: boolean, error?: string }) => { if (!settled) { settled = true; resolve(r) } }
-        // JS-level fallback: the native conn_timeout does not reliably fire on a
-        // stalled handshake, so guarantee the probe resolves and the loop advances.
-        const timer = setTimeout(() => done({ ok: false, error: 'timeout' }), (PROBE_TIMEOUT_S + 2) * 1000)
-        rawSql.open({ conn_str: connStr, conn_timeout: PROBE_TIMEOUT_S }, (err: any, conn: any) => {
-          clearTimeout(timer)
-          if (err) {
-            const msgs = (Array.isArray(err) ? err : [err])
-              .map((e: any) => (typeof e?.message === 'string' ? e.message : String(e)))
-              .filter(Boolean).join('; ')
-            done({ ok: false, error: msgs })
-          } else {
-            conn.close(() => done({ ok: true }))
-          }
-        })
-      })
-
-      if (result.ok) return candidate
-
-      const isDriverMissing = result.error?.includes('Data source name not found') || result.error?.includes('IM002')
-      if (isDriverMissing) continue
-
-      // Real error (auth failure, server unreachable, timeout). Wrap timeouts with a
-      // diagnostic naming what timed out, where, and what to check.
-      if (/timeout|timed? out/i.test(result.error || '')) {
-        throw new Error(
-          `Integrated authentication probe timed out after ${PROBE_TIMEOUT_S}s using Driver={${candidate.driver}} against ${server},${port}. ` +
-          `TCP is reachable but the ODBC SSPI/Kerberos negotiation did not return. This usually means an SPN/Kerberos issue on the SQL Server or a blocked path to the domain controller.`
-        )
-      }
-      throw new Error(result.error)
+    // Set a connection-string clause, replacing it in place or appending it when
+    // mssql's generated string omits it -- so the discovered driver and
+    // Trusted_Connection are never silently dropped.
+    const setClause = (connStr: string, key: string, value: string): string => {
+      const re = new RegExp(`${key}=[^;]*`, 'i')
+      return re.test(connStr)
+        ? connStr.replace(re, `${key}=${value}`)
+        : `${connStr.replace(/;?\s*$/, '')};${key}=${value}`
     }
 
-    throw new Error(
+    // Flatten every nested message out of an mssql/msnodesqlv8 error so a missing
+    // driver can be told apart from a real auth/connect failure (mssql wraps native
+    // errors and exposes them via originalError / precedingErrors).
+    const errorText = (err: any): string => {
+      const parts: string[] = []
+      const visit = (e: any) => {
+        if (!e) return
+        if (typeof e === 'string') { parts.push(e); return }
+        if (typeof e.message === 'string') parts.push(e.message)
+        if (e.originalError) visit(e.originalError)
+        if (Array.isArray(e.precedingErrors)) e.precedingErrors.forEach(visit)
+      }
+      if (Array.isArray(err)) err.forEach(visit); else visit(err)
+      return parts.join('; ')
+    }
+    const isDriverMissing = (text: string): boolean =>
+      /IM002|IM003|data source name not found|specified driver could not be loaded|can'?t open lib|file not found/i.test(text)
+
+    const driverMissingError = () => new Error(
       (process.platform === 'win32'
         ? 'Integrated authentication requires an ODBC Driver for SQL Server. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft.'
         : 'Integrated authentication requires unixODBC and the Microsoft "ODBC Driver 18 for SQL Server" installed on this machine.') +
       ` See ${WIN_AUTH_DOCS_URL} for setup.`
     )
+
+    for (let i = 0; i < candidates.length; i++) {
+      const candidate = candidates[i]
+      // mssql ignores the driver name and emits Trusted_Connection as a boolean
+      // (ODBC needs yes/no); set both, plus TrustServerCertificate when asked.
+      const connecting = new sqlWindows.ConnectionPool({
+        ...this.dbConfig,
+        connectionTimeout: CONNECT_TIMEOUT_S * 1000,
+        beforeConnect: (cfg: any) => {
+          cfg.conn_str = setClause(cfg.conn_str, 'Driver', `{${candidate.driver}}`)
+          cfg.conn_str = setClause(cfg.conn_str, 'Trusted_Connection', 'yes')
+          if (trustCert) cfg.conn_str = setClause(cfg.conn_str, 'TrustServerCertificate', 'yes')
+          cfg.conn_timeout = CONNECT_TIMEOUT_S
+        }
+      }).connect()
+
+      try {
+        const pool = await withDeadline(
+          connecting,
+          CONNECT_TIMEOUT_S * 1000,
+          `Integrated authentication timed out after ${CONNECT_TIMEOUT_S}s connecting to ${server},${port} with Driver={${candidate.driver}}. ` +
+          `The server is reachable but the SSPI/Kerberos login handshake did not complete in time. ` +
+          `Check the SQL Server SPN registration and that the current user's Kerberos ticket (kinit) or NTLM fallback can reach a domain controller.`
+        )
+        if (candidate.legacy) {
+          log.warn('Integrated authentication is using the legacy "{SQL Server}" ODBC driver, ' +
+            'which does not support TLS 1.2. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft for secure connections.')
+        }
+        return pool
+      } catch (err) {
+        // A missing driver is not fatal while other candidates remain; advance to
+        // the next. Any other failure (auth, unreachable, or the withDeadline
+        // timeout above) is real and already carries a useful message.
+        if (isDriverMissing(errorText(err))) {
+          if (i < candidates.length - 1) continue
+          throw driverMissingError()
+        }
+        throw err instanceof Error ? err : new Error(errorText(err))
+      }
+    }
+
+    // Only reached if the candidate list is empty (it never is).
+    throw driverMissingError()
   }
 
   private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, signal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -44,6 +44,20 @@ const mmsqlErrors = {
   CANCELED: 'ECANCEL',
 };
 
+// Wrap a promise with a JS-level deadline. msnodesqlv8/ODBC's native conn_timeout
+// does NOT reliably cancel a stalled SQLDriverConnect -- it only covers the TCP
+// connect, not the post-connect TDS prelogin / SSPI handshake -- so a stalled
+// Kerberos/NTLM negotiation would otherwise hang indefinitely. This guarantees the
+// attempt rejects; the orphaned native handle may persist, but the app stays
+// responsive and surfaces a clear error instead of locking up.
+function withDeadline<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
 type SQLServerVersion = {
   supportOffsetFetch: boolean
   releaseYear: number
@@ -1084,7 +1098,12 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     await super.connect();
 
     this.dbConfig = await this.configDatabase(this.server, this.database, signal)
-    this.pool = await new ConnectionPool(this.dbConfig).connect();
+
+    if (this.server.config.windowsAuthEnabled) {
+      this.pool = await this.connectWindowsAuth()
+    } else {
+      this.pool = await new ConnectionPool(this.dbConfig).connect();
+    }
 
     this.pool.on('error', (err) => {
       if (err instanceof ConnectionError) {
@@ -1237,6 +1256,131 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
   }
 
+  // SQL Server integrated authentication (SSPI). The OS/ODBC layer negotiates the
+  // actual protocol: Kerberos when the host is domain-joined with a reachable KDC
+  // and a matching SPN (typically connecting by hostname/FQDN), otherwise NTLM.
+  // tedious cannot do this, so we route through the native msnodesqlv8 driver.
+  // Works on Windows (SSPI) and on Linux/macOS when unixODBC + the Microsoft ODBC
+  // Driver 18 + a Kerberos ticket (kinit) are configured on the host.
+  private async connectWindowsAuth(): Promise<ConnectionPool> {
+    let sqlWindows: any
+    try {
+      sqlWindows = require('mssql/msnodesqlv8')
+    } catch {
+      throw new Error(
+        process.platform === 'win32'
+          ? 'Integrated authentication is unavailable: the msnodesqlv8 native module could not be loaded. Try reinstalling Beekeeper Studio.'
+          : 'Integrated authentication is unavailable: the msnodesqlv8 native module could not be loaded. Install unixODBC and the Microsoft ODBC Driver 18 for SQL Server, then reinstall Beekeeper Studio.'
+      )
+    }
+
+    const { driver, legacy } = await this.findWindowsAuthDriver()
+    if (legacy) {
+      log.warn('Integrated authentication is using the legacy "{SQL Server}" ODBC driver, ' +
+        'which does not support TLS 1.2. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft for secure connections.')
+    }
+
+    const trustCert = this.dbConfig.options?.trustServerCertificate
+    const server = this.dbConfig.server
+    const port = this.dbConfig.port || 1433
+    const CONNECT_TIMEOUT_S = 15
+
+    // Patch mssql's generated connection string before msnodesqlv8 uses it: mssql
+    // ignores the driver name, emits Trusted_Connection as a boolean (must be
+    // yes/no), and omits TrustServerCertificate.
+    const connecting = new sqlWindows.ConnectionPool({
+      ...this.dbConfig,
+      connectionTimeout: CONNECT_TIMEOUT_S * 1000,
+      beforeConnect: (cfg: any) => {
+        cfg.conn_str = cfg.conn_str
+          .replace(/Driver=[^;]*/i, `Driver={${driver}}`)
+          .replace(/Trusted_Connection=[^;]*/i, 'Trusted_Connection=yes')
+        if (trustCert) cfg.conn_str += ';TrustServerCertificate=yes'
+        cfg.conn_timeout = CONNECT_TIMEOUT_S
+      }
+    }).connect()
+
+    return await withDeadline(
+      connecting,
+      CONNECT_TIMEOUT_S * 1000,
+      `Integrated authentication timed out after ${CONNECT_TIMEOUT_S}s connecting to ${server},${port} with Driver={${driver}}. ` +
+      `The server is reachable but the SSPI/Kerberos login handshake did not complete in time. ` +
+      `Check the SQL Server SPN registration and that the current user's Kerberos ticket (kinit) or NTLM fallback can reach a domain controller.`
+    )
+  }
+
+  // Probe directly via msnodesqlv8 to (a) discover which ODBC driver is installed
+  // and (b) surface real connection errors -- mssql wraps native msnodesqlv8 errors
+  // into opaque strings. Prefers modern ODBC drivers (TLS 1.2 support).
+  private async findWindowsAuthDriver(): Promise<{ driver: string, legacy: boolean }> {
+    let rawSql: any
+    try {
+      rawSql = require('msnodesqlv8')
+    } catch {
+      throw new Error('Integrated authentication requires the msnodesqlv8 native module, which failed to load.')
+    }
+    const server = this.dbConfig.server
+    const port = this.dbConfig.port || 1433
+    const database = this.dbConfig.database || 'master'
+    const trustCert = this.dbConfig.options?.trustServerCertificate ? 'yes' : 'no'
+
+    const candidates: { driver: string, legacy: boolean }[] = [
+      { driver: 'ODBC Driver 18 for SQL Server', legacy: false },
+      { driver: 'ODBC Driver 17 for SQL Server', legacy: false },
+    ]
+    // The legacy built-in driver only exists on Windows; it's a last resort.
+    if (process.platform === 'win32') {
+      candidates.push({ driver: 'SQL Server', legacy: true })
+    }
+
+    const PROBE_TIMEOUT_S = 10
+
+    for (const candidate of candidates) {
+      const connStr =
+        `Driver={${candidate.driver}};Server=${server},${port};Database=${database};` +
+        `Trusted_Connection=yes;TrustServerCertificate=${trustCert};`
+      const result: { ok: boolean, error?: string } = await new Promise((resolve) => {
+        let settled = false
+        const done = (r: { ok: boolean, error?: string }) => { if (!settled) { settled = true; resolve(r) } }
+        // JS-level fallback: the native conn_timeout does not reliably fire on a
+        // stalled handshake, so guarantee the probe resolves and the loop advances.
+        const timer = setTimeout(() => done({ ok: false, error: 'timeout' }), (PROBE_TIMEOUT_S + 2) * 1000)
+        rawSql.open({ conn_str: connStr, conn_timeout: PROBE_TIMEOUT_S }, (err: any, conn: any) => {
+          clearTimeout(timer)
+          if (err) {
+            const msgs = (Array.isArray(err) ? err : [err])
+              .map((e: any) => (typeof e?.message === 'string' ? e.message : String(e)))
+              .filter(Boolean).join('; ')
+            done({ ok: false, error: msgs })
+          } else {
+            conn.close(() => done({ ok: true }))
+          }
+        })
+      })
+
+      if (result.ok) return candidate
+
+      const isDriverMissing = result.error?.includes('Data source name not found') || result.error?.includes('IM002')
+      if (isDriverMissing) continue
+
+      // Real error (auth failure, server unreachable, timeout). Wrap timeouts with a
+      // diagnostic naming what timed out, where, and what to check.
+      if (/timeout|timed? out/i.test(result.error || '')) {
+        throw new Error(
+          `Integrated authentication probe timed out after ${PROBE_TIMEOUT_S}s using Driver={${candidate.driver}} against ${server},${port}. ` +
+          `TCP is reachable but the ODBC SSPI/Kerberos negotiation did not return. This usually means an SPN/Kerberos issue on the SQL Server or a blocked path to the domain controller.`
+        )
+      }
+      throw new Error(result.error)
+    }
+
+    throw new Error(
+      process.platform === 'win32'
+        ? 'Integrated authentication requires an ODBC Driver for SQL Server. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft.'
+        : 'Integrated authentication requires unixODBC and the Microsoft "ODBC Driver 18 for SQL Server" installed on this machine.'
+    )
+  }
+
   private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, signal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes
     const config: any = {
       server: server.config.host,
@@ -1258,6 +1402,23 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
 
       config.options = {
         encrypt: true
+      };
+
+      return config;
+    }
+
+    if (server.config.windowsAuthEnabled) {
+      config.port = Number(server.config.port);
+
+      if (server.sshTunnel) {
+        config.server = server.config.localHost;
+        config.port = server.config.localPort;
+      }
+
+      // trustedConnection delegates auth to the OS (SSPI -> Kerberos/NTLM) via msnodesqlv8.
+      config.options = {
+        trustedConnection: true,
+        trustServerCertificate: server.config.trustServerCertificate,
       };
 
       return config;

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -44,6 +44,9 @@ const mmsqlErrors = {
   CANCELED: 'ECANCEL',
 };
 
+// Setup guide for SQL Server integrated / Kerberos authentication prerequisites.
+const WIN_AUTH_DOCS_URL = 'https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/'
+
 // Wrap a promise with a JS-level deadline. msnodesqlv8/ODBC's native conn_timeout
 // does NOT reliably cancel a stalled SQLDriverConnect -- it only covers the TCP
 // connect, not the post-connect TDS prelogin / SSPI handshake -- so a stalled
@@ -1268,9 +1271,10 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       sqlWindows = require('mssql/msnodesqlv8')
     } catch {
       throw new Error(
-        process.platform === 'win32'
+        (process.platform === 'win32'
           ? 'Integrated authentication is unavailable: the msnodesqlv8 native module could not be loaded. Try reinstalling Beekeeper Studio.'
-          : 'Integrated authentication is unavailable: the msnodesqlv8 native module could not be loaded. Install unixODBC and the Microsoft ODBC Driver 18 for SQL Server, then reinstall Beekeeper Studio.'
+          : 'Integrated authentication is unavailable: the msnodesqlv8 native module could not be loaded. Install unixODBC and the Microsoft ODBC Driver 18 for SQL Server, then reinstall Beekeeper Studio.') +
+        ` See ${WIN_AUTH_DOCS_URL} for setup.`
       )
     }
 
@@ -1375,9 +1379,10 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
 
     throw new Error(
-      process.platform === 'win32'
+      (process.platform === 'win32'
         ? 'Integrated authentication requires an ODBC Driver for SQL Server. Install "ODBC Driver 18 for SQL Server" (or 17) from Microsoft.'
-        : 'Integrated authentication requires unixODBC and the Microsoft "ODBC Driver 18 for SQL Server" installed on this machine.'
+        : 'Integrated authentication requires unixODBC and the Microsoft "ODBC Driver 18 for SQL Server" installed on this machine.') +
+      ` See ${WIN_AUTH_DOCS_URL} for setup.`
     )
   }
 

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -278,6 +278,9 @@ export interface IDbConnectionServerConfig {
   localHost?: string,
   localPort?: number,
   trustServerCertificate?: boolean
+  // SQL Server only. Use OS-level integrated authentication (SSPI/Kerberos/NTLM)
+  // via the native msnodesqlv8 ODBC driver instead of a username/password.
+  windowsAuthEnabled?: boolean
   instantClientLocation?: string
   oracleConfigLocation?: string
   options?: any

--- a/apps/studio/src/migration/20260618_add_windows_auth_to_connections.js
+++ b/apps/studio/src/migration/20260618_add_windows_auth_to_connections.js
@@ -1,0 +1,12 @@
+export default {
+  name: '20260618-windows-auth-enabled',
+  async run(runner) {
+    const queries = [
+      `ALTER TABLE saved_connection ADD COLUMN windowsAuthEnabled boolean not null default false`,
+      `ALTER TABLE used_connection ADD COLUMN windowsAuthEnabled boolean not null default false`,
+    ]
+    for (let i = 0; i < queries.length; i++) {
+      await runner.query(queries[i])
+    }
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -92,6 +92,7 @@ import cleanupDuplicateLicenseKeys from './20260421_cleanup_duplicate_license_ke
 import createTabulatorPersistence from './20260424_create_tabulator_persistence'
 import clearLogFiles from './20260527_clear_log_files'
 import addSnowflakeOptions from './20260501_add_snowflake_options'
+import addWindowsAuthToConnections from './20260618_add_windows_auth_to_connections'
 
 import ultimate from './ultimate/index'
 
@@ -144,7 +145,8 @@ const realMigrations = [
   cleanupDuplicateLicenseKeys,
   createTabulatorPersistence,
   clearLogFiles,
-  addSnowflakeOptions
+  addSnowflakeOptions,
+  addWindowsAuthToConnections
 ]
 
 // fixtures require the models

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver-winauth.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver-winauth.spec.ts
@@ -1,0 +1,69 @@
+import os from 'os'
+import { createServer } from '@commercial/backend/lib/db/server'
+import { IDbConnectionServerConfig } from '@/lib/db/types'
+
+// Exercises the SQL Server integrated-authentication path (windowsAuthEnabled +
+// msnodesqlv8 + ODBC driver probe). It only runs on Windows -- the SSPI/ODBC stack
+// is available there without extra host setup -- and self-skips on Linux/macOS so
+// the integration matrix can still discover the file.
+//
+// IMPORTANT: the CI runner is NOT domain-joined and connects to a LOCAL SQL Server
+// over localhost/hostname, so SSPI here negotiates NTLM, not Kerberos. This proves
+// the msnodesqlv8 plumbing and the "no credentials" behaviour; it is the same code
+// path that negotiates Kerberos in a domain environment. Real Kerberos must be
+// validated manually against an AD/KDC (confirm auth_scheme = KERBEROS).
+//
+// CI expectation: a live SQL Server (Express) listens on localhost:1433 and the
+// runner user is a sysadmin. The companion workflow
+// .github/workflows/windows-login-tests.yaml provisions that environment.
+
+const describeWin = process.platform === 'win32' ? describe : describe.skip
+
+const hostCases = [
+  { label: 'localhost', host: 'localhost' },
+  { label: 'hostname', host: os.hostname() },
+]
+
+hostCases.forEach(({ label, host }) => {
+  describeWin(`SQLServerClient -- Integrated Authentication (no password) via ${label} [${host}]`, () => {
+    let server: ReturnType<typeof createServer>
+    let connection: any
+
+    beforeAll(async () => {
+      const config = {
+        client: 'sqlserver',
+        host,
+        port: 1433,
+        user: null,
+        password: null,
+        windowsAuthEnabled: true,
+        trustServerCertificate: true,
+        readOnlyMode: false,
+      } as IDbConnectionServerConfig
+
+      server = createServer(config)
+      connection = server.createConnection('master')
+      await connection.connect()
+    })
+
+    afterAll(async () => {
+      if (server) await server.disconnect()
+    })
+
+    it('authenticates via SSPI with no credentials supplied', async () => {
+      const result = await connection.driverExecuteSingle('SELECT SUSER_SNAME() AS loginName')
+      const loginName = result.data.recordset[0].loginName
+      expect(loginName).toBeTruthy()
+    })
+
+    it('can execute a trivial query against master', async () => {
+      const result = await connection.driverExecuteSingle('SELECT @@VERSION AS v')
+      expect(String(result.data.recordset[0].v)).toMatch(/SQL Server/i)
+    })
+
+    it('lists databases', async () => {
+      const dbs = await connection.listDatabases()
+      expect(dbs).toEqual(expect.arrayContaining(['master']))
+    })
+  })
+})

--- a/docs/user_guide/connecting/sql-server.md
+++ b/docs/user_guide/connecting/sql-server.md
@@ -1,0 +1,119 @@
+---
+title: SQL Server
+summary: "Connect to Microsoft SQL Server, including integrated Windows / Kerberos authentication."
+description: "Beekeeper Studio connects to SQL Server with SQL logins, Azure authentication, and integrated Windows / Kerberos (SSPI) authentication. This guide covers the prerequisites for passwordless integrated authentication on Windows, Linux, and macOS."
+icon: material/database
+---
+
+# How To Connect to SQL Server
+
+Beekeeper Studio supports several ways to authenticate to Microsoft SQL Server:
+
+1. **SQL Login** — a username and password managed by SQL Server. No extra setup.
+2. **Windows / Kerberos (Integrated)** — passwordless authentication using the
+   identity of the currently logged-in OS user (SSPI). Requires the prerequisites
+   described below.
+3. **Azure Active Directory / Entra ID** — see [Azure / Entra ID](azure-entraid.md).
+
+The **Domain** field on the connection form performs password-based **NTLM** and is
+distinct from integrated authentication — integrated authentication uses no username
+or password at all.
+
+!!! info "Enterprise feature"
+    Integrated Windows / Kerberos authentication is part of the paid Enterprise
+    Authentication feature set.
+
+## Kerberos vs NTLM
+
+"Integrated Authentication" (SSPI) is an umbrella over two wire protocols. The same
+connection — no username, no password — negotiates one of:
+
+- **Kerberos**: used when the host is domain-joined, a matching **SPN** is registered
+  for the SQL Server, and a Key Distribution Center (KDC / domain controller) is
+  reachable. This normally requires connecting by **hostname or FQDN** (not `localhost`
+  or an IP).
+- **NTLM**: the fallback used for standalone/workgroup machines, `localhost`
+  connections, or when the Kerberos prerequisites are not met.
+
+Beekeeper Studio uses the same code path for both; the host environment determines
+which protocol is negotiated.
+
+## Prerequisites by operating system
+
+### Windows
+
+Usually nothing extra is required. Windows ships an ODBC driver and SSPI support, so
+selecting **Windows / Kerberos (Integrated)** and connecting by hostname/FQDN works
+out of the box on a domain-joined machine.
+
+If connections fail, install the latest
+[Microsoft ODBC Driver 18 for SQL Server](https://learn.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server).
+
+### Linux
+
+Integrated authentication on Linux requires the following host packages — they are
+**not** bundled with Beekeeper Studio because they register system-wide and depend on
+your distribution's libraries:
+
+1. **unixODBC** — the ODBC driver manager.
+2. **Microsoft ODBC Driver 18 for SQL Server** (`msodbcsql18`). Follow Microsoft's
+   [install guide](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server).
+3. **Kerberos client** (`krb5-user` on Debian/Ubuntu, `krb5-workstation` on
+   RHEL/Fedora) with a valid `/etc/krb5.conf` pointing at your realm/KDC.
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install unixodbc krb5-user
+
+# RHEL / Fedora
+sudo dnf install unixODBC krb5-workstation
+```
+
+Then obtain a Kerberos ticket for your domain user before connecting:
+
+```bash
+kinit user@YOUR.REALM
+klist   # confirm a valid ticket exists
+```
+
+!!! note "Clock sync"
+    Kerberos rejects tickets when the client and KDC clocks differ by more than a few
+    minutes. Keep the machine time-synced (e.g. with `chrony` or `ntpd`).
+
+### macOS
+
+macOS support is best-effort. Install **unixODBC** and the **Microsoft ODBC Driver 18**
+(both available via [Homebrew](https://brew.sh) per Microsoft's
+[macOS guide](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/install-microsoft-odbc-driver-sql-server-macos)),
+and obtain a Kerberos ticket with `kinit` as on Linux.
+
+## Connecting
+
+1. Add a new SQL Server connection.
+2. Set **Authentication** to **Windows / Kerberos (Integrated)**. The username and
+   password fields are hidden — authentication uses your current OS identity.
+3. Enter the server **hostname or FQDN** (use the fully qualified name so Kerberos can
+   match the SPN) and port.
+4. Connect.
+
+## Troubleshooting
+
+- **"Integrated authentication requires ... ODBC Driver 18 for SQL Server"** — the ODBC
+  driver (and unixODBC on Linux/macOS) is not installed. See the prerequisites above.
+- **The connection times out during login** — TCP reached the server but the
+  SSPI/Kerberos handshake did not complete. Check the SQL Server's **SPN registration**
+  and that the client can reach a domain controller. Confirm you have a valid ticket
+  with `klist`.
+- **Verify which protocol was negotiated** — once connected, run:
+
+    ```sql
+    SELECT auth_scheme FROM sys.dm_exec_connections WHERE session_id = @@SPID;
+    ```
+
+    `KERBEROS` confirms Kerberos; `NTLM` means it fell back (commonly because you
+    connected by `localhost`/IP or no matching SPN exists).
+- **Confirm the authenticated principal**:
+
+    ```sql
+    SELECT SUSER_SNAME();
+    ```

--- a/docs/user_guide/connecting/sql-server.md
+++ b/docs/user_guide/connecting/sql-server.md
@@ -7,21 +7,41 @@ icon: material/database
 
 # How To Connect to SQL Server
 
-Beekeeper Studio supports several ways to authenticate to Microsoft SQL Server:
+Beekeeper Studio supports several ways to authenticate to Microsoft SQL Server.
+Pick the one that matches how your server is set up:
 
-1. **SQL Login** — a username and password managed by SQL Server. No extra setup.
-2. **Windows / Kerberos (Integrated)** — passwordless authentication using the
-   identity of the currently logged-in OS user (SSPI). Requires the prerequisites
-   described below.
-3. **Azure Active Directory / Entra ID** — see [Azure / Entra ID](azure-entraid.md).
+### SQL Login
 
-The **Domain** field on the connection form performs password-based **NTLM** and is
-distinct from integrated authentication — integrated authentication uses no username
-or password at all.
+A **username and password** managed by SQL Server itself. This is the default and
+works everywhere with **no extra setup** — no system packages, no Kerberos ticket.
+Choose this if your DBA gave you a SQL Server login, or for local/development
+instances using `sa`.
+
+### Domain (NTLM)
+
+Enter a **username, password, and Domain** on the connection form. This performs
+password-based **NTLM** authentication against a Windows domain account. It is
+distinct from integrated authentication: you still supply credentials, and it needs
+none of the system prerequisites below.
+
+### Windows / Kerberos (Integrated)
+
+**Passwordless** authentication using the identity of the currently logged-in OS
+user (SSPI). The username and password fields are hidden — the connection uses your
+current OS session. This mode is the only one that requires the
+[system prerequisites](#prerequisites-for-integrated-authentication) described below.
+
+### Azure Active Directory / Entra ID
+
+Sign in with an Azure / Entra ID identity (interactive browser, Azure CLI, service
+principal, and more). This is configured separately — see
+[Azure / Entra ID](azure-entraid.md) — and does **not** need the integrated-auth
+prerequisites.
 
 !!! info "Enterprise feature"
     Integrated Windows / Kerberos authentication is part of the paid Enterprise
-    Authentication feature set.
+    Authentication feature set. SQL Login and Domain (NTLM) are available in all
+    editions.
 
 ## Kerberos vs NTLM
 
@@ -38,7 +58,12 @@ connection — no username, no password — negotiates one of:
 Beekeeper Studio uses the same code path for both; the host environment determines
 which protocol is negotiated.
 
-## Prerequisites by operating system
+## Prerequisites for integrated authentication
+
+!!! warning "These apply only to Windows / Kerberos (Integrated) mode"
+    SQL Login, Domain (NTLM), and Azure / Entra ID need **none** of the packages
+    below. Only the passwordless **Windows / Kerberos (Integrated)** mode relies on a
+    system ODBC driver and a Kerberos client.
 
 ### Windows
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -151,6 +151,7 @@ nav:
     - user_guide/connecting/mongodb.md
     - user_guide/connecting/oracle-database.md
     - user_guide/connecting/redis.md
+    - SQL Server: user_guide/connecting/sql-server.md
     - SQLite: user_guide/connecting/sqlite.md
     - Trino: user_guide/connecting/trino.md
     - user_guide/connecting/surrealdb.md

--- a/yarn.lock
+++ b/yarn.lock
@@ -10455,6 +10455,15 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+msnodesqlv8@^5.1.5:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/msnodesqlv8/-/msnodesqlv8-5.2.0.tgz#aabfe9ae8fc05f47cdbb3c3f43da37e1d08b4d9d"
+  integrity sha512-kSZnvGNo21EGon3HIZ9xkWTh9ndzkdKmfSLj4kKiam2ZqSN7c+ifcTRUpTq5hX8SZiVOlOzWWZFc6aYrxFEHUQ==
+  dependencies:
+    node-abi "^4.28.0"
+    node-addon-api "^8.7.0"
+    prebuild-install "^7.1.3"
+
 mssql@^12.2.1:
   version "12.2.1"
   resolved "https://registry.yarnpkg.com/mssql/-/mssql-12.2.1.tgz#5c36af0b83ea34c35cee0424a88e6cdb7153ec79"
@@ -10567,6 +10576,13 @@ node-abi@^4.2.0:
   dependencies:
     semver "^7.6.3"
 
+node-abi@^4.28.0:
+  version "4.31.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-4.31.0.tgz#ac1e244d05d1b8c9e82d6fdcaa37b6407a47bf66"
+  integrity sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==
+  dependencies:
+    semver "^7.6.3"
+
 node-addon-api@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
@@ -10576,6 +10592,11 @@ node-addon-api@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.5.0.tgz#c91b2d7682fa457d2e1c388150f0dff9aafb8f3f"
   integrity sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==
+
+node-addon-api@^8.7.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.8.0.tgz#b742be05007b37ebc1741bbaf370d22bf25d208a"
+  integrity sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==
 
 node-api-version@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
## Summary

Adds support for SQL Server integrated authentication (SSPI/Kerberos/NTLM) via the `msnodesqlv8` native ODBC driver. This enables passwordless connections using the OS user's identity on Windows, Linux, and macOS.

## Key Changes

- **SQL Server client (`sqlserver.ts`)**: 
  - Added `connectWindowsAuth()` method to establish connections via `msnodesqlv8` instead of the default `tedious` driver
  - Added `findWindowsAuthDriver()` to probe for installed ODBC drivers (prefers modern drivers with TLS 1.2 support)
  - Added `withDeadline()` utility to wrap promises with JS-level timeouts, since native ODBC connection timeouts don't reliably cancel stalled SSPI/Kerberos handshakes
  - Updated `configDatabase()` to configure trusted connection mode when `windowsAuthEnabled` is set
  - Routes connections through `msnodesqlv8` when integrated auth is selected

- **UI Components**:
  - Updated `SqlServerForm.vue` to add "Windows / Kerberos (Integrated)" authentication option
  - Modified `CommonServerInputs.vue` to hide username/password fields when integrated auth is selected
  - Added feature gating (Enterprise Authentication tier required)

- **Database Models & Types**:
  - Added `windowsAuthEnabled` boolean field to connection models (`saved_connection`, `used_connection`)
  - Updated `IDbConnectionServerConfig` and `ISimpleConnection` interfaces
  - Added database migration to add the new column

- **Build & Dependencies**:
  - Added `msnodesqlv8` as an optional dependency in `package.json`
  - Updated `electron-builder-config.js` to unpack native `.node` binaries for `msnodesqlv8`
  - Updated `esbuild.mjs` to mark `msnodesqlv8` as external

- **Testing & Documentation**:
  - Added Windows-only integration test (`sqlserver-winauth.spec.ts`) covering both localhost and hostname connections
  - Added GitHub Actions workflow (`windows-login-tests.yaml`) to run tests on Windows with SQL Server Express
  - Added comprehensive user guide (`sql-server.md`) covering prerequisites, Kerberos vs NTLM, and troubleshooting for Windows/Linux/macOS

## Implementation Details

- **Protocol negotiation**: The same code path handles both Kerberos (domain-joined, matching SPN) and NTLM (fallback) — the OS/ODBC layer determines which is used
- **Timeout handling**: Custom `withDeadline()` wrapper ensures stalled SSPI handshakes don't hang the app indefinitely; native ODBC timeouts only cover TCP connect, not the post-connect TDS prelogin
- **Driver probing**: Attempts modern ODBC drivers first (18, 17) for TLS 1.2 support, falls back to legacy `{SQL Server}` driver on Windows only
- **Error messages**: Detailed diagnostics guide users through setup (missing drivers, SPN issues, Kerberos ticket problems)
- **Feature gating**: Integrated auth is part of the paid Enterprise Authentication tier

https://claude.ai/code/session_01BBtbdbH7wGU7JVhPCmLKYu