### PR TITLE
fix(table): use filtered count when jumping to last page

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -337,7 +337,7 @@ import TableLength from '@/components/common/TableLength.vue'
 import { mapGetters, mapState } from 'vuex';
 import { TableUpdate, TableUpdateResult, ExtendedTableColumn } from '@/lib/db/models';
 import { dialectFor, formatOptionsFor, TableKey } from '@shared/lib/dialects/models'
-import { normalizeFilters, safeSqlFormat, createTableFilter, isNumericDataType, isDateDataType, rowHeaderField } from '@/common/utils'
+import { normalizeFilters, safeSqlFormat, createTableFilter, isNumericDataType, isDateDataType, rowHeaderField, joinFilters } from '@/common/utils'
 import { TableFilter } from '@/lib/db/models';
 import { LanguageData } from '../../lib/editor/languageData'
 import { escapeHtml, FormatterParams } from '@shared/lib/tabulator';
@@ -2062,12 +2062,32 @@ export default Vue.extend({
     },
     async jumpToLastPage() {
       try {
-        const totalRows = await this.connection.getTableLength(this.table.name, this.table.schema); // -> SELECT (*) FROM table
+        let totalRows: number
 
-        const lastPage = Math.ceil(totalRows / this.limit);
+        if (Array.isArray(this.filters) && this.filters.length > 0) {
+          const allFilters: string[] = []
+          for (const filter of this.filters) {
+            allFilters.push(await this.connection.getQueryForFilter(filter))
+          }
+          const count = await this.connection.getFilteredDataCount(
+            this.table.name,
+            this.table.schema,
+            joinFilters(allFilters, this.filters)
+          )
+          totalRows = Number(count) || 0
+        } else if (_.isString(this.filters) && this.filters) {
+          const count = await this.connection.getFilteredDataCount(
+            this.table.name,
+            this.table.schema,
+            this.filters
+          )
+          totalRows = Number(count) || 0
+        } else {
+          totalRows = await this.connection.getTableLength(this.table.name, this.table.schema)
+        }
 
-        this.page = lastPage;
-
+        const lastPage = Math.max(1, Math.ceil(totalRows / this.limit))
+        this.page = lastPage
       } catch (error) {
         console.error("Error jumping to the last page:", error);
       }


### PR DESCRIPTION
## Summary
- `jumpToLastPage()` now uses `getFilteredDataCount` when filters are active
- Matches existing logic in `TableLength.vue`
- `Math.max(1, ...)` avoids page 0 when count is empty


## Test plan
- [ ] Large table, no filters → End goes to correct last page
- [ ] Filter reduces rows → End goes to last **filtered** page
- [ ] Raw SQL filter string → same behavior
- [ ] Filter with zero rows → stays on page 1

# Before

https://github.com/user-attachments/assets/569da52b-bc33-4d4f-acbc-6cfe946f6c51

# After

https://github.com/user-attachments/assets/23cdf145-76db-4989-86bf-972fe8fd25db