### PR TITLE
fix: preserve table column order in SQL->SQL exports

### DIFF
--- a/apps/studio/src/components/export/forms/ExportFormSQL.vue
+++ b/apps/studio/src/components/export/forms/ExportFormSQL.vue
@@ -30,6 +30,21 @@
         <span>Create Table Before Inserting</span>
       </label>
     </div>
+    <div class="form-group row">
+      <label
+        for="preserveColumnOrder"
+        class="checkbox-group"
+      >
+        <input
+          v-model="options.preserveColumnOrder"
+          id="preserveColumnOrder"
+          type="checkbox"
+          name="preserveColumnOrder"
+          class="form-control"
+        >
+        <span>Preserve Column Order</span>
+      </label>
+    </div>
   </div>
 </template>
 
@@ -45,6 +60,7 @@ export default {
       options: {
         createTable: false,
         schema: false,
+        preserveColumnOrder: false,
       },
     };
   },

--- a/apps/studio/src/lib/export/formats/sql.ts
+++ b/apps/studio/src/lib/export/formats/sql.ts
@@ -66,6 +66,17 @@ export class SqlExporter extends Export {
     return ""
   }
 
+  private getColumnNames(rowLength: number, columns: TableColumn[]): string[] {
+    const storedColumns = this.dedupedColumns
+    const hasColumnNames = (candidate: TableColumn[]) =>
+      candidate.length === rowLength && candidate.every(column => column.columnName != null)
+
+    if (hasColumnNames(storedColumns)) return storedColumns.map(column => column.columnName)
+    if (hasColumnNames(columns)) return columns.map(column => column.columnName)
+
+    return Array.from({ length: rowLength }, (_value, index) => `col_${index + 1}`)
+  }
+
   formatRow(rowArray: any[], columns: TableColumn[] = []): string {
     const sanitized = rowArray.map((val, idx) => {
       // Handle bit columns - convert booleans and buffers to 0/1
@@ -82,15 +93,37 @@ export class SqlExporter extends Export {
       }
       return val
     })
-    const row = this.rowToObject(sanitized)
 
     let knex = this.knex(this.table.name)
     if (this.outputOptions.schema && this.table.schema) {
       knex = knex.withSchema(this.table.schema)
     }
 
+    const columnNames = this.getColumnNames(sanitized.length, columns)
+    const values = sanitized.map(value => {
+      if (value === undefined) {
+        if (this.connection.connectionType === "sqlite") {
+          throw new Error(
+            "SQLite does not support DEFAULT in INSERT values"
+          )
+        }
 
-    const content = knex.insert(row).toQuery()
+        return this.knex.raw("DEFAULT")
+      }
+    
+      if (_.isPlainObject(value)) {
+        return JSON.stringify(value)
+      }
+
+      return value
+    })
+
+    const insertBody = this.knex.raw(
+      `(${columnNames.map(() => '??').join(', ')}) values (${values.map(() => '?').join(', ')})`,
+      [...columnNames, ...values]
+    )
+
+    const content = knex.insert(insertBody).toQuery()
     return content
   }
 }

--- a/apps/studio/src/lib/export/formats/sql.ts
+++ b/apps/studio/src/lib/export/formats/sql.ts
@@ -8,7 +8,8 @@ import { ExportOptions } from '../models';
 
 interface OutputOptionsSql {
   createTable: boolean,
-  schema: boolean
+  schema: boolean,
+  preserveColumnOrder: boolean
 }
 export class SqlExporter extends Export {
   public static extension = "sql"
@@ -99,6 +100,11 @@ export class SqlExporter extends Export {
       knex = knex.withSchema(this.table.schema)
     }
 
+    if (this.outputOptions.preserveColumnOrder !== true) {
+      const row = this.rowToObject(sanitized)
+      return knex.insert(row).toQuery()
+    }
+
     const columnNames = this.getColumnNames(sanitized.length, columns)
     const values = sanitized.map(value => {
       if (value === undefined) {
@@ -110,7 +116,7 @@ export class SqlExporter extends Export {
 
         return this.knex.raw("DEFAULT")
       }
-    
+
       if (_.isPlainObject(value)) {
         return JSON.stringify(value)
       }

--- a/apps/studio/tests/unit/lib/export/formats/sql.spec.js
+++ b/apps/studio/tests/unit/lib/export/formats/sql.spec.js
@@ -20,7 +20,7 @@ describe('sql exporter', () => {
       "",
       [],
       {},
-      {}
+      { preserveColumnOrder: true }
     );
 
     const columns = [
@@ -35,6 +35,29 @@ describe('sql exporter', () => {
     expect(result).toBe(`insert into "table" ("id", "name", "age") values (1, 'Alice', 20)`);
   });
 
+  it("Should keep Knex's default column order unless enabled", () => {
+    const defaultExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "postgresql" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      { preserveColumnOrder: false }
+    );
+
+    const columns = [
+      { columnName: "id", dataType: "int" },
+      { columnName: "name", dataType: "varchar" },
+      { columnName: "age", dataType: "int" },
+    ];
+    defaultExporter.columns = columns;
+
+    const result = defaultExporter.formatRow([1, "Alice", 20], columns);
+    expect(result).toBe(`insert into "table" ("age", "id", "name") values (20, 1, 'Alice')`);
+  });
+
   it("Should preserve the order of numeric-looking column names", () => {
     const orderedExporter = new SqlExporter(
       "./tmp/sql.export",
@@ -44,7 +67,7 @@ describe('sql exporter', () => {
       "",
       [],
       {},
-      {}
+      { preserveColumnOrder: true }
     );
 
     const columns = [
@@ -67,7 +90,7 @@ describe('sql exporter', () => {
       "",
       [],
       {},
-      {}
+      { preserveColumnOrder: true }
     );
 
     const columns = [{ columnName: "", dataType: "int" }];
@@ -93,7 +116,7 @@ describe('sql exporter', () => {
       "",
       [],
       {},
-      {}
+      { preserveColumnOrder: true }
     );
     const columns = [{ columnName: "id", dataType: "int" }];
     undefinedExporter.columns = columns;
@@ -111,7 +134,7 @@ describe('sql exporter', () => {
       "",
       [],
       {},
-      {}
+      { preserveColumnOrder: true }
     );
     const columns = [{ columnName: "id", dataType: "int" }];
     sqliteExporter.columns = columns;

--- a/apps/studio/tests/unit/lib/export/formats/sql.spec.js
+++ b/apps/studio/tests/unit/lib/export/formats/sql.spec.js
@@ -55,7 +55,6 @@ describe('sql exporter', () => {
     orderedExporter.columns = columns;
 
     const result = orderedExporter.formatRow([10, 2, 1], columns);
-
     expect(result).toBe(`insert into "table" ("10", "2", "1") values (10, 2, 1)`);
   });
 
@@ -75,18 +74,14 @@ describe('sql exporter', () => {
     namedExporter.columns = columns;
 
     const result = namedExporter.formatRow([1], columns);
-    expect(result).toBe(
-      `insert into "table" ("") values (1)`
-    );
+    expect(result).toBe(`insert into "table" ("") values (1)`);
   });
 
   it("Should fall back to generated names when a column name is missing", () => {
     const columns = [{ dataType: "int" }];
 
     const result = exporter.formatRow([1], columns);
-    expect(result).toBe(
-      `insert into "table" ("col_1") values (1)`
-    );
+    expect(result).toBe(`insert into "table" ("col_1") values (1)`);
   });
 
   it("Should use DEFAULT for undefined values", () => {
@@ -104,9 +99,7 @@ describe('sql exporter', () => {
     undefinedExporter.columns = columns;
 
     const result = undefinedExporter.formatRow([undefined], columns);
-    expect(result).toBe(
-      `insert into "table" ("id") values (DEFAULT)`
-    );
+    expect(result).toBe(`insert into "table" ("id") values (DEFAULT)`);
   });
 
   it("Should reject undefined values for SQLite", () => {

--- a/apps/studio/tests/unit/lib/export/formats/sql.spec.js
+++ b/apps/studio/tests/unit/lib/export/formats/sql.spec.js
@@ -11,6 +11,123 @@ describe('sql exporter', () => {
     expect(result).toBe(`insert into "table" ("col_1", "col_2") values ('a', 'b')`)
   });
 
+  it("Should preserve column order in the insert", () => {
+    const orderedExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "postgresql" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      {}
+    );
+
+    const columns = [
+      { columnName: "id", dataType: "int" },
+      { columnName: "name", dataType: "varchar" },
+      { columnName: "age", dataType: "int" },
+    ];
+    orderedExporter.columns = columns
+    const input = [1, "Alice", 20];
+
+    const result = orderedExporter.formatRow(input, columns);
+    expect(result).toBe(`insert into "table" ("id", "name", "age") values (1, 'Alice', 20)`);
+  });
+
+  it("Should preserve the order of numeric-looking column names", () => {
+    const orderedExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "postgresql" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      {}
+    );
+
+    const columns = [
+      { columnName: "10", dataType: "int" },
+      { columnName: "2", dataType: "int" },
+      { columnName: "1", dataType: "int" },
+    ];
+    orderedExporter.columns = columns;
+
+    const result = orderedExporter.formatRow([10, 2, 1], columns);
+
+    expect(result).toBe(`insert into "table" ("10", "2", "1") values (10, 2, 1)`);
+  });
+
+  it("Should preserve an empty column name", () => {
+    const namedExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "postgresql" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      {}
+    );
+
+    const columns = [{ columnName: "", dataType: "int" }];
+    namedExporter.columns = columns;
+
+    const result = namedExporter.formatRow([1], columns);
+    expect(result).toBe(
+      `insert into "table" ("") values (1)`
+    );
+  });
+
+  it("Should fall back to generated names when a column name is missing", () => {
+    const columns = [{ dataType: "int" }];
+
+    const result = exporter.formatRow([1], columns);
+    expect(result).toBe(
+      `insert into "table" ("col_1") values (1)`
+    );
+  });
+
+  it("Should use DEFAULT for undefined values", () => {
+    const undefinedExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "postgresql" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      {}
+    );
+    const columns = [{ columnName: "id", dataType: "int" }];
+    undefinedExporter.columns = columns;
+
+    const result = undefinedExporter.formatRow([undefined], columns);
+    expect(result).toBe(
+      `insert into "table" ("id") values (DEFAULT)`
+    );
+  });
+
+  it("Should reject undefined values for SQLite", () => {
+    const sqliteExporter = new SqlExporter(
+      "./tmp/sql.export",
+      { connectionType: "sqlite" },
+      { name: "table" },
+      "",
+      "",
+      [],
+      {},
+      {}
+    );
+    const columns = [{ columnName: "id", dataType: "int" }];
+    sqliteExporter.columns = columns;
+
+    expect(() => sqliteExporter.formatRow([undefined], columns)).toThrow(
+      "SQLite does not support DEFAULT in INSERT values"
+    );
+  });
+
   it("Should generate an insert with json", () => {
     const input = ['a', {x: 'y'}];
     const result = exporter.formatRow(input)
@@ -61,6 +178,7 @@ describe('sql exporter', () => {
     const safeFilename = "exported_data";
     let exporter = new SqlExporter(`${safeFilename}.sql`, {connectionType: 'postgresql'}, { name: 'table'}, '', '', [], {}, {})
 
-    expect(exporter.getFileName()).toBe("exported_data.sql");
+    const result = exporter.getFileName();
+    expect(result).toBe("exported_data.sql");
   });
 });


### PR DESCRIPTION
- works around Knex sorting object keys before generating insert queries, that's why export had different order than in the UI
- uses Knex’s raw query helper to build the insert body directly from ordered column and value arrays instead of passing a row object to Knex (to avoid the object sorting mentioned above)
  - investigated a way to use the original `this.rowToObject()` function, looping over the returned keys and values but JS/TS doesn't preserve the order of integer-like string keys such as `"10"` or `"2"` during object enumeration
- preserves existing bit, json, fallback-column, and Knex behavior
- adds a defensive SQLite check for undefined values although the ui should never pass these, and this matches Knex’s existing SQLite restriction
- passes existing unit tests and added some to cover the ordering behavior

SS showing sql outputs after exporting, **left** is _BEFORE_ and **right** is _AFTER_:

<img width="3014" height="1786" alt="image" src="https://github.com/user-attachments/assets/c620930a-63e3-4478-926d-6bc7a7c5d890" />



closes #4266 