### PR TITLE
ci: upgrade GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/delete-draft-releases.yml
+++ b/.github/workflows/delete-draft-releases.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Delete all draft releases
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: releases } = await github.rest.repos.listReleases({

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13.7'  # or any specific version
         cache: 'pip' # caching pip dependencies

--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Python 3.11 (non-Mac)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
         if: runner.os != 'macOS'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-nm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -71,7 +71,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results-${{ matrix.os }}
           path: apps/studio/test-results

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
   prep:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-nm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
@@ -67,10 +67,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: test-results
           path: apps/studio/test-results

--- a/.github/workflows/rc-branch-prs.yml
+++ b/.github/workflows/rc-branch-prs.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sqlserver-kerberos-tests.yaml
+++ b/.github/workflows/sqlserver-kerberos-tests.yaml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run the dockerized Kerberos integration test
         run: bash dev/docker_sqlserver_kerberos/run.sh

--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v2
+        uses: samuelmeuli/action-snapcraft@v3
         if: "contains(matrix.os, 'ubuntu')"
 
       - name: Install python 3.11 (not Mac)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
         if: "!startsWith(matrix.os, 'macos')"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-nm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -128,7 +128,7 @@ jobs:
           USE_SYSTEM_FPM: true
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.os }}
           path: |
@@ -147,10 +147,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download DEB artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ubuntu-22.04
           path: ./deb-package

--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -18,7 +18,7 @@ jobs:
       id: ${{ steps.create_release.outputs.id }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Create draft release
         id: create_release
@@ -38,7 +38,7 @@ jobs:
       deb_codename: ${{steps.extract_channel.outputs.deb_codename}}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
       - name: Extract Channel from package.json
         id: extract_channel
         run: bash ./.github/scripts/extract_channel.sh
@@ -87,7 +87,7 @@ jobs:
         if: matrix.os.type == 'linux'
 
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Install flatpak tools
         if: matrix.os.setup_flatpak
@@ -140,7 +140,7 @@ jobs:
         env:
           OWNER: 'beekeeper-studio'
           REPO: 'beekeeper-studio'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs')
@@ -164,7 +164,7 @@ jobs:
 
 
       - name: "Install python 3.11 (NOT Mac)"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
         if: matrix.os.setup_python
@@ -224,7 +224,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-nm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -325,7 +325,7 @@ jobs:
 
       - name: Delete latest-mac.yml
         if: matrix.os.type == 'macos'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           RELEASE_ID: ${{needs.create_draft_release.outputs.id}}
         with:
@@ -350,7 +350,7 @@ jobs:
       - name: Set yaml files
         id: set_yaml
         if: matrix.os.type == 'macos'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           ARCH: ${{ matrix.os.arch }}
           CHANNEL: ${{needs.identify_channel.outputs.channel}}
@@ -360,7 +360,7 @@ jobs:
             const content = fs.readFileSync(`apps/studio/dist_electron/latest-mac.yml`, 'utf8')
             core.setOutput(`mac_${process.env.ARCH}_yml`, content)
       - name: Upload DEB/RPM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: matrix.os.type == 'linux'
         with:
           name: "${{matrix.os.type}}-${{matrix.os.arch}}"
@@ -385,7 +385,7 @@ jobs:
       - uses: actions/setup-node@v6
       - run: npm install js-yaml
       - name: Merge yml files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           INTEL_YML: ${{ needs.release.outputs.mac_x64_yml }}
           ARM_YML: ${{ needs.release.outputs.mac_arm64_yml }}
@@ -421,7 +421,7 @@ jobs:
             const merge = mergeFiles();
             fs.writeFileSync('mac.yml', merge, 'utf8');
       - name: Upload fixed mac yml
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           RELEASE_ID: ${{ needs.create_draft_release.outputs.id }}
         with:
@@ -463,7 +463,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -486,7 +486,7 @@ jobs:
       - run: "rm -rf ./artifacts; mkdir artifacts"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./artifacts
 

--- a/.github/workflows/studio-snap-test.yml
+++ b/.github/workflows/studio-snap-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup LXD
         uses: canonical/setup-lxd@main
@@ -36,7 +36,7 @@ jobs:
         uses: samuelmeuli/action-snapcraft@v3
 
       - name: Install python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
 
@@ -57,7 +57,7 @@ jobs:
           USE_SYSTEM_FPM: true
 
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: snap-${{ matrix.os }}
           path: apps/studio/dist_electron/*.snap

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -33,7 +33,7 @@ jobs:
           version: "1.7"
           force: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - id: set-test-chunks
         name: Set Chunks
@@ -46,7 +46,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-nm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -72,7 +72,7 @@ jobs:
     needs: [prep]
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6
@@ -132,7 +132,7 @@ jobs:
         chunk: ${{ fromJson(needs.prep.outputs['test-chunks']) }}
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6

--- a/.github/workflows/ui-kit-publish.yml
+++ b/.github/workflows/ui-kit-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Install Node.js, NPM and Yarn
         uses: actions/setup-node@v6

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 10
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Check if supported_databases.md changed
         id: check_changes
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const { execSync } = require('child_process');
@@ -42,7 +42,7 @@ jobs:
       - name: Update README files if necessary
         if: steps.check_changes.outputs.changed == 'true'
         id: update_readme
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/windows-login-tests.yaml
+++ b/.github/workflows/windows-login-tests.yaml
@@ -24,10 +24,10 @@ jobs:
         shell: pwsh
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: '.nvmrc'
 


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Bump all
official actions still running on Node 20 (or 16) to their Node 24
default majors:

- actions/checkout       v4/v1 -> v5
- actions/setup-node     v4    -> v6
- actions/cache          v4    -> v5  (matches existing cache/restore@v5)
- actions/setup-python   v5    -> v6
- actions/github-script  v6/v7 -> v8
- actions/upload-artifact v4   -> v6  (v5 still defaulted to Node 20)
- actions/download-artifact v4 -> v7  (v6 still defaulted to Node 20)
- samuelmeuli/action-snapcraft v2 -> v3

The github-script blocks don't redeclare getOctokit, so the only v8
breaking change does not apply here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RwZ7wqTJ5WRi5qxCfYKVqz