### PR TITLE
Fix Sql Server Schema

### DIFF
--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -31,13 +31,12 @@ import {
   ExecutionContext,
   QueryLogOptions
 } from './BasicDatabaseClient'
-import { FilterOptions, OrderBy, TableFilter, ExtendedTableColumn, TableIndex, TableProperties, TableResult, StreamResults, Routine, TableOrView, NgQueryResult, DatabaseFilterOptions, TableChanges, ImportFuncOptions, DatabaseEntity, BksFieldType, BksField } from '../models';
+import { FilterOptions, OrderBy, TableFilter, ExtendedTableColumn, TableIndex, TableProperties, TableResult, StreamResults, Routine, TableOrView, NgQueryResult, DatabaseFilterOptions, TableChanges, ImportFuncOptions, DatabaseEntity, BksFieldType, BksField, IncludedFilterTypes } from '../models';
 import { AlterTableSpec, IndexAlterations, RelationAlterations } from '@shared/lib/dialects/models';
 import { AzureAuthService } from '../authentication/azure';
 import { IDbConnectionServer } from '../backendTypes';
 import { GenericBinaryTranscoder } from '../serialization/transcoders';
 import { IdentifyResult } from 'sql-query-identifier/lib/defines';
-import { safelyIdentify } from '../sql_tools';
 const log = logRaw.scope('sql-server')
 
 const D = SqlServerData
@@ -257,7 +256,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
   }
 
-  async selectTop(table: string, offset: number, limit: number, orderBy: OrderBy[], filters: string | TableFilter[], schema?: string, selects = ['*']): Promise<TableResult> {
+  async selectTop(table: string, offset: number, limit: number, orderBy: OrderBy[], filters: string | TableFilter[], schema: string = this._defaultSchema, selects = ['*']): Promise<TableResult> {
     this.logger().debug("filters", filters)
     const query = await this.selectTopSql(table, offset, limit, orderBy, filters, schema, selects)
     this.logger().debug(query)
@@ -275,7 +274,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     limit: number,
     orderBy: OrderBy[],
     filters: string | TableFilter[],
-    schema?: string,
+    schema: string = this._defaultSchema,
     selects?: string[]
   ) {
     return this.version.supportOffsetFetch
@@ -327,7 +326,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }))
   }
 
-  async getPrimaryKey(table: string, schema: string) {
+  async getPrimaryKey(table: string, schema: string = this._defaultSchema) {
     const res = await this.getPrimaryKeys(table, schema)
     return res.length === 1 ? res[0].columnName : null
   }
@@ -392,7 +391,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     const triggers = await this.listTableTriggers(table, schema)
     const indexes = await this.listTableIndexes(table, schema)
     const description = await this.getTableDescription(table, schema)
-    const qualified = `${D.wrapIdentifier(schema)}.${D.wrapIdentifier(table)}`;
+    const qualified = `${this.wrapIdentifier(schema)}.${this.wrapIdentifier(table)}`;
     const sizeQuery = `EXEC sp_spaceused N'${escapeString(qualified)}'; `
     const { data }  = await this.driverExecuteSingle(sizeQuery, { overrideReadonly: true })
     const row = data.recordset ? data.recordset[0] || {} : {}
@@ -407,7 +406,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
   }
 
-  async getOutgoingKeys(table: string, schema?: string) {
+  async getOutgoingKeys(table: string, schema: string = this._defaultSchema) {
     // Simplified approach to get foreign keys with ordinal position for proper ordering in composite keys
     const sql = `
       SELECT
@@ -493,7 +492,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     return result;
   }
 
-  async getIncomingKeys(table: string, schema?: string) {
+  async getIncomingKeys(table: string, schema: string = this._defaultSchema) {
     // Query for foreign keys TO this table (incoming - other tables referencing this table)
     const sql = `
       SELECT
@@ -606,13 +605,13 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       return ''
     }
 
-    elementName = this.wrapValue(`${D.wrapIdentifier(schema)}.${D.wrapIdentifier(elementName)}`)
+    elementName = this.wrapValue(`${this.wrapIdentifier(schema)}.${this.wrapIdentifier(elementName)}`)
     newElementName = this.wrapValue(newElementName)
 
     return `EXEC sp_rename ${elementName}, ${newElementName};`
   }
 
