### PR TITLE
fix(postgres): use selected overload for SQL: Create on overloaded functions

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -70,7 +70,7 @@ export interface IConnectionHandlers {
   'conn/getTableCreateScript': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<string>,
   'conn/getViewCreateScript': ({ view, schema, sId }: { view: string, schema?: string, sId: string }) => Promise<string[]>,
   'conn/getMaterializedViewCreateScript': ({ view, schema, sId }: { view: string, schema?: string, sId: string }) => Promise<string[]>,
-  'conn/getRoutineCreateScript': ({ routine, type, schema, sId }: { routine: string, type: string, schema?: string, sId: string }) => Promise<string[]>,
+  'conn/getRoutineCreateScript': ({ routine, type, schema, id, sId }: { routine: string, type: string, schema?: string, id?: string, sId: string }) => Promise<string[]>,
   'conn/createTable': ({ table }: { table: CreateTableSpec }) => Promise<void>,
   'conn/getCollectionValidation': ({ collection, sId }: { collection: string, sId: string }) => Promise<any>,
   'conn/setCollectionValidation': ({ params, sId }: { params: any, sId: string }) => Promise<void>,
@@ -428,9 +428,9 @@ export const ConnHandlers: IConnectionHandlers = {
     return await state(sId).connection.getMaterializedViewCreateScript(view, schema);
   },
 
-  'conn/getRoutineCreateScript': async function({ routine, type, schema, sId }: { routine: string, type: string, schema?: string, sId: string }) {
+  'conn/getRoutineCreateScript': async function({ routine, type, schema, id, sId }: { routine: string, type: string, schema?: string, id?: string, sId: string }) {
     checkConnection(sId);
-    return await state(sId).connection.getRoutineCreateScript(routine, type, schema);
+    return await state(sId).connection.getRoutineCreateScript(routine, type, schema, id);
   },
 
   'conn/createTable': async function({ table, sId }: { table: CreateTableSpec, sId: string }) {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -1003,7 +1003,7 @@ export default Vue.extend({
       }
     },
     async loadRoutineCreate(routine) {
-      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema);
+      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema, routine.id);
       const stringResult = safeFormat(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
       this.createQuery(stringResult);
     },

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -1003,7 +1003,7 @@ export default Vue.extend({
       }
     },
     async loadRoutineCreate(routine) {
-      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema, routine.id);
+      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema, routine.oid);
       const stringResult = safeFormat(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
       this.createQuery(stringResult);
     },

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -322,7 +322,7 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   async getMaterializedViewCreateScript(_view: string, _schema?: string): Promise<string[]> {
     return [];
   }
-  abstract getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]>;
+  abstract getRoutineCreateScript(routine: string, type: string, schema?: string, id?: string): Promise<string[]>;
 
   // This is just for Mongo, calling it createTable in case we want to use it for other dbs in the future
   async createTable(_table: CreateTableSpec): Promise<void> {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -286,8 +286,11 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
         r.routine_schema as routine_schema,
         r.routine_name as name,
         r.routine_type as routine_type,
-        r.data_type as data_type
+        r.data_type as data_type,
+        p.oid::text as oid
       FROM INFORMATION_SCHEMA.ROUTINES r
+      LEFT JOIN pg_catalog.pg_proc p
+        ON r.specific_name::text = p.proname || '_' || p.oid::text
       where r.routine_schema not in ('sys', 'information_schema',
                                      'pg_catalog', 'performance_schema')
         ${schemaFilter ? `AND ${schemaFilter}` : ''}
@@ -329,6 +332,7 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
         returnType: row.data_type,
         entityType: 'routine',
         id: row.id,
+        oid: row.oid,
         routineParams: params.map((p, i) => {
           return {
             name: p.parameter_name || `arg${i + 1}`,

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1030,18 +1030,20 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
     return data.rows.map((row) => `${createViewSql}\n${row.pg_get_viewdef}`);
   }
 
-  async getRoutineCreateScript(routine: string, _type: string, schema: string = this._defaultSchema): Promise<string[]> {
+  async getRoutineCreateScript(routine: string, _type: string, schema: string = this._defaultSchema, id?: string): Promise<string[]> {
     const sql = `
       SELECT pg_get_functiondef(p.oid)
       FROM pg_proc p
              LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
       WHERE proname = $1
         AND n.nspname = $2
+        ${id ? 'AND p.oid = $3::oid' : ''}
     `;
 
     const params = [
       routine,
       schema,
+      ...(id ? [id] : []),
     ];
 
     const data = await this.driverExecuteSingle(sql, { params });

--- a/apps/studio/src/lib/db/models.ts
+++ b/apps/studio/src/lib/db/models.ts
@@ -232,6 +232,7 @@ export const RoutineTypeNames = {
 
 export interface Routine extends DatabaseEntity {
   id: string;
+  oid?: string;
   returnType: string;
   returnTypeLength?: number;
   routineParams?: RoutineParam[];

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -358,7 +358,7 @@ export interface IBasicDatabaseClient {
   getTableCreateScript(table: string, schema?: string): Promise<string>,
   getViewCreateScript(view: string, schema?: string): Promise<string[]>,
   getMaterializedViewCreateScript(view: string, schema?: string): Promise<string[]>,
-  getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]>,
+  getRoutineCreateScript(routine: string, type: string, schema?: string, id?: string): Promise<string[]>,
   createTable(table: CreateTableSpec): Promise<void>,
   getCollectionValidation(collection: string): Promise<any>,
   setCollectionValidation(params: any): Promise<void>,

--- a/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
+++ b/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
@@ -158,8 +158,8 @@ export class ElectronUtilityConnectionClient implements IBasicDatabaseClient {
     return await Vue.prototype.$util.send('conn/getMaterializedViewCreateScript', { view, schema });
   }
 
-  async getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]> {
-    return await Vue.prototype.$util.send('conn/getRoutineCreateScript', { routine, type, schema });
+  async getRoutineCreateScript(routine: string, type: string, schema?: string, id?: string): Promise<string[]> {
+    return await Vue.prototype.$util.send('conn/getRoutineCreateScript', { routine, type, schema, id });
   }
 
   async createTable(table: CreateTableSpec): Promise<void> {

--- a/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/postgres.spec.ts
@@ -732,6 +732,41 @@ function testWith(dockerTag: TestVersion, socket = false, readonly = false) {
       expect(selfRefKey.onDelete).toBe('SET DEFAULT');
     })
 
+    // regression test: SQL Create must resolve the selected overload, not the first one
+    it("should generate the create script for the selected routine overload", async () => {
+      if (util.connection.readOnlyMode) return;
+
+      await util.knex.raw(`
+        CREATE FUNCTION public.overload_test(integer) RETURNS integer
+          LANGUAGE sql IMMUTABLE AS 'SELECT $1::integer + 1';
+        CREATE FUNCTION public.overload_test(text) RETURNS text
+          LANGUAGE sql IMMUTABLE AS 'SELECT $1::text || ''!''';
+      `);
+
+      const routines = await util.connection.listRoutines({ schema: 'public' });
+      const overloads = routines.filter((r) => r.name === 'overload_test');
+
+      expect(overloads.length).toBe(2);
+      expect(overloads[0].oid).toBeTruthy();
+      expect(overloads[1].oid).toBeTruthy();
+      expect(overloads[0].oid).not.toEqual(overloads[1].oid);
+
+      const textOverload = overloads.find((r) => r.routineParams?.[0]?.type === 'text');
+      const intOverload = overloads.find((r) => r.routineParams?.[0]?.type === 'integer');
+
+      const textDef = await util.connection.getRoutineCreateScript(
+        textOverload.name, textOverload.type, textOverload.schema, textOverload.oid
+      );
+      const intDef = await util.connection.getRoutineCreateScript(
+        intOverload.name, intOverload.type, intOverload.schema, intOverload.oid
+      );
+
+      expect(textDef[0]).toContain('RETURNS text');
+      expect(intDef[0]).toContain('RETURNS integer');
+      expect(textDef[0]).not.toContain('RETURNS integer');
+      expect(intDef[0]).not.toContain('RETURNS text');
+    })
+
     describe("Common Tests", () => {
       if (readonly) {
         runReadOnlyTests(() => util)

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -190,4 +190,18 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(client.getTableOwner).toHaveBeenCalledWith('test_table', 'public');
   })
 
+  it("Should fetch the create script for the specific routine overload", async () => {
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({
+      rows: [{ pg_get_functiondef: 'CREATE OR REPLACE FUNCTION public.foo(a integer) ...' }]
+    });
+
+    const result = await client.getRoutineCreateScript('foo', 'function', 'public', '16385');
+
+    expect(client.driverExecuteSingle).toHaveBeenCalledWith(
+      expect.stringContaining('AND p.oid = $3::oid'),
+      { params: ['foo', 'public', '16385'] }
+    );
+    expect(result).toEqual(['CREATE OR REPLACE FUNCTION public.foo(a integer) ...']);
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes #4513.

When using **SQL: Create** on overloaded PostgreSQL functions, Beekeeper Studio always generated the definition for the first overload instead of the selected one.

This change propagates the routine identifier through the existing flow and uses it when generating the CREATE script so the selected overload is resolved correctly.

## What changed

- Added an optional routine identifier parameter to `getRoutineCreateScript`.
- Passed the selected routine's identifier from the routine tree through the IPC layer.
- Updated the PostgreSQL implementation to filter by routine OID when the identifier is available.
- Added a unit test covering overloaded PostgreSQL functions.

## Behavior

Before:

- `SQL: Create` always returned the first overload matching the function name.

After:

- `SQL: Create` returns the definition for the exact overload selected in the routine tree.

When no routine identifier is available, the existing lookup behavior is preserved.

## Testing

- Added a unit test covering overloaded PostgreSQL functions.
- Verified existing PostgreSQL tests continue to pass.
- Confirmed no behavior changes for other database clients.