### PR TITLE
Persist global sidebar active item selection to local storage

### DIFF
--- a/apps/studio/src/store/modules/SidebarModule.ts
+++ b/apps/studio/src/store/modules/SidebarModule.ts
@@ -19,16 +19,25 @@ interface State {
   secondarySidebarWidth: number;
   secondarySidebarOpen: boolean;
   secondaryActiveTabId?: string;
-  globalSidebarActiveItem: "tables" | "history" | "queries";
+  globalSidebarActiveItem: GlobalSidebarActiveItem;
 }
 
 const PRIMARY_SIDEBAR_OPEN_KEY = 'primarySidebarOpen-v2'
 const PRIMARY_SIDEBAR_WIDTH_KEY = "primarySidebarWidth-v3"
 const SECONDARY_SIDEBAR_OPEN_KEY = 'secondarySidebarOpen-v2'
 const SECONDARY_SIDEBAR_WIDTH_KEY = "secondarySidebarWidth-v3"
+const GLOBAL_SIDEBAR_ACTIVE_ITEM_KEY = "globalSidebarActiveItem-v1"
 
 const PRIMARY_SIDEBAR_INITIAL_WIDTH = 240 // in pixels
 const SECONDARY_SIDEBAR_INITIAL_WIDTH = 240 // in pixels
+
+type GlobalSidebarActiveItem = "tables" | "history" | "queries";
+const GLOBAL_SIDEBAR_ITEMS: GlobalSidebarActiveItem[] = ["tables", "history", "queries"];
+
+function getInitialGlobalSidebarActiveItem(): GlobalSidebarActiveItem {
+  const stored = SmartLocalStorage.getJSON(GLOBAL_SIDEBAR_ACTIVE_ITEM_KEY);
+  return GLOBAL_SIDEBAR_ITEMS.includes(stored) ? stored : "tables";
+}
 
 export const SidebarModule: Module<State, RootState> = {
   namespaced: true,
@@ -49,7 +58,7 @@ export const SidebarModule: Module<State, RootState> = {
     secondarySidebarWidth: SmartLocalStorage.getJSON(SECONDARY_SIDEBAR_WIDTH_KEY, SECONDARY_SIDEBAR_INITIAL_WIDTH),
     secondaryActiveTabId: "json-viewer",
 
-    globalSidebarActiveItem: "tables",
+    globalSidebarActiveItem: getInitialGlobalSidebarActiveItem(),
   }),
   getters: {
   },
@@ -61,7 +70,7 @@ export const SidebarModule: Module<State, RootState> = {
     primarySidebarWidth(state, width: number) {
       state.primarySidebarWidth = width
     },
-    globalSidebarActiveItem(state, item: "tables" | "history" | "queries") {
+    globalSidebarActiveItem(state, item: GlobalSidebarActiveItem) {
       state.globalSidebarActiveItem = item
     },
 
@@ -111,7 +120,8 @@ export const SidebarModule: Module<State, RootState> = {
       context.commit("secondaryActiveTabId", tabId);
     },
 
-    setGlobalSidebarActiveItem(context, item: "tables" | "history" | "queries") {
+    setGlobalSidebarActiveItem(context, item: GlobalSidebarActiveItem) {
+      SmartLocalStorage.addItem(GLOBAL_SIDEBAR_ACTIVE_ITEM_KEY, item);
       context.commit("globalSidebarActiveItem", item);
     },
 


### PR DESCRIPTION
## Summary
Added persistence for the global sidebar active item selection so that the user's choice of "tables", "history", or "queries" is remembered across sessions.

## Key Changes
- Extracted `GlobalSidebarActiveItem` type to a named type alias for better reusability
- Added `GLOBAL_SIDEBAR_ITEMS` constant array for validation of stored values
- Created `getInitialGlobalSidebarActiveItem()` function to restore the sidebar state from local storage on app startup, with "tables" as the fallback default
- Updated the state initialization to use the new function instead of hardcoded "tables"
- Modified `setGlobalSidebarActiveItem()` action to persist the selected item to local storage via `SmartLocalStorage.addItem()` before committing the state change
- Updated type annotations throughout to use the new `GlobalSidebarActiveItem` type

## Implementation Details
- Uses the existing `SmartLocalStorage` utility for consistent local storage handling
- Validates stored values against the `GLOBAL_SIDEBAR_ITEMS` array to ensure only valid sidebar items are restored
- Follows the existing pattern of versioned storage keys (`globalSidebarActiveItem-v1`) to support future schema migrations

https://claude.ai/code/session_01HkW4yfPhKFiDimiCZnPanU