### PR TITLE
fix too long error make status bar unusable

### DIFF
--- a/apps/studio/src/assets/styles/app/statusbar.scss
+++ b/apps/studio/src/assets/styles/app/statusbar.scss
@@ -285,6 +285,7 @@ $button-height:     $statusbar-height * 0.72;
       > span {
         text-overflow: ellipsis;
         overflow: hidden;
+        max-width: 30rem;
       }
     }
   }


### PR DESCRIPTION
fix #3462 

Very long error text will push pagnation and reset/apply button to outside of the window, which PlanetScale database will return very long error text.