### PR TITLE
fix: show favorite title in delete confirmation

### DIFF
--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -371,7 +371,8 @@ export default {
       this.trigger('favoriteClick', item, { openHistory: true })
     },
     async remove(favorite) {
-      if (await this.$confirm(`Delete "${favorite.name}"?`, undefined, { variant: "danger" })) {
+      const name = favorite.title || favorite.name
+      if (await this.$confirm(`Delete "${name}"?`, undefined, { variant: "danger" })) {
         await this.$store.dispatch('data/queries/remove', favorite)
       }
     },


### PR DESCRIPTION
## Summary
- Use `favorite.title` (with `name` fallback) in the saved-query delete confirmation dialog

## Test plan
- [ ] Open a saved query in the sidebar favorites list
- [ ] Delete it via context menu — dialog shows the query title
- [ ] Multi-select delete (`removeCheckedFavorites`) — each dialog shows the correct title

Before:
<img width="680" height="347" alt="image" src="https://github.com/user-attachments/assets/095bcd9d-b416-4e5b-bec0-dc00e09ac7d9" />

After:
<img width="637" height="244" alt="image" src="https://github.com/user-attachments/assets/5ec23448-c4bc-47e8-b066-20227ace6959" />

