### PR TITLE
Pin ClickHouse integration tests to version 26.5

### DIFF
--- a/apps/studio/tests/integration/lib/db/clients/clickhouse.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/clickhouse.spec.ts
@@ -8,10 +8,15 @@ import fs from 'fs';
 import path from 'path';
 import { identify } from 'sql-query-identifier';
 
+// Pin to explicit ClickHouse versions. Do NOT use the `latest` tag here: it is
+// mutable, so a new ClickHouse release silently changes what CI runs against.
+// ClickHouse 26.6.1 (published 2026-06-26) made these integration tests hang
+// until the 20-minute CI job timeout; 26.5 is the last release the suite passed
+// against. Bump this tag deliberately, not implicitly.
 const TEST_VERSIONS = [
-  { tag: 'latest', readOnly: false, dropInformation: false },
-  { tag: 'latest', readOnly: false, dropInformation: true },
-  { tag: 'latest', readOnly: true, dropInformation: false },
+  { tag: '26.5', readOnly: false, dropInformation: false },
+  { tag: '26.5', readOnly: false, dropInformation: true },
+  { tag: '26.5', readOnly: true, dropInformation: false },
   { tag: '24.2', readOnly: false, dropInformation: false },
   { tag: '24.2', readOnly: false, dropInformation: true },
   { tag: '24.2', readOnly: true, dropInformation: false },


### PR DESCRIPTION
## Summary
Updated the ClickHouse integration test suite to use a pinned version (26.5) instead of the mutable `latest` tag, and added documentation explaining why this is necessary.

## Changes
- **Pinned test versions**: Changed all three test configurations from `latest` to `26.5`
  - `{ tag: '26.5', readOnly: false, dropInformation: false }`
  - `{ tag: '26.5', readOnly: false, dropInformation: true }`
  - `{ tag: '26.5', readOnly: true, dropInformation: false }`
- **Added explanatory comment**: Documented that ClickHouse 26.6.1 causes the integration tests to hang until the 20-minute CI timeout, and that 26.5 is the last stable version for this test suite
- **Preserved existing tests**: Kept the existing 24.2 test configurations unchanged

## Rationale
Using the `latest` tag in CI is problematic because it's mutable—new ClickHouse releases can silently change what the CI runs against without explicit code changes. This change ensures consistent, reproducible test runs and prevents unexpected failures when ClickHouse releases new versions with breaking changes or performance regressions.

https://claude.ai/code/session_01SaQk3eTXjutFzXL5DiA47w