### PR TITLE
Fix table auto refresh

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1577,7 +1577,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.selectedResult = 0
         let identification = []
         try {
-          const { queries: identification, error } = safelyIdentify(rawQuery, { dialect: this.identifyDialect, identifyTables: true, identifyColumns: true })
+          const { queries, error } = safelyIdentify(rawQuery, { dialect: this.identifyDialect, identifyTables: true, identifyColumns: true });
+          identification = queries;
           if (error) {
             log.error("Unable to identify query.", error)
           }

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1575,13 +1575,11 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.resultEditableMap = []
         this.editingResult = false
         this.selectedResult = 0
-        let identification = []
+        const { queries: identification, error } = safelyIdentify(rawQuery, { dialect: this.identifyDialect, identifyTables: true, identifyColumns: true });
+        if (error) {
+          log.error("Unable to identify query.", error)
+        }
         try {
-          const { queries, error } = safelyIdentify(rawQuery, { dialect: this.identifyDialect, identifyTables: true, identifyColumns: true });
-          identification = queries;
-          if (error) {
-            log.error("Unable to identify query.", error)
-          }
 
           if (this.canManageTransactions && identification.some((value: IdentifyResult) => value.executionType === "TRANSACTION")) {
             const startTransaction = identification.filter((value: IdentifyResult) => value.type === "BEGIN_TRANSACTION").length


### PR DESCRIPTION
We were accidentally shadowing the identification in submitQuery, so references outside the try catch would always be referencing an empty array :)