### PR TITLE
Add SQL: Select * to table context menus

### DIFF
--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1496,7 +1496,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
       })
     }
 
-    const selectSQL = `SELECT ${selects.join(', ')}`
+    const selectSQL = `SELECT ${selects.map(wrapIdentifier).join(', ')}`
     const baseSQL = `
       FROM ${wrapIdentifier(options.schema)}.${wrapIdentifier(options.table)}
       ${filterString}

--- a/apps/studio/src/mixins/TableListContextMenus.ts
+++ b/apps/studio/src/mixins/TableListContextMenus.ts
@@ -1,8 +1,13 @@
 import { AppEvent } from "@/common/AppEvent";
 import { IConnection } from "@/common/interfaces/IConnection";
+import { safeSqlFormat } from "@/common/utils";
+import { TableOrView } from "@/lib/db/models";
 import { DatabaseElement } from "@/lib/db/types";
 import { ContextOption } from "@/plugins/BeekeeperPlugin";
-import { DialectData } from "@shared/lib/dialects/models";
+import { dialectFor, DialectData, formatOptionsFor } from "@shared/lib/dialects/models";
+import rawLog from "@bksLogger";
+
+const log = rawLog.scope("TableListContextMenus");
 
 function disabled(...args: boolean[]) {
   return args.some((v) => v) ? 'disabled' : '';
@@ -104,6 +109,11 @@ export default {
 
         {
           type: 'divider'
+        },
+        {
+          name: "SQL: Select *",
+          slug: 'sql-select',
+          handler: this.openSelectQuery
         },
         {
           name: "SQL: Create",
@@ -213,6 +223,37 @@ export default {
     }
   },
   methods: {
+    async openSelectQuery({ item }: { item: TableOrView }) {
+      try {
+        const connection = this.$store.state.connection;
+        const columns = item.entityType === 'materialized-view'
+          ? await connection.listMaterializedViewColumns(item.name, item.schema)
+          : await connection.listTableColumns(item.name, item.schema);
+        const columnNames = columns.length
+          ? columns.map(({ columnName }) => columnName)
+          : ['*'];
+        const query = await connection.selectTopSql(
+          item.name,
+          0,
+          1000,
+          [],
+          [],
+          item.schema,
+          columnNames,
+        );
+        const configuredDialect = this.$store.getters.dialectData?.queryDialectOverride
+          ?? this.$store.getters.dialect;
+        const formatted = safeSqlFormat(
+          query,
+          formatOptionsFor(dialectFor(configuredDialect)),
+        );
+
+        this.$root.$emit(AppEvent.newTab, formatted);
+      } catch (error) {
+        log.error("Error opening query tab:", error);
+        this.$noty.error("Unable to open query tab. See dev console for details.");
+      }
+    },
     routineMenuClick({ item, option }) {
       switch (option.slug) {
         case 'copy-name':

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -74,6 +74,22 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(result).toBe(expected)
   })
 
+  it("Should quote explicit column names in select queries", () => {
+    const result = client.buildSelectTopQueries({
+      table: 'order',
+      schema: 'public',
+      selects: ['select', 'display name', 'quoted"column'],
+      filters: [],
+      orderBy: [],
+      limit: 1000,
+      offset: 0,
+    })
+
+    expect(result.query.replace(/\s+/g, ' ').trim()).toBe(
+      'SELECT "select", "display name", "quoted""column" FROM "public"."order" LIMIT 1000 OFFSET 0'
+    )
+  })
+
   it("Should generate correct alter table type change statement", async () => {
     const input = {
       table: 'foo',

--- a/apps/studio/tests/unit/mixins/TableListContextMenus.spec.ts
+++ b/apps/studio/tests/unit/mixins/TableListContextMenus.spec.ts
@@ -1,0 +1,112 @@
+import { AppEvent } from "@/common/AppEvent";
+import TableListContextMenus from "@/mixins/TableListContextMenus";
+
+const tableMenuOptions = TableListContextMenus.computed.tableMenuOptions as () => any[];
+const openSelectQuery = TableListContextMenus.methods.openSelectQuery as (
+  payload: { item: any },
+) => Promise<void>;
+
+function createContext(connectionOverrides = {}) {
+  const connection = {
+    listTableColumns: jest.fn().mockResolvedValue([
+      { columnName: "customer id", dataType: "integer" },
+      { columnName: "status", dataType: "text" },
+    ]),
+    listMaterializedViewColumns: jest.fn(),
+    selectTopSql: jest.fn().mockResolvedValue(
+      'SELECT "customer id", "status" FROM "sales"."orders" LIMIT 1000 OFFSET 0',
+    ),
+    ...connectionOverrides,
+  };
+  const context = {
+    $store: {
+      getters: {
+        dialect: "postgresql",
+        dialectData: { disabledFeatures: {} },
+      },
+      state: {
+        connection,
+        usedConfig: { readOnlyMode: false },
+      },
+    },
+    $root: { $emit: jest.fn() },
+    $noty: { error: jest.fn() },
+    openSelectQuery: jest.fn(),
+    trigger: jest.fn(),
+    $copyText: jest.fn(),
+  };
+
+  return { connection, context };
+}
+
+describe("TableListContextMenus", () => {
+  it("offers a SQL: Select * action for tables", () => {
+    const { context } = createContext();
+
+    const option = tableMenuOptions.call(context).find(({ slug }) => slug === "sql-select");
+    const item = { name: "orders", schema: "sales", entityType: "table" };
+
+    expect(option).toMatchObject({ name: "SQL: Select *", slug: "sql-select" });
+    option.handler({ item });
+    expect(context.openSelectQuery).toHaveBeenCalledWith({ item });
+  });
+
+  it("opens a formatted query tab with every column and a 1000-row limit", async () => {
+    const { connection, context } = createContext();
+    const item = { name: "orders", schema: "sales", entityType: "table" };
+
+    await openSelectQuery.call(context, { item });
+
+    expect(connection.listTableColumns).toHaveBeenCalledWith("orders", "sales");
+    expect(connection.selectTopSql).toHaveBeenCalledWith(
+      "orders",
+      0,
+      1000,
+      [],
+      [],
+      "sales",
+      ["customer id", "status"],
+    );
+    expect(context.$root.$emit).toHaveBeenCalledWith(
+      AppEvent.newTab,
+      expect.stringContaining('"customer id"'),
+    );
+  });
+
+  it("loads columns through the materialized-view API when needed", async () => {
+    const columns = [{ columnName: "total", dataType: "numeric" }];
+    const { connection, context } = createContext({
+      listMaterializedViewColumns: jest.fn().mockResolvedValue(columns),
+    });
+    const item = { name: "sales_totals", schema: "reports", entityType: "materialized-view" };
+
+    await openSelectQuery.call(context, { item });
+
+    expect(connection.listMaterializedViewColumns).toHaveBeenCalledWith("sales_totals", "reports");
+    expect(connection.listTableColumns).not.toHaveBeenCalled();
+    expect(connection.selectTopSql).toHaveBeenCalledWith(
+      "sales_totals",
+      0,
+      1000,
+      [],
+      [],
+      "reports",
+      ["total"],
+    );
+  });
+
+  it("shows an error instead of opening an empty tab when query generation fails", async () => {
+    const { context } = createContext({
+      listTableColumns: jest.fn().mockRejectedValue(new Error("column lookup failed")),
+    });
+
+    await openSelectQuery.call(context, {
+      item: { name: "orders", schema: "sales", entityType: "table" },
+    });
+
+    expect(context.$root.$emit).not.toHaveBeenCalled();
+    expect(context.$noty.error).toHaveBeenCalledWith(
+      "Unable to open query tab. See dev console for details.",
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- add a `SQL: Select *` action to the shared table sidebar context menu
- load every table, view, or materialized-view column and generate an editable column list
- cap the generated query at 1,000 rows and open it in a formatted SQL tab
- quote explicit PostgreSQL column identifiers, including reserved words and names with spaces or quotes

## Why

This makes quick table exploration available directly from the sidebar while following the accepted direction in #3095: the generated query names each column so users can remove unwanted fields easily.

## User impact

Right-clicking a table-like entity now creates a dialect-aware query without requiring users to type the table or column names manually. Existing read-only behavior is unchanged because this action only creates a query tab.

## Validation

- `yarn all:lint` (0 errors; 365 existing warnings)
- `yarn workspace beekeeper-studio test:unit --runInBand --no-watchman` (82 suites, 3,108 tests passed)
- `yarn workspace beekeeper-studio build`
- `yarn lib:build`
- `yarn run electron:build --linux AppImage` completed the UI/app build and Linux packaging preparation; final AppImage assembly could not execute the downloaded Linux helper on macOS arm64 (`spawn Unknown system error -86`)

## AI assistance

Codex assisted with implementation and tests. I reviewed the resulting diff and ran the validation above.

Fixes #3095
