### PR TITLE
Surface the real cause when file imports fail

### DIFF
--- a/apps/studio/src-commercial/backend/lib/import/formats/json.ts
+++ b/apps/studio/src-commercial/backend/lib/import/formats/json.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import Import from '@/lib/import';
 import _ from 'lodash';
+import { flattenErrorMessage } from '@/common/utils';
 
 export default class extends Import {
 
@@ -42,7 +43,9 @@ export default class extends Import {
       return dataObj
     } catch (e) {
       this.logger().error('json file read error', e)
-      throw new Error(e)
+      // new Error(e) would stringify the error and drop the nested
+      // driver detail explaining why the import actually failed
+      throw new Error(flattenErrorMessage(e))
     }
   }
 

--- a/apps/studio/src-commercial/backend/lib/import/formats/jsonline.ts
+++ b/apps/studio/src-commercial/backend/lib/import/formats/jsonline.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import readline from 'readline'
 import _ from 'lodash'
 import JSONImporter from "./json"
+import { flattenErrorMessage } from '@/common/utils'
 
 export default class extends JSONImporter {
 
@@ -30,22 +31,18 @@ export default class extends JSONImporter {
       })
 
       for await (const line of rl) {
-        try {
-          const lineData = this.handleObjectParse(line)
-          if (lineData && finalPreviewLines.length <= 10) {
-            finalPreviewLines.push(lineData)
-          }
-          if (isPreview && finalPreviewLines.length === 10) {
-            break;
-          }
-          
-          if (!isPreview) {
-            const importData = this.buildDataObj([lineData])
-            const importSql = await this.connection.getImportSQL([importData], this.table.name, this.table.schema || null, updatedImportScriptOptions.storeValues.runAsUpsert)
-            await this.connection.importLineReadCommand(this.table, importSql, updatedImportScriptOptions)
-          }
-        } catch (err) {
-          throw new Error(err)
+        const lineData = this.handleObjectParse(line)
+        if (lineData && finalPreviewLines.length <= 10) {
+          finalPreviewLines.push(lineData)
+        }
+        if (isPreview && finalPreviewLines.length === 10) {
+          break;
+        }
+
+        if (!isPreview) {
+          const importData = this.buildDataObj([lineData])
+          const importSql = await this.connection.getImportSQL([importData], this.table.name, this.table.schema || null, updatedImportScriptOptions.storeValues.runAsUpsert)
+          await this.connection.importLineReadCommand(this.table, importSql, updatedImportScriptOptions)
         }
       }
 
@@ -73,8 +70,10 @@ export default class extends JSONImporter {
         data: finalPreviewLines
       }
     } catch (err) {
-      this.logger().error('error reading jsonline file')
-      throw new Error(err)
+      this.logger().error('error reading jsonline file', err)
+      // new Error(err) would stringify the error and drop the nested
+      // driver detail explaining why the import actually failed
+      throw new Error(flattenErrorMessage(err))
     } finally {
       finalPreviewLines = []
     }

--- a/apps/studio/src-commercial/backend/lib/import/formats/xlsx.ts
+++ b/apps/studio/src-commercial/backend/lib/import/formats/xlsx.ts
@@ -2,6 +2,7 @@ import XLSX from 'xlsx';
 import fs from 'fs';
 import Import from '@/lib/import';
 import _ from 'lodash';
