### PR TITLE
fix: reposition AND/OR operators in table filters

### DIFF
--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -449,6 +449,9 @@
       padding-left: 0.45rem;
       padding-right: 0.25rem;
     }
+    .filter-mode-spacer {
+      visibility: hidden;
+    }
     .multiple-filter  {
       flex-grow: 1;
       & > * {

--- a/apps/studio/src/components/tableview/RowFilterBuilder.vue
+++ b/apps/studio/src/components/tableview/RowFilterBuilder.vue
@@ -72,6 +72,11 @@
               <i class="material-icons">code</i>
             </button>
           </div>
+          <span
+            v-else
+            class="btn-fab filter-mode-spacer"
+            aria-hidden="true"
+          />
           <div
             class="btn-wrap"
             v-for="(filter, index) in additionalFilters"


### PR DESCRIPTION
added a hidden spacer when raw filters are unavailable, keeping the and/or operators aligned with the filters they apply to. the spacer uses `visibility: hidden` because the empty spacer inherited an unintended button hover effect.

screenshot shown for MongoDB and also separately tested in Trino
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/4ba83c54-b550-406e-a76e-61ad72d96804" />

closes #4433 