### PR TITLE
Bug Fix: Adding a new field to a table becomes invisible when dragging to its change order

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -69,7 +69,8 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
       }
       &.tabulator-moving {
         position: absolute;
-      } 
+        background: $row-add !important;
+      }
     }
     &.deleted,
     &.deleted:hover {

--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -67,6 +67,9 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
       .tabulator-editing {
         box-shadow: inset 0 -1px $theme-base!important;
       }
+      &.tabulator-moving {
+        position: absolute;
+      } 
     }
     &.deleted,
     &.deleted:hover {


### PR DESCRIPTION
## Link to original issue
[4375](https://github.com/beekeeper-studio/beekeeper-studio/issues/4375#issuecomment-4737378810)

## Overview 
When you create a new field, when you drag it around the table to change its order it'll go invisible. 

I fixed this by adding a tabulator-moving rule to preserve new row styling during drag

## Screenshot of fix
https://github.com/user-attachments/assets/ccd19b87-c1ed-42c6-b725-fc2b819b782a