+import { flattenErrorMessage } from '@/common/utils';
 
 export default class extends Import {
   constructor(filePath, options, connection, table) {
@@ -54,7 +55,9 @@ export default class extends Import {
       return dataObj
     } catch(e) {
       this.logger().error('xlsx file read error', e)
-      throw new Error(e)
+      // new Error(e) would stringify the error and drop the nested
+      // driver detail explaining why the import actually failed
+      throw new Error(flattenErrorMessage(e))
     }
   }
 

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -110,6 +110,31 @@ export function makeString(value: any): string {
   return _.toString(value);
 }
 
+// Flatten an error and any nested driver errors into a single message.
+// Drivers like mssql report the real failure (type mismatch, constraint
+// violation) via originalError / precedingErrors while the top-level
+// message is often just "Transaction has been aborted." — only the
+// message string survives the trip to the UI, so the detail has to be
+// folded in here.
+export function flattenErrorMessage(err: unknown): string {
+  const parts: string[] = []
+  const seen = new Set<unknown>()
+  const visit = (e: any) => {
+    if (!e || seen.has(e)) return
+    if (typeof e !== 'object') {
+      parts.push(String(e))
+      return
+    }
+    seen.add(e)
+    if (typeof e.message === 'string' && e.message) parts.push(e.message)
+    if (e.originalError) visit(e.originalError)
+    if (Array.isArray(e.precedingErrors)) e.precedingErrors.forEach(visit)
+    if (e.cause) visit(e.cause)
+  }
+  visit(err)
+  return _.uniq(parts).join('; ') || _.toString(err)
+}
+
 // Format SQL / SQL-like text using sql-formatter. Accepts both the classic
 // `{ language }` shape (built-in dialects like postgresql, mysql, trino) and
 // the v15 `{ dialect }` shape for custom dialect definitions (PartiQL). Falls

--- a/apps/studio/tests/unit/backend/lib/import/xlsx.spec.ts
+++ b/apps/studio/tests/unit/backend/lib/import/xlsx.spec.ts
@@ -1,0 +1,89 @@
+import XlsxImporter from '@commercial/backend/lib/import/formats/xlsx'
+import XLSX from 'xlsx'
+
+jest.mock('xlsx', () => ({
+  set_fs: jest.fn(),
+  readFile: jest.fn(),
+  utils: {
+    sheet_to_json: jest.fn(),
+  },
+}))
+
+const mockOptions = {
+  trimWhitespaces: false,
+  nullableValues: [],
+  importMap: [{ fileColumn: 'name', tableColumn: 'name' }],
+}
+
+function makeImporter(connection: any) {
+  const table = { name: 'test_table', schema: null } as any
+  const importer = new XlsxImporter('/fake/file.xlsx', mockOptions, connection, table)
+  importer.importScriptOptions = {
+    storeValues: { runAsUpsert: false },
+    executeOptions: { multiple: true },
+  }
+  return importer
+}
+
+function mockWorkbook() {
+  (XLSX.readFile as jest.Mock).mockReturnValue({
+    SheetNames: ['Sheet1'],
+    Sheets: { Sheet1: {} },
+  })
+  ;(XLSX.utils.sheet_to_json as jest.Mock).mockReturnValue([{ name: 'row1' }])
+}
+
+describe('XlsxImporter error handling (bug #4468)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockWorkbook()
+  })
+
+  it('surfaces nested driver error detail instead of the generic message', async () => {
+    // Shaped like an mssql RequestError: generic top-level message with
+    // the real cause in precedingErrors.
+    const driverError = new Error('Transaction has been aborted.') as any
+    driverError.precedingErrors = [
+      new Error("Conversion failed when converting date and/or time from character string."),
+    ]
+
+    const connection = {
+      getImportSQL: jest.fn().mockResolvedValue('INSERT INTO test_table ...'),
+      importLineReadCommand: jest.fn().mockRejectedValue(driverError),
+    }
+
+    const importer = makeImporter(connection)
+
+    await expect(
+      importer.read({ isPreview: false }, { connection: {} })
+    ).rejects.toThrow(
+      'Transaction has been aborted.; Conversion failed when converting date and/or time from character string.'
+    )
+  })
+
+  it('does not produce "[object Object]" for non-Error rejections', async () => {
+    const connection = {
+      getImportSQL: jest.fn().mockResolvedValue('INSERT INTO test_table ...'),
+      importLineReadCommand: jest.fn().mockRejectedValue({ message: 'driver blew up' }),
+    }
+
+    const importer = makeImporter(connection)
+
+    const err = await importer.read({ isPreview: false }, { connection: {} }).catch(e => e)
+    expect(err.message).toBe('driver blew up')
+    expect(err.message).not.toContain('[object Object]')
+  })
+
+  it('still returns parsed data when the import succeeds', async () => {
+    const connection = {
+      getImportSQL: jest.fn().mockResolvedValue('INSERT INTO test_table ...'),
+      importLineReadCommand: jest.fn().mockResolvedValue(undefined),
+    }
+
+    const importer = makeImporter(connection)
+    const result = await importer.read({ isPreview: false }, { connection: {} })
+
+    expect(result.data).toEqual([{ name: 'row1' }])
+    expect(connection.importLineReadCommand).toHaveBeenCalled()
+  })
+})

