### PR TITLE
fix: fix inability to discover or launch az cli on windows

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
@@ -51,7 +51,7 @@ export const CliHandlers: ICliHandlers = {
 
       proc.on('close', (code) => {
         if (code === 0) {
-          const result = stdout.trim().split('\n')[0]; // pick first match
+          const result = stdout.trim().split(/\r?\n/)[0]; // pick first match
           resolve(result);
         } else {
           reject(`cli/which failed (code ${code})\nSTDERR: ${stderr}\nSTDOUT: ${stdout}`);

--- a/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from "child_process";
+import { spawn } from "child_process";
 import path from "path";
 import platformInfo from "@/common/platform_info";
 
@@ -25,17 +25,14 @@ export const CliHandlers: ICliHandlers = {
 
     // Pass the environment explicitly so we can prepend Homebrew bin dirs.
     const env = { ...process.env };
-    const newPath = [...extraToolSearchDirs, env.Path].filter(Boolean).join(path.delimiter);
-    if (env.Path) {
-      // Windows is case-insensitive, so PATH is usually capitalized as Path
-      env.Path = newPath;
+    if (env.Path && platformInfo.isWindows) {
+      env.Path = [...extraToolSearchDirs, env.Path].filter(Boolean).join(path.delimiter);
     } else {
-      env.PATH = newPath;
+      env.PATH = [...extraToolSearchDirs, env.PATH].filter(Boolean).join(path.delimiter);
     }
 
     return new Promise((resolve, reject) => {
-      // Use exec on windows as spawn won't launch cmd files (e.g. azure cli) on windows with shell: false, see: CVE-2024-27980
-      const proc = platformInfo.isWindows ? exec(`${command} ${toolName}`, { env }) : spawn(command, [toolName], { shell: false, env });
+      const proc = spawn(command, [toolName], { shell: false, env });
 
       let stdout = '';
       let stderr = '';

--- a/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/cliHandlers.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { exec, spawn } from "child_process";
 import path from "path";
 import platformInfo from "@/common/platform_info";
 
@@ -25,19 +25,26 @@ export const CliHandlers: ICliHandlers = {
 
     // Pass the environment explicitly so we can prepend Homebrew bin dirs.
     const env = { ...process.env };
-    env.PATH = [...extraToolSearchDirs, env.PATH].filter(Boolean).join(path.delimiter);
+    const newPath = [...extraToolSearchDirs, env.Path].filter(Boolean).join(path.delimiter);
+    if (env.Path) {
+      // Windows is case-insensitive, so PATH is usually capitalized as Path
+      env.Path = newPath;
+    } else {
+      env.PATH = newPath;
+    }
 
     return new Promise((resolve, reject) => {
-      const proc = spawn(command, [toolName], { shell: false, env });
+      // Use exec on windows as spawn won't launch cmd files (e.g. azure cli) on windows with shell: false, see: CVE-2024-27980
+      const proc = platformInfo.isWindows ? exec(`${command} ${toolName}`, { env }) : spawn(command, [toolName], { shell: false, env });
 
       let stdout = '';
       let stderr = '';
 
-      proc.stdout.on('data', (chunk) => {
+      proc.stdout?.on('data', (chunk) => {
         stdout += chunk.toString();
       });
 
-      proc.stderr.on('data', (chunk) => {
+      proc.stderr?.on('data', (chunk) => {
         stderr += chunk.toString();
       });
 

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -179,7 +179,7 @@ export class AzureAuthService {
     }
 
     return new Promise<AuthConfig>((resolve, reject) => {
-    const commandArgs = [
+      const commandArgs = [
         'account',
         'get-access-token',
         '--resource',
@@ -187,6 +187,11 @@ export class AzureAuthService {
         '--output',
         'json'
       ];
+
+      if (platformInfo.isWindows && /["\r\n]/.test(options.cliPath)) {
+        throw new Error('Invalid azure CLI Path');
+      }
+
       // spawn doesn't launch .cmd files, they need a shell, so we manually spawn
       // cmd to all .cmd files to be run on windows, but not allow for escaping into
       // the shell :)

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -5,10 +5,11 @@ import rawLog from '@bksLogger';
 import {TokenCache} from '@/common/appdb/models/token_cache';
 import globals from '@/common/globals';
 import {AzureAuthOptions, AzureAuthType} from '../types';
-import {spawn} from 'child_process'
+import {exec, spawn} from 'child_process'
 import {getEntraOptions} from "@/lib/db/clients/utils";
 import {IDbConnectionServer} from "@/lib/db/backendTypes";
 import BksConfig from '@/common/bksConfig';
+import platformInfo from "@/common/platform_info";
 
 const log = rawLog.scope('auth/azure');
 
@@ -178,23 +179,25 @@ export class AzureAuthService {
     }
 
     return new Promise<AuthConfig>((resolve, reject) => {
-      const proc = spawn(options.cliPath, [
+    const commandArgs = [
         'account',
         'get-access-token',
         '--resource',
         BksConfig.azure.azSQLLoginScope,
         '--output',
         'json'
-      ], { shell: false });
+      ];
+      // Use exec on windows as spawn won't launch cmd files (e.g. azure cli) on windows with shell: false, see: CVE-2024-27980
+      const proc = platformInfo.isWindows ? exec(`"${options.cliPath}" ${commandArgs.join(' ')}`) : spawn(options.cliPath, commandArgs, { shell: false });
 
       let stdout = '';
       let stderr = '';
 
-      proc.stdout.on('data', (chunk) => {
+      proc.stdout?.on('data', (chunk) => {
         stdout += chunk.toString();
       });
 
-      proc.stderr.on('data', (chunk) => {
+      proc.stderr?.on('data', (chunk) => {
         stderr += chunk.toString();
       });
 

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -187,8 +187,12 @@ export class AzureAuthService {
         '--output',
         'json'
       ];
-      // Use exec on windows as spawn won't launch cmd files (e.g. azure cli) on windows with shell: false, see: CVE-2024-27980
-      const proc = platformInfo.isWindows ? exec(`"${options.cliPath}" ${commandArgs.join(' ')}`) : spawn(options.cliPath, commandArgs, { shell: false });
+      // spawn doesn't launch .cmd files, they need a shell, so we manually spawn
+      // cmd to all .cmd files to be run on windows, but not allow for escaping into
+      // the shell :)
+      const proc = platformInfo.isWindows
+        ? spawn('cmd.exe', ['/c', options.cliPath, ...commandArgs], { shell: false })
+        : spawn(options.cliPath, commandArgs, { shell: false });
 
       let stdout = '';
       let stderr = '';

--- a/apps/studio/src/lib/db/authentication/azure.ts
+++ b/apps/studio/src/lib/db/authentication/azure.ts
@@ -5,7 +5,7 @@ import rawLog from '@bksLogger';
 import {TokenCache} from '@/common/appdb/models/token_cache';
 import globals from '@/common/globals';
 import {AzureAuthOptions, AzureAuthType} from '../types';
-import {exec, spawn} from 'child_process'
+import {spawn} from 'child_process'
 import {getEntraOptions} from "@/lib/db/clients/utils";
 import {IDbConnectionServer} from "@/lib/db/backendTypes";
 import BksConfig from '@/common/bksConfig';
@@ -191,7 +191,7 @@ export class AzureAuthService {
       // cmd to all .cmd files to be run on windows, but not allow for escaping into
       // the shell :)
       const proc = platformInfo.isWindows
-        ? spawn('cmd.exe', ['/c', options.cliPath, ...commandArgs], { shell: false })
+        ? spawn('cmd.exe', ['/d', '/s', '/c', `""${options.cliPath}" ${commandArgs.join(' ')}"`], { shell: false, windowsVerbatimArguments: true })
         : spawn(options.cliPath, commandArgs, { shell: false });
 
       let stdout = '';


### PR DESCRIPTION
Today on Windows (Beekeeper v5.9.2), it appears that discovering and using the `az` CLI for Azure CLI Authentication are both broken. This is due to a couple of issues:

1. On Windows, environment variables are case-insensitive, and as a result, the `PATH` variable is at `process.env.Path`, not `process.env.PATH` (which the code currently looks for).
2. The `az` cli is a `cmd` file, and since Node patched [CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high), using `child_process.spawn` with `{ shell: false}` for `.cmd` files results in `EINVAL` (as described in the aforementioned security release, and which you see in the app if you manually find the `az.cmd` file and run test/connect, as shown in the screenshot below).

This PR does the following:

1. Use `process.env.Path` instead of `process.env.PATH`, if set (i.e. on Windows).
2. Use `child_process.exec` instead of `process.spawn` on Windows (as [recommended](https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows) in the Node docs) for both discovering and executing the `az` CLI.

I've manually verified these fixes on Windows and also verified working functionality on Mac is not broken (haven't testing Linux).

## Screenshots

1. `az` CLI not found on Windows even though installed in default location and in PATH:
<img width="589" height="373" alt="Screenshot 2026-07-24 135930" src="https://github.com/user-attachments/assets/558d2829-d31e-4506-9221-6b0422fb4f21" />

2. `EINVAL` error when manually finding `az.cmd` file and testing the connection:
<img width="633" height="896" alt="Screenshot 2026-07-23 091619" src="https://github.com/user-attachments/assets/5bd0f663-5492-46a7-b6e8-2c5490bffa1d" />

3. After fixes in this PR, app is able to discover and run `az` CLI on Windows for Azure CLI Authentication.
<img width="574" height="266" alt="image" src="https://github.com/user-attachments/assets/5b284feb-5590-4069-88ef-5335fe1bae84" />

Question: I'm not sure if you'd like to see tests for this? Let me know.

Thanks!