### PR TITLE
fix: show grab/grabbing cursor on table column reorder handle

### DIFF
--- a/apps/studio/src/assets/styles/app/vendor/tabulator.scss
+++ b/apps/studio/src/assets/styles/app/vendor/tabulator.scss
@@ -494,6 +494,16 @@ $columnResizeGuideColor:      color.mix($query-editor-bg, $theme-base, 80%);
         color: $text-dark;
       }
 
+      // Column headers are the reorder drag handle (movableColumns is enabled),
+      // so show a grab cursor on hover and a grabbing cursor while a column is
+      // being dragged. See issue #3165.
+      &:hover {
+        cursor: grab;
+      }
+      &.tabulator-moving {
+        cursor: grabbing;
+      }
+
       &:first-of-type .tabulator-col-content {
         padding-left: $gutter-w * 1.5;
       }


### PR DESCRIPTION
Closes #3165

## What

Table column headers are the reorder drag handle (`movableColumns: true` is set in the Tabulator config in `apps/studio/src/common/tabulator.ts`), but hovering a column header showed the default cursor, giving no indication that columns can be dragged to reorder. This adds the expected `grab`/`grabbing` cursor feedback.

## Changes

In `apps/studio/src/assets/styles/app/vendor/tabulator.scss`, within the `.tabulator-col` block:

- `.tabulator-col:hover { cursor: grab; }` — indicates the header is draggable on hover
- `.tabulator-col.tabulator-moving { cursor: grabbing; }` — `tabulator-moving` is the class Tabulator applies to a column while it is being dragged

CSS-only change, no logic touched.

## Notes

- This targets the **table column** reorder handle (the TableTableView result grid), which is what #3165 describes. The pinned-table/entity-list drag handle was already addressed in #4045 (a maintainer noted in that PR that #3165 refers to the table columns, so the issue stayed open).
- The existing `cursor: pointer` rules in this file apply to cells and the fk-link, not column headers, so there is no conflict.
- Labeled `good-for-ai` and `accepted` on the issue.