### PR TITLE
fix: show loading spinner and detailed error on Test connection

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -213,7 +213,8 @@
                       type="button"
                       @click.prevent="testConnection"
                     >
-                      Test
+                      <loading-spinner v-if="testing" :size="12" />
+                      <template v-else>Test</template>
                     </button>
                     <button
                       :disabled="testing || connecting"
@@ -321,6 +322,7 @@ import { AppEvent } from '@/common/AppEvent'
 import { isUltimateType } from '@/common/interfaces/IConnection'
 import { SmartLocalStorage } from '@/common/LocalStorage'
 import ContentPlaceholderHeading from '@/components/common/loading/ContentPlaceholderHeading.vue'
+import LoadingSpinner from '@/components/common/loading/LoadingSpinner.vue'
 import { FriendlyErrorHelper } from '@/frontend/utils/FriendlyErrorHelper'
 import PrivacyBanner from './PrivacyBanner.vue'
 
@@ -328,7 +330,7 @@ const log = rawLog.scope('ConnectionInterface')
 // import ImportUrlForm from './connection/ImportUrlForm';
 
 export default Vue.extend({
-  components: { ConnectionSidebar, MysqlForm, BedrockForm, PostgresForm, RedshiftForm, CassandraForm, Sidebar, SqliteForm, SqlServerForm, SaveConnectionForm, ImportButton, ErrorAlert, OracleForm, BigQueryForm, FirebirdForm, UpgradePanel, LibSqlForm: LibSQLForm, LoadingSsoModal: LoadingSSOModal, ClickHouseForm, TrinoForm, MongoDbForm, DuckDbForm, SqlAnywhereForm, RedisForm, DynamoDbForm, ContentPlaceholderHeading, SurrealDbForm, PrivacyBanner, SnowflakeForm
+  components: { ConnectionSidebar, MysqlForm, BedrockForm, PostgresForm, RedshiftForm, CassandraForm, Sidebar, SqliteForm, SqlServerForm, SaveConnectionForm, ImportButton, ErrorAlert, OracleForm, BigQueryForm, FirebirdForm, UpgradePanel, LibSqlForm: LibSQLForm, LoadingSsoModal: LoadingSSOModal, ClickHouseForm, TrinoForm, MongoDbForm, DuckDbForm, SqlAnywhereForm, RedisForm, DynamoDbForm, ContentPlaceholderHeading, SurrealDbForm, PrivacyBanner, SnowflakeForm, LoadingSpinner
   },
 
   data() {
@@ -607,7 +609,7 @@ export default Vue.extend({
         return true
       } catch (ex) {
         this.connectionError = ex
-        this.$noty.error("Error establishing a connection")
+        this.$noty.error(`Error establishing a connection: ${ex?.message ?? ex}`)
       } finally {
         this.testing = false
         this.afterConnect()


### PR DESCRIPTION
Closes #4456

## What

When clicking the **Test** button on the connection screen and the connection times out or fails, the UI showed no loading indicator and the toast notification used a generic "Error establishing a connection" message without the actual error detail.

## Changes

In `apps/studio/src/components/ConnectionInterface.vue`:

- **Loading spinner on the Test button**: added the existing `LoadingSpinner` component (already used in `LoadingSSOModal.vue`), shown via `v-if="testing"`. Gives immediate feedback that a test is in progress, even when the connection takes a long time to time out.
- **Detailed error in the toast**: changed the `testConnection()` catch block to include the actual error message (`Error establishing a connection: <error>`) instead of the generic hardcoded string. The `ErrorAlert` below the button already shows the full error; the toast is now useful too.

The Connect path is unchanged.

## Testing

1. Configure a connection that will time out (wrong host / SSL mismatch)
2. Click Test
3. Spinner appears on the Test button while testing
4. On failure, the toast includes the actual error (e.g. `Error establishing a connection: connect ETIMEDOUT 10.0.0.1:3306`)
5. The ErrorAlert below the button still shows the full error with helpful links