### PR TITLE
fix exporting query from favourites

### DIFF
--- a/apps/studio/src/backend/lib/FileHelpers.ts
+++ b/apps/studio/src/backend/lib/FileHelpers.ts
@@ -13,7 +13,7 @@ export type SaveFileOptions = {
 
 /** Save a file after showing a dialog */
 async function save(options: SaveFileOptions) {
-  const encoding = options.encoding ?? "utf8";
+  const encoding: BufferEncoding = options.encoding as BufferEncoding ?? "utf8";
 
   const result = await dialog.showSaveDialog({
     defaultPath: options.fileName,
@@ -22,7 +22,7 @@ async function save(options: SaveFileOptions) {
 
   if (result.canceled) return false;
 
-  writeFileSync(result.filePath, options.content, encoding);
+  writeFileSync(result.filePath, options.content, { encoding });
 
   return true;
 }

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -972,10 +972,12 @@ export default Vue.extend({
       const notyQueue = 'export-query'
       this.$noty.info('Exporting query',  { queue: notyQueue })
 
+      const fullQuery = await this.$store.dispatch('data/queries/findOne', query.id);
+
       try {
         const saved = await window.main.fileHelpers.save({
           fileName: lastExportPath,
-          content: query.text,
+          content: fullQuery.text,
           filters: [
             { name: 'SQL (*.sql)', extensions: ['sql'] },
             { name: 'All Files (*.*)', extensions: ['*'] },


### PR DESCRIPTION
Our query system was modified to list slim versions of the query, so when right-clicking to export a query, the text would not be present on the object in the list view. So we load the full version of the query before exporting now.