### PR TITLE
CI: Remove temporary branch from SQL Server Kerberos tests

### DIFF
--- a/.github/workflows/sqlserver-kerberos-tests.yaml
+++ b/.github/workflows/sqlserver-kerberos-tests.yaml
@@ -11,18 +11,12 @@ permissions:
 # job needs nothing on the runner except Docker -- it runs the exact same command a developer
 # runs locally.
 on:
+  # Always run on master so the suite is exercised on every merge, regardless of
+  # which files changed. PRs are path-filtered below to avoid spending the heavy
+  # multi-container job on unrelated changes.
   push:
     branches:
       - master
-      # Temporary: run directly on the development branch to validate the suite in CI.
-      # Remove before/at merge -- PRs are already covered by the pull_request trigger below.
-      - claude/kerberos-sqlserver-ci-tests-ujxon1
-    paths:
-      - 'apps/studio/src/lib/db/clients/sqlserver.ts'
-      - 'apps/studio/src/lib/db/types.ts'
-      - 'apps/studio/tests/integration/lib/db/clients/sqlserver-kerberos.spec.ts'
-      - 'dev/docker_sqlserver_kerberos/**'
-      - '.github/workflows/sqlserver-kerberos-tests.yaml'
   pull_request:
     paths:
       - 'apps/studio/src/lib/db/clients/sqlserver.ts'


### PR DESCRIPTION
## Summary
Removes the temporary development branch from the SQL Server Kerberos CI workflow and simplifies the trigger configuration. The workflow now runs on every master push (without path filtering) to ensure the test suite is exercised on all merges, while PRs remain path-filtered to avoid unnecessary runs on unrelated changes.

## Changes
- Removed `claude/kerberos-sqlserver-ci-tests-ujxon1` from the push branches trigger (temporary development branch)
- Removed path filtering from the master push trigger to ensure the suite runs on every merge
- Kept path filtering on the pull_request trigger to avoid running on unrelated file changes
- Updated comments to clarify the rationale for the trigger configuration

## Details
The temporary development branch was used to validate the SQL Server Kerberos test suite in CI during development. Now that the feature is ready, the branch is no longer needed. The workflow will continue to run on all PRs that modify relevant files, while always running on master to ensure comprehensive test coverage on every merge.

https://claude.ai/code/session_011fnEY4R3LGe9N62LiBNaqC