### PR TITLE
Restoring edited text of saved queries was broken

### DIFF
--- a/apps/studio/e2e/tests/savedQueryRestore.test.ts
+++ b/apps/studio/e2e/tests/savedQueryRestore.test.ts
@@ -1,0 +1,72 @@
+import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test';
+import * as path from 'path';
+import * as os from 'os';
+
+async function launch(): Promise<{ app: ElectronApplication; win: Page }> {
+  const app = await electron.launch({
+    args: ['dist/main.js'],
+    env: { ...process.env, TEST_MODE: '1' },
+  });
+  const win = await app.firstWindow();
+  await win.setViewportSize({ width: 1600, height: 1000 });
+  await win.waitForTimeout(1500);
+  try {
+    await win.getByText("Don't show again", { exact: false }).click({ timeout: 800 });
+  } catch (e) { /* no dialog */ }
+  return { app, win };
+}
+
+test('restores in-progress edits to a SAVED query after relaunch', async () => {
+  const dbFile = path.join(os.tmpdir(), `bks-restore-${Date.now()}.db`);
+  const dbName = path.basename(dbFile);
+  const SAVED = 'select 1 as original_saved_text;';
+  const EDITED = 'select 999 as restored_after_relaunch;';
+
+  // ---------- First launch: connect, save a query, edit it, let it autosave ----------
+  let { app, win } = await launch();
+
+  await win.getByLabel('Connection Type').selectOption('sqlite');
+  await win.locator('#Database').fill(dbFile);
+  await win.getByRole('button', { name: 'Connect' }).click();
+
+  const editor = win.locator('#tab-0').getByRole('textbox');
+  await expect(editor).toBeVisible({ timeout: 30000 });
+  await editor.click();
+  await editor.fill(SAVED);
+
+  // Save as a favorite/saved query (Ctrl+S opens the save modal)
+  await win.keyboard.press('Control+s');
+  const titleInput = win.locator('input[name="title"]');
+  await expect(titleInput).toBeVisible({ timeout: 10000 });
+  await titleInput.fill('RestoreTestQuery');
+  await win.locator('form button[type="submit"].btn-primary').first().click();
+  await win.waitForTimeout(1500); // let the save settle
+
+  // Now edit the saved query and wait past the 1s autosave debounce
+  await editor.click();
+  await editor.fill(EDITED);
+  await expect(editor).toContainText('restored_after_relaunch');
+  await win.waitForTimeout(2500);
+
+  await app.close();
+
+  // ---------- Second launch: reconnect to the same DB, expect the edits restored ----------
+  ({ app, win } = await launch());
+
+  // Recent connections connect on double-click; the item shows the db file name
+  const recent = win.locator('.recent-connection-list').getByText(dbName, { exact: false }).first();
+  await expect(recent).toBeVisible({ timeout: 15000 });
+  await recent.dblclick();
+
+  const editor2 = win.locator('#tab-0').getByRole('textbox');
+  await expect(editor2).toBeVisible({ timeout: 30000 });
+
+  // The fix: the editor should show the EDITED text (restored from unsavedQueryText),
+  // not revert to the SAVED text.
+  await expect(editor2).toContainText('restored_after_relaunch', { timeout: 15000 });
+  await expect(editor2).not.toContainText('original_saved_text');
+
+  await win.screenshot({ path: 'e2e/savedQueryRestore.png', fullPage: false });
+
+  await app.close();
+});

--- a/apps/studio/src/common/transport/TransportOpenTab.ts
+++ b/apps/studio/src/common/transport/TransportOpenTab.ts
@@ -138,6 +138,30 @@ export function duplicate(obj: TransportOpenTab): TransportOpenTab {
   return result;
 }
 
