### PR TITLE
fix(deps): bump sql-query-identifier to ^3.2.0 for Postgres dollar-quote splitting

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -132,7 +132,7 @@
     "source-map-support": "^0.5.21",
     "split.js": "^1.6.5",
     "sql-formatter": "15.7.3",
-    "sql-query-identifier": "^3.1.0",
+    "sql-query-identifier": "^3.2.0",
     "sqlanywhere": "beekeeper-studio/node-sqlanywhere#54d1ef2052ccdfe963f0956a3e4d024ee6f1fd8d",
     "ssh-config": "5.2.0",
     "ssh2": "^1.14.0",

--- a/apps/studio/tests/unit/lib/db/sql_tool.spec.js
+++ b/apps/studio/tests/unit/lib/db/sql_tool.spec.js
@@ -192,3 +192,28 @@ describe("SQL Formatter", () => {
     });
   });
 });
+
+describe("Postgres dollar-quoted function bodies", () => {
+  // Regression for #4550: run-current-query (Ctrl+Shift+Enter) on a line inside
+  // a CREATE FUNCTION ... $$ ... $$ must not merge the function with the next
+  // statement. The $$ ... $$ body must be treated as part of the function.
+  it("splits a $$-quoted function and the following statement separately", () => {
+    const sql = [
+      "create table test_table (test_id int);",
+      "insert into test_table select * from generate_series(1, 10);",
+      "",
+      "create or replace function getTest(int) returns setof test_table as $$",
+      "  select * from test_table where test_id in ($1);",
+      "$$ language sql;",
+      "",
+      "select * from getTest(1);",
+    ].join("\n");
+    const result = splitQueries(sql, "psql");
+    expect(result.length).toBe(4);
+    // The trailing statement must be the standalone SELECT, not glued to the function:
+    expect(result[3].text).toMatch(/select \* from getTest\(1\)/);
+    // And the function statement must end at the $$ ... language sql; line,
+    // not swallow the trailing select:
+    expect(result[2].text).toMatch(/\$\$ language sql;/);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -12592,10 +12592,10 @@ sql-query-identifier@^2.10.0:
   resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-2.10.0.tgz#ee46e7ffb941a5f03a4f1b297d47d438dc6c14e1"
   integrity sha512-SBYnk1PPIDJ4M1+O3YXKfc4L++RyntcJAGhEWqBv0xrOzzp2k7lTeM7Ow//IfmDsfyh7dVas03UJWoL2P+nPEQ==
 
-sql-query-identifier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-3.1.0.tgz#012d29144a53660e907aebeca79a843bcf69dde0"
-  integrity sha512-zkxEUdm4CmwC346F5eszYAiuF2jfxBpr6KS5TPhmUq3CJgHXgLOLJlipZrVWOZ7H10OO2wy0RrHlTuqaHQEA0Q==
+sql-query-identifier@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/sql-query-identifier/-/sql-query-identifier-3.2.0.tgz#c2e184258da21b821d8404ece45892a8709b4f17"
+  integrity sha512-DUIx0pyyPYIJzFCuD5euzHOjj1n9BxTEkq8iXOHgOTd/RwuKsHUMhn0tb6pAwJR2rccy925Fhe4NaDDadIjTUQ==
 
 sqlanywhere@beekeeper-studio/node-sqlanywhere#54d1ef2052ccdfe963f0956a3e4d024ee6f1fd8d:
   version "2.0.4"


### PR DESCRIPTION
Closes #4550.

## Problem

On Postgres, `run-current-query` over-executes when the cursor is inside a `$$ … $$` dollar-quoted function body: the query splitter (`sql-query-identifier`) merges the function body with the following statement, so "run current" sends more than the intended statement. Root cause is a stale `yarn.lock` — the app pins `sql-query-identifier@3.1.0` (floor of `^3.1.0`), but upstream fixed dollar-quote handling in 3.1.1; 3.2.0 carries the fix.

## Fix

Bump `sql-query-identifier` to `^3.2.0` (stricter-than-minimum floor — the fix is in 3.1.1+, but 3.2.0 forecloses any 3.1.x resolution on a fresh install) and update `yarn.lock` to resolve 3.2.0.

## Test

New `sql_tool.spec.js` case "Postgres dollar-quoted function bodies" asserts the splitter returns 4 statements (not 3) for a `CREATE FUNCTION … $$ … $$ LANGUAGE sql;` followed by a trailing `SELECT` — the trailing SELECT must stand alone.

- **RED proven**: against the stock `master` lock (3.1.0) the new test fails with `Expected: 4, Received: 3` (3.1.0 merges the function body with the trailing SELECT — exactly the #4550 over-execution).
- **GREEN**: on 3.2.0 it returns 4.

## Test plan

- [x] `yarn workspace beekeeper-studio test:unit` — **3129 tests passed, 82 suites, 0 failed** (no regression; no pre-existing test asserted the old buggy splitting).
- [x] Adversarial review (logic + test-integrity): APPROVE, 0 blockers — `^3.2.0` floor consistent with yarn.lock (resolves 3.2.0), no workspace desync (ui-kit pins a different major `^2.10.0`), only the public `identify`/types API consumed.

---

Authored by `@YuriNachos`. Implementation written by a `cccc` (Claude Code, GLM-5.2) worker under orchestrator acceptance — gate green (3129 passed) and an independent adversarial review returned APPROVE with no blocking findings.
