### PR TITLE
bump ai shell 3.2.0

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -42,7 +42,7 @@
     "@azure/msal-node": "^2.12.0",
     "@babel/core": "^7.29.6",
     "@babel/plugin-transform-class-static-block": "^7.26.0",
-    "@beekeeperstudio/bks-ai-shell": "^3.1.0",
+    "@beekeeperstudio/bks-ai-shell": "^3.2.0",
     "@beekeeperstudio/bks-er-diagram": "^1.1.0",
     "@beekeeperstudio/plugin": "^1.6.0",
     "@cleverbrush/async": "^1.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,10 +1962,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@beekeeperstudio/bks-ai-shell@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@beekeeperstudio/bks-ai-shell/-/bks-ai-shell-3.1.0.tgz#492ac7dda65cd22ba93b7143dfd05ea1acede777"
-  integrity sha512-6dWgXdr5PDerNs1UthaZG6UQLN2Dztst8SzWNqjRm9XRgph/5cqfg8Z2vk8SngdycUePBEuuBBhTVksGzBfUzg==
+"@beekeeperstudio/bks-ai-shell@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@beekeeperstudio/bks-ai-shell/-/bks-ai-shell-3.2.0.tgz#113bc6a234bbb948503e0a7efc8f82ee05ebfc10"
+  integrity sha512-eEs90zidE0z7/lyXqCQzCe5oOtfbVUtl9PCeu9UodcVRAiYgnYK0cdyP9qW2WU2z2PRM/PtJ+/OeqcbAgn6MeQ==
 
 "@beekeeperstudio/bks-er-diagram@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
AI Shell v3.2.0 - https://github.com/beekeeper-studio/bks-ai-shell/releases/tag/v3.2.0

## Models Update

### Added

* **Anthropic:** claude-fable-5, claude-sonnet-5, claude-opus-4-8, claude-opus-4-6
* **Z.AI (GLM):** glm-5.2
* **OpenAI:** gpt-5.5-pro, gpt-5.5, gpt-5.4-pro

### Removed (retired models)

* **Anthropic:** claude-opus-4-20250514, claude-sonnet-4-20250514
* **Google:** gemini-3.1-flash-lite-preview, gemini-2.0-flash, gemini-2.0-flash-lite
* **OpenAI:** gpt-4o

**Full Changelog**: https://github.com/beekeeper-studio/bks-ai-shell/compare/v3.1.0...v3.2.0