### PR TITLE
Remove appimage toolset version from electron-builder config

### DIFF
--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -26,9 +26,6 @@ module.exports = {
     releaseNotesFile: "build/release-notes.md"
   },
   generateUpdatesFilesForAllChannels: true,
-  toolsets: {
-    appimage: "1.0.3"
-  },
   directories: {
     output: "dist_electron"
   },


### PR DESCRIPTION
## Summary
Removes the explicit `appimage` toolset version specification from the Electron Builder configuration.

## Changes
- Removed the `toolsets` configuration object that specified `appimage: "1.0.3"` from `electron-builder-config.js`

## Details
This change allows Electron Builder to use its default AppImage toolset version instead of pinning to version 1.0.3. This simplifies the build configuration and may improve compatibility with newer versions of the build tools.

https://claude.ai/code/session_01SE3vmXP2V8F9ZuNAJXTafB