### PR TITLE
Add settings toggle to disable SQL autocomplete as workaround for #4492

### DIFF
--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -72,6 +72,7 @@
         :columns-getter="columnsGetter"
         :default-schema="defaultSchema"
         :language-id="languageIdForDialect"
+        :disable-autocomplete="disableSqlAutocomplete"
         :clipboard="$native.clipboard"
         :replace-extensions="replaceExtensions"
         :context-menu-items="editorContextMenu"
@@ -718,6 +719,9 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       },
       editorComponent() {
         return this.connectionType === 'surrealdb' ? SurrealTextEditor : SqlTextEditor;
+      },
+      disableSqlAutocomplete() {
+        return this.settings?.disableSqlAutocomplete?.value ?? false;
       },
       enabled() {
         return !this.dialectData?.disabledFeatures?.queryEditor;

--- a/apps/studio/src/components/editor/QueryEditorStatusBar.vue
+++ b/apps/studio/src/components/editor/QueryEditorStatusBar.vue
@@ -223,6 +223,15 @@
             Wrap Text
           </x-label>
         </x-menuitem>
+        <x-menuitem
+          togglable
+          :toggled="disableSqlAutocomplete"
+          @click.prevent="toggleDisableSqlAutocomplete"
+        >
+          <x-label class="flex-between">
+            Disable SQL Autocomplete
+          </x-label>
+        </x-menuitem>
       </x-menu>
     </x-button>
   </statusbar>
@@ -307,6 +316,9 @@ export default {
         this.$store.dispatch('settings/save', { key: 'hideResultsDropdown', value })
       }
     },
+    disableSqlAutocomplete() {
+      return this.settings?.disableSqlAutocomplete?.value ?? false
+    },
     rowCount() {
       return this.result && this.result.rows ? this.result.rows.length : 0
     },
@@ -363,6 +375,9 @@ export default {
     }
   },
   methods: {
+    toggleDisableSqlAutocomplete() {
+      this.$store.dispatch('settings/save', { key: 'disableSqlAutocomplete', value: !this.disableSqlAutocomplete })
+    },
     changeSelectedResult(direction) {
       const newIndex =  this.selectedResult + direction;
       if (newIndex >= 0 && newIndex < this.results?.length) {

--- a/apps/studio/src/migration/20260714_add_disable_sql_autocomplete_setting.js
+++ b/apps/studio/src/migration/20260714_add_disable_sql_autocomplete_setting.js
@@ -1,0 +1,7 @@
+export default {
+  name: "20260714_add_disable_sql_autocomplete_setting",
+  async run(runner) {
+    const query = `INSERT OR IGNORE INTO user_setting (key, defaultValue, userValue, valueType) VALUES ('disableSqlAutocomplete', 'false', 'false', 5)`;
+    await runner.query(query);
+  }
+}

--- a/apps/studio/src/migration/index.js
+++ b/apps/studio/src/migration/index.js
@@ -94,6 +94,7 @@ import clearLogFiles from './20260527_clear_log_files'
 import addSnowflakeOptions from './20260501_add_snowflake_options'
 import addWindowsAuthToConnections from './20260618_add_windows_auth_to_connections'
 import addSqlServerOptions from './20260626_add_sqlserver_options'
+import addDisableSqlAutocompleteSetting from './20260714_add_disable_sql_autocomplete_setting'
 
 import ultimate from './ultimate/index'
 
@@ -148,7 +149,8 @@ const realMigrations = [
   clearLogFiles,
   addSnowflakeOptions,
   addWindowsAuthToConnections,
-  addSqlServerOptions
+  addSqlServerOptions,
+  addDisableSqlAutocompleteSetting
 ]
 
 // fixtures require the models

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
@@ -52,6 +52,8 @@ export default Vue.extend({
       return new SqlTextEditor({
         identiferDialect: this.identifierDialect,
         paramTypes: this.paramTypes,
+        disableSchemaCompletion: this.disableAutocomplete,
+        disableKeywordCompletion: this.disableAutocomplete,
         onQuerySelectionChange: (params) => {
           this.selectedQuery = params.selectedQuery.text;
           this.$emit("bks-query-selection-change", params)

--- a/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/sql.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/extensions/vendor/@codemirror/lang-sql/src/sql.ts
@@ -26,13 +26,22 @@ function schemaCompletion(config: SQLConfig): Extension {
 /// SQL language support for the given SQL dialect, with keyword
 /// completion, and, if provided, schema-based completion as extra
 /// extensions.
+///
+/// The `disableSchemaCompletion` and `disableKeywordCompletion` flags (custom
+/// extensions to SQLConfig) allow callers to turn off either completion source
+/// entirely. This is useful as a workaround for performance issues on very
+/// large schemas (see beekeeper-studio issue #4492).
 export function sql(config: SQLConfig = {}) {
   let lang = config.dialect || StandardSQL
-  return new LanguageSupport(lang.language, [
-    schemaCompletion(config),
-    lang.language.data.of({
+  const extensions: Extension[] = []
+  if (!(config as any).disableSchemaCompletion) {
+    extensions.push(schemaCompletion(config))
+  }
+  if (!(config as any).disableKeywordCompletion) {
+    extensions.push(lang.language.data.of({
       autocomplete: keywordCompletionSource(lang, config.upperCaseKeywords, config.keywordCompletion)
-    })
-  ])
+    }))
+  }
+  return new LanguageSupport(lang.language, extensions)
 }
 

--- a/apps/ui-kit/lib/components/sql-text-editor/props.ts
+++ b/apps/ui-kit/lib/components/sql-text-editor/props.ts
@@ -65,6 +65,16 @@ export default {
   formatterModalId: {
     type: String,
     default: ''
+  },
+  /**
+   * Disable SQL autocomplete entirely (both schema-based and keyword-based
+   * completion). This is a workaround for performance issues on very large
+   * schemas where autocomplete can freeze/crash the app.
+   * See beekeeper-studio issue #4492.
+   */
+  disableAutocomplete: {
+    type: Boolean,
+    default: false
   }
 
   // --- replaced with languageId


### PR DESCRIPTION
## Summary

This PR exposes the existing `disableSchemaCompletion` and `disableKeywordCompletion` flags — already defined in the SQL text editor config type (`apps/ui-kit/lib/components/sql-text-editor/extensions/customSql.ts`) — as a user-facing settings toggle. This gives users an immediate workaround for the autocomplete freeze/crash on large schemas while the deeper performance issue is investigated.

**This is a workaround, not a root-cause fix for the underlying performance problem.** As @rathboma noted in the issue, more details are needed about the schema sizes involved. This PR simply gives affected users a way to keep working.

Addresses #4492

## What changed

The `disableSchemaCompletion` and `disableKeywordCompletion` flags already existed in the `SQLConfig` type extension in `customSql.ts`, but were **not actually consumed** by the vendored `sql()` function. This PR wires them through end-to-end:

### ui-kit (`@beekeeperstudio/ui-kit`)
1. **`vendor/@codemirror/lang-sql/src/sql.ts`** — The vendored `sql()` function now checks `disableSchemaCompletion` and `disableKeywordCompletion`. When either is `true`, the corresponding completion source (schema-based or keyword-based) is omitted entirely from the `LanguageSupport` extensions.
2. **`sql-text-editor/props.ts`** — Added a `disableAutocomplete` boolean prop (default `false`).
3. **`sql-text-editor/SqlTextEditor.vue`** — Passes `disableAutocomplete` through to the `SqlTextEditor` constructor as both `disableSchemaCompletion` and `disableKeywordCompletion`.

### studio (desktop app)
4. **`TabQueryEditor.vue`** — Added a `disableSqlAutocomplete` computed property that reads the `disableSqlAutocomplete` user setting from the Vuex settings store, and passes it as `:disable-autocomplete` to the editor component.
5. **`QueryEditorStatusBar.vue`** — Added a "Disable SQL Autocomplete" toggle in the editor settings dropdown (alongside "Editor keymap" and "Wrap Text"). Toggling it saves the setting via `settings/save`.
6. **Migration** — Added `20260714_add_disable_sql_autocomplete_setting.js` to seed the `disableSqlAutocomplete` boolean user setting (default `false`). Registered in `migration/index.js`.

## How to use

1. Open a query tab
2. Click the **⚙️ settings** button in the query editor status bar
3. Toggle **"Disable SQL Autocomplete"**
4. Autocomplete (both schema-based and keyword-based) is now fully disabled — no freeze, no crash

The setting persists across sessions via the existing user settings store.

## Notes

- The flags were already defined in the type system (`SQLConfig` in `customSql.ts`) and already used in the test suite (`completions.spec.ts`), so this PR completes the plumbing rather than introducing new concepts.
- The vendored `sql()` uses `(config as any).disableSchemaCompletion` because the upstream `@codemirror/lang-sql` `SQLConfig` type doesn't include these custom fields — they're added by Beekeeper's type extension in `customSql.ts`. Using `as any` avoids importing the custom type into the vendored file.
- This disables **all** autocomplete (schema + keywords) via a single toggle. If more granularity is desired later (e.g. disable schema completion but keep keyword completion), the underlying flags already support that — only the UI would need to change.

---

🤖 This PR was created with AI assistance. The implementation was generated programmatically and follows existing patterns in the codebase (settings store, migration system, editor props).
