### PR TITLE
ci: pin canonical/setup-lxd to a full commit SHA

### DIFF
--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -81,7 +81,7 @@ jobs:
       # core24 snaps always run a full `snapcraft pack --use-lxd` build, so every
       # Linux runner needs an initialised LXD (previously only arm64 required it).
       - name: setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
         if: matrix.os.type == 'linux'
 
       - name: Check out Git repository

--- a/.github/workflows/studio-snap-test.yml
+++ b/.github/workflows/studio-snap-test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: setup LXD
-        uses: canonical/setup-lxd@main
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v1
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v3


### PR DESCRIPTION
## What
Pin `canonical/setup-lxd` in `studio-publish.yml` and `studio-snap-test.yml` from the mutable `@main` branch to the v1 release commit.

## Why
In `studio-publish.yml` this runs early in the `release` job, which holds a large set of signing/publishing secrets (Apple, Windows codesign, GCP KMS, AWS, Cloudflare) and a write-scoped `GITHUB_TOKEN`. Because `@main` is a moving branch, the exact third-party code that prepares that environment can change without any change here — the tj-actions/changed-files class of risk. Pinning to a full SHA closes that; behaviour unchanged (I pinned the `v1` release commit; happy to use `@main`'s current SHA instead if you'd prefer to stay on latest).

I used AI assistance to identify this and draft the change; I verified the workflow and the credential exposure myself.