+/**
+ * Decide what the query editor should show when a tab is (re)opened.
+ * - originalText: the saved baseline used for dirty-comparison / discard.
+ * - editorText:   what to load into the editor — the auto-saved in-progress
+ *                 edits when the tab was left dirty, otherwise the baseline.
+ *
+ * `savedText` is the text of the linked saved query (FavoriteQuery / cloud
+ * query), or null/undefined for a query that has never been saved.
+ */
+export function resolveEditorText(
+  obj: Pick<TransportOpenTab, 'unsavedChanges' | 'unsavedQueryText'>,
+  savedText?: string | null
+): { originalText: string | null; editorText: string | null } {
+  const baselineText = savedText || obj.unsavedQueryText || null
+  // When the tab was left dirty, the auto-saved edits live in unsavedQueryText.
+  // Restore those into the editor while keeping the saved text as the baseline,
+  // so the dirty indicator shows and discarding reverts to the saved version.
+  const editorText =
+    obj.unsavedChanges && obj.unsavedQueryText != null
+      ? obj.unsavedQueryText
+      : baselineText
+  return { originalText: baselineText, editorText }
+}
+
 export function findTable(obj: TransportOpenTab, tables: TableOrView[]): TableOrView | null {
   const result = tables.find((t) => {
     return obj.tableName === t.name &&

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -570,7 +570,7 @@
   import MergeManager from '@/components/editor/MergeManager.vue'
   import { AppEvent } from '@/common/AppEvent'
   import { PropType } from 'vue'
-  import { TransportOpenTab, findQuery } from '@/common/transport/TransportOpenTab'
+  import { TransportOpenTab, findQuery, resolveEditorText } from '@/common/transport/TransportOpenTab'
   import { blankFavoriteQuery } from '@/common/transport'
   import { FieldEditData, TableOrView } from "@/lib/db/models";
   import { FormatterDialect, dialectFor, formatOptionsFor } from "@shared/lib/dialects/models"
@@ -1696,20 +1696,17 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         }
       },
       initializeQueries() {
-        if (!this.tab.unsavedChanges && this.query?.text) {
-          this.unsavedText = null
-        }
-        const originalText = this.query?.text || this.tab.unsavedQueryText
-        if (originalText) {
+        const { originalText, editorText } = resolveEditorText(this.tab, this.query?.text)
+        if (editorText) {
           // The run methods should catch any errors, so we don't need to do that here
-          const { queries } = safelyIdentify(originalText, { dialect: this.identifierDialect, paramTypes: this.paramTypes })
+          const { queries } = safelyIdentify(editorText, { dialect: this.identifierDialect, paramTypes: this.paramTypes })
           if (queries.length > 0) {
             this.individualQueries = queries
             this.currentlySelectedQuery = queries[0]
           }
 
           this.originalText = originalText
-          this.unsavedText = originalText
+          this.unsavedText = editorText
         }
       },
       fakeRemoteChange() {

--- a/apps/studio/tests/unit/common/transport/TransportOpenTab.spec.ts
+++ b/apps/studio/tests/unit/common/transport/TransportOpenTab.spec.ts
@@ -1,4 +1,4 @@
-import { matches, TransportOpenTab } from '@/common/transport/TransportOpenTab'
+import { matches, resolveEditorText, TransportOpenTab } from '@/common/transport/TransportOpenTab'
 
 function buildTab(overrides: Partial<TransportOpenTab> = {}): TransportOpenTab {
   return {
@@ -83,5 +83,38 @@ describe('TransportOpenTab.matches', () => {
       const b = buildTab({ queryId: 5 })
       expect(matches(a, b)).toBe(true)
     })
+  })
+})
+
+describe('TransportOpenTab.resolveEditorText', () => {
+  it('restores the auto-saved edits for a new (never-saved) query', () => {
+    const tab = buildTab({ unsavedChanges: true, unsavedQueryText: 'select 1' })
+    const { originalText, editorText } = resolveEditorText(tab, undefined)
+    expect(editorText).toBe('select 1')
+    expect(originalText).toBe('select 1')
+  })
+
+  it('shows the saved text when a saved query has no unsaved changes', () => {
+    const tab = buildTab({ unsavedChanges: false, unsavedQueryText: 'select 1' })
+    const { originalText, editorText } = resolveEditorText(tab, 'select * from users')
+    expect(editorText).toBe('select * from users')
+    expect(originalText).toBe('select * from users')
+  })
+
+  // This is the bug from the user report: edits to an existing saved query were
+  // auto-saved to unsavedQueryText, but on reopen the editor loaded the saved
+  // text and discarded the in-progress edits.
+  it('restores in-progress edits for a saved query left dirty, keeping the saved baseline', () => {
+    const tab = buildTab({ unsavedChanges: true, unsavedQueryText: 'select * from users where id = 1' })
+    const { originalText, editorText } = resolveEditorText(tab, 'select * from users')
+    expect(editorText).toBe('select * from users where id = 1')
+    expect(originalText).toBe('select * from users')
+  })
+
+  it('returns nulls when there is nothing to show', () => {
+    const tab = buildTab({ unsavedChanges: false })
+    const { originalText, editorText } = resolveEditorText(tab, undefined)
+    expect(editorText).toBeNull()
+    expect(originalText).toBeNull()
   })
 })


### PR DESCRIPTION
- when restoring tabs we now restore the unsaved changes properly
- backed up with both an e2e test, and a unit test