### PR TITLE
Fix desktop environment window association on Linux

### DIFF
--- a/apps/studio/electron-builder-config-test.js
+++ b/apps/studio/electron-builder-config-test.js
@@ -124,6 +124,7 @@ module.exports = {
     target: [
       'appImage'
     ],
+    syncDesktopName: true,
     desktop: {
       'StartupWMClass': 'beekeeper-studio'
     },

--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -175,6 +175,11 @@ module.exports = {
       'flatpak',
       'pacman'
     ],
+    // Align the installed .desktop filename with the WM_CLASS Electron reports at
+    // runtime (derived from desktopName in package.json) so desktop environments
+    // associate running windows with the launcher entry. Both resolve to
+    // beekeeper-studio.desktop / StartupWMClass=beekeeper-studio.
+    syncDesktopName: true,
     desktop: {
       entry: {
         'StartupWMClass': 'beekeeper-studio',

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -2,6 +2,7 @@
   "name": "beekeeper-studio",
   "version": "5.9.0-beta.2",
   "private": true,
+  "desktopName": "beekeeper-studio.desktop",
   "description": "An easy-to use SQL query editor and database UI for Mac, Windows, and Linux",
   "author": {
     "name": "Beekeeper Studio Team",


### PR DESCRIPTION
## Summary
Configures the Electron builder to align the installed `.desktop` filename with the WM_CLASS that Electron reports at runtime, ensuring desktop environments properly associate running windows with the launcher entry on Linux.

## Changes
- Added `desktopName: "beekeeper-studio.desktop"` to `package.json` to explicitly define the desktop filename
- Enabled `syncDesktopName: true` in both production and test Electron builder configurations to synchronize the desktop filename with the WM_CLASS value
- Added explanatory comment documenting why this configuration is necessary for proper window association

## Implementation Details
The `syncDesktopName` option ensures that:
- The installed `.desktop` file is named `beekeeper-studio.desktop`
- The `StartupWMClass` entry in the desktop file matches this name
- Both resolve to the same value that Electron reports at runtime (derived from `desktopName` in package.json)
- Desktop environments can correctly associate running application windows with their launcher entries

This fixes window grouping and taskbar behavior on Linux desktop environments that rely on WM_CLASS matching.

https://claude.ai/code/session_01L3tX8WuCpyrYWTSC1N4iJU