### PR TITLE
ui: change table edit trigger from double to single click

### DIFF
--- a/apps/studio/default.config.ini
+++ b/apps/studio/default.config.ini
@@ -53,6 +53,8 @@ maxColumnWidth = 1000
 minColumnWidth = 100
 maxInitialWidth = 500
 defaultColumnWidth = 125
+; The event that triggers cell edit mode ("click" or "doubleclick")
+editTrigger = doubleclick
 
 [ui.tableTriggers]
 maxColumnWidth = 300

--- a/apps/studio/src/common/tabulator.ts
+++ b/apps/studio/src/common/tabulator.ts
@@ -63,7 +63,9 @@ export function tabulatorForTableData(
     resizableColumnGuide: true,
     movableColumns: true,
     height: "100%",
-    editTriggerEvent: "dblclick",
+    editTriggerEvent: window.bksConfig.ui.tableTable.editTrigger === "click" 
+      ? "click" 
+      : "dblclick",
     debugInvalidComponentFuncs: false,
     history: true,
     keybindings: {

--- a/apps/studio/src/typings/bksConfig.d.ts
+++ b/apps/studio/src/typings/bksConfig.d.ts
@@ -491,6 +491,7 @@ declare interface IBksConfig {
         };
         tableTable: {
             defaultColumnWidth: number;
+            editTrigger: string;
             largeFieldWidth: number;
             maxColumnWidth: number;
             maxInitialWidth: number;


### PR DESCRIPTION
Users had to double click every cell to enter edit mode. Editing a long row required too many clicks and felt very slow. The double click requirement adds unnecessary friction to simple data entry tasks.
BEFORE:

https://github.com/user-attachments/assets/18b984ad-89f5-4694-b13c-134bf8deb7d0

AFTER:

https://github.com/user-attachments/assets/8b166964-8fe5-4216-948b-37a18744a1a6

We reduce 50% of friction by doing this little improvement.

We change the global tabulator configuration to trigger edit mode on a single click. This cuts the required clicks in half. Data entry is now fast and intuitive.

This improves overall user experience significantly.