### PR TITLE
Fix Ctrl+Z undoing multiple steps at once in the query editor

### DIFF
--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -22,8 +22,12 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
     undo: {
       id: 'undo',
       label: "Undo",
+      // Displayed only — the focused editor (CodeMirror, text inputs)
+      // handles the shortcut itself. Registering it would fire an extra
+      // webContents.undo() per keypress, undoing 2-3 steps at once.
       accelerator: "CommandOrControl+Z",
       click: actionHandler.undo,
+      registerAccelerator: false,
       role: 'undo',
     },
     redo: {
@@ -31,6 +35,7 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
       label: "Redo",
       accelerator: platformInfo.isWindows ? 'Ctrl+Y' : 'Shift+CommandOrControl+Z',
       click: actionHandler.redo,
+      registerAccelerator: false,
       role: 'redo',
     },
     cut: {

--- a/apps/studio/tests/unit/common/menus/menuItems.spec.ts
+++ b/apps/studio/tests/unit/common/menus/menuItems.spec.ts
@@ -1,0 +1,47 @@
+import { menuItems } from "@/common/menus/MenuItems";
+import { IMenuActionHandler } from "@/common/interfaces/IMenuActionHandler";
+import { IGroupedUserSettings } from "@/common/transport/TransportUserSetting";
+import { IPlatformInfo } from "@/common/IPlatformInfo";
+
+// menuItems only dereferences handler properties, so a permissive proxy is
+// enough to build the full template.
+const actionHandler = new Proxy({} as IMenuActionHandler, {
+  get: () => jest.fn(),
+});
+
+const settings = {} as IGroupedUserSettings;
+
+function buildItems(platform: Partial<IPlatformInfo>) {
+  return menuItems(actionHandler, settings, platform as IPlatformInfo);
+}
+
+describe("menuItems", () => {
+  // Regression test for #4491: the focused editor (CodeMirror, text inputs)
+  // already handles these shortcuts. If the accelerator is also registered,
+  // NewAppMenu binds it via v-hotkey and each keypress fires an extra
+  // webContents call, e.g. Ctrl+Z undoing 2-3 steps at once.
+  const editorScopedItems = ["undo", "redo", "cut", "copy", "paste"];
+
+  it.each(editorScopedItems)(
+    "does not register the accelerator for %s",
+    (id) => {
+      const items = buildItems({ isMac: false, isWindows: true });
+      expect(items[id].registerAccelerator).toBe(false);
+    }
+  );
+
+  it.each(editorScopedItems)(
+    "keeps the %s menu item clickable with a visible shortcut",
+    (id) => {
+      const items = buildItems({ isMac: false, isWindows: true });
+      expect(items[id].accelerator).toBeTruthy();
+      expect(typeof items[id].click).toBe("function");
+    }
+  );
+
+  it("keeps undo/redo bound to their native roles", () => {
+    const items = buildItems({ isMac: true });
+    expect(items.undo.role).toBe("undo");
+    expect(items.redo.role).toBe("redo");
+  });
+});


### PR DESCRIPTION
## Problem

Pressing Ctrl+Z (Cmd+Z) in the query editor undoes 2-3 history steps at once instead of one. Using Edit > Undo from the menu works correctly. Fixes #4491.

## Root cause

On Windows/Linux the app uses the custom in-window menu bar (`NewAppMenu.vue`), which registers every menu accelerator that has a `click` handler through `v-hotkey`. For undo/redo, one Ctrl+Z keypress therefore fires twice:

1. the menu hotkey -> `ClientMenuActionHandler.undo()` -> IPC -> `webContents.undo()`
2. CodeMirror's own Ctrl+Z keymap in the editor

`NewAppMenu.shortcut()` already skips items marked `registerAccelerator: false` - that's how `cut`/`copy`/`paste` avoid this exact double-execution - but `undo`/`redo` were missing the flag.

## Fix

Mark `undo` and `redo` as `registerAccelerator: false` in `MenuItems.ts`, matching the existing cut/copy/paste idiom. The accelerator is still displayed in the menu, Edit > Undo/Redo clicks still work via the `click` path, and the macOS native `role` behavior is unchanged. The shortcut itself is now handled solely by the focused editor.

## Testing

Added `tests/unit/common/menus/menuItems.spec.ts` asserting that all editor-scoped edit items (`undo`, `redo`, `cut`, `copy`, `paste`) are display-only and remain clickable with their roles intact. `yarn test:unit` passes locally apart from pre-existing environment-dependent suites (unbuilt ui-kit lib / DB-connection suites), which are unrelated to this change.