### PR TITLE
feat: add configurable backup filename templates with variable support

### DIFF
--- a/apps/studio/src/components/backup/BackupSettings.vue
+++ b/apps/studio/src/components/backup/BackupSettings.vue
@@ -132,6 +132,7 @@
                         type="text"
                         :name="control.settingName"
                         :id="control.settingName"
+                        spellcheck="false"
                         @change="onChange(control)"
                         v-model="config[control.settingName]"
                       >
@@ -165,6 +166,13 @@
                           <span v-if="action.value">{{ callIfFunction(action.value) }}</span>
                         </a>
                       </div>
+                    </div>
+                    <div
+                      v-if="control.supportsTemplate && control.showPreview"
+                      class="filename-preview"
+                    >
+                      <span class="filename-preview-label">Preview</span>
+                      <code class="filename-preview-value">{{ previewFilename }}</code>
                     </div>
                   </div>
                   <div
@@ -220,6 +228,7 @@ import Vue from 'vue';
 import { mapGetters, mapState } from 'vuex';
 import FilePicker from '@/components/common/form/FilePicker.vue'
 import { CommandSettingControl, CommandSettingSection } from '@/lib/db/models';
+import { DEFAULT_FILENAME_TEMPLATE, resolveFilenameTemplate } from '@/lib/utils/filenameTemplate';
 import _ from 'lodash';
 
 export default Vue.extend({
@@ -233,6 +242,11 @@ export default Vue.extend({
     }
   },
   watch: {
+    'config.filenameTemplate'(value) {
+      if (value !== undefined) {
+        this.$store.dispatch('settings/save', { key: 'backupFilenameTemplate', value });
+      }
+    }
   },
   computed: {
     ...mapGetters('backups', {
@@ -245,6 +259,14 @@ export default Vue.extend({
     },
     controls() {
       return _.flatten(this.sections.map((x) => x.controls));
+    },
+    previewFilename() {
+      const control = this.controls.find((c: CommandSettingControl) => c.supportsTemplate);
+      if (!control || !control.showPreview) return '';
+
+      const base = resolveFilenameTemplate(this.config[control.settingName], this.database ?? '');
+      const extension = this.$store.getters['backups/commandClient'].resolveFileExtension(this.config);
+      return `${base}${extension}`;
     }
   },
   methods: {
@@ -258,8 +280,10 @@ export default Vue.extend({
       }
     },
     async onNext() {
-      await this.$store.commit('backups/updateConfig', this.config);
+      // Set the database first so the filename template is resolved against the
+      // currently selected database.
       await this.$store.commit('backups/setDatabase', this.database);
+      await this.$store.commit('backups/updateConfig', this.config);
     },
     canContinue() {
       let cont = true;
@@ -298,6 +322,13 @@ export default Vue.extend({
   },
   mounted() {
     this.sections = this.$store.getters['backups/settingsSections'];
+
+    // Seed the filename template from the persisted setting, falling back to
+    // the default template which resolves to the legacy default filename.
+    const template = this.$store.getters['settings/backupFilenameTemplate'];
+    if (this.config.filenameTemplate == null) {
+      this.config.filenameTemplate = template ?? DEFAULT_FILENAME_TEMPLATE;
+    }
   }
 })
 </script>
@@ -359,6 +390,25 @@ export default Vue.extend({
 .textarea {
   resize: none;
   height: 10rem;
+}
+
+.filename-preview {
+  display: flex;
+  align-items: baseline;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+
+  .filename-preview-label {
+    color: var(--text-color-sub);
+    margin-right: 0.5rem;
+  }
+
+  .filename-preview-value {
+    word-break: break-all;
+    background: var(--background-main);
+    border-radius: 3px;
+    padding: 0.1rem 0.4rem;
+  }
 }
 
 .btn-icon {

--- a/apps/studio/src/lib/db/BaseCommandClient.ts
+++ b/apps/studio/src/lib/db/BaseCommandClient.ts
@@ -1,7 +1,8 @@
 import { BackupConfig } from "./models/BackupConfig";
 import { IConnection } from "@/common/interfaces/IConnection";
 import { ConnectionType, IDbConnectionServerConfig } from "./types";
-import { SupportedBackupFeatures, Command, CommandSettingSection, CommandControlAction, CommandSettingControl, SupportedFeatures } from "./models";
+import { SupportedBackupFeatures, Command, CommandSettingSection, CommandSettingControl, SupportedFeatures } from "./models";
+import { resolveFilenameTemplate } from "@/lib/utils/filenameTemplate";
 import { TempFileManager } from "../TempFileManager";
 import Vue from "vue";
 
@@ -134,17 +135,34 @@ export abstract class BaseCommandClient {
       this._config.toolName = this.toolName;
     } else {
       Object.assign(this._config, value);
+      // Resolve the filename template into a concrete filename as soon as the
+      // config is committed, so the review and execution steps only ever see a
+      // resolved name. The extension is appended later by the filename getter.
+      if ("filenameTemplate" in value) {
+        this._config.filename = resolveFilenameTemplate(
+          this._config.filenameTemplate ?? '',
+          BaseCommandClient.databaseName
+        );
+      }
     }
   }
 
   get settingsConfig() {
-    const settings = {};
+    // Reactive so the settings form (and the filename template live preview)
+    // update as the user types, before the config is committed on "next".
+    const settings = Vue.observable({});
     this.settingsSections.forEach((section) => {
       section.controls.forEach((control) => {
-        settings[control.settingName] = this._config[control.settingName];
+        if (control.settingName) {
+          settings[control.settingName] = this._config[control.settingName];
+        }
       })
     });
     return settings;
+  }
+
+  public resolveFileExtension(config: BackupConfig = this._config): string {
+    return this.determineFileType(config);
   }
 
   protected get binaryLocation(): CommandSettingSection {
@@ -259,15 +277,14 @@ export abstract class BaseCommandClient {
         },
         !isRestore ? {
           controlType: 'input',
-          settingName: 'filename',
-          settingDesc: 'Filename',
-          required: true,
+          settingName: 'filenameTemplate',
+          settingDesc: 'Filename Template',
+          required: false,
+          supportsTemplate: true,
+          showPreview: true,
           show: (config: BackupConfig): boolean => {
             return config.format != 'd';
           },
-          actions: isRestore ? [] : [
-            this.fileTypeAction
-          ]
         } : null,
       ].filter((s) => !!s) as any[]
     }
@@ -321,15 +338,6 @@ export abstract class BaseCommandClient {
         required: true
       }
     ];
-  }
-
-  protected get fileTypeAction(): CommandControlAction {
-    return {
-      disabled: true,
-      value: ((config: BackupConfig): string => {
-        return this.determineFileType(config);
-      })
-    }
   }
 
   protected get customSettings(): CommandSettingSection {

--- a/apps/studio/src/lib/db/backup-clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/backup-clients/sqlserver.ts
@@ -55,12 +55,11 @@ export class SqlServerBackupClient extends BaseCommandClient {
         },
         {
           controlType: 'input',
-          settingName: 'filename',
-          settingDesc: 'Filename',
-          required: true,
-          actions: [
-            this.fileTypeAction
-          ]
+          settingName: 'filenameTemplate',
+          settingDesc: 'Filename Template',
+          required: false,
+          supportsTemplate: true,
+          showPreview: true,
         }
       ]
     }

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -374,6 +374,8 @@ export interface CommandSettingControl {
   infoTitle?: string;
   onValueChange?: (config: BackupConfig) => void;
   actions?: CommandControlAction[];
+  supportsTemplate?: boolean;
+  showPreview?: boolean;
 }
 
 export interface CommandControlAction {

--- a/apps/studio/src/lib/db/models/BackupConfig.ts
+++ b/apps/studio/src/lib/db/models/BackupConfig.ts
@@ -19,6 +19,8 @@ export class BackupConfig {
   // TEXT INPUT CONTROLS ----------------------------------------------------
   filename?: string = dateFormat(new Date(), 'yyyy-mm-dd_HHMMss');
 
+  filenameTemplate?: string = null;
+
   encryptionCertificate?: string = null;
 
   encryptionKey?: string = null;

--- a/apps/studio/src/lib/utils/filenameTemplate.ts
+++ b/apps/studio/src/lib/utils/filenameTemplate.ts
@@ -1,0 +1,39 @@
+import dateFormat from "dateformat";
+
+export const DEFAULT_FILENAME_TEMPLATE = "{YYYY}-{MM}-{DD}_{HH}{mm}{SS}";
+
+const INVALID_FILENAME_CHARS = /[\\/:*?"<>|]/g;
+
+export function sanitizeFilename(value: string): string {
+  return value.replace(INVALID_FILENAME_CHARS, "_");
+}
+
+function templateValues(date: Date, dbName: string): Record<string, string> {
+  return {
+    "{dbname}": dbName ?? "",
+    "{YYYY}": dateFormat(date, "yyyy"),
+    "{YY}": dateFormat(date, "yy"),
+    "{MM}": dateFormat(date, "mm"),
+    "{DD}": dateFormat(date, "dd"),
+    "{HH}": dateFormat(date, "HH"),
+    "{mm}": dateFormat(date, "MM"),
+    "{SS}": dateFormat(date, "ss"),
+  };
+}
+
+export function resolveFilenameTemplate(
+  template: string,
+  dbName: string,
+  date = new Date()
+): string {
+  if (!template || template.trim() === "") {
+    return dateFormat(date, "yyyy-mm-dd_HHMMss");
+  }
+
+  let result = template;
+  for (const [token, value] of Object.entries(templateValues(date, dbName))) {
+    result = result.replaceAll(token, value);
+  }
+
+  return sanitizeFilename(result);
+}

--- a/apps/studio/src/store/modules/settings/SettingStoreModule.ts
+++ b/apps/studio/src/store/modules/settings/SettingStoreModule.ts
@@ -105,6 +105,10 @@ const SettingStoreModule: Module<State, any> = {
       if (!state.settings.sqliteExtensionFile) return null
       return state.settings.sqliteExtensionFile
     },
+    backupFilenameTemplate(state) {
+      if (!state.settings.backupFilenameTemplate) return null;
+      return state.settings.backupFilenameTemplate.value;
+    },
     privacyMode(state) {
       if (!state.settings.privacyMode) return false;
       return state.settings.privacyMode.value;

--- a/apps/studio/tests/unit/lib/utils/filenameTemplate.spec.ts
+++ b/apps/studio/tests/unit/lib/utils/filenameTemplate.spec.ts
@@ -1,0 +1,58 @@
+import {
+  resolveFilenameTemplate,
+  sanitizeFilename,
+  DEFAULT_FILENAME_TEMPLATE,
+} from '@/lib/utils/filenameTemplate'
+
+const date = new Date(2026, 6, 31, 19, 46, 5)
+
+describe('resolveFilenameTemplate', () => {
+  it('replaces all variables with their values', () => {
+    expect(resolveFilenameTemplate('{YYYY}-{MM}-{DD}_{HH}{mm}{SS}', 'sandbox', date)).toBe('2026-07-31_194605')
+  })
+
+  it('matches the issue example {dbname}_{YYYY}{MM}{DD}_{HH}{mm}', () => {
+    expect(resolveFilenameTemplate('{dbname}_{YYYY}{MM}{DD}_{HH}{mm}', 'sandbox', date)).toBe('sandbox_20260731_1946')
+  })
+
+  it('replaces repeated variables', () => {
+    expect(resolveFilenameTemplate('{dbname}-{dbname}', 'sandbox', date)).toBe('sandbox-sandbox')
+  })
+
+  it('mixes variables with arbitrary static text', () => {
+    expect(resolveFilenameTemplate('backup_{dbname}_{YYYY}-{MM}-{DD}', 'sandbox', date)).toBe('backup_sandbox_2026-07-31')
+  })
+
+  it('resolves the default template to the legacy default name', () => {
+    expect(resolveFilenameTemplate(DEFAULT_FILENAME_TEMPLATE, 'sandbox', date)).toBe('2026-07-31_194605')
+  })
+
+  it('keeps unknown placeholders unchanged', () => {
+    expect(resolveFilenameTemplate('backup_{unknown}_x', 'sandbox', date)).toBe('backup_{unknown}_x')
+  })
+
+  it('sanitizes invalid filename characters', () => {
+    expect(resolveFilenameTemplate('a/b\\c:d*e?f"g<h>i|j', 'sandbox', date)).toBe('a_b_c_d_e_f_g_h_i_j')
+  })
+
+  it('sanitizes database names containing invalid characters', () => {
+    expect(resolveFilenameTemplate('{dbname}', 'my/db:name', date)).toBe('my_db_name')
+  })
+
+  it('returns the legacy default name for an empty template', () => {
+    expect(resolveFilenameTemplate('', 'sandbox', date)).toBe('2026-07-31_194605')
+    expect(resolveFilenameTemplate('   ', 'sandbox', date)).toBe('2026-07-31_194605')
+    expect(resolveFilenameTemplate(null as any, 'sandbox', date)).toBe('2026-07-31_194605')
+    expect(resolveFilenameTemplate(undefined as any, 'sandbox', date)).toBe('2026-07-31_194605')
+  })
+})
+
+describe('sanitizeFilename', () => {
+  it('replaces every invalid character with an underscore', () => {
+    expect(sanitizeFilename('a\\/:*?"<>|b')).toBe('a_________b')
+  })
+
+  it('leaves valid characters unchanged', () => {
+    expect(sanitizeFilename('sandbox_2026-07-31')).toBe('sandbox_2026-07-31')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #4516

This PR adds configurable backup filename templates with variable substitution, allowing users to customize backup filenames while preserving the existing default behavior.

### ✨ Features

- Added support for filename template variables:
  - `{dbname}`
  - `{YYYY}`
  - `{YY}`
  - `{MM}`
  - `{DD}`
  - `{HH}`
  - `{mm}`
  - `{SS}`
- Added live filename preview that updates based on:
  - template changes
  - selected database
  - selected backup format/extension
- Automatically sanitizes invalid filename characters.
- Persists the filename template using the existing settings mechanism.
- Preserves the current backup naming behavior as the default for backward compatibility.

### 🏗️ Implementation

- Added a reusable filename template resolver utility.
- Extended the backup filename control to support template-aware behavior while keeping the existing declarative settings architecture.
- Resolved filename templates before backup execution, allowing the existing backup clients and extension handling to remain unchanged.
- Kept export functionality unchanged.

### 🧪 Tests

Added unit tests covering:

- Variable replacement
- Repeated variables
- Static text with variables
- Invalid filename sanitization
- Empty templates
- Unknown placeholders
- Database names containing invalid filename characters

### Backward Compatibility

The default template resolves to the same filename format used today:

```text
{YYYY}-{MM}-{DD}_{HH}{mm}{SS}
```

which produces filenames like:

```text
2026-07-31_204530
```

so existing users will experience no behavior changes unless they customize the template.