### PR TITLE
ui: add multi-select deletion for saved queries

### DIFF
--- a/apps/studio/src/assets/styles/app/sidebar/favorite-list.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/favorite-list.scss
@@ -66,6 +66,11 @@
     height: initial;
     line-height: initial;
     padding: $gutter-h ($gutter-w * 0.75);
+    &.bulk-selection-active {
+      .item-icon {
+        visibility: hidden;
+      }
+    }
     &:hover {
       transition: display 0.15s ease-in-out;
       .badge {
@@ -74,12 +79,12 @@
       .btn-fab {
         display: inline-flex;
       }
-      // .delete-checkbox {
-      //   display: block;
-      // }
-      // .item-icon {
-      //   visibility: hidden;
-      // }
+      .delete-checkbox {
+        display: block;
+      }
+      .item-icon {
+        visibility: hidden;
+      }
     }
     .btn-fab {
       display: none;

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -106,10 +106,13 @@
                 :key="item.id"
                 :item="item"
                 :active="isActive(item)"
-                :selected="selected === item"
+                :selected="isChecked(item) || selected === item"
+                :checked="isChecked(item)"
+                :bulk-selection-active="checkedFavorites.length > 0"
                 :class="{ 'drag-pending': (pendingSaveIds || []).includes(item.id) }"
                 @remove="remove"
                 @select="select"
+                @toggle-check="toggleChecked"
                 @open="open"
                 @open-history="openHistory"
                 @export="exportTo"
@@ -143,10 +146,13 @@
                   :key="item.id"
                   :item="item"
                   :active="isActive(item)"
-                  :selected="selected === item"
+                  :selected="isChecked(item) || selected === item"
+                  :checked="isChecked(item)"
+                  :bulk-selection-active="checkedFavorites.length > 0"
                   :class="{ 'drag-pending': (pendingSaveIds || []).includes(item.id) }"
                   @remove="remove"
                   @select="select"
+                  @toggle-check="toggleChecked"
                   @open="open"
                   @open-history="openHistory"
                   @export="exportTo"
@@ -169,10 +175,13 @@
               :key="item.id"
               :item="item"
               :active="isActive(item)"
-              :selected="selected === item"
+              :selected="isChecked(item) || selected === item"
+              :checked="isChecked(item)"
+              :bulk-selection-active="checkedFavorites.length > 0"
               :class="{ 'drag-pending': (pendingSaveIds || []).includes(item.id) }"
               @remove="remove"
               @select="select"
+              @toggle-check="toggleChecked"
               @open="open"
               @open-history="openHistory"
               @export="exportTo"
@@ -197,6 +206,20 @@
           </span>
         </div>
       </div>
+    </div>
+    <div
+      class="toolbar btn-group row flex-right"
+      v-show="checkedFavorites.length > 0"
+    >
+      <a
+        class="btn btn-link"
+        @click="discardCheckedFavorites"
+      >Cancel</a>
+      <a
+        class="btn btn-primary"
+        :title="removeTitle"
+        @click="removeCheckedFavorites"
+      >Remove</a>
     </div>
     <portal to="modals">
       <modal
@@ -266,6 +289,7 @@ export default {
     return {
       checkedFavorites: [],
       selected: null,
+      selectionAnchor: null,
       folderModalName: '',
       folderModalItem: null,
       folderModalParentId: null,
@@ -317,7 +341,18 @@ export default {
     },
     removeTitle() {
       return `Remove ${this.checkedFavorites.length} saved queries`;
-    }
+    },
+    flatVisibleQueries() {
+      const result = []
+      for (const { items, subfolders } of this.foldersWithQueries) {
+        result.push(...items)
+        for (const { items: subItems } of subfolders) {
+          result.push(...subItems)
+        }
+      }
+      result.push(...this.lonelyQueries)
+      return result
+    },
   },
   methods: {
     getFolderExpanded(folderId) {
@@ -361,8 +396,45 @@ export default {
     isActive(item) {
       return this.activeTab && this.activeTab.queryId === item.id
     },
-    select(item) {
+    isChecked(item) {
+      return this.checkedFavorites.some((f) => f.id === item.id)
+    },
+    toggleChecked(item) {
+      const idx = this.checkedFavorites.findIndex((f) => f.id === item.id)
+      if (idx >= 0) {
+        this.checkedFavorites.splice(idx, 1)
+      } else {
+        this.checkedFavorites.push(item)
+      }
+      this.selectionAnchor = item
+    },
+    selectRange(anchor, item) {
+      const list = this.flatVisibleQueries
+      const anchorIndex = list.findIndex((i) => i.id === anchor.id)
+      const itemIndex = list.findIndex((i) => i.id === item.id)
+      if (anchorIndex < 0 || itemIndex < 0) return
+      const [start, end] = anchorIndex < itemIndex
+        ? [anchorIndex, itemIndex]
+        : [itemIndex, anchorIndex]
+      for (const query of list.slice(start, end + 1)) {
+        if (!this.isChecked(query)) {
+          this.checkedFavorites.push(query)
+        }
+      }
+    },
+    select(item, event) {
+      if (event?.shiftKey && this.selectionAnchor != null) {
+        this.selectRange(this.selectionAnchor, item)
+        this.selected = item
+        return
+      }
+      if (event?.metaKey || event?.ctrlKey) {
+        this.toggleChecked(item)
+        this.selected = item
+        return
+      }
       this.selected = item
+      this.selectionAnchor = item
     },
     open(item) {
       this.$root.$emit('favoriteClick', item)
@@ -376,13 +448,21 @@ export default {
       }
     },
     async removeCheckedFavorites() {
-      for(let i = 0; i < this.checkedFavorites.length; i++) {
-        await this.remove(this.checkedFavorites[i])
+      const count = this.checkedFavorites.length
+      if (count === 0) return
+      const message = count === 1
+        ? `Delete "${this.checkedFavorites[0].title}"?`
+        : `Delete ${count} saved queries?`
+      if (!await this.$confirm(message, undefined, { variant: 'danger' })) {
+        return
       }
-      this.checkedFavorites = [];
+      for (const favorite of [...this.checkedFavorites]) {
+        await this.$store.dispatch('data/queries/remove', favorite)
+      }
+      this.checkedFavorites = []
     },
     discardCheckedFavorites() {
-      this.checkedFavorites = [];
+      this.checkedFavorites = []
     },
     createFolder() {
       if (!this.canCreateFolders) {

--- a/apps/studio/src/components/sidebar/core/favorite_list/FavoriteListItem.vue
+++ b/apps/studio/src/components/sidebar/core/favorite_list/FavoriteListItem.vue
@@ -9,10 +9,18 @@
         content: truncatedText,
         delay: { show: 500 },
       }"
-      @click.prevent="$emit('select', item)"
+      @click.prevent="$emit('select', item, $event)"
       @dblclick.prevent="$emit('open', item)"
-      :class="{active, selected}"
+      :class="{active, selected, 'bulk-selection-active': bulkSelectionActive}"
     >
+      <input
+        @click.stop=""
+        type="checkbox"
+        class="form-control delete-checkbox"
+        :class="{ shown: bulkSelectionActive }"
+        :checked="checked"
+        @change="$emit('toggle-check', item)"
+      >
       <i class="item-icon query material-icons">code</i>
       <div class="list-text">
         <div class="list-title flex-col">
@@ -38,7 +46,7 @@ import { AppEvent } from '@/common/AppEvent'
 
 export default Vue.extend({
   components: { EditableText },
-  props: ['item', 'selected', 'active'],
+  props: ['item', 'selected', 'active', 'checked', 'bulkSelectionActive'],
   data: () => ({
     timeAgo: new TimeAgo('en-US'),
     rename: false,

--- a/apps/studio/tests/unit/components/sidebar/FavoriteListBulkDelete.spec.ts
+++ b/apps/studio/tests/unit/components/sidebar/FavoriteListBulkDelete.spec.ts
@@ -1,0 +1,184 @@
+import FavoriteList from "@/components/sidebar/core/FavoriteList.vue";
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuex, { Store } from "vuex";
+
+Vue.use(Vuex);
+
+const q1 = { id: 1, title: "Query 1", queryFolderId: null };
+const q2 = { id: 2, title: "Query 2", queryFolderId: null };
+const q3 = { id: 3, title: "Query 3", queryFolderId: null };
+
+function createStore(queries = [q1, q2, q3]) {
+  const remove = jest.fn().mockResolvedValue(undefined);
+  const store = new Vuex.Store({
+    getters: {
+      workspace: () => ({}),
+      isCloud: () => false,
+      isUltimate: () => false,
+      canCreateFolders: () => true,
+    },
+    modules: {
+      tabs: {
+        namespaced: true,
+        state: { active: null },
+      },
+      "data/queries": {
+        namespaced: true,
+        state: {
+          items: queries,
+          loading: false,
+          error: null,
+          filter: undefined,
+          pendingSaveIds: [],
+        },
+        getters: {
+          filteredQueries: (state) => state.items,
+        },
+        actions: { remove },
+      },
+      "data/queryFolders": {
+        namespaced: true,
+        state: { items: [], loading: false, error: null },
+        getters: {
+          foldersWithQueries: () => () => [],
+        },
+      },
+    },
+  });
+  return { store, remove };
+}
+
+function mountFavoriteList(store: Store<unknown>) {
+  const confirm = jest.fn().mockResolvedValue(true);
+  const wrapper = shallowMount(FavoriteList as any, {
+    store,
+    stubs: {
+      Draggable: true,
+      SidebarFolder: true,
+      FavoriteListItem: true,
+      portal: true,
+      modal: true,
+      ErrorAlert: true,
+      ExpiredFolderAlert: true,
+      SidebarLoading: true,
+    },
+    mocks: {
+      $confirm: confirm,
+      $modal: { show: jest.fn(), hide: jest.fn() },
+      $noty: { success: jest.fn(), error: jest.fn() },
+      $root: { $emit: jest.fn() },
+      $bks: { openMenu: jest.fn() },
+    },
+  });
+  return { wrapper, confirm };
+}
+
+describe("FavoriteList bulk delete", () => {
+  it("toggleChecked adds and removes items by id", () => {
+    const { store } = createStore();
+    const { wrapper } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.toggleChecked(q1);
+    expect(vm.isChecked(q1)).toBe(true);
+    expect(vm.checkedFavorites).toHaveLength(1);
+
+    vm.toggleChecked(q2);
+    expect(vm.checkedFavorites).toHaveLength(2);
+
+    vm.toggleChecked(q1);
+    expect(vm.isChecked(q1)).toBe(false);
+    expect(vm.checkedFavorites).toHaveLength(1);
+    expect(vm.checkedFavorites[0].id).toBe(2);
+  });
+
+  it("selectRange selects contiguous visible items", () => {
+    const { store } = createStore();
+    const { wrapper } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.selectionAnchor = q1;
+    vm.selectRange(q1, q3);
+
+    expect(vm.checkedFavorites.map((q: { id: number }) => q.id)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("select with shiftKey uses range selection from the anchor", () => {
+    const { store } = createStore();
+    const { wrapper } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.selectionAnchor = q1;
+    vm.select(q3, { shiftKey: true });
+
+    expect(vm.checkedFavorites.map((q: { id: number }) => q.id)).toEqual([
+      1, 2, 3,
+    ]);
+    expect(vm.selected).toBe(q3);
+  });
+
+  it("select with metaKey toggles bulk selection", () => {
+    const { store } = createStore();
+    const { wrapper } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.select(q1, { metaKey: true });
+    vm.select(q2, { metaKey: true });
+
+    expect(vm.checkedFavorites.map((q: { id: number }) => q.id)).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("removeCheckedFavorites shows one confirm and removes all checked items", async () => {
+    const { store, remove } = createStore();
+    const { wrapper, confirm } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.checkedFavorites = [q1, q2];
+
+    await vm.removeCheckedFavorites();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledWith("Delete 2 saved queries?", undefined, {
+      variant: "danger",
+    });
+    expect(remove).toHaveBeenCalledTimes(2);
+    expect(remove).toHaveBeenCalledWith(expect.anything(), q1);
+    expect(remove).toHaveBeenCalledWith(expect.anything(), q2);
+    expect(vm.checkedFavorites).toHaveLength(0);
+  });
+
+  it("removeCheckedFavorites uses the item title when deleting one query", async () => {
+    const { store, remove } = createStore([q1]);
+    const { wrapper, confirm } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    vm.checkedFavorites = [q1];
+
+    await vm.removeCheckedFavorites();
+
+    expect(confirm).toHaveBeenCalledWith('Delete "Query 1"?', undefined, {
+      variant: "danger",
+    });
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it("removeCheckedFavorites does nothing when confirm is declined", async () => {
+    const { store, remove } = createStore();
+    const { wrapper, confirm } = mountFavoriteList(store);
+    const vm = wrapper.vm as any;
+
+    confirm.mockResolvedValue(false);
+    vm.checkedFavorites = [q1, q2];
+
+    await vm.removeCheckedFavorites();
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(remove).not.toHaveBeenCalled();
+    expect(vm.checkedFavorites).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
I'm currently dealing with an issue where this would help me a lot. I have so many items in my saved queries that it's practically impossible to delete them one by one because of how long it would take.

Example:
<img width="347" height="559" alt="image" src="https://github.com/user-attachments/assets/9bdbfeb7-418f-41d7-826a-932fcfc9f4a2" />


----

# Ai slop text bellow

## Summary
- Add multi-select deletion for Saved Queries via per-item checkboxes, Cmd/Ctrl+click toggle, and Shift+click range selection
- Show a bottom Remove/Cancel toolbar when one or more queries are selected
- Bulk delete uses a single confirmation dialog instead of one per item
- Hide the query code icon while bulk selection mode is active

## Test plan
- [ ] Select multiple saved queries with checkboxes, Cmd/Ctrl+click, and Shift+click
- [ ] Remove toolbar appears; Cancel clears selection without deleting
- [ ] Remove shows one confirm dialog and deletes all selected queries
- [ ] Context menu Delete on a single item still works with per-item confirm
- [ ] Drag-and-drop reordering still works
- [ ] `yarn test:unit tests/unit/components/sidebar/FavoriteListBulkDelete.spec.ts` passes (7 tests)

Made with [Cursor](https://cursor.com)