### PR TITLE
Fix MongoDB Decimal128 rendering as raw bytes in table/JSON view

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/mongodb.ts
@@ -1,12 +1,12 @@
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import { BasicDatabaseClient, ExecutionContext, QueryLogOptions } from "@/lib/db/clients/BasicDatabaseClient";
 import { DatabaseElement, IDbConnectionDatabase } from "@/lib/db/types";
-import { AggregationCursor, Collection, Db, Document, MongoClient, ObjectId } from 'mongodb';
+import { AggregationCursor, Collection, Db, Decimal128, Document, MongoClient, ObjectId } from 'mongodb';
 import rawLog from '@bksLogger';
 import { BksField, BksFieldType, CancelableQuery, ExtendedTableColumn, NgQueryResult, OrderBy, PrimaryKeyColumn, Routine, SchemaFilterOptions, StreamResults, SupportedFeatures, TableChanges, TableColumn, TableDelete, TableFilter, TableIndex, TableInsert, TableOrView, TableProperties, TableResult, TableTrigger, TableUpdate, TableUpdateResult } from "@/lib/db/models";
 import { CreateTableSpec, IndexAlterations, TableKey } from "@/shared/lib/dialects/models";
 import _ from 'lodash';
-import { MongoDBObjectIdTranscoder } from "@/lib/db/serialization/transcoders";
+import { MongoDBDecimal128Transcoder, MongoDBObjectIdTranscoder } from "@/lib/db/serialization/transcoders";
 import { ElectronRuntime as MongoRuntime } from '@mongosh/browser-runtime-electron';
 import { NodeDriverServiceProvider } from '@mongosh/service-provider-node-driver';
 import { createCancelablePromise } from "@/common/utils";
