### PR TITLE
Fix window clipping

### DIFF
--- a/apps/studio/src/assets/styles/app/core-interface.scss
+++ b/apps/studio/src/assets/styles/app/core-interface.scss
@@ -45,6 +45,10 @@
       flex: 1 1 auto;
       min-width: 350px;
     }
+    &.main-content {
+      flex: 1 1 0;
+      min-width: 0;
+    }
     z-index: 1;
     min-width: 10rem;
   }

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -370,6 +370,7 @@
 <style scoped>
 .split-container {
   display: flex;
-  width: 100%;
+  flex: 1 1 0;
+  min-width: 0;
 }
 </style>


### PR DESCRIPTION
Content on the right side of the window could sometimes be clipped if the json-viewer was hiddeng (specifically parts of the add tab and run button)

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0c38a76f-e607-490a-8a24-7521c4640328" />

After:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ee1a9208-e906-4a81-b64d-a30233dd8330" />


