### PR TITLE
Use mssql dialect for sql server, and update quoting logic

### DIFF
--- a/apps/studio/src/shared/lib/dialects/sqlserver.ts
+++ b/apps/studio/src/shared/lib/dialects/sqlserver.ts
@@ -54,12 +54,7 @@ export const SqlServerData: DialectData = {
   },
   escapeString: defaultEscapeString,
   usesOffsetPagination: true,
-  /**
-   * Fix #1985 by using text/x-sql instead of text/x-mssql.
-   * For some reason, text/x-mssql messes up the editor.getToken()
-   * function which is used for autocomplete.
-   **/
-  textEditorMode: "text/x-sql",
+  textEditorMode: "text/x-mssql",
   disabledFeatures: {
     shell: true,
     alter: {

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
@@ -9,7 +9,7 @@ import {
   SQLExtensionsConfig,
 } from "./extensions";
 import { ExtensionConfiguration } from "@/components";
-import { Cassandra, MySQL, PostgreSQL, SQLite, StandardSQL } from "@codemirror/lang-sql";
+import { Cassandra, MSSQL, MySQL, PostgreSQL, SQLite, StandardSQL } from "@codemirror/lang-sql";
 import { GreengageSQL, PartiQL } from "./customDialects";
 
 export interface CompletionSource {
@@ -25,6 +25,7 @@ const langIdToDialect = {
   "text/x-cassandra": Cassandra,
   "text/x-sqlite": SQLite,
   "text/x-partiql": PartiQL,
+  "text/x-mssql": MSSQL
 };
 
 export class SqlTextEditor extends TextEditor {

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.ts
@@ -9,8 +9,8 @@ import {
   SQLExtensionsConfig,
 } from "./extensions";
 import { ExtensionConfiguration } from "@/components";
-import { Cassandra, MSSQL, MySQL, PostgreSQL, SQLite, StandardSQL } from "@codemirror/lang-sql";
-import { GreengageSQL, PartiQL } from "./customDialects";
+import { Cassandra, MySQL, PostgreSQL, SQLite, StandardSQL } from "@codemirror/lang-sql";
+import { GreengageSQL, PartiQL, SQLServer } from "./customDialects";
 
 export interface CompletionSource {
   defaultSchema?: string;
@@ -25,7 +25,7 @@ const langIdToDialect = {
   "text/x-cassandra": Cassandra,
   "text/x-sqlite": SQLite,
   "text/x-partiql": PartiQL,
-  "text/x-mssql": MSSQL
+  "text/x-mssql": SQLServer
 };
 
 export class SqlTextEditor extends TextEditor {

--- a/apps/ui-kit/lib/components/sql-text-editor/customDialects.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/customDialects.ts
@@ -1,4 +1,4 @@
-import {PostgreSQL, SQLDialect} from "@codemirror/lang-sql";
+import {MSSQL, PostgreSQL, SQLDialect} from "@codemirror/lang-sql";
 
 const GREENGAGE_EXTRA_KEYWORDS = [
   "distributed", "exchange", "inclusive", "list", "protocol", "resource",
@@ -9,6 +9,11 @@ export const GreengageSQL = SQLDialect.define({
   ...PostgreSQL.spec,
   keywords: (PostgreSQL.spec.keywords || "") + " " + GREENGAGE_EXTRA_KEYWORDS,
 });
+
+export const SQLServer = SQLDialect.define({
+  ...MSSQL,
+  identifierQuotes: "[\""
+})
 
 // PartiQL — the SQL-compatible dialect AWS DynamoDB exposes via
 // ExecuteStatementCommand. Identifiers are double-quoted (PartiQL/ANSI style)

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
@@ -264,7 +264,7 @@ class CompletionLevel {
 
 export function nameCompletion(label: string, type: string, idQuote: string, idCaseInsensitive: boolean): Completion {
   if ((new RegExp("^[a-z_][a-z_\\d]*$", idCaseInsensitive ? "i" : "")).test(label)) return {label, type}
-  return {label, type, apply: idQuote + label + idQuote}
+  return {label, type, apply: idQuote + label + getClosingQuote(idQuote)}
 }
 
 export function buildCompletionLevels(schema: SQLNamespace,

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/complete.ts
@@ -24,7 +24,7 @@ function tokenBefore(tree: SyntaxNode) {
 
 function idName(doc: Text, node: SyntaxNode): string {
   let text = doc.sliceString(node.from, node.to)
-  let quoted = /^([`'"])(.*)\1$/.exec(text)
+  let quoted = /^([`'"\[])(.*)([`'"\]])$/.exec(text)
   return quoted ? quoted[2] : text
 }
 
@@ -97,12 +97,11 @@ function getAliases(doc: Text, at: SyntaxNode) {
   return aliases
 }
 
-function maybeQuoteCompletions(quote: string | null, completions: readonly Completion[]) {
-  if (!quote) return completions
-  return completions.map(c => ({...c, label: c.label[0] == quote ? c.label : quote + c.label + quote, apply: undefined}))
+function maybeQuoteCompletions(openingQuote: string, closingQuote: string, completions: readonly Completion[]) {
+  return completions.map(c => ({...c, label: c.label[0] == openingQuote ? c.label : openingQuote + c.label + closingQuote, apply: undefined}))
 }
 
-const Span = /^\w*$/, QuotedSpan = /^[`'"]?\w*[`'"]?$/
+const Span = /^\w*$/, QuotedSpan = /^[`'"\[]?\w*[`'"\]]?$/
 
 function isSelfTag(namespace: SQLNamespace): namespace is {self: Completion, children: SQLNamespace} {
   return (namespace as any).self && typeof (namespace as any).self.label == "string"
@@ -338,6 +337,10 @@ export const completeConfig = Facet.define<
   combine: (values) => values.reduce((a, b) => ({ ...a, ...b }), {}),
 });
 
+function getClosingQuote(openingQuote: string) {
+  return openingQuote === "[" ? "]" : openingQuote
+}
+
 // Some of this is more gnarly than it has to be because we're also
 // supporting the deprecated, not-so-well-considered style of
 // supplying the schema (dotted property names for schemas, separate
@@ -369,18 +372,31 @@ export function completeFromSchema(schema: SQLNamespace,
       if (!next) return null
       level = next
     }
-    let quoteAfter = quoted && context.state.sliceDoc(context.pos, context.pos + 1) == quoted
+
     let options = level.list
     if (level == top && aliases)
       options = options.concat(Object.keys(aliases).map(name => ({label: name, type: "constant"})))
 
     options = await optionsFilter(context, { parents, from, quoted, empty, aliases }, options);
 
-    return {
-      from,
-      to: quoteAfter ? context.pos + 1 : undefined,
-      options: maybeQuoteCompletions(quoted, options),
-      validFor: quoted ? QuotedSpan : Span
+    if (quoted) {
+      let openingQuote = quoted[0]
+      let closingQuote = getClosingQuote(openingQuote)
+
+      let quoteAfter = context.state.sliceDoc(context.pos, context.pos + 1) == closingQuote
+
+      return {
+        from,
+        to: quoteAfter ? context.pos + 1 : undefined,
+        options: maybeQuoteCompletions(openingQuote, closingQuote, options),
+        validFor: QuotedSpan
+      }
+    } else {
+      return {
+        from,
+        options: options,
+        validFor: Span
+      }
     }
   }
 }

--- a/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/completions.spec.ts
@@ -6,6 +6,7 @@ import {CompletionContext, CompletionSource} from "@codemirror/autocomplete"
 import {PostgreSQL, MySQL, SQLConfig, SQLDialect} from "@codemirror/lang-sql"
 import theIst from "ist"
 import { extensions as sql, SQLExtensionsConfig } from "../../../lib/components/sql-text-editor/extensions"
+import { SQLServer } from "../../../lib/components/sql-text-editor/customDialects"
 
 function get(doc: string, conf: SQLExtensionsConfig & {explicit?: boolean, keywords?: boolean} = {}) {
   let cur = doc.indexOf("|"), dialect = conf.dialect || PostgreSQL
@@ -591,5 +592,45 @@ describe("SQL completion", () => {
     const result = await str(list)
     ist(result.includes("u_col"))
     ist(result.includes("o_col"))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Bracket-quoted identifiers (SQL Server / MSSQL dialect).
+//
+// The SQLServer dialect sets `identifierQuotes: "["`, so the opening quote
+// is `[` and the closing quote is `]`. These tests exercise the asymmetric
+// open/close quoting logic (getClosingQuote, maybeQuoteCompletions,
+// nameCompletion, and the bracket-aware idName/QuotedSpan regexes).
+// ---------------------------------------------------------------------------
+
+describe("SQL completion (bracket-quoted identifiers)", () => {
+  it("completes bracket-quoted table names and closes with ]", () => {
+    ist(str(get("select [u|", {dialect: SQLServer, schema: schema1})),
+        "[products], [users]")
+  })
+
+  it("completes bracket-quoted column names under a bracket-quoted table", () => {
+    ist(str(get('select [users].[|', {dialect: SQLServer, schema: schema1})),
+        "[address], [id], [name]")
+  })
+
+  it("strips brackets when resolving a bracket-quoted parent table", () => {
+    // [users] must resolve to the `users` table so its columns are offered.
+    ist(str(get('select [users].|', {dialect: SQLServer, schema: schema1})),
+        "address, id, name")
+  })
+
+  it("consumes a trailing closing bracket", async () => {
+    // 'select [u' is 9 chars; the cursor sits before the closing ']' at index 9,
+    // so the completion range should extend to index 10 to overwrite it.
+    let r = await get('select [u|]', {dialect: SQLServer, schema: schema1})
+    ist(r!.to, 10)
+  })
+
+  it("applies the closing bracket for non-word identifiers (nameCompletion)", () => {
+    // Without getClosingQuote this would wrongly produce "[b c[" / "[b-c[".
+    ist(str(get("foo.b|", {schema: {foo: ["b c", "b-c", "bup"]}, dialect: SQLServer})),
+        "[b c], [b-c], bup")
   })
 })


### PR DESCRIPTION
Update some of the quoting logic in the vendored complete from upstream, and move to using the mssql dialect in codemirror (the note about it being broken is from before we upgraded codemirror and no longer applies).