### PR TITLE
Update github actions so they use node 24 by default

### DIFF
--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -39,7 +39,7 @@ jobs:
           echo "/opt/homebrew/opt/python@3.11/libexec/bin" >> $GITHUB_PATH
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -91,7 +91,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Restore Playwright browsers cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -75,7 +75,7 @@ jobs:
           python-version: 3.11
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 

--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -215,7 +215,7 @@ jobs:
           fi
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -367,7 +367,7 @@ jobs:
     needs: [release, create_draft_release, identify_channel]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
       - run: npm install js-yaml
       - name: Merge yml files
         uses: actions/github-script@v7

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -40,7 +40,7 @@ jobs:
         run: echo "test-chunks=$(./bin/get-db-files-as-json.sh)" >> $GITHUB_OUTPUT
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 
@@ -180,7 +180,7 @@ jobs:
   #     uses: actions/checkout@v2
 
   #   - name: Install Node.js, NPM and Yarn
-  #     uses: actions/setup-node@v3
+  #     uses: actions/setup-node@v6
   #     with:
   #       node-version-file: '.nvmrc'
   #       cache: yarn

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -80,7 +80,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -140,7 +140,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Restore node_modules cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/ui-kit-publish.yml
+++ b/.github/workflows/ui-kit-publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Install Node.js, NPM and Yarn
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
           cache: yarn

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 10
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
setup-node: upgrade from v3 to v6, now uses node 24
cache/restore: upgrade from v4 to v5, now uses node 24