### PR TITLE
fix: re-fetch table columns on manual table refresh to reflect renames

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -2085,6 +2085,9 @@ export default Vue.extend({
 
       // Re-fetch table keys on explicit refresh to pick up schema changes (issue #3775)
       await this.getTableKeys()
+      // Re-fetch column metadata on explicit refresh so renames show up without
+      // reopening the connection (issue #4567). No-ops when columns are unchanged.
+      await this.$store.dispatch('updateTableColumns', this.table)
 
       await this.tabulator.replaceData()
       const layout = this.tabulator.getColumnLayout();

--- a/apps/studio/tests/unit/components/tableview/TableTable.spec.ts
+++ b/apps/studio/tests/unit/components/tableview/TableTable.spec.ts
@@ -93,3 +93,41 @@ describe("TableTable.vue — buildPendingInserts", () => {
     expect(insert.data[0].data).toEqual({ hello: "world" });
   });
 });
+
+// Regression coverage for #4567.
+// `refreshTable()` used to re-fetch table KEYS but not column metadata, so a
+// column rename was invisible after Refresh until the connection was reopened.
+describe("TableTable.vue — refreshTable re-fetches columns (#4567)", () => {
+  const refreshTable = (TableTable as any).options.methods.refreshTable;
+
+  function makeRefreshCtx({ table }: { table: any }) {
+    return {
+      // the component instance state refreshTable touches:
+      table,
+      tabulator: {
+        getPage: () => 1,
+        replaceData: jest.fn().mockResolvedValue(undefined),
+        getColumnLayout: () => [],
+        setColumns: jest.fn().mockResolvedValue(undefined),
+        setColumnLayout: jest.fn(),
+        setPage: jest.fn(),
+      },
+      tableColumns: [],
+      active: true,
+      forceRedraw: false,
+      // sibling method refreshTable calls:
+      getTableKeys: jest.fn().mockResolvedValue(undefined),
+      // the store dispatch we are asserting on:
+      $store: { dispatch: jest.fn().mockResolvedValue(undefined) },
+    };
+  }
+
+  it("dispatches updateTableColumns on explicit refresh (issue-4567)", async () => {
+    const table = { name: "t", schema: "public", columns: [{ columnName: "c" }] };
+    const ctx = makeRefreshCtx({ table });
+
+    await refreshTable.call(ctx);
+
+    expect(ctx.$store.dispatch).toHaveBeenCalledWith("updateTableColumns", table);
+  });
+});


### PR DESCRIPTION
Closes #4567.

## Problem

`refreshTable()` re-fetches table **keys** on an explicit Refresh but not column **metadata**, so a column rename (or any schema change to existing columns) is invisible after Refresh until the user reopens the table/connection.

## Fix

In `TableTable.vue` `refreshTable()`, after the existing `getTableKeys()` call, dispatch `updateTableColumns` for the current table. That store action re-fetches the column metadata, so renames show up on a manual Refresh without reopening the connection. It no-ops when columns are unchanged.

```diff
 // Re-fetch table keys on explicit refresh to pick up schema changes (issue #3775)
 await this.getTableKeys()
+// Re-fetch column metadata on explicit refresh so renames show up without
+// reopening the connection (issue #4567). No-ops when columns are unchanged.
+await this.$store.dispatch('updateTableColumns', this.table)
 await this.tabulator.replaceData()
```

## Test

New regression spec `TableTable.spec.ts` — `refreshTable re-fetches columns (#4567)`: drives the real `refreshTable` method against a hand-built context and asserts `updateTableColumns` is dispatched with the table. Mutation-verifiable: removing the new `dispatch` line flips the assertion red.

## Test plan

- [x] `yarn workspace beekeeper-studio test:unit` — **3129 tests passed, 82 suites, 0 failed**.
- [x] Adversarial logic + test-integrity review of the diff.
- [ ] Manual: rename a column in a table, hit Refresh, confirm the rename appears without reopening the connection (left for the owner).

---

Authored by `@YuriNachos`. Implementation written by a `cccc` (Claude Code, GLM-5.2) worker under orchestrator acceptance — gate green (`test:unit`, 3129 passed) and an independent adversarial review confirmed correctness.
