### PR TITLE
Add support for ssh include directive

### DIFF
--- a/apps/studio/src/lib/ssh/sshConfigReader.ts
+++ b/apps/studio/src/lib/ssh/sshConfigReader.ts
@@ -25,6 +25,50 @@ export interface SshConfigResult {
   warnings?: SshConfigWarning[];
 }
 
+type ReadConfigResult = {
+  content: string;
+  warning?: SshConfigWarning;
+};
+
+function readConfigFile(configPath: string): ReadConfigResult {
+  const trustIssue = configTrustIssue(configPath);
+
+  if (trustIssue) {
+    log.warn(`Ignoring ${configPath}: ${trustIssue}`);
+    return {
+      content: "",
+      warning: {
+        code: "untrusted",
+        message: `${tildify(configPath)} was ignored because ${trustIssue}.`,
+      },
+    };
+  }
+
+  try {
+    return {
+      content: fs.readFileSync(configPath, "utf8"),
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    log.warn(`Ignoring ${configPath}: ${message}`);
+    return {
+      content: "",
+      warning: {
+        code: "invalid",
+        message: `${tildify(configPath)} could not be read and was ignored.`,
+      },
+    };
+  }
+}
+
+// ssh(1) resolves a relative Include against the directory of the config that
+// declared it, not the working directory.
+function resolveIncludePattern(pattern: string, includeRoot: string): string {
+  const expanded = resolveHomePathToAbsolute(pattern);
+  return path.isAbsolute(expanded) ? expanded : path.join(includeRoot, expanded);
+}
+
 // Display ~/.ssh/config instead of the absolute path when it's under home.
 function tildify(p: string): string {
   const home = os.homedir();
@@ -57,30 +101,65 @@ function configTrustIssue(configPath: string): string | null {
 
 export function readSshConfig(
   host: string,
-  configPath?: string,
+  rootConfigPath?: string,
   user?: string
 ): SshConfigResult {
   const endResult: SshConfigResult = { host };
-  configPath = configPath ?? path.join(os.homedir(), ".ssh", "config");
-  if (!fs.existsSync(configPath)) {
+  const warnings: SshConfigWarning[] = [];
+
+  rootConfigPath = rootConfigPath ?? path.join(os.homedir(), ".ssh", "config");
+  if (!fs.existsSync(rootConfigPath)) {
     return endResult;
   }
 
-  const trustIssue = configTrustIssue(configPath);
-  if (trustIssue) {
-    log.warn(`Ignoring ${configPath}: ${trustIssue}`);
-    endResult.warnings = [
-      {
-        code: "untrusted",
-        message: `${tildify(configPath)} was ignored because ${trustIssue}.`,
-      },
-    ];
+  const rootConfig = readConfigFile(rootConfigPath);
+  if (rootConfig.warning) {
+    endResult.warnings = [rootConfig.warning];
     return endResult;
   }
+
+  const includeRoot = path.dirname(rootConfigPath);
+
+  // Expanded in place so ordering holds. Nested Includes are not expanded.
+  const includeRegex = /^Include[ \t]+(.+)$/gim;
+  const expandedConfig = rootConfig.content.replace(includeRegex, (_, rawPattern) => {
+    // The leading whitespace keeps a `#` inside a filename intact.
+    const pattern = rawPattern.replace(/\s+#.*$/, "").trim();
+    let combinedConfig = "";
+
+    // A bad include must not take down the rest of the config.
+    let matchedEntries: fs.Dirent[];
+    try {
+      matchedEntries = fs
+        .globSync(resolveIncludePattern(pattern, includeRoot), {
+          withFileTypes: true,
+        })
+        .filter((entry) => !entry.isDirectory());
+    } catch (err) {
+      log.warn(`Ignoring Include ${pattern}: ${err.message}`);
+      warnings.push({
+        code: "invalid",
+        message: `Include ${pattern} could not be expanded and was ignored.`,
+      });
+      return "";
+    }
+
+    for (const entry of matchedEntries) {
+      const filePath = path.join(entry.parentPath, entry.name);
+      const includedFile = readConfigFile(filePath);
+
+      if (includedFile.warning) {
+        warnings.push(includedFile.warning);
+      }
+
+      combinedConfig += includedFile.content + "\n";
+    }
+
+    return combinedConfig;
+  });
 
   try {
-    const raw = fs.readFileSync(configPath, "utf-8");
-    const config = SSHConfig.parse(raw);
+    const config = SSHConfig.parse(expandedConfig);
     // Pass the connection username so `Match user`/`Match localuser` rules are
     // evaluated against it. Without it, compute() falls back to the OS user and
     // those Match blocks never fire.
@@ -114,13 +193,15 @@ export function readSshConfig(
       endResult.user = result.user as string;
     }
   } catch (err) {
-    log.error("Failed to read or parse ~/.ssh/config:", err);
-    endResult.warnings = [
-      {
-        code: "invalid",
-        message: `${tildify(configPath)} could not be parsed and was ignored.`,
-      },
-    ];
+    log.error("Failed to parse ~/.ssh/config:", err);
+    warnings.push({
+      code: "invalid",
+      message: `${tildify(rootConfigPath)} could not be parsed and was ignored.`,
+    });
+  }
+
+  if (warnings.length) {
+    endResult.warnings = warnings;
   }
 
   return endResult;

--- a/apps/studio/tests/unit/lib/ssh/sshConfigReader.spec.ts
+++ b/apps/studio/tests/unit/lib/ssh/sshConfigReader.spec.ts
@@ -231,4 +231,80 @@ Host myserver
     const result = readSshConfig("myserver", configPath);
     expect(result.identityFile).toBe("/keys/ok");
   });
+
+  describe("Include Directive", () => {
+    // Include fixtures need sibling files, so they get a directory rather than
+    // the standalone tmp file writeConfig() creates.
+    function configDir() {
+      const dir = tmp.dirSync({ unsafeCleanup: true }).name;
+      fs.mkdirSync(path.join(dir, "conf.d"));
+
+      function write(relativePath: string, content: string): string {
+        const filePath = path.join(dir, relativePath);
+        fs.writeFileSync(filePath, content, "utf-8");
+        fs.chmodSync(filePath, 0o600);
+        return filePath;
+      }
+
+      return { dir, write };
+    }
+
+    it("resolves a host defined in an included file", () => {
+      const { write } = configDir();
+      const included = write(
+        "conf.d/work.conf",
+        `Host work
+  HostName work.example.com
+  Port 2222`
+      );
+      const configPath = write("config", `Include ${included}`);
+
+      const result = readSshConfig("work", configPath);
+      expect(result).toEqual({ host: "work.example.com", port: 2222 });
+    });
+
+    it("merges every file matched by an Include glob", () => {
+      const { dir, write } = configDir();
+      write("conf.d/a.conf", `Host alpha\n  HostName alpha.example.com`);
+      write("conf.d/b.conf", `Host beta\n  HostName beta.example.com`);
+      const configPath = write(
+        "config",
+        `Include ${path.join(dir, "conf.d", "*.conf")}`
+      );
+
+      expect(readSshConfig("alpha", configPath).host).toBe("alpha.example.com");
+      expect(readSshConfig("beta", configPath).host).toBe("beta.example.com");
+    });
+
+    // The fixture dir is never the cwd, so a cwd-relative lookup matches nothing.
+    it("resolves a relative Include against the config's own directory", () => {
+      const { write } = configDir();
+      write("conf.d/work.conf", `Host work\n  HostName work.example.com`);
+      const configPath = write("config", `Include conf.d/*.conf`);
+
+      expect(readSshConfig("work", configPath).host).toBe("work.example.com");
+    });
+
+    // An untrusted fragment can inject `Match exec` just as the root config can.
+    itPosix("ignores an untrusted included file but keeps the rest", () => {
+      const { dir, write } = configDir();
+      write("conf.d/good.conf", `Host good\n  HostName good.example.com`);
+      const bad = write(
+        "conf.d/bad.conf",
+        `Host bad\n  HostName bad.example.com`
+      );
+      fs.chmodSync(bad, 0o666);
+      const configPath = write(
+        "config",
+        `Include ${path.join(dir, "conf.d", "*.conf")}`
+      );
+
+      const result = readSshConfig("good", configPath);
+      expect(result.host).toBe("good.example.com");
+      expect(result.warnings).toEqual([
+        expect.objectContaining({ code: "untrusted" }),
+      ]);
+      expect(readSshConfig("bad", configPath).host).toBe("bad");
+    });
+  });
 });

--- a/docs/user_guide/connecting/connecting.md
+++ b/docs/user_guide/connecting/connecting.md
@@ -188,6 +188,19 @@ When you also enter a value in the form, the form value wins — `~/.ssh/config`
 
 `Match exec` runs an arbitrary command, exactly as `ssh` does. To avoid running commands from a config you don't control, Beekeeper mirrors OpenSSH's safeguard: your `~/.ssh/config` is only read when it is **owned by you (or root) and not writable by group or other users** (e.g. `chmod 600`). A config with looser permissions is ignored entirely and a warning is logged. This check is POSIX-only; on Windows the file is always read. Note that `Match exec` is evaluated through your system shell, so its availability depends on the platform.
 
+#### `Include`
+
+`Include` support is partial. Included files are read in place, and glob patterns work:
+
+```
+Include ~/.ssh/config.d/*.conf
+Include work/bastion.conf
+```
+
+Paths can be absolute, start with `~`, or be relative to the folder holding the config file. Included files must meet the same permission requirements as `~/.ssh/config`.
+
+Two limits: an `Include` must start at the beginning of a line, so an indented one inside a `Host` block is ignored, and an `Include` inside an already-included file is skipped.
+
 #### Supported and unsupported `ssh_config` features
 
 **Supported**
@@ -197,12 +210,13 @@ When you also enter a value in the form, the form value wins — `~/.ssh/config`
 - `IdentityFile` (one or more; Automatic mode), with missing files skipped
 - `IdentitiesOnly`
 - Glob patterns and negation (`!`) in `Host` / `Match host` patterns
+- `Include`, at the start of a line, including glob patterns
 
 **Not supported (ignored)**
 
 - `ProxyJump` / `ProxyCommand` — configure the bastion host explicitly in the connection form instead
 - `ForwardAgent`, `LocalForward`, `RemoteForward`, `DynamicForward`
-- `Include`d config files
+- Indented `Include` directives, and `Include`s inside an already-included file
 - Any other directive not listed under *Supported* above
 
 If you rely on `ProxyJump`, configure the bastion host explicitly in the connection form.


### PR DESCRIPTION
I rely on the Include directive to separate my ssh configs by groups of machines, this pr gives support for said directive. 

This is not a full implementation, but it should have the features that most people need. For example one thing not supported is an include directive within a host block:
```
# Supported:
Include ~/.ssh/conf.d/*.conf

# Not supported:
Host my-server
    HostName 192.168.1.50
    User dev
    Include ~/.ssh/extras/my-server-settings.conf`
```

There is a world where include directory resolving lives in: https://github.com/beekeeper-studio/ssh-config 
But that kind of moves away from the purpose of that library in its current state.