--- a/apps/studio/tests/unit/common/utils.spec.js
+++ b/apps/studio/tests/unit/common/utils.spec.js
@@ -1,4 +1,4 @@
-import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType } from "@/common/utils"
+import { flattenErrorMessage, checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType } from "@/common/utils"
 import { PostgresData } from '@/shared/lib/dialects/postgresql'
 import { MysqlData } from '@/shared/lib/dialects/mysql'
 import { SqliteData } from '@/shared/lib/dialects/sqlite'
@@ -224,5 +224,45 @@ describe("isDateDataType", () => {
     expect(isDateDataType('int2(16,0)')).toBe(false)
     expect(isDateDataType('varchar(255)')).toBe(false)
     expect(isDateDataType('text')).toBe(false)
+  })
+})
+describe("flattenErrorMessage", () => {
+  it("returns the message of a plain error", () => {
+    expect(flattenErrorMessage(new Error("boom"))).toBe("boom")
+  })
+
+  it("includes nested originalError and precedingErrors messages", () => {
+    const err = new Error("Transaction has been aborted.")
+    err.precedingErrors = [new Error("Column 'created_at' cannot convert varchar to datetime")]
+    err.originalError = new Error("Request failed")
+    expect(flattenErrorMessage(err)).toBe(
+      "Transaction has been aborted.; Request failed; Column 'created_at' cannot convert varchar to datetime"
+    )
+  })
+
+  it("de-duplicates repeated messages", () => {
+    const err = new Error("same message")
+    err.originalError = new Error("same message")
+    expect(flattenErrorMessage(err)).toBe("same message")
+  })
+
+  it("handles strings and objects without a message", () => {
+    expect(flattenErrorMessage("plain string")).toBe("plain string")
+    expect(flattenErrorMessage({ code: 42 })).toBe("[object Object]")
+    expect(flattenErrorMessage(null)).toBe("")
+  })
+
+  it("survives circular error chains", () => {
+    const a = new Error("a")
+    const b = new Error("b")
+    a.originalError = b
+    b.originalError = a
+    expect(flattenErrorMessage(a)).toBe("a; b")
+  })
+
+  it("follows the standard cause property", () => {
+    const err = new Error("outer")
+    err.cause = new Error("inner cause")
+    expect(flattenErrorMessage(err)).toBe("outer; inner cause")
   })
 })


### PR DESCRIPTION
## Problem

When an XLSX (or JSON/JSONL) import fails, the UI only shows the generic top-level message - e.g. 'Transaction has been aborted.' for SQL Server - with no indication of the actual cause (type mismatch, constraint violation, ...). Users have to open Developer Tools to diagnose anything. Fixes #4468.

## Root cause

The xlsx/json/jsonline format handlers wrapped caught errors with `new Error(e)`, which stringifies the error object. Drivers like mssql report the real failure via `originalError`/`precedingErrors` on the error object, and all of that structure was discarded. Since only the message string survives the trip from the utility process to the renderer (`TabImportTable.vue` shows `err.message`), the detail was unrecoverable by the time it reached the user.

## Fix

- Add `flattenErrorMessage()` to `src/common/utils.ts`: walks `message`, `originalError`, `precedingErrors`, and the standard `cause`, de-duplicates, and joins into a single message (cycle-safe). For plain errors the behavior is unchanged - the message passes through as-is.
- Use it in the xlsx, json, and jsonline handlers instead of `new Error(e)`, so the thrown message reads e.g. `Transaction has been aborted.; Conversion failed when converting date and/or time from character string.`
- Remove a redundant inner try/catch in jsonline that double-wrapped errors (flagged by `no-useless-catch`).

The CSV handler already collects readable messages per chunk (see `csv.spec.ts`), so it's untouched.

## Testing

- New `tests/unit/backend/lib/import/xlsx.spec.ts` (modeled on the existing `csv.spec.ts`): asserts nested driver detail is surfaced, no `[object Object]` for non-Error rejections, and the success path is unaffected.
- New `flattenErrorMessage` cases in `tests/unit/common/utils.spec.js`: nesting, de-duplication, circular chains, `cause`, and non-object inputs.

All 90 tests across the touched suites pass; ESLint clean.