### PR TITLE
fix: display formatted keybindings in tooltips

### DIFF
--- a/apps/studio/jest.config.js
+++ b/apps/studio/jest.config.js
@@ -32,6 +32,7 @@ module.exports = {
     '^@commercial(.*)$': '<rootDir>/src-commercial/$1',
     '^@bksLogger$': '<rootDir>/src/lib/log/mainLogger.ts',
     '^@tests(.*)$': '<rootDir>/tests/$1',
+    '^@beekeeperstudio/ui-kit$': resolve(__dirname, '../ui-kit/lib/index.ts'),
   },
   // serializer for snapshots
   snapshotSerializers: [

--- a/apps/studio/src/common/bksConfig/ConfigMetadataProvider.ts
+++ b/apps/studio/src/common/bksConfig/ConfigMetadataProvider.ts
@@ -1,9 +1,10 @@
 import type { IPlatformInfo } from "../IPlatformInfo";
 import type { ConfigMetadata, KeybindingSection } from "@/types";
-import type { BksConfig } from "./BksConfigProvider";
+import type { BksConfig, KeybindingPath } from "./BksConfigProvider";
 import { convertKeybinding, ConfigValue } from "./BksConfigProvider";
 import { InvalidConfigMetadata } from "./errors";
 import defaultMetadata from "../../../config-metadata.json";
+import { formatDisplayKeybinding } from "@beekeeperstudio/ui-kit";
 
 /**
  * Provides UI-specific config functionality that requires metadata.
@@ -43,6 +44,19 @@ export class ConfigMetadataProvider {
       throw new InvalidConfigMetadata(missingLabels);
     }
     return sections;
+  }
+
+  getKeybindingLabel(path: KeybindingPath): string {
+    const keybindings = this.options.bksConfig.getKeybindings(
+      "context-menu",
+      path
+    );
+
+    const bindings = Array.isArray(keybindings)
+      ? keybindings
+      : [keybindings]
+
+    return bindings.map(formatDisplayKeybinding).join(", ");
   }
 
   private parseKeybindingSections(

--- a/apps/studio/src/components/tableinfo/TableIndexes.vue
+++ b/apps/studio/src/components/tableinfo/TableIndexes.vue
@@ -34,13 +34,13 @@
             <div class="actions">
               <a
                 @click.prevent="$emit('refresh')"
-                v-tooltip="`${ctrlOrCmd('r')} or F5`"
+                v-tooltip="$bksConfigUI.getKeybindingLabel('general.refresh')"
                 class="btn btn-link btn-fab"
               ><i class="material-icons">refresh</i></a>
               <a
                 v-if="enabled"
                 @click.prevent="addRow"
-                v-tooltip="ctrlOrCmd('n')"
+                v-tooltip="$bksConfigUI.getKeybindingLabel('general.addRow')"
                 class="btn btn-primary btn-fab"
               ><i class="material-icons">add</i></a>
             </div>

--- a/apps/studio/src/components/tableinfo/TablePartitions.vue
+++ b/apps/studio/src/components/tableinfo/TablePartitions.vue
@@ -20,13 +20,13 @@
             <a
               @click.prevent="refreshPartitions"
               class="btn btn-link btn-fab"
-              v-tooltip="`${ctrlOrCmd('r')} or F5`"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.refresh')"
             ><i class="material-icons">refresh</i></a>
             <a
               v-if="editable"
               @click.prevent="addRow"
               class="btn btn-primary btn-fab"
-              v-tooltip="ctrlOrCmd('n')"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.addRow')"
             ><i class="material-icons">add</i></a>
           </div>
         </div>

--- a/apps/studio/src/components/tableinfo/TableRelations.vue
+++ b/apps/studio/src/components/tableinfo/TableRelations.vue
@@ -27,13 +27,13 @@
           <div class="actions">
             <a
               @click.prevent="$emit('refresh')"
-              v-tooltip="`${ctrlOrCmd('r')} or F5`"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.refresh')"
               class="btn btn-link btn-fab"
             ><i class="material-icons">refresh</i></a>
             <a
               v-if="enabled && canAdd"
               @click.prevent="addRow"
-              v-tooltip="ctrlOrCmd('n')"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.addRow')"
               class="btn btn-primary btn-fab"
             ><i class="material-icons">add</i></a>
           </div>

--- a/apps/studio/src/components/tableinfo/TableSchema.vue
+++ b/apps/studio/src/components/tableinfo/TableSchema.vue
@@ -28,12 +28,12 @@
           <div class="actions">
             <a
               @click.prevent="refreshColumns"
-              v-tooltip="`${ctrlOrCmd('r')} or F5`"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.refresh')"
               class="btn btn-link btn-fab"
             ><i class="material-icons">refresh</i></a>
             <a
               v-if="editable"
-              v-tooltip="ctrlOrCmd('n')"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.addRow')"
               @click.prevent="addRow"
               class="btn btn-primary btn-fab"
             ><i class="material-icons">add</i></a>
@@ -560,4 +560,3 @@ export default Vue.extend({
   },
 })
 </script>
-

--- a/apps/studio/src/components/tableinfo/TableSchemaValidation.vue
+++ b/apps/studio/src/components/tableinfo/TableSchemaValidation.vue
@@ -19,7 +19,7 @@
           <div class="actions">
             <a
               @click.prevent="refresh"
-              v-tooltip="`${ctrlOrCmd('r')} or F5`"
+              v-tooltip="$bksConfigUI.getKeybindingLabel('general.refresh')"
               class="btn btn-link btn-fab"
             ><i class="material-icons">refresh</i></a>
           </div>
@@ -188,10 +188,6 @@ export default {
     }
   },
   methods: {
-    ctrlOrCmd(key) {
-      return platformInfo.isMac ? `⌘${key.toUpperCase()}` : `Ctrl+${key}`
-    },
-    
     async loadValidation() {
       if (this.loading) return
       this.loading = true

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -95,14 +95,14 @@
           <a
             v-if="(this.page > 1)"
             @click="page = 1"
-            v-tooltip="$bksConfig.keybindings.tableTable.firstPage"
+            v-tooltip="$bksConfigUI.getKeybindingLabel('tableTable.firstPage')"
           ><i
             class="material-icons"
           >first_page</i></a>
           <a
             v-if="(this.page > 1)"
             @click="page = page - 1"
-            v-tooltip="$bksConfig.keybindings.tableTable.previousPage"
+            v-tooltip="$bksConfigUI.getKeybindingLabel('tableTable.previousPage')"
           ><i
             class="material-icons"
           >navigate_before</i></a>
@@ -113,12 +113,12 @@
           <a
             v-if="hasNextPage"
             @click="page = page + 1"
-            v-tooltip="$bksConfig.keybindings.tableTable.nextPage"
+            v-tooltip="$bksConfigUI.getKeybindingLabel('tableTable.nextPage')"
           ><i class="material-icons">navigate_next</i></a>
           <a
             v-if="hasNextPage && canJumpToLastPage"
             @click="jumpToLastPage"
-            v-tooltip="$bksConfig.keybindings.tableTable.lastPage"
+            v-tooltip="$bksConfigUI.getKeybindingLabel('tableTable.lastPage')"
           >
             <i class="material-icons">last_page</i>
           </a>
@@ -208,7 +208,7 @@
 
         <!-- Actions -->
         <x-button
-          v-tooltip="`Refresh Table (${$bksConfig.keybindings.general.refresh})`"
+          v-tooltip="`Refresh Table (${$bksConfigUI.getKeybindingLabel('general.refresh')})`"
           class="btn btn-flat"
           @click="refreshTable"
         >
@@ -527,7 +527,7 @@ export default Vue.extend({
     addRowTooltip() {
       return this.usedConfig.readOnlyMode ?
         "Read Only Mode is enabled for this connection. Cannot add rows." :
-        `Add row (${this.$bksConfig.keybindings.general.addRow})`;
+        `Add row (${this.$bksConfigUI.getKeybindingLabel("general.addRow")})`;
     },
     readOnlyNotice() {
       if (this.usedConfig.readOnlyMode) {

--- a/apps/studio/src/typings/global.d.ts
+++ b/apps/studio/src/typings/global.d.ts
@@ -11,6 +11,8 @@ declare interface DOMEvent<T extends EventTarget> extends Event {
 declare type DeepKeyOf<T> = (
   [T] extends [never]
     ? ""
+    : T extends readonly unknown[]
+    ? ""
     : T extends Record<string, any>
     ? {
         [K in Exclude<keyof T, symbol>]: `${K}${DotPrefix<DeepKeyOf<T[K]>>}`;

--- a/apps/studio/tests/unit/config-metadata.spec.js
+++ b/apps/studio/tests/unit/config-metadata.spec.js
@@ -128,4 +128,27 @@ describe("Config Metadata", () => {
     });
     expect(() => bksConfigUI.getKeybindingSections()).not.toThrow();
   });
+
+  it.each([
+    ["single shortcut", "general.addRow", "Ctrl+N"],
+    ["multiple shortcuts", "general.refresh", "F5, Ctrl+R"],
+  ])("Should format %s correctly in labels", (_name, path, expected) => {
+    const raw = parseIni(fullConfigIni);
+    const processed = processRawConfig(raw);
+    const source = {
+      defaultConfig: processed,
+      systemConfig: {},
+      userConfig: {},
+      warnings: [],
+    };
+
+    const bksConfig = BksConfigProvider.create(source, linuxPlatformInfo);
+    const bksConfigUI = new ConfigMetadataProvider({
+      bksConfig,
+      metadata: fullMetadata,
+      platformInfo: linuxPlatformInfo,
+    });
+
+    expect(bksConfigUI.getKeybindingLabel(path)).toBe(expected);
+  });
 });

--- a/apps/ui-kit/lib/index.ts
+++ b/apps/ui-kit/lib/index.ts
@@ -3,3 +3,4 @@ import "./style.scss"
 export type * from "./components"
 export { setClipboard } from "./utils/clipboard";
 export { divider } from "./components/context-menu";
+export { formatDisplayKeybinding } from "./utils/formatDisplayKeybinding";


### PR DESCRIPTION
added the helper suggested in the issue to display formatted keybindings in tooltips instead of the unparsed versions.

updated `DeepKeyOf` in `global.d.ts` so array-valued keybindings, like `general.refresh`, are recognized as valid type-safe paths when passed to the helper.

added unit test

demo showing keybindings in tooltips:

https://github.com/user-attachments/assets/103ef428-d113-40f2-8ca8-5d28c0b9fe4b

also replaced these ones in the `structure` view of tables that were showing 'Meta+R' for example before
<img width="842" height="359" alt="image" src="https://github.com/user-attachments/assets/fbfef5db-39b8-4a8a-b150-a906292d524c" />

closes #4525 