-  async dropElement (elementName: string, typeOfElement: DatabaseElement, schema = 'dbo') {
+  async dropElement (elementName: string, typeOfElement: DatabaseElement, schema: string = this._defaultSchema) {
     const sql = `DROP ${D.wrapLiteral(typeOfElement)} ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(elementName)}`
     await this.driverExecuteSingle(sql)
   }
@@ -695,9 +694,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     return runQuery(options.connection ? options.connection : this.pool.request());
   }
 
-  async truncateAllTables() {
-    const schema = await this.getSchema()
-
+  async truncateAllTables(schema: string = this._defaultSchema) {
     const sql = `
       SELECT table_name
       FROM INFORMATION_SCHEMA.TABLES
@@ -716,11 +713,11 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     await this.driverExecuteSingle(truncateAll);
   }
 
-  async truncateElementSql(elementName: string, typeOfElement: DatabaseElement, schema = 'dbo') {
+  async truncateElementSql(elementName: string, typeOfElement: DatabaseElement, schema: string = this._defaultSchema) {
     return `TRUNCATE ${D.wrapLiteral(typeOfElement)} ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(elementName)}`
   }
 
-  async duplicateTable(tableName: string, duplicateTableName: string, schema = 'dbo') {
+  async duplicateTable(tableName: string, duplicateTableName: string, schema: string = this._defaultSchema) {
     // duplicateTableSql produces a `SELECT ... INTO` statement. The query
     // identifier classifies that as a plain SELECT, so the read-only guard in
     // driverExecuteSingle never trips even though it creates a table. Enforce
@@ -734,7 +731,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     await this.driverExecuteSingle(sql)
   }
 
-  async duplicateTableSql(tableName: string, duplicateTableName: string, schema) {
+  async duplicateTableSql(tableName: string, duplicateTableName: string, schema: string = this._defaultSchema) {
     return `SELECT * INTO ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(duplicateTableName)} FROM ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(tableName)}`
   }
 
@@ -922,18 +919,18 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     }
   }
 
-  async getQuerySelectTop(table: string, limit: number): Promise<string> {
-    return `SELECT TOP ${limit} * FROM ${this.wrapIdentifier(table)}`;
+  async getQuerySelectTop(table: string, limit: number, schema: string = this._defaultSchema): Promise<string> {
+    return `SELECT TOP ${limit} * FROM ${this.wrapIdentifier(schema)}.${this.wrapIdentifier(table)}`;
   }
 
-  async getTableCreateScript(table: string): Promise<string> {
+  async getTableCreateScript(table: string, schema: string = this._defaultSchema): Promise<string> {
     // Reference http://stackoverflow.com/a/317864
     const sql = `
-      SELECT  ('CREATE TABLE ' + so.name + ' (' +
+      SELECT  ('CREATE TABLE ${this.wrapIdentifier(schema)}.' + so.name + ' (' +
         CHAR(13)+CHAR(10) + REPLACE(o.list, '&#x0D;', CHAR(13)) +
         ')' + CHAR(13)+CHAR(10) +
         CASE WHEN tc.constraint_name IS NULL THEN ''
-             ELSE + CHAR(13)+CHAR(10) + 'ALTER TABLE ' + so.Name +
+             ELSE + CHAR(13)+CHAR(10) + 'ALTER TABLE ${this.wrapIdentifier(schema)}.' + so.Name +
              ' ADD CONSTRAINT ' + tc.constraint_name  +
              ' PRIMARY KEY ' + '(' + LEFT(j.list, Len(j.list)-1) + ')'
         END) AS createtable
@@ -973,12 +970,15 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
                  THEN ' DEFAULT '+ INFORMATION_SCHEMA.COLUMNS.column_default
                  ELSE ''
             END + ',' + CHAR(13)+CHAR(10)
-         FROM INFORMATION_SCHEMA.COLUMNS WHERE table_name = so.name
+         FROM INFORMATION_SCHEMA.COLUMNS
+         WHERE table_name = so.name
+         AND table_schema = '${schema}'
          ORDER BY ordinal_position
          FOR XML PATH('')
       ) o (list)
       LEFT JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
       ON  tc.table_name       = so.name
