### PR TITLE
Fix overlapping context menus in the data grid

### DIFF
--- a/apps/studio/src/mixins/assignContextMenuToAllInputs.ts
+++ b/apps/studio/src/mixins/assignContextMenuToAllInputs.ts
@@ -21,6 +21,10 @@ export const assignContextMenuToAllInputs: ComponentOptions<Vue> = {
 
   methods: {
     ctxMenu_showContextMenu(event: MouseEvent) {
+      if (event.defaultPrevented) {
+        return;
+      }
+
       if (!this.ctxMenu_isTextInput(event.target)) {
         return;
       }


### PR DESCRIPTION
- Added `event.defaultPrevented` guard to the root listener. 
<img width="815" height="994" alt="image" src="https://github.com/user-attachments/assets/26d3856a-f64f-476b-9028-e1184cd62b03" />


Closes: https://github.com/beekeeper-studio/beekeeper-studio/issues/4517