@@ -92,7 +92,7 @@ export class MongoDBClient extends BasicDatabaseClient<QueryResult> {
   conn: MongoClient;
   runtime: MongoRuntime;
   queryLeaf: QueryLeaf;
-  transcoders = [MongoDBObjectIdTranscoder];
+  transcoders = [MongoDBObjectIdTranscoder, MongoDBDecimal128Transcoder];
 
   constructor(server: IDbConnectionServer, database: IDbConnectionDatabase) {
     super(knex, mongoContext, server, database);
@@ -469,6 +469,8 @@ export class MongoDBClient extends BasicDatabaseClient<QueryResult> {
       let bksType: BksFieldType = 'UNKNOWN';
       if (row[column] instanceof ObjectId) {
         bksType = 'OBJECTID';
+      } else if (row[column] instanceof Decimal128) {
+        bksType = 'DECIMAL';
       }
       return { name: column, bksType };
     })

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -170,7 +170,7 @@ export interface BksField {
   bksType: BksFieldType;
 }
 
-export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID';
+export type BksFieldType = 'BINARY' | 'UNKNOWN' | 'OBJECTID' | 'SURREALID' | 'DECIMAL';
 
 export interface TableChanges {
   inserts: TableInsert[];

--- a/apps/studio/src/lib/db/serialization/transcoders.ts
+++ b/apps/studio/src/lib/db/serialization/transcoders.ts
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { BksField } from "../models";
 import rawLog from "@bksLogger";
 import { DuckDBBlobValue } from "@duckdb/node-api";
-import { ObjectId } from "mongodb";
+import { Decimal128, ObjectId } from "mongodb";
 import { RecordId, StringRecordId } from "surrealdb";
 
 const log = rawLog.scope("transcoders");
@@ -56,6 +56,36 @@ export const MongoDBObjectIdTranscoder: Transcoder<ObjectId, Uint8Array> = {
     return _.isTypedArray(value);
   }
 }
+
+export const MongoDBDecimal128Transcoder: Transcoder<Decimal128, string> = {
+  serialize(value) {
+    if (!(value instanceof Decimal128)) {
+      log.warn("MongoDBDecimal128Transcoder: cannot serialize non-decimal128 value");
+      return value;
+    }
+    // Decimal128.toString() yields the readable decimal (e.g. "12.34") rather
+    // than the raw { bytes } buffer the BSON value serializes to by default.
+    return value.toString();
+  },
+  deserialize(value) {
+    if (!_.isString(value)) {
+      log.warn("MongoDBDecimal128Transcoder: cannot deserialize non-string value");
+      return value;
+    }
+    return Decimal128.fromString(value);
+  },
+  serializeCheckByField(field: BksField): boolean {
+    return field.bksType === "DECIMAL";
+  },
+  deserializeCheckByValue(value): value is string {
+    // Display-only: deserializeValue picks a transcoder from the value alone
+    // with no field context, so claiming every string here would hijack all
+    // edited string write-backs. Scope this transcoder to the read/display
+    // path and leave write-back untouched.
+    void value;
+    return false;
+  },
+};
 
 export const GenericBinaryTranscoder: Transcoder<Buffer, Uint8Array> = {
   serialize(value) {

--- a/apps/studio/tests/unit/lib/db/serialization/transcoders.spec.ts
+++ b/apps/studio/tests/unit/lib/db/serialization/transcoders.spec.ts
@@ -1,0 +1,66 @@
+import { Decimal128 } from "mongodb";
+import {
+  MongoDBDecimal128Transcoder,
+} from "@/lib/db/serialization/transcoders";
+import { BksField } from "@/lib/db/models";
+
+const field = (bksType: BksField["bksType"]): BksField => ({
+  name: "value",
+  bksType,
+});
+
+describe("MongoDBDecimal128Transcoder", () => {
+  describe("serialize", () => {
+    it("renders a Decimal128 as its readable decimal string", () => {
+      expect(MongoDBDecimal128Transcoder.serialize(Decimal128.fromString("12.34"))).toBe(
+        "12.34"
+      );
+    });
+
+    it("preserves precision for high-precision values", () => {
+      const raw = "0.0000000000000000001";
+      expect(MongoDBDecimal128Transcoder.serialize(Decimal128.fromString(raw))).toBe(raw);
+    });
+
+    it("preserves precision for large-magnitude values", () => {
+      const raw = "123456789012345678901234567890";
+      expect(MongoDBDecimal128Transcoder.serialize(Decimal128.fromString(raw))).toBe(raw);
+    });
+
+    it("returns a non-Decimal128 value unchanged", () => {
+      const value = { bytes: { 0: 176 } } as unknown as Decimal128;
+      expect(MongoDBDecimal128Transcoder.serialize(value)).toBe(value);
+    });
+  });
+
+  describe("serializeCheckByField", () => {
+    it("matches DECIMAL fields", () => {
+      expect(MongoDBDecimal128Transcoder.serializeCheckByField(field("DECIMAL"))).toBe(true);
+    });
+
+    it("ignores non-DECIMAL fields", () => {
+      expect(MongoDBDecimal128Transcoder.serializeCheckByField(field("UNKNOWN"))).toBe(false);
+      expect(MongoDBDecimal128Transcoder.serializeCheckByField(field("OBJECTID"))).toBe(false);
+    });
+  });
+
+  describe("deserialize", () => {
+    it("parses a decimal string back into an equal Decimal128", () => {
+      const result = MongoDBDecimal128Transcoder.deserialize("12.34");
+      expect(result).toBeInstanceOf(Decimal128);
+      expect(result.toString()).toBe(Decimal128.fromString("12.34").toString());
+    });
+
+    it("returns a non-string value unchanged", () => {
+      const value = 42 as unknown as string;
+      expect(MongoDBDecimal128Transcoder.deserialize(value)).toBe(value);
+    });
+  });
+
+  describe("deserializeCheckByValue", () => {
+    it("never claims a value (display-only; write-back left untouched)", () => {
+      expect(MongoDBDecimal128Transcoder.deserializeCheckByValue("12.34")).toBe(false);
+      expect(MongoDBDecimal128Transcoder.deserializeCheckByValue("any string")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When viewing MongoDB documents that contain a `Decimal128` field, the value is rendered as a raw `{ bytes: { 0: 176, 1: 4, ... } }` object instead of a human-readable decimal number, both in the table view and the JSON detail view. This mirrors the earlier ObjectId issue (#3024), but for `Decimal128`.

Fixes #4258.

## Root cause

The MongoDB client serializes row values through a per-field transcoder pipeline (`BasicDatabaseClient.serializeQueryResult`), which selects a transcoder by each field's `bksType`. `MongoDBClient.parseQueryResultColumns` only tags a column as `OBJECTID` when the value is an `ObjectId`; every other BSON type — including `Decimal128` — falls through to `UNKNOWN`. With no matching transcoder, the raw `Decimal128` object (which carries an internal `bytes` buffer) is passed straight to the view and JSON-stringified as `{ bytes: {...} }`.

## Fix

Add a `Decimal128` transcoder alongside the existing ObjectId one, following the same pattern:

- `MongoDBDecimal128Transcoder` (in `src/lib/db/serialization/transcoders.ts`) serializes a `Decimal128` to its readable decimal string via `value.toString()` (e.g. `"12.34"`).
- A new `DECIMAL` member on `BksFieldType`.
- `MongoDBClient.parseQueryResultColumns` now detects `instanceof Decimal128` and tags the column `DECIMAL`, and the client registers the new transcoder.

`deserializeCheckByValue` deliberately returns `false`: `deserializeValue` picks a transcoder from the value alone with no field context, so claiming every string would hijack unrelated edited-string write-backs. The transcoder is therefore scoped to the read/display path, which is what the issue reports.

## Testing

Added `apps/studio/tests/unit/lib/db/serialization/transcoders.spec.ts` — pure unit tests for the new transcoder (no live database):

- serializes `Decimal128` to its readable decimal string, preserving precision for both high-precision and large-magnitude values
- returns a non-`Decimal128` value unchanged
- `serializeCheckByField` matches only `DECIMAL` fields
- `deserialize` round-trips a decimal string back to an equal `Decimal128`
- `deserializeCheckByValue` never claims a value (documents the display-only write-back scope)