+      AND tc.table_schema     = '${schema}'
       AND tc.constraint_type  = 'PRIMARY KEY'
       CROSS APPLY
           (SELECT column_name + ', '
@@ -989,7 +989,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
           ) j (list)
       WHERE   xtype = 'U'
       AND name    NOT IN ('dtproperties')
-      AND so.name = '${table}'
+      AND so.id = OBJECT_ID('${schema}.${table}')
     `
 
     const { data } = await this.driverExecuteSingle(sql)
@@ -997,8 +997,8 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     return data.recordset.map((row) => row.createtable)[0]
   }
 
-  async getViewCreateScript(view: string) {
-    const sql = `SELECT OBJECT_DEFINITION (OBJECT_ID('${view}')) AS ViewDefinition;`;
+  async getViewCreateScript(view: string, schema: string = this._defaultSchema) {
+    const sql = `SELECT OBJECT_DEFINITION (OBJECT_ID('${schema}.${view}')) AS ViewDefinition;`;
 
     const { data } = await this.driverExecuteSingle(sql);
 
@@ -1009,11 +1009,11 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     return []
   }
 
-  async getRoutineCreateScript(routine: string) {
+  async getRoutineCreateScript(routine: string, _type: string, schema: string = this._defaultSchema) {
     const sql = `
       SELECT definition
       FROM sys.sql_modules
-      WHERE OBJECT_NAME(object_id) = '${routine}'
+      WHERE object_id = OBJECT_ID('${schema}.${routine}')
     `
 
     const { data } = await this.driverExecuteSingle(sql)
@@ -1152,7 +1152,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       restore: false,
       indexNullsNotDistinct: false,
       transactions: true,
-      filterTypes: ['standard']
+      filterTypes: ['standard' as IncludedFilterTypes]
     }
   }
 
@@ -1584,13 +1584,6 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       select count(*) as total ${baseSQL}
     `
     return countQuery
-  }
-
-  private async getSchema() {
-    const sql = 'SELECT schema_name() AS \'schema\''
-    const { data } = await this.driverExecuteSingle(sql)
-
-    return (data.recordsets[0] as any).schema
   }
 
   private async listDefaultConstraints(table: string, schema: string = this._defaultSchema) {

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -376,6 +376,93 @@ function testWith(dockerTag: string, readonly: boolean) {
       })
     })
 
+    // Regression test -> create scripts clashed between objects with the same
+    // name in different schemas.
+    describe("Same-named objects across schemas", () => {
+      beforeAll(async () => {
+        await util.knex.schema.raw(`CREATE SCHEMA sales_clash`)
+        await util.knex.schema.raw(`CREATE SCHEMA hr_clash`)
+
+        await util.knex.schema.raw(
+          `CREATE TABLE sales_clash.records(id int, sale_amount int)`
+        )
+        await util.knex.schema.raw(
+          `CREATE TABLE hr_clash.records(id int, employee_name varchar(255))`
+        )
+
+        await util.knex.schema.raw(
+          `CREATE VIEW sales_clash.summary AS SELECT sale_amount FROM sales_clash.records`
+        )
+        await util.knex.schema.raw(
+          `CREATE VIEW hr_clash.summary AS SELECT employee_name FROM hr_clash.records`
+        )
+
+        await util.knex.schema.raw(
+          `CREATE PROCEDURE sales_clash.refresh_proc AS SELECT 'sales_clash_marker' AS marker`
+        )
+        await util.knex.schema.raw(
+          `CREATE PROCEDURE hr_clash.refresh_proc AS SELECT 'hr_clash_marker' AS marker`
+        )
+      })
+
+      afterAll(async () => {
+        try {
+          await util.knex.schema.raw(`DROP PROCEDURE sales_clash.refresh_proc`)
+          await util.knex.schema.raw(`DROP PROCEDURE hr_clash.refresh_proc`)
+          await util.knex.schema.raw(`DROP VIEW sales_clash.summary`)
+          await util.knex.schema.raw(`DROP VIEW hr_clash.summary`)
+          await util.knex.schema.raw(`DROP TABLE sales_clash.records`)
+          await util.knex.schema.raw(`DROP TABLE hr_clash.records`)
+          await util.knex.schema.raw(`DROP SCHEMA sales_clash`)
+          await util.knex.schema.raw(`DROP SCHEMA hr_clash`)
+        } catch (e) {
+          console.warn('Failed to clean up cross-schema clash objects:', e)
+        }
+      })
+
+      it("getTableCreateScript resolves the table in the requested schema", async () => {
+        const salesScript = await util.connection.getTableCreateScript('records', 'sales_clash')
+        expect(salesScript).toContain('sale_amount')
+        expect(salesScript).toContain('sales_clash')
+        expect(salesScript).not.toContain('employee_name')
+
+        const hrScript = await util.connection.getTableCreateScript('records', 'hr_clash')
+        expect(hrScript).toContain('employee_name')
+        expect(hrScript).toContain('hr_clash')
+        expect(hrScript).not.toContain('sale_amount')
+      })
+
+      it("getViewCreateScript resolves the view in the requested schema", async () => {
+        const salesDef = (await util.connection.getViewCreateScript('summary', 'sales_clash')).join('\n')
+        expect(salesDef).toContain('sale_amount')
+        expect(salesDef).not.toContain('employee_name')
+
+        const hrDef = (await util.connection.getViewCreateScript('summary', 'hr_clash')).join('\n')
+        expect(hrDef).toContain('employee_name')
+        expect(hrDef).not.toContain('sale_amount')
+      })
+
+      it("getRoutineCreateScript resolves the routine in the requested schema", async () => {
+        const salesDef = (await util.connection.getRoutineCreateScript('refresh_proc', 'PROCEDURE', 'sales_clash')).join('\n')
+        expect(salesDef).toContain('sales_clash_marker')
+        expect(salesDef).not.toContain('hr_clash_marker')
+
+        const hrDef = (await util.connection.getRoutineCreateScript('refresh_proc', 'PROCEDURE', 'hr_clash')).join('\n')
+        expect(hrDef).toContain('hr_clash_marker')
+        expect(hrDef).not.toContain('sales_clash_marker')
+      })
+
+      it("getQuerySelectTop qualifies the table with its schema", async () => {
+        const salesQuery = await util.connection.getQuerySelectTop('records', 10, 'sales_clash')
+        expect(salesQuery).toContain('sales_clash')
+        expect(salesQuery).toContain('records')
+
+        const hrQuery = await util.connection.getQuerySelectTop('records', 10, 'hr_clash')
+        expect(hrQuery).toContain('hr_clash')
+        expect(hrQuery).toContain('records')
+      })
+    })
+
     // Regression test for #2476 -> routine create script truncates large procedures
     it("Should be able to get routine create script", async () => {
       if (readonly) return;


### PR DESCRIPTION
Some functions were not taking schema into effect when generating scripts. Specifically `getTableCreateScript`, `getViewCreateScript` and `getRoutineCreateScript`. If the requested table was not on the `dbo` schema, then nothing was returned for some of these functions, if there were clashing names sometimes it mangled the script entirely, all around just bad. This ensures that we:
1. Actually take in and use a schema field if given
2. Default to our default schema (`dbo`) in the case that we don't get a schema for a method call. 