### PR TITLE
fix: detect direct AppImage execution for auto-updater

### DIFF
--- a/apps/studio/src/background/update_manager.ts
+++ b/apps/studio/src/background/update_manager.ts
@@ -13,7 +13,7 @@ autoUpdater.logger = log
 
 // HACK(mc, 2019-09-10): work around https://github.com/electron-userland/electron-builder/issues/4046
 function dealWithAppImage() {
-  if (platformInfo.isAppImage) {
+  if (process.env.DESKTOPINTEGRATION === 'AppImageLauncher') {
     // remap temporary running AppImage to actual source
     // THIS IS PROBABLY SUPER BRITTLE AND MAKES ME WANT TO STOP USING APPIMAGE
     // eslint-disable-next-line

--- a/apps/studio/src/common/platform_info/mainPlatformInfo.ts
+++ b/apps/studio/src/common/platform_info/mainPlatformInfo.ts
@@ -93,7 +93,7 @@ export function mainPlatformInfo(): IPlatformInfo {
     isFlatpak: !!p.env.FLATPAK_ID || existsSync('/.flatpak-info'),
     isPortable: isWindows && p.env.PORTABLE_EXECUTABLE_DIR,
     isDevelopment: isDevEnv,
-    isAppImage: p.env.DESKTOPINTEGRATION === 'AppImageLauncher',
+    isAppImage: p.env.DESKTOPINTEGRATION === 'AppImageLauncher' || !!p.env.APPIMAGE,
     sshAuthSock: p.env.SSH_AUTH_SOCK,
     sshConfigExists: existsSync(join(homeDirectory, '.ssh', 'config')),
     defaultSshIdentityFile: ['id_ed25519', 'id_ecdsa', 'id_rsa', 'id_dsa']


### PR DESCRIPTION
## Summary

Fix AppImage detection so the auto-updater is available when Beekeeper Studio is run directly as an AppImage.

### Changes

- Detect AppImage execution using the `APPIMAGE` environment variable in addition to `DESKTOPINTEGRATION=AppImageLauncher`.
- Restrict the AppImageLauncher-specific `APPIMAGE` rewrite workaround to AppImageLauncher only.

### Why

Previously, `isAppImage` was only true when Beekeeper Studio was launched through AppImageLauncher. As a result, users running the AppImage directly did not have access to the built-in auto-updater, despite automatic updates being documented for AppImage installations.

Using the `APPIMAGE` environment variable allows Beekeeper Studio to correctly detect direct AppImage execution while preserving the existing AppImageLauncher-specific workaround.

closes: #4540 