### PR TITLE
Decouple snap publishing from build matrix

### DIFF
--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -49,8 +49,6 @@ jobs:
     outputs:
       mac_x64_yml: ${{ steps.set_yaml.outputs.mac_x64_yml }}
       mac_arm64_yml: ${{ steps.set_yaml.outputs.mac_arm64_yml }}
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}
 
     strategy:
       fail-fast: false
@@ -359,7 +357,7 @@ jobs:
             const fs = require('fs')
             const content = fs.readFileSync(`apps/studio/dist_electron/latest-mac.yml`, 'utf8')
             core.setOutput(`mac_${process.env.ARCH}_yml`, content)
-      - name: Upload DEB/RPM artifacts
+      - name: Upload DEB/RPM/snap artifacts
         uses: actions/upload-artifact@v6
         if: matrix.os.type == 'linux'
         with:
@@ -367,6 +365,7 @@ jobs:
           path: |
             apps/studio/dist_electron/*.deb
             apps/studio/dist_electron/*.rpm
+            apps/studio/dist_electron/*.snap
 
       - name: Cleanup artifacts
         if: ${{!startsWith(matrix.os.name, 'windows')}}
@@ -443,17 +442,42 @@ jobs:
                 'content-type': 'application/octet-stream'
               }
             });
+  # Publishing the snap to the store is done here as a final step rather than
+  # inside the build. This decouples it from the slow build matrix so it can be
+  # retried on its own when store credentials are stale or snapcraft is having a
+  # bad day, without rebuilding every platform.
   publish_snapcraft:
-    # The release pushes to edge. We need to promote the edge release if we have a stable release
     needs: [release, identify_channel]
     runs-on: ubuntu-latest
-    if: needs.identify_channel.outputs.channel == 'latest'
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}
     steps:
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v3
+
+      - run: "rm -rf ./artifacts; mkdir artifacts"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: ./artifacts
+
+      # Every build pushes to edge; the stable channel is promoted separately
+      # below only for the latest channel.
+      - name: Upload snaps to edge
+        run: |
+          snaps=$(find ./artifacts -type f -name "*.snap")
+          if [ -z "$snaps" ]; then
+            echo "No .snap files found in artifacts" >&2
+            exit 1
+          fi
+          for snap in $snaps; do
+            echo "Uploading $snap to latest/edge"
+            snapcraft upload "$snap" --release latest/edge
+          done
+
       - name: Move release snap from edge to stable
+        if: needs.identify_channel.outputs.channel == 'latest'
         continue-on-error: true
         run: |
           snapcraft promote beekeeper-studio --from-channel "latest/edge" --to-channel "latest/stable" --yes

--- a/apps/studio/electron-builder-config.js
+++ b/apps/studio/electron-builder-config.js
@@ -221,9 +221,12 @@ module.exports = {
   },
   snapcraft: {
     base: 'core24',
+    // Only attach the built .snap to the GitHub release here. Pushing to the
+    // snap store is done as a separate final step (see publish_snapcraft in
+    // studio-publish.yml) so it can be retried without rebuilding when
+    // credentials are stale or the store is unavailable.
     publish: [
-      'github',
-      'snapStore'
+      'github'
     ],
     core24: {
       // Build the core24 snap in an isolated LXD container. CI provisions LXD


### PR DESCRIPTION
## Summary
Refactors the snap publishing workflow to be independent of the build matrix, allowing snap uploads to be retried without rebuilding all platforms when store credentials are stale or the snapcraft service is unavailable.

## Key Changes

- **Removed snap store publishing from build step**: Updated `electron-builder-config.js` to only publish snaps to GitHub releases, not directly to the snap store
- **Moved snap store upload to separate job**: Created a new `publish_snapcraft` workflow step that downloads built snap artifacts and uploads them to the snap store
- **Improved artifact handling**: 
  - Added `.snap` files to the artifact upload list in the build job
  - New job downloads all snap artifacts and uploads them to `latest/edge` channel
  - Promotion to `latest/stable` only occurs for the latest channel release
- **Removed environment variable from build job**: Moved `SNAPCRAFT_STORE_CREDENTIALS` from the build job to the dedicated `publish_snapcraft` job where it's actually needed
- **Added documentation**: Included comments explaining the rationale for decoupling snap publishing from the build process

## Implementation Details

The new workflow:
1. Build job creates snap artifacts and uploads them to GitHub releases
2. Separate `publish_snapcraft` job runs after the build completes
3. Downloads all snap artifacts from the build matrix
4. Uploads each snap to `latest/edge` channel
5. For latest channel releases, promotes from edge to stable

This approach allows the snap publishing step to be retried independently when transient issues occur with the snap store or credentials, without requiring a full rebuild of all platforms.

https://claude.ai/code/session_014em69tca3hiFRTMmM6Y5ML