### PR TITLE
Add migration for kerberosSpn connection field

### DIFF
--- a/apps/studio/src/migration/20260625_add_kerberos_spn.js
+++ b/apps/studio/src/migration/20260625_add_kerberos_spn.js
@@ -1,0 +1,12 @@
+export default {
+  name: '20260625-kerberos-spn',
+  async run(runner) {
+    const queries = [
+      `ALTER TABLE saved_connection ADD COLUMN kerberosSpn varchar`,
+      `ALTER TABLE used_connection ADD COLUMN kerberosSpn varchar`,
+    ]
+    for (let i = 0; i < queries.length; i++) {
+      await runner.query(queries[i])
+    }
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -93,6 +93,7 @@ import createTabulatorPersistence from './20260424_create_tabulator_persistence'
 import clearLogFiles from './20260527_clear_log_files'
 import addSnowflakeOptions from './20260501_add_snowflake_options'
 import addWindowsAuthToConnections from './20260618_add_windows_auth_to_connections'
+import addKerberosSpn from './20260625_add_kerberos_spn'
 
 import ultimate from './ultimate/index'
 
@@ -146,7 +147,8 @@ const realMigrations = [
   createTabulatorPersistence,
   clearLogFiles,
   addSnowflakeOptions,
-  addWindowsAuthToConnections
+  addWindowsAuthToConnections,
+  addKerberosSpn
 ]
 
 // fixtures require the models


### PR DESCRIPTION
Adds the kerberosSpn varchar column to the saved_connection and
used_connection tables, backing the optional Kerberos SPN override
for SQL Server integrated authentication (PR #4430).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U8J3gkNRbgnnyL2AwUJish