### PR TITLE
Prompt user before deleting a connection, add "danger" variant to confirmation modal

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -489,6 +489,9 @@ export default Vue.extend({
       this.connectionError = null
     },
     async remove(config) {
+      if (!await this.$confirm(`Delete "${config.name}"?`, undefined, { variant: "danger" })) {
+        return
+      }
       if (this.config === config) {
         this.$util.send('appdb/saved/new').then((conn) => {
           this.config = conn;

--- a/apps/studio/src/components/common/modals/ConfirmationModal.vue
+++ b/apps/studio/src/components/common/modals/ConfirmationModal.vue
@@ -1,71 +1,56 @@
 <template>
-  <portal to="modals">
-    <modal
-      class="vue-dialog beekeeper-modal confirmation-modal"
-      :name="id"
-      @opened="opened"
-      @before-close="beforeClose"
-    >
-      <div v-kbd-trap="true">
-        <div class="dialog-content">
-          <div class="dialog-c-title">
-            <slot name="title">
-              Are you sure?
-            </slot>
-          </div>
-          <slot name="message">
-            <div>This action cannot be undone.</div>
-          </slot>
-        </div>
-        <div class="vue-dialog-buttons">
-          <button
-            class="btn btn-flat"
-            type="button"
-            ref="cancelBtn"
-            autofocus
-            @click.prevent="cancel"
-          >
-            <slot name="cancel-label">
-              Cancel
-            </slot>
-          </button>
-          <button
-            class="btn btn-primary"
-            type="button"
-            @click.prevent="confirm"
-          >
-            <slot name="confirm-label">
-              Confirm
-            </slot>
-          </button>
-        </div>
-      </div>
-    </modal>
-  </portal>
+  <base-modal :name="id" @submit="confirm">
+    <template #title>
+      <slot name="title">Are you sure?</slot>
+    </template>
+    <slot name="message">This action cannot be undone.</slot>
+    <template #footer>
+      <button class="btn btn-flat" type="button" @click.prevent="cancel">
+        <slot name="cancel-label">Cancel</slot>
+      </button>
+      <button class="btn btn-primary" type="submit" :data-variant="variant">
+        <slot name="confirm-label">Confirm</slot>
+      </button>
+    </template>
+  </base-modal>
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { MODAL_CLOSE_EVENT, ModalCloseEventData } from "@/components/common/modals/utils";
+import Vue, { PropType } from "vue";
+import {
+  MODAL_CLOSE_EVENT,
+  ModalCloseEventData,
+} from "@/components/common/modals/utils";
+import BaseModal from "@/components/common/modals/BaseModal.vue";
 
 export default Vue.extend({
-  props: ['id'],
+  components: { BaseModal },
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    variant: {
+      type: String as PropType<"normal" | "danger">,
+      default: "normal",
+    },
+  },
   methods: {
-    opened() {
-      this.$refs.cancelBtn.focus()
-    },
-    beforeClose(e: { params?: boolean }) {
-      const event: ModalCloseEventData = {
-        modalId: this.id,
-        confirmed: e.params ?? false,
-      };
-      this.trigger(MODAL_CLOSE_EVENT, event);
-    },
     confirm() {
-      this.$modal.hide(this.id, true);
+      this.trigger(MODAL_CLOSE_EVENT, {
+        modalId: this.id,
+        confirmed: true,
+      } as ModalCloseEventData);
+
+      this.$modal.hide(this.id);
     },
     cancel() {
-      this.$modal.hide(this.id, false);
+      this.trigger(MODAL_CLOSE_EVENT, {
+        modalId: this.id,
+        confirmed: false,
+      } as ModalCloseEventData);
+
+      this.$modal.hide(this.id);
     },
   },
   mounted() {
@@ -75,3 +60,10 @@ export default Vue.extend({
   },
 });
 </script>
+
+<style scoped>
+.btn[data-variant=danger] {
+  background-color: var(--brand-danger);
+  color: white;
+}
+</style>

--- a/apps/studio/src/components/common/modals/ConfirmationModalManager.vue
+++ b/apps/studio/src/components/common/modals/ConfirmationModalManager.vue
@@ -5,6 +5,7 @@
         v-if="!modal.noDisplay"
         :id="modal.id"
         :key="modal.id"
+        :variant="modal.variant"
       >
         <template #title v-if="modal.title">
           {{ modal.title }}
@@ -35,6 +36,7 @@ interface ModalOptions {
   message?: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  variant?: "normal" | "danger";
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -58,7 +60,7 @@ export default Vue.extend({
   components: { ConfirmationModal },
   data() {
     return {
-      modals: [],
+      modals: [] as ModalContext[],
       idCounter: 0,
     };
   },
@@ -93,13 +95,12 @@ export default Vue.extend({
     },
     async createModal(options: ModalOptions) {
       const modal: ModalContext = {
+        ...options,
         id: `${MODAL_NAME_PREFIX}-${this.idCounter++}`,
         title: options.title || DEFAULT_TITLE,
         message: options.message || DEFAULT_MESSAGE,
         cancelLabel: options.cancelLabel || DEFAULT_NO_LABEL,
         confirmLabel: options.confirmLabel || DEFAULT_YES_LABEL,
-        onConfirm: options.onConfirm,
-        onCancel: options.onCancel,
         noDisplay: false,
       }
       this.modals.push(modal);

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -369,7 +369,7 @@ export default {
       this.trigger('favoriteClick', item, { openHistory: true })
     },
     async remove(favorite) {
-      if (await this.$confirm("Really delete?")) {
+      if (await this.$confirm(`Delete "${favorite.name}"?`, undefined, { variant: "danger" })) {
         await this.$store.dispatch('data/queries/remove', favorite)
       }
     },


### PR DESCRIPTION
- User will be prompted before deleting a connection to avoid accidental deletion

- Introduce `variant: danger` for confirmation modal (the only difference is the color of the button lol):

```ts
const confirmed = await this.$confirm(`Delete ${connection.name}?`, "This cannot be undone", { variant: "danger" });
// OR
const confirmed = await this.$confirm(`Delete ${connection.name}?`, undefined, { variant: "danger" });
```

<img width="530" height="140" alt="image" src="https://github.com/user-attachments/assets/31e28886-97aa-4759-887d-1e80f0f654fb" />

- `ConfirmationModal.vue` is now based on`BaseModal.vue`