### PR TITLE
fix: apply editor font size to modal editors (#4146)

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -1,9 +1,8 @@
 <template>
-  <div class="style-wrapper">
+  <div class="style-wrapper" :style="{ '--bks-text-editor-font-size': `${editorFontSize}px` }">
     <div
       class="beekeeper-studio-wrapper"
       :class="{ 'beekeeper-studio-minimal-mode': $store.getters.minimalMode }"
-      :style="{ '--bks-text-editor-font-size': `${editorFontSize}px` }"
     >
       <titlebar />
       <template v-if="storeInitialized">


### PR DESCRIPTION
Closes #4146

## What

"View > Increase/decrease editor font size" only changed the font size of the query editor, not of code editors inside modals (e.g. the trigger/stored-procedure editor, or any text editor rendered in a modal dialog).

## Root cause

The `--bks-text-editor-font-size` CSS variable was set on the `.beekeeper-studio-wrapper` div:

```html
<div class="style-wrapper">
  <div class="beekeeper-studio-wrapper" :style="{ '--bks-text-editor-font-size': `${editorFontSize}px` }">
    …main app content…
  </div>
  <portal-target name="modals" multiple />   <!-- outside .beekeeper-studio-wrapper -->
  …
</div>
```

Modal editors are rendered through `<portal-target name="modals">`, which lives **outside** `.beekeeper-studio-wrapper` but **inside** `.style-wrapper`. Since the CSS variable was only set on the inner wrapper, it never cascaded to the portaled modal content — so `var(--bks-text-editor-font-size, 0.875rem)` in `text-editor.scss` always fell back to the default `0.875rem` inside modals.

## Fix

Move the `:style` binding from `.beekeeper-studio-wrapper` up to the parent `.style-wrapper` div. Both the main app content and all portal targets are descendants of `.style-wrapper`, so the variable now reaches every code editor including those in modals.

One file changed, one line moved — no logic changes.

---

🤖 This PR was generated with AI assistance. The fix was identified by tracing the CSS variable scope through the component template.
