### PR TITLE
Fix macOS cold-start open-file/open-url ignoring the URL

### DIFF
--- a/apps/studio/src-commercial/entrypoints/main.ts
+++ b/apps/studio/src-commercial/entrypoints/main.ts
@@ -45,6 +45,8 @@ function initUserDirectory(d: string) {
 
 let utilityProcess: Electron.UtilityProcess
 let newWindows: number[] = [];
+let appReady = false
+let pendingOpens: string[] = []
 
 async function createUtilityProcess() {
   if (utilityProcess) {
@@ -120,15 +122,16 @@ log.debug("registering schema")
 // Scheme must be registered before the app is ready
 protocol.registerSchemesAsPrivileged([{scheme: 'app', privileges: { secure: true, standard: true } }])
 protocol.registerSchemesAsPrivileged([{scheme: 'plugin', privileges: { secure: true, standard: true } }])
-let initialized = false
+let initPromise: Promise<IGroupedUserSettings> | null = null
 
-async function initBasics() {
-  // this creates the app:// protocol we use for loading assets
-  ProtocolBuilder.createAppProtocol()
-  // this creates the plugin:// protocol we use for loading plugins
-  ProtocolBuilder.createPluginProtocol()
-  if (initialized) return settings
-  initialized = true
+// callers can run concurrently (eg 'ready' and 'open-url'), so they all share
+// one init, and all wait for it to actually finish before getting settings.
+function initBasics() {
+  if (!initPromise) initPromise = doInitBasics()
+  return initPromise
+}
+
+async function doInitBasics() {
   await ormConnection.connect()
   console.log("LD_LIBRARY_PATH", process.env.LD_LIBRARY_PATH)
   log.info("running migrations!!")
@@ -185,7 +188,9 @@ ipcMain.handle('bksConfigSource', () => {
 app.on('activate', async (_event, hasVisibleWindows) => {
   // On macOS it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (!hasVisibleWindows) {
+  // 'activate' also fires on first launch, where the ready handler is still
+  // building the initial window - don't race it with an empty one.
+  if (!hasVisibleWindows && appReady) {
     if (!settings) throw "No settings initialized!"
     await createUtilityProcess()
 
@@ -220,22 +225,26 @@ app.on('ready', async () => {
 
   }
 
-  // this gets positional arguments
-  const options = platformInfo.parsedArgs._.map((url: string) => ({ url }))
+  // this creates the app:// protocol we use for loading assets
+  ProtocolBuilder.createAppProtocol()
+  // this creates the plugin:// protocol we use for loading plugins
+  ProtocolBuilder.createPluginProtocol()
+
   const settings = await initBasics()
+  initializeSecurity(app);
+  initializeFileHelpers();
+  await createUtilityProcess()
 
-  if (options.length > 0) {
+  // positional arguments, plus anything macOS handed us via open-file /
+  // open-url before we were ready
+  const urls = [...platformInfo.parsedArgs._, ...pendingOpens]
+  pendingOpens = []
+  appReady = true
 
-    await Promise.all(options.map((option) => buildWindow(settings, option)))
-  } else {
-    if (getActiveWindows().length === 0) {
-      const settings = await initBasics()
-      initializeSecurity(app);
-      initializeFileHelpers();
-      await createUtilityProcess()
-
-      await buildWindow(settings)
-    }
+  if (urls.length > 0) {
+    urls.forEach((url: string) => buildWindow(settings, { url }))
+  } else if (getActiveWindows().length === 0) {
+    buildWindow(settings)
   }
 
 })
@@ -274,19 +283,27 @@ ipcMain.handle('requestPorts', async () => {
   }
 })
 
-// Open a connection from a file (e.g. ./sqlite.db)
-app.on('open-file', async (event, file) => {
-  event.preventDefault();
+// On macOS a cold start fires open-file / open-url before 'ready'. Nothing can
+// be built that early, so queue it and let the ready handler open the window.
+async function openFromUrl(url: string) {
+  if (!appReady) {
+    pendingOpens.push(url)
+    return
+  }
   const settings = await initBasics()
-  await buildWindow(settings, { url: file })
+  await buildWindow(settings, { url })
+}
+
+// Open a connection from a file (e.g. ./sqlite.db)
+app.on('open-file', (event, file) => {
+  event.preventDefault();
+  openFromUrl(file).catch((e) => log.error("error opening file", file, e))
 });
 
 // Open a connection from a url (e.g. postgres://host)
-app.on('open-url', async (event, url) => {
+app.on('open-url', (event, url) => {
   event.preventDefault();
-  const settings = await initBasics()
-
-  await buildWindow(settings, { url })
+  openFromUrl(url).catch((e) => log.error("error opening url", url, e))
 });
 
 ipcMain.handle('isMaximized', () => {


### PR DESCRIPTION
Fixes #4214

## Problem

On macOS, cold-starting the app by double-clicking a SQLite file or via a URL scheme (`postgresql://...`) opened a blank New Connection screen — the file/URL was ignored. Doing the same thing again while the app was already running worked fine.

## Root cause

On a macOS cold start, `open-file` / `open-url` fire **before** `app.ready`. Both handlers called `initBasics()`, which starts with `ProtocolBuilder.createAppProtocol()` → `protocol.registerBufferProtocol()`. That API touches the default session, which throws before ready. The handler's promise rejected silently, the URL was dropped, and the `ready` handler then built a plain empty window.

This regressed when protocol registration was moved to the top of `initBasics()` (4f192ec43).

## Fix (`apps/studio/src-commercial/entrypoints/main.ts`)

- Register the `app://` and `plugin://` protocols in the `ready` handler instead of `initBasics()` — registered exactly once, and only when legal (previously they were also re-registered on every `open-url`).
- `open-file` / `open-url` arriving before `ready` are queued in `pendingOpens`; the `ready` handler drains the queue alongside positional CLI args and opens one window per URL.
- `initBasics()` now memoizes its promise. The old `if (initialized) return settings` guard returned immediately while init was still running, handing a concurrent caller `undefined` settings.
- `initializeSecurity` / `initializeFileHelpers` / `createUtilityProcess` now run unconditionally in `ready`; previously they were skipped entirely when the app was launched with a positional file argument.
- Guarded `activate` so it can't race the startup path before the initial window exists.

## Testing

Verified on macOS (arm64) with unsigned local builds via LaunchServices (`open -a`), app fully quit before each test:

| Scenario | Before | After |
|---|---|---|
| Cold start, double-click/`open` a `.db` file | blank New Connection | connects to the file |
| Cold start, `mysql://root@localhost:3306` | blank New Connection | connects |
| Cold start, `postgresql://...` | blank New Connection | reaches connect (fails only if no server) |
| Warm app, same opens | works | still works |

Verified via the `used_connection` table in app.db as well as visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJKHfV26Pct7fyYVjvmNwe