### PR TITLE
Fix SSH tunneling for MongoDB, ClickHouse, and Firebird

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/clickhouse.ts
@@ -143,10 +143,21 @@ export class ClickHouseClient extends BasicDatabaseClient<Result> {
 
     if (this.server.config.url) {
       url = this.server.config.url
+      // Route the user-provided URL through the SSH tunnel's local endpoint.
+      if (this.server.sshTunnel) {
+        const urlObj = new URL(url);
+        urlObj.hostname = this.server.config.localHost;
+        urlObj.port = this.server.config.localPort.toString();
+        url = urlObj.toString();
+      }
     } else {
       const urlObj = new URL('http://example.com/');
-      urlObj.hostname = this.server.config.host;
-      urlObj.port = this.server.config.port.toString();
+      urlObj.hostname = this.server.sshTunnel
+        ? this.server.config.localHost
+        : this.server.config.host;
+      urlObj.port = (this.server.sshTunnel
+        ? this.server.config.localPort
+        : this.server.config.port).toString();
       urlObj.protocol = this.server.config.ssl ? 'https:' : 'http:';
       url = urlObj.toString();
     }

--- a/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/firebird.ts
@@ -254,9 +254,17 @@ export class FirebirdClient extends BasicDatabaseClient<FirebirdResult, Firebird
   async connect(): Promise<void> {
     await super.connect();
 
+    // Route through the SSH tunnel's local endpoint when a tunnel is active.
+    const host = this.server.sshTunnel
+      ? this.server.config.localHost
+      : this.server.config.host;
+    const port = this.server.sshTunnel
+      ? this.server.config.localPort
+      : this.server.config.port;
+
     const config = {
-      host: this.server.config.host,
-      port: this.server.config.port,
+      host,
+      port,
       user: this.server.config.user,
       password: this.server.config.password,
       database: this.database.database,
@@ -282,8 +290,8 @@ export class FirebirdClient extends BasicDatabaseClient<FirebirdResult, Firebird
     const knex = knexlib({
       client: Client_Firebird,
       connection: {
-        host: serverConfig.host,
-        port: serverConfig.port,
+        host,
+        port,
         user: serverConfig.user,
         password: serverConfig.password,
         database: this.database.database,

--- a/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
@@ -28,6 +28,35 @@ interface QueryResult {
   arrayMode: boolean;
 }
 
+const DEFAULT_MONGO_PORT = 27017;
+
+// Extract the host/port a MongoDB URL points at so an SSH tunnel can forward to it.
+// Returns null for URLs the standard URL parser can't handle (e.g. multi-host
+// seed lists or mongodb+srv), where SSH tunnelling isn't supported anyway.
+export function parseMongoHost(url: string): { host: string; port: number } | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname) return null;
+    return {
+      host: parsed.hostname,
+      port: parsed.port ? parseInt(parsed.port, 10) : DEFAULT_MONGO_PORT,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Rewrite a MongoDB URL's host:port to point at the local end of an SSH tunnel.
+export function rewriteMongoUrlHost(url: string, localHost: string, localPort: number): string {
+  try {
+    const parsed = new URL(url);
+    parsed.host = `${localHost}:${localPort}`;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
 const mongoContext = {
   getExecutionContext(): ExecutionContext {
     return null;
@@ -49,9 +78,31 @@ export class MongoDBClient extends BasicDatabaseClient<QueryResult> {
   }
 
   async connect(): Promise<void> {
+    // The MongoDB form only collects a connection URL, so config.host/config.port
+    // are never populated. The SSH tunnel forwards a local port to config.host:config.port,
+    // so derive them from the URL before the base class opens the tunnel.
+    if (this.server.config.ssh && !this.server.sshTunnel) {
+      const target = parseMongoHost(this.server.config.url);
+      if (target) {
+        this.server.config.host = target.host;
+        this.server.config.port = target.port;
+      }
+    }
+
     await super.connect();
 
-    this.conn = new MongoClient(this.server.config.url);
+    let url = this.server.config.url;
+
+    // Route the connection through the SSH tunnel's local endpoint.
+    if (this.server.sshTunnel) {
+      url = rewriteMongoUrlHost(
+        url,
+        this.server.config.localHost,
+        this.server.config.localPort
+      );
+    }
+
+    this.conn = new MongoClient(url);
 
     this.conn.on('connectionCreated', (event) => {
       log.debug('Pool connection %d acquired on %s', event.connectionId, event.address);

--- a/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
@@ -47,10 +47,16 @@ export function parseMongoHost(url: string): { host: string; port: number } | nu
 }
 
 // Rewrite a MongoDB URL's host:port to point at the local end of an SSH tunnel.
+// Forces directConnection so the driver talks to the tunnelled node directly
+// instead of running topology discovery and trying to reach the server's
+// self-reported address (which isn't routable through the tunnel).
 export function rewriteMongoUrlHost(url: string, localHost: string, localPort: number): string {
   try {
     const parsed = new URL(url);
     parsed.host = `${localHost}:${localPort}`;
+    if (!parsed.searchParams.has('directConnection')) {
+      parsed.searchParams.set('directConnection', 'true');
+    }
     return parsed.toString();
   } catch {
     return url;

--- a/apps/studio/src/components/connection/MongoDBForm.vue
+++ b/apps/studio/src/components/connection/MongoDBForm.vue
@@ -11,12 +11,15 @@
       <label for="defaultDatabase">Default Database</label>
       <input type="text" class="form-control" v-model="config.defaultDatabase">
     </div>
+    <common-advanced :config="config" />
   </div>
 </template>
 
 <script lang="ts">
+import CommonAdvanced from './CommonAdvanced.vue'
 
 export default {
+  components: { CommonAdvanced },
   props: ['config']
 }
 </script>

--- a/apps/studio/src/vendor/node-ssh-forward/index.ts
+++ b/apps/studio/src/vendor/node-ssh-forward/index.ts
@@ -97,6 +97,10 @@ class SSHConnection {
     this.debug("Shutdown connections")
     for (const connection of this.connections) {
       connection.removeAllListeners()
+      // Swallow late errors (e.g. the remote resetting the socket, ECONNRESET)
+      // emitted while the connection is closing. Without a handler these would
+      // surface as unhandled 'error' events and crash the process.
+      connection.on('error', () => { /* ignore during teardown */ })
       connection.end()
     }
     return new Promise<void>((resolve) => {
@@ -279,6 +283,11 @@ class SSHConnection {
           if (error) {
             return reject(error)
           }
+          // Handle errors on both ends of the forward (e.g. the remote or the
+          // local client resetting the socket, ECONNRESET) so they don't
+          // surface as unhandled 'error' events and crash the process.
+          socket.on('error', () => { socket.destroy() })
+          stream.on('error', () => { stream.destroy?.() })
           socket.pipe(stream)
           stream.pipe(socket)
         })

--- a/apps/studio/tests/docker/ssh-mongo.yml
+++ b/apps/studio/tests/docker/ssh-mongo.yml
@@ -10,6 +10,12 @@ services:
       MONGO_INITDB_ROOT_USERNAME: beekeeper
       MONGO_INITDB_ROOT_PASSWORD: password
       MONGO_INITDB_DATABASE: bee
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+      start_period: 5s
     networks:
       # mongo is only reachable from the ssh container, never from the test runner
       - ssh_mongo

--- a/apps/studio/tests/docker/ssh-mongo.yml
+++ b/apps/studio/tests/docker/ssh-mongo.yml
@@ -1,0 +1,33 @@
+version: '3'
+networks:
+  testrunner_ssh:
+  ssh_mongo:
+services:
+  mongo:
+    image: mongo:latest
+    container_name: test_ssh_mongo
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: beekeeper
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_DATABASE: bee
+    networks:
+      # mongo is only reachable from the ssh container, never from the test runner
+      - ssh_mongo
+  ssh:
+    build:
+      context: ./
+      dockerfile: ./SSHDockerFile
+    container_name: test_ssh_mongo_gateway
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=password
+      - USER_NAME=beekeeper
+      - SUDO_ACCESS=true
+    ports:
+      - 2222
+    networks:
+      - testrunner_ssh
+      - ssh_mongo

--- a/apps/studio/tests/docker/ssh-mongo.yml
+++ b/apps/studio/tests/docker/ssh-mongo.yml
@@ -1,6 +1,8 @@
 version: '3'
 networks:
   testrunner_ssh:
+  testrunner_bastion:
+  bastion_ssh:
   ssh_mongo:
 services:
   mongo:
@@ -36,4 +38,23 @@ services:
       - 2222
     networks:
       - testrunner_ssh
+      - bastion_ssh
       - ssh_mongo
+  bastion:
+    build:
+      context: ./
+      dockerfile: ./SSHDockerFile
+    container_name: test_ssh_mongo_bastion
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/London
+      - PASSWORD_ACCESS=true
+      - USER_PASSWORD=password
+      - USER_NAME=beekeeper
+      - SUDO_ACCESS=true
+    ports:
+      - 2222
+    networks:
+      - testrunner_bastion
+      - bastion_ssh

--- a/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
@@ -1,0 +1,66 @@
+import { DockerComposeEnvironment, Wait } from 'testcontainers'
+import ConnectionProvider from '@commercial/backend/lib/connection-provider';
+import { dbtimeout } from '../../../../lib/db'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection';
+
+// Verifies that MongoDB connections work through an SSH tunnel. The mongo
+// container is only reachable from the ssh container (the ssh_mongo network),
+// so the connection can only succeed if the tunnel is established and the
+// MongoDB URL is rewritten to point at the tunnel's local endpoint.
+describe("MongoDB SSH Tunnel Tests", () => {
+  jest.setTimeout(dbtimeout)
+
+  let sshContainer
+  let connection
+  let database
+  let environment
+
+  beforeAll(async () => {
+    await TestOrmConnection.connect()
+
+    environment = await new DockerComposeEnvironment("tests/docker", "ssh-mongo.yml")
+      .withWaitStrategy('test_ssh_mongo', Wait.forListeningPorts())
+      .withWaitStrategy('test_ssh_mongo_gateway', Wait.forListeningPorts())
+      .up()
+
+    sshContainer = environment.getContainer('test_ssh_mongo_gateway')
+
+    const config = {
+      connectionType: 'mongodb',
+      // mongo is reachable from the ssh container via the ssh_mongo network (by container name)
+      url: 'mongodb://beekeeper:password@mongo:27017/bee?authSource=admin',
+      sshEnabled: true,
+      sshMode: 'userpass',
+      // ssh is directly reachable from the test runner via its mapped port
+      sshHost: sshContainer.getHost(),
+      sshPort: sshContainer.getMappedPort(2222),
+      sshUsername: 'beekeeper',
+      sshPassword: 'password',
+    }
+
+    console.log("Starting MongoDB SSH test with config", config)
+    connection = ConnectionProvider.for(config)
+    database = connection.createConnection('bee')
+    await database.connect()
+  })
+
+  it("should connect and read the server version through the tunnel", async () => {
+    const version = await database.versionString()
+    expect(version).toBeTruthy()
+  })
+
+  it("should list tables through the tunnel", async () => {
+    const tables = await database.listTables()
+    expect(Array.isArray(tables)).toBe(true)
+  })
+
+  afterAll(async () => {
+    if (database) {
+      await database.disconnect()
+    }
+    if (environment) {
+      await environment.stop()
+    }
+    await TestOrmConnection.disconnect()
+  })
+})

--- a/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
@@ -11,6 +11,7 @@ describe("MongoDB SSH Tunnel Tests", () => {
   jest.setTimeout(dbtimeout)
 
   let sshContainer
+  let bastionContainer
   let connection
   let database
   let environment
@@ -21,9 +22,11 @@ describe("MongoDB SSH Tunnel Tests", () => {
     environment = await new DockerComposeEnvironment("tests/docker", "ssh-mongo.yml")
       .withWaitStrategy('test_ssh_mongo', Wait.forHealthCheck())
       .withWaitStrategy('test_ssh_mongo_gateway', Wait.forListeningPorts())
+      .withWaitStrategy('test_ssh_mongo_bastion', Wait.forListeningPorts())
       .up()
 
     sshContainer = environment.getContainer('test_ssh_mongo_gateway')
+    bastionContainer = environment.getContainer('test_ssh_mongo_bastion')
 
     const config = {
       connectionType: 'mongodb',
@@ -52,6 +55,45 @@ describe("MongoDB SSH Tunnel Tests", () => {
   it("should list tables through the tunnel", async () => {
     const tables = await database.listTables()
     expect(Array.isArray(tables)).toBe(true)
+  })
+
+  describe("Can SSH via bastion host", () => {
+    let bastionDatabase
+
+    beforeAll(async () => {
+      const config = {
+        connectionType: 'mongodb',
+        url: 'mongodb://beekeeper:password@mongo:27017/bee?authSource=admin',
+        sshEnabled: true,
+        sshMode: 'userpass',
+        // ssh is reachable from the bastion container via the bastion_ssh network (by container name)
+        sshHost: 'test_ssh_mongo_gateway',
+        sshPort: 2222,
+        sshUsername: 'beekeeper',
+        sshPassword: 'password',
+        // bastion is the only ssh container reachable from the test runner via its mapped port
+        sshBastionHost: bastionContainer.getHost(),
+        sshBastionHostPort: bastionContainer.getMappedPort(2222),
+        sshBastionMode: 'userpass',
+        sshBastionUsername: 'beekeeper',
+        sshBastionPassword: 'password',
+      }
+
+      const conn = ConnectionProvider.for(config)
+      bastionDatabase = conn.createConnection('bee')
+      await bastionDatabase.connect()
+    })
+
+    it("should read the server version through the bastion tunnel", async () => {
+      const version = await bastionDatabase.versionString()
+      expect(version).toBeTruthy()
+    })
+
+    afterAll(async () => {
+      if (bastionDatabase) {
+        await bastionDatabase.disconnect()
+      }
+    })
   })
 
   afterAll(async () => {

--- a/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-mongodb.spec.js
@@ -19,7 +19,7 @@ describe("MongoDB SSH Tunnel Tests", () => {
     await TestOrmConnection.connect()
 
     environment = await new DockerComposeEnvironment("tests/docker", "ssh-mongo.yml")
-      .withWaitStrategy('test_ssh_mongo', Wait.forListeningPorts())
+      .withWaitStrategy('test_ssh_mongo', Wait.forHealthCheck())
       .withWaitStrategy('test_ssh_mongo_gateway', Wait.forListeningPorts())
       .up()
 


### PR DESCRIPTION
## Summary

Several database clients exposed SSH tunnel options in their connection form but ignored the tunnel at connect time — they connected to the raw configured host/port instead of the tunnel's local endpoint, so SSH simply didn't work for them.

I audited every database whose form exposes SSH options and fixed the broken ones.

## Audit results

| Database | Before | Action |
| --- | --- | --- |
| Postgres, MySQL, SQL Server, Oracle, SurrealDB | OK | — |
| Redshift, Cockroach, Greengage (inherit Postgres) | OK | — |
| Bedrock, TiDB (inherit MySQL) | OK | — |
| ScyllaDB (inherits Cassandra) | OK | — |
| **MongoDB** | Broken | Fixed |
| **ClickHouse** | Broken | Fixed |
| **Firebird** | Broken | Fixed |

## Changes

**MongoDB**
- Add the shared `CommonAdvanced` (SSH) options to `MongoDBForm` — the form previously had no SSH fields at all.
- The MongoDB form only collects a URL, so `config.host`/`config.port` were never populated and the tunnel had no forward target. Derive host/port from the URL before the tunnel is opened, then rewrite the URL to the tunnel's local endpoint when a tunnel is active.
- Force `directConnection=true` on the tunnelled URL (unless the user set it) so the driver talks to the tunnelled node directly instead of running topology discovery and trying to reach the server's self-reported address, which isn't routable through the tunnel.

**ClickHouse**
- Route through `localHost`/`localPort` when a tunnel is active, for both the host/port and the user-provided URL forms.

**Firebird**
- Route the pool and knex connections through `localHost`/`localPort` when a tunnel is active.

**node-ssh-forward (vendored)**
- Attach error handlers to the ssh connection (during shutdown) and to the forwarded socket/stream pair. A reset socket (`ECONNRESET`) during teardown, or a dropped client in normal use, previously surfaced as an unhandled `'error'` event that could crash the process.

## Tests

- New MongoDB SSH integration test covering both a direct tunnel and a bastion (jump) host. The MongoDB container is reachable only through the SSH container, so the test passes only if the tunnel is actually used.

## Verification

Run locally against real containers:
- MongoDB SSH (direct + bastion) — 3 passed
- Postgres SSH (direct + bastion), as a regression check for the node-ssh-forward change — 2 passed
- Full ClickHouse and Firebird suites, as a regression check for the client changes — 481 passed

Note: ClickHouse and Firebird don't yet have dedicated SSH integration tests; their fixes were verified by code and confirmed not to regress their existing suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)