### PR TITLE
fix(postgres): use selected overload for SQL: Create on overloaded functions

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -70,7 +70,7 @@ export interface IConnectionHandlers {
   'conn/getTableCreateScript': ({ table, schema, sId }: { table: string, schema?: string, sId: string }) => Promise<string>,
   'conn/getViewCreateScript': ({ view, schema, sId }: { view: string, schema?: string, sId: string }) => Promise<string[]>,
   'conn/getMaterializedViewCreateScript': ({ view, schema, sId }: { view: string, schema?: string, sId: string }) => Promise<string[]>,
-  'conn/getRoutineCreateScript': ({ routine, type, schema, sId }: { routine: string, type: string, schema?: string, sId: string }) => Promise<string[]>,
+  'conn/getRoutineCreateScript': ({ routine, type, schema, routineId, sId }: { routine: string, type: string, schema?: string, routineId?: string, sId: string }) => Promise<string[]>,
   'conn/createTable': ({ table }: { table: CreateTableSpec }) => Promise<void>,
   'conn/getCollectionValidation': ({ collection, sId }: { collection: string, sId: string }) => Promise<any>,
   'conn/setCollectionValidation': ({ params, sId }: { params: any, sId: string }) => Promise<void>,
@@ -428,9 +428,9 @@ export const ConnHandlers: IConnectionHandlers = {
     return await state(sId).connection.getMaterializedViewCreateScript(view, schema);
   },
 
-  'conn/getRoutineCreateScript': async function({ routine, type, schema, sId }: { routine: string, type: string, schema?: string, sId: string }) {
+  'conn/getRoutineCreateScript': async function({ routine, type, schema, routineId, sId }: { routine: string, type: string, schema?: string, routineId?: string, sId: string }) {
     checkConnection(sId);
-    return await state(sId).connection.getRoutineCreateScript(routine, type, schema);
+    return await state(sId).connection.getRoutineCreateScript(routine, type, schema, routineId);
   },
 
   'conn/createTable': async function({ table, sId }: { table: CreateTableSpec, sId: string }) {

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -1003,7 +1003,7 @@ export default Vue.extend({
       }
     },
     async loadRoutineCreate(routine) {
-      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema);
+      const result = await this.connection.getRoutineCreateScript(routine.name, routine.type, routine.schema, routine.id);
       const stringResult = safeFormat(_.isArray(result) ? result[0] : result, { language: FormatterDialect(this.dialect) })
       this.createQuery(stringResult);
     },

--- a/apps/studio/src/lib/db/clients/BaseV1DatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BaseV1DatabaseClient.ts
@@ -46,7 +46,7 @@ export abstract class BaseV1DatabaseClient<RawResultType extends BaseQueryResult
     return [];
   }
 
-  async getRoutineCreateScript(_routine: string, _type: string, _schema?: string): Promise<string[]> {
+  async getRoutineCreateScript(_routine: string, _type: string, _schema?: string, _routineId?: string): Promise<string[]> {
     log.error("V1 Drivers do not support generating scripts");
     return [];
   }

--- a/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
+++ b/apps/studio/src/lib/db/clients/BasicDatabaseClient.ts
@@ -322,7 +322,7 @@ export abstract class BasicDatabaseClient<RawResultType extends BaseQueryResult,
   async getMaterializedViewCreateScript(_view: string, _schema?: string): Promise<string[]> {
     return [];
   }
-  abstract getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]>;
+  abstract getRoutineCreateScript(routine: string, type: string, schema?: string, routineId?: string): Promise<string[]>;
 
   // This is just for Mongo, calling it createTable in case we want to use it for other dbs in the future
   async createTable(_table: CreateTableSpec): Promise<void> {

--- a/apps/studio/src/lib/db/clients/postgresql.ts
+++ b/apps/studio/src/lib/db/clients/postgresql.ts
@@ -1030,7 +1030,30 @@ export class PostgresClient extends BasicDatabaseClient<QueryResult, PoolClient>
     return data.rows.map((row) => `${createViewSql}\n${row.pg_get_viewdef}`);
   }
 
-  async getRoutineCreateScript(routine: string, _type: string, schema: string = this._defaultSchema): Promise<string[]> {
+  async getRoutineCreateScript(routine: string, _type: string, schema: string = this._defaultSchema, routineId?: string): Promise<string[]> {
+    const oidMatch = routineId ? routineId.match(/\d+$/) : null;
+    const oid = oidMatch ? oidMatch[0] : null;
+
+    if (oid) {
+      const sql = `
+        SELECT pg_get_functiondef(p.oid)
+        FROM pg_proc p
+               LEFT JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE proname = $1
+          AND n.nspname = $2
+          AND p.oid = $3::oid
+      `;
+
+      const params = [
+        routine,
+        schema,
+        oid,
+      ];
+
+      const data = await this.driverExecuteSingle(sql, { params });
+      return data.rows.map((row) => row.pg_get_functiondef);
+    }
+
     const sql = `
       SELECT pg_get_functiondef(p.oid)
       FROM pg_proc p

--- a/apps/studio/src/lib/db/types.ts
+++ b/apps/studio/src/lib/db/types.ts
@@ -356,7 +356,7 @@ export interface IBasicDatabaseClient {
   getTableCreateScript(table: string, schema?: string): Promise<string>,
   getViewCreateScript(view: string, schema?: string): Promise<string[]>,
   getMaterializedViewCreateScript(view: string, schema?: string): Promise<string[]>,
-  getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]>,
+  getRoutineCreateScript(routine: string, type: string, schema?: string, routineId?: string): Promise<string[]>,
   createTable(table: CreateTableSpec): Promise<void>,
   getCollectionValidation(collection: string): Promise<any>,
   setCollectionValidation(params: any): Promise<void>,

--- a/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
+++ b/apps/studio/src/lib/utility/ElectronUtilityConnectionClient.ts
@@ -158,8 +158,8 @@ export class ElectronUtilityConnectionClient implements IBasicDatabaseClient {
     return await Vue.prototype.$util.send('conn/getMaterializedViewCreateScript', { view, schema });
   }
 
-  async getRoutineCreateScript(routine: string, type: string, schema?: string): Promise<string[]> {
-    return await Vue.prototype.$util.send('conn/getRoutineCreateScript', { routine, type, schema });
+  async getRoutineCreateScript(routine: string, type: string, schema?: string, routineId?: string): Promise<string[]> {
+    return await Vue.prototype.$util.send('conn/getRoutineCreateScript', { routine, type, schema, routineId });
   }
 
   async createTable(table: CreateTableSpec): Promise<void> {

--- a/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
+++ b/apps/studio/tests/unit/lib/db/clients/postgres.spec.js
@@ -190,4 +190,18 @@ describe("Postgres UNIT tests (no connection required)", () => {
     expect(client.getTableOwner).toHaveBeenCalledWith('test_table', 'public');
   })
 
+  it("Should fetch the create script for a specific routine overload using routineId", async () => {
+    client.driverExecuteSingle = jest.fn().mockResolvedValue({
+      rows: [{ pg_get_functiondef: 'CREATE OR REPLACE FUNCTION public.foo(a integer) ...' }]
+    });
+
+    const result = await client.getRoutineCreateScript('foo', 'function', 'public', 'foo_16385');
+
+    expect(client.driverExecuteSingle).toHaveBeenCalledWith(
+      expect.stringContaining('AND p.oid = $3::oid'),
+      { params: ['foo', 'public', '16385'] }
+    );
+    expect(result).toEqual(['CREATE OR REPLACE FUNCTION public.foo(a integer) ...']);
+  })
+
 })


### PR DESCRIPTION
## Summary

Fixes #4513.

### Problem

For overloaded PostgreSQL functions, `SQL: Create` always generated the definition for the first overload instead of the selected overload.

### Solution

- Preserve the selected routine identifier through the existing call chain.
- Pass the routine identifier to `getRoutineCreateScript`.
- Safely extract the PostgreSQL OID from PostgreSQL's `specific_name`.
- Query the selected overload by OID when available.
- Preserve the existing lookup path for backward compatibility.

### Testing

- Added unit test coverage.
- Verified backward compatibility when no routine identifier is supplied.