### PR TITLE
Fix parameter detection on initial query load

### DIFF
--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/querySelection.ts
@@ -43,31 +43,6 @@ interface QuerySelectionState {
 // Effects for updating the state
 const setDialectEffect = StateEffect.define<Options["dialect"]>();
 const setParamTypesEffect = StateEffect.define<Options["paramTypes"]>();
-// State for storing dialect
-const dialectState = StateField.define<Options["dialect"]>({
-  create: () => "generic",
-  update: (value, tr) => {
-    for (const effect of tr.effects) {
-      if (effect.is(setDialectEffect)) {
-        return effect.value || "generic";
-      }
-    }
-    return value;
-  }
-});
-
-const paramTypeState = StateField.define<Options["paramTypes"]>({
-  create: () => null,
-  update: (value, tr) => {
-    for (const effect of tr.effects) {
-      if (effect.is(setParamTypesEffect)) {
-        return effect.value
-      }
-    }
-    return value;
-  }
-})
-
 
 function getSelectedQueryPosition(
   queries: IdentifyResult[],
@@ -126,75 +101,104 @@ function splitQueries(
   return safelyIdentify(queryText, { dialect, paramTypes });
 }
 
-// State field that manages query selection
-const querySelectionState = StateField.define<QuerySelectionState>({
-  create: () => ({
-    queries: [],
-    selectedQueryIndex: -1,
-    selectedQueryPosition: null,
-    decorations: Decoration.none,
-    error: null,
-  }),
-
-  update: (state, tr) => {
-    const dialect = tr.state.field(dialectState);
-    const paramTypes = tr.state.field(paramTypeState);
-
-    // Get cursor positions
-    const cursor = tr.state.selection.main;
-    const cursorIndex = cursor.head;
-    const cursorIndexAnchor = cursor.anchor;
-
-    // Split queries
-    const { queries, error } = splitQueries(tr.state.doc.toString(), dialect, paramTypes);
-    const selectedQueryIndex = getSelectedQueryIndex(
-      queries,
-      cursorIndex,
-      cursorIndexAnchor
-    );
-    const selectedQueryPosition = getSelectedQueryPosition(
-      queries,
-      selectedQueryIndex
-    );
-
-    // Check if anything changed
-    if (
-      _.isEqual(queries, state.queries) &&
-      _.isEqual(selectedQueryIndex, state.selectedQueryIndex) &&
-      _.isEqual(selectedQueryPosition, state.selectedQueryPosition)
-    ) {
-      return state;
-    }
-
-    // Create decorations for highlighting
-    let decorations = Decoration.none;
-    if (queries && queries.length >= 2 && selectedQueryPosition) {
-      const mark = Decoration.mark({
-        class: "cm-query-highlight",
-      });
-      decorations = Decoration.set([
-        mark.range(selectedQueryPosition.from, selectedQueryPosition.to)
-      ]);
-    }
-
-    return {
-      queries,
-      selectedQueryIndex,
-      selectedQueryPosition,
-      decorations,
-      error,
-    };
-  },
-
-  provide: f => EditorView.decorations.from(f, state => state.decorations)
-});
-
 // Extension factory function
 export function querySelection(
   dialect?: Options["dialect"],
   paramTypes?: Options["paramTypes"],
   onQuerySelectionChange?: (params: QuerySelectionChangeParams) => void
 ): Extension {
+  // Seed the dialect/paramTypes state with the values supplied at construction so the
+  // very first identification uses them. Previously these defaulted to "generic"/null and
+  // were only corrected one transaction later (via the effects dispatched below), which meant
+  // the initial query split — and the onQuerySelectionChange callback it fires — ran without
+  // paramTypes, so parameters in a freshly loaded query went undetected until the next edit.
+  const dialectState = StateField.define<Options["dialect"]>({
+    create: () => dialect || "generic",
+    update: (value, tr) => {
+      for (const effect of tr.effects) {
+        if (effect.is(setDialectEffect)) {
+          return effect.value || "generic";
+        }
+      }
+      return value;
+    }
+  });
+
+  const paramTypeState = StateField.define<Options["paramTypes"]>({
+    create: () => paramTypes ?? null,
+    update: (value, tr) => {
+      for (const effect of tr.effects) {
+        if (effect.is(setParamTypesEffect)) {
+          return effect.value
+        }
+      }
+      return value;
+    }
+  });
+
+  // State field that manages query selection
+  const querySelectionState = StateField.define<QuerySelectionState>({
+    create: () => ({
+      queries: [],
+      selectedQueryIndex: -1,
+      selectedQueryPosition: null,
+      decorations: Decoration.none,
+      error: null,
+    }),
+
+    update: (state, tr) => {
+      const dialect = tr.state.field(dialectState);
+      const paramTypes = tr.state.field(paramTypeState);
+
+      // Get cursor positions
+      const cursor = tr.state.selection.main;
+      const cursorIndex = cursor.head;
+      const cursorIndexAnchor = cursor.anchor;
+
+      // Split queries
+      const { queries, error } = splitQueries(tr.state.doc.toString(), dialect, paramTypes);
+      const selectedQueryIndex = getSelectedQueryIndex(
+        queries,
+        cursorIndex,
+        cursorIndexAnchor
+      );
+      const selectedQueryPosition = getSelectedQueryPosition(
+        queries,
+        selectedQueryIndex
+      );
+
+      // Check if anything changed
+      if (
+        _.isEqual(queries, state.queries) &&
+        _.isEqual(selectedQueryIndex, state.selectedQueryIndex) &&
+        _.isEqual(selectedQueryPosition, state.selectedQueryPosition)
+      ) {
+        return state;
+      }
+
+      // Create decorations for highlighting
+      let decorations = Decoration.none;
+      if (queries && queries.length >= 2 && selectedQueryPosition) {
+        const mark = Decoration.mark({
+          class: "cm-query-highlight",
+        });
+        decorations = Decoration.set([
+          mark.range(selectedQueryPosition.from, selectedQueryPosition.to)
+        ]);
+      }
+
+      return {
+        queries,
+        selectedQueryIndex,
+        selectedQueryPosition,
+        decorations,
+        error,
+      };
+    },
+
+    provide: f => EditorView.decorations.from(f, state => state.decorations)
+  });
+
   return [
     dialectState,
     paramTypeState,

--- a/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
@@ -145,6 +145,33 @@ describe("querySelection", () => {
     editor.destroy();
   });
 
+  it("should detect numbered params on the first callback with a seeded dialect", () => {
+    const onQuerySelectionChange = vi.fn();
+    // Seed both a non-default dialect and numbered paramTypes at construction — the
+    // Postgres "$1" case, which is the most common real-world trigger for this bug.
+    // Exercises the dialect-seeded create() path alongside numbered param detection.
+    const editor = initializeEditor(
+      new SqlTextEditor({
+        onQuerySelectionChange,
+        identiferDialect: "psql",
+        paramTypes: { numbered: ["$"] },
+      }),
+      "SELECT * FROM users WHERE id = $1 AND org = $2"
+    );
+
+    editor.view.dispatch({
+      selection: EditorSelection.cursor(0),
+    });
+
+    expect(onQuerySelectionChange).toHaveBeenCalled();
+    const params = onQuerySelectionChange.mock.calls[0][0];
+    expect(params.selectedQuery.parameters).toEqual(
+      expect.arrayContaining(["$1", "$2"])
+    );
+
+    editor.destroy();
+  });
+
   it("should fall back to a single whole-text query and report the error when identify throws", () => {
     const onQuerySelectionChange = vi.fn();
     const editor = initializeEditor(

--- a/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
+++ b/apps/ui-kit/tests/unit/sql-text-editor/querySelection.spec.ts
@@ -122,6 +122,29 @@ describe("querySelection", () => {
     editor.destroy();
   });
 
+  it("should detect parameters on the first callback for a freshly loaded query", () => {
+    const onQuerySelectionChange = vi.fn();
+    // Editor loaded with an existing (saved) query containing a named param, and paramTypes
+    // supplied at construction — mirrors loading a saved query then running it without editing.
+    const editor = initializeEditor(
+      new SqlTextEditor({ onQuerySelectionChange, paramTypes: { named: [":"] } }),
+      "SELECT * FROM users WHERE id = :id"
+    );
+
+    // First interaction (e.g. clicking Run/moving the cursor) fires the callback. The params
+    // must already be identified here — previously paramTypes lagged one transaction behind,
+    // so this first callback reported no parameters until the query was edited.
+    editor.view.dispatch({
+      selection: EditorSelection.cursor(0),
+    });
+
+    expect(onQuerySelectionChange).toHaveBeenCalled();
+    const params = onQuerySelectionChange.mock.calls[0][0];
+    expect(params.selectedQuery.parameters).toContain(":id");
+
+    editor.destroy();
+  });
+
   it("should fall back to a single whole-text query and report the error when identify throws", () => {
     const onQuerySelectionChange = vi.fn();
     const editor = initializeEditor(


### PR DESCRIPTION
## Summary
Fixed a timing issue where SQL parameters were not detected on the first callback when loading a saved query with `paramTypes` supplied at construction. Previously, `paramTypes` defaulted to `null` and was only corrected one transaction later, causing the initial query split and `onQuerySelectionChange` callback to run without parameter type information.

## Changes
- Moved `dialectState` and `paramTypeState` field definitions inside the `querySelection()` extension factory function so they can be seeded with the values supplied at construction time
- Updated `dialectState.create()` to use the `dialect` parameter (defaulting to `"generic"`)
- Updated `paramTypeState.create()` to use the `paramTypes` parameter (defaulting to `null`)
- Added test case verifying that parameters are correctly detected in the first callback when a query is loaded with `paramTypes` supplied at construction

## Implementation Details
The state fields are now scoped to the extension factory function, allowing them to capture the construction-time parameters. This ensures the very first query identification uses the correct dialect and parameter types, rather than waiting for effects to be dispatched in a subsequent transaction. This is particularly important for the initial `onQuerySelectionChange` callback fired when the editor is first interacted with.

https://claude.ai/code/session_01GiGADkxQEx7E3dqEoAKfEj