### PR TITLE
fix new folder cleared by poll

### DIFF
--- a/apps/studio/src/common/utils/folderTree.ts
+++ b/apps/studio/src/common/utils/folderTree.ts
@@ -17,46 +17,26 @@ export interface ExtendedItemNode<T extends HasId = HasId> extends ItemNode {
   parentIdKey: string;
 }
 
-/** A draft folder has no id until it is saved. */
-export function isDraftFolder(folder: Pick<IFolder, "id">): boolean {
-  return folder.id == null;
-}
-
 /**
  * `children` holds references to the same node objects, so a flat array still
  * describes the whole tree.
  */
 export function buildFolderNodes(folders: IFolder[]): ExtendedFolderNode[] {
   const nodes: ExtendedFolderNode[] = folders.map(buildFolderNode);
-  let draftIdx: number = -1;
 
   const byId = new Map<FolderNode["id"], ExtendedFolderNode>();
   for (const node of nodes) {
     byId.set(node.id, node);
   }
 
-  for (let i = 0; i < nodes.length; i++) {
-    const node = nodes[i];
-    if (isDraftFolder(node.ref)) {
-      draftIdx = i;
-    }
+  for (const node of nodes) {
     if (node.parentId === null) {
       continue;
     }
     const parent = byId.get(node.parentId);
     if (parent && parent !== node) {
-      if (isDraftFolder(node.ref)) {
-        parent.children.unshift(node);
-      } else {
-        parent.children.push(node);
-      }
+      parent.children.push(node);
     }
-  }
-
-  // The tree renders root folders in array order, so the draft leads the list.
-  if (draftIdx !== -1) {
-    const draft = nodes.splice(draftIdx, 1)[0];
-    nodes.unshift(draft);
   }
 
   return nodes;

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -185,7 +185,7 @@
               </template>
               <tree
                 v-show="!searching"
-                :folders="folderNodes"
+                :folders="extendedFolderNodes"
                 :items="sortedItemNodes"
                 :expanded-ids="expandedNodeIds"
                 @update:expandedIds="setExpandedIds"
@@ -335,7 +335,7 @@ import rawLog from '@bksLogger'
 import SidebarSortButtons from '../common/SidebarSortButtons.vue'
 import EditableText from '@/components/common/EditableText.vue'
 import Noty from 'noty'
-import { parseReorderTarget } from '@/common/utils/folderTree'
+import { buildFolderNodes, parseReorderTarget } from '@/common/utils/folderTree'
 
 const log = rawLog.scope('connection-sidebar');
 
@@ -369,6 +369,8 @@ export default {
     justCreatedFolderId: null,
     justCreatedTimeout: null,
     loadingFolderIds: [],
+    drafting: false,
+    draftParentId: null,
   }),
   watch: {
     async sort(newSort) {
@@ -391,7 +393,6 @@ export default {
       folders: 'items',
       foldersLoading: 'loading',
       foldersError: 'error',
-      draft: 'draft',
     }),
     ...mapState('sidebar/connections', {
       expandedFolderIds: 'expandedIds',
@@ -414,6 +415,15 @@ export default {
       set(newFilter) {
         this.$store.dispatch('data/connections/setConnectionFilter', newFilter);
       }
+    },
+    draft() {
+      return { id: null, parentId: this.draftParentId, name: 'Untitled folder' };
+    },
+    extendedFolderNodes() {
+      if (this.drafting) {
+        return buildFolderNodes([this.draft, ...this.folders]);
+      }
+      return this.folderNodes;
     },
     expandedNodeIds() {
       return this.expandedFolderIds.map((id) => `folder-${id}`);
@@ -490,8 +500,6 @@ export default {
       loadConnectionFolders: 'data/connectionFolders/loadByParentIds',
       unloadConnections: 'data/connections/unloadByParentIds',
       unloadConnectionFolders: 'data/connectionFolders/unloadByParentIds',
-      startDrafting: 'data/connectionFolders/startDrafting',
-      stopDrafting: 'data/connectionFolders/stopDrafting',
     }),
     ...mapMutations({
       setExpandedFolderIds: 'sidebar/connections/expandedIds',
@@ -583,6 +591,13 @@ export default {
       } else {
         this.startDrafting(null);
       }
+    },
+    startDrafting(parentId) {
+      this.draftParentId = parentId
+      this.drafting = true
+    },
+    stopDrafting() {
+      this.drafting = false
     },
     markJustCreated(folderId) {
       clearTimeout(this.justCreatedTimeout)

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -113,7 +113,7 @@
           </template>
           <tree
             v-show="!searching"
-            :folders="folderNodes"
+            :folders="extendedFolderNodes"
             :items="sortedItemNodes"
             :expanded-ids="expandedNodeIds"
             @update:expandedIds="setExpandedIds"
@@ -222,7 +222,7 @@ import { Tree, TreeFolder } from "@beekeeperstudio/ui-kit/vue/tree";
 import EditableText from '@/components/common/EditableText.vue'
 import ContentPlaceholder from '@/components/common/loading/ContentPlaceholder.vue'
 import ContentPlaceholderText from '@/components/common/loading/ContentPlaceholderText.vue'
-import { parseReorderTarget } from '@/common/utils/folderTree'
+import { buildFolderNodes, parseReorderTarget } from '@/common/utils/folderTree'
 
 export default {
   components: { SidebarLoading, ErrorAlert, ExpiredFolderAlert, FavoriteListItem, Tree, TreeFolder, EditableText, ContentPlaceholder, ContentPlaceholderText },
@@ -234,6 +234,8 @@ export default {
       justCreatedFolderId: null,
       justCreatedTimeout: null,
       loadingFolderIds: [],
+      drafting: false,
+      draftParentId: null,
     }
   },
   mounted() {
@@ -259,11 +261,19 @@ export default {
       'folders': 'items',
       'foldersLoading': 'loading',
       'foldersError': 'error',
-      'draft': 'draft',
     }),
     ...mapState('sidebar/queries', {
       expandedFolderIds: 'expandedIds',
     }),
+    draft() {
+      return { id: null, parentId: this.draftParentId, name: 'Untitled folder' };
+    },
+    extendedFolderNodes() {
+      if (this.drafting) {
+        return buildFolderNodes([this.draft, ...this.folders]);
+      }
+      return this.folderNodes;
+    },
     expandedNodeIds() {
       return this.expandedFolderIds.map((id) => `folder-${id}`);
     },
@@ -304,8 +314,6 @@ export default {
       loadQueryFolders: 'data/queryFolders/loadByParentIds',
       unloadQueries: 'data/queries/unloadByParentIds',
       unloadQueryFolders: 'data/queryFolders/unloadByParentIds',
-      startDrafting: 'data/queryFolders/startDrafting',
-      stopDrafting: 'data/queryFolders/stopDrafting',
     }),
     ...mapMutations({
       setExpandedFolderIds: 'sidebar/queries/expandedIds',
@@ -410,6 +418,13 @@ export default {
       } else {
         this.startDrafting(null);
       }
+    },
+    startDrafting(parentId) {
+      this.draftParentId = parentId
+      this.drafting = true
+    },
+    stopDrafting() {
+      this.drafting = false
     },
     markJustCreated(folderId) {
       clearTimeout(this.justCreatedTimeout)

--- a/apps/studio/src/store/modules/data/connection_folder/CloudConnectionFolderModule.ts
+++ b/apps/studio/src/store/modules/data/connection_folder/CloudConnectionFolderModule.ts
@@ -3,7 +3,7 @@ import { IConnectionFolder } from "@/common/interfaces/IQueryFolder";
 import { actionsFor, DataState, DataStore, mutationsFor } from "@/store/modules/data/DataModuleBase";
 import { accessGrantMutations, accessGrantActions } from "@/store/modules/data/access_grant/accessGrantStore";
 import { FolderFetchModule, treeActions } from "@/store/modules/data/tree/treeStore";
-import { FolderableState, folderableActions, folderableMutations } from "@/store/modules/data/tree/folderableStore";
+import { FolderableState, folderableActions } from "@/store/modules/data/tree/folderableStore";
 import { FolderNodeModule } from "@/store/modules/data/tree/FolderNodeModule";
 
 type State = DataState<IConnectionFolder> & FolderableState<IConnectionFolder>;
@@ -15,12 +15,10 @@ export const CloudConnectionFolderModule: DataStore<IConnectionFolder, State> = 
     loading: false,
     error: null,
     pollError: null,
-    draft: null,
   },
   mutations: {
     ...mutationsFor<IConnectionFolder>({}, { field: 'name', direction: 'asc'}),
     ...accessGrantMutations(),
-    ...folderableMutations(),
   },
   modules: {
     nodes: FolderNodeModule,

--- a/apps/studio/src/store/modules/data/connection_folder/LocalConnectionFolderModule.ts
+++ b/apps/studio/src/store/modules/data/connection_folder/LocalConnectionFolderModule.ts
@@ -6,7 +6,7 @@ import { safely } from "@/store/modules/data/StoreHelpers";
 import { accessGrantActions, accessGrantMutations } from "@/store/modules/data/access_grant/accessGrantStore";
 import { LocalWorkspace } from "@/common/interfaces/IWorkspace";
 import { FolderFetchModule, treeActions } from "@/store/modules/data/tree/treeStore";
-import { FolderableState, folderableActions, folderableMutations } from "@/store/modules/data/tree/folderableStore";
+import { FolderableState, folderableActions } from "@/store/modules/data/tree/folderableStore";
 import { FolderNodeModule } from "@/store/modules/data/tree/FolderNodeModule";
 
 type State = DataState<IConnectionFolder> & FolderableState<IConnectionFolder>
@@ -18,12 +18,10 @@ export const LocalConnectionFolderModule: DataStore<IConnectionFolder, State> = 
     loading: false,
     error: null,
     pollError: null,
-    draft: null,
   },
   mutations: {
     ...mutationsFor<IConnectionFolder>({}, { field: 'name', direction: 'asc' }),
     ...accessGrantMutations(),
-    ...folderableMutations(),
   },
   modules: {
     nodes: FolderNodeModule,

--- a/apps/studio/src/store/modules/data/query_folder/CloudQueryFolderModule.ts
+++ b/apps/studio/src/store/modules/data/query_folder/CloudQueryFolderModule.ts
@@ -2,7 +2,7 @@ import { IQueryFolder } from "@/common/interfaces/IQueryFolder";
 import { actionsFor, DataState, DataStore, mutationsFor } from "@/store/modules/data/DataModuleBase";
 import { accessGrantMutations, accessGrantActions } from "@/store/modules/data/access_grant/accessGrantStore";
 import { FolderFetchModule, treeActions } from "@/store/modules/data/tree/treeStore";
-import { FolderableState, folderableActions, folderableMutations } from "@/store/modules/data/tree/folderableStore";
+import { FolderableState, folderableActions } from "@/store/modules/data/tree/folderableStore";
 import { FolderNodeModule } from "@/store/modules/data/tree/FolderNodeModule";
 
 type State = DataState<IQueryFolder> & FolderableState<IQueryFolder>;
@@ -14,12 +14,10 @@ export const CloudQueryFolderModule: DataStore<IQueryFolder, State> = {
     loading: false,
     error: null,
     pollError: null,
-    draft: null,
   },
   mutations: {
     ...mutationsFor<IQueryFolder>({}, { field: 'name', direction: 'asc'}),
     ...accessGrantMutations(),
-    ...folderableMutations(),
   },
   modules: {
     nodes: FolderNodeModule,

--- a/apps/studio/src/store/modules/data/query_folder/LocalQueryFolderModule.ts
+++ b/apps/studio/src/store/modules/data/query_folder/LocalQueryFolderModule.ts
@@ -6,7 +6,7 @@ import { safely } from "@/store/modules/data/StoreHelpers";
 import { accessGrantActions, accessGrantMutations } from "@/store/modules/data/access_grant/accessGrantStore";
 import { LocalWorkspace } from "@/common/interfaces/IWorkspace";
 import { FolderFetchModule, treeActions } from "@/store/modules/data/tree/treeStore";
-import { FolderableState, folderableActions, folderableMutations } from "@/store/modules/data/tree/folderableStore";
+import { FolderableState, folderableActions } from "@/store/modules/data/tree/folderableStore";
 import { FolderNodeModule } from "@/store/modules/data/tree/FolderNodeModule";
 
 type State = DataState<IQueryFolder> & FolderableState<IQueryFolder>
@@ -18,12 +18,10 @@ export const LocalQueryFolderModule: DataStore<IQueryFolder, State> = {
     loading: false,
     error: null,
     pollError: null,
-    draft: null,
   },
   mutations: {
     ...mutationsFor<IQueryFolder>({}, { field: 'name', direction: 'asc' }),
     ...accessGrantMutations(),
-    ...folderableMutations(),
   },
   modules: {
     nodes: FolderNodeModule,

--- a/apps/studio/src/store/modules/data/tree/FolderNodeModule.ts
+++ b/apps/studio/src/store/modules/data/tree/FolderNodeModule.ts
@@ -6,7 +6,6 @@ import {
   ExtendedFolderNode as Node,
   buildFolderNode,
   buildFolderNodes,
-  isDraftFolder,
 } from "@/common/utils/folderTree";
 import { ReplacePayload } from "@/store/modules/data/DataModuleBase";
 
@@ -34,11 +33,7 @@ function applyUpsert(state: State, folders: IFolder[]) {
     const existing = state.items.find((i) => i.id === node.id);
 
     if (!existing) {
-      if (isDraftFolder(folder)) {
-        state.items.unshift(node);
-      } else {
-        state.items.push(node);
-      }
+      state.items.push(node);
       attaching.push(node);
       continue;
     }
@@ -59,11 +54,7 @@ function applyUpsert(state: State, folders: IFolder[]) {
   for (const node of attaching) {
     const parent = state.items.find((i) => i.id === node.parentId);
     if (parent) {
-      if (isDraftFolder(node.ref)) {
-        parent.children.unshift(node);
-      } else {
-        parent.children.push(node);
-      }
+      parent.children.push(node);
     }
   }
 }

--- a/apps/studio/src/store/modules/data/tree/folderableStore.ts
+++ b/apps/studio/src/store/modules/data/tree/folderableStore.ts
@@ -1,28 +1,21 @@
 /**
- * What a folder module needs beyond `treeStore`: loading the default folders,
- * and making a draft folder.
+ * What a folder module needs beyond `treeStore`: loading the default folders.
  *
  * Requires `mutationsFor`, `actionsFor` (or `utilActionsFor`), and `treeStore`.
  *
  * @example
  * ```ts
  * export const CloudConnectionFolderModule = {
- *   mutations: {
- *     ...mutationsFor<IConnectionFolder>({}),
- *     ...folderableMutations<IConnectionFolder>(),
- *   },
  *   actions: {
  *     ...actionsFor<IConnectionFolder>("connectionFolders", {}),
  *     ...treeActions<IConnectionFolder>({ plural: "parentIds", singular: "parentId" }),
  *     ...folderableActions<IConnectionFolder>(),
  *   },
  * }
- *
- * store.dispatch("data/connectionFolders/startDrafting", parentId)
  * ```
  **/
 
-import { ActionTree, MutationTree } from "vuex";
+import { ActionTree } from "vuex";
 import { State as RootState } from "@/store";
 import { ClientError } from "@/store/modules/data/StoreHelpers";
 import { IFolder } from "@/common/interfaces/IQueryFolder";
@@ -32,8 +25,6 @@ export type FolderableState<T> = {
   loading: boolean;
   error: ClientError;
   items: T[];
-  /** The folder being created right now, or null when nothing is being named. */
-  draft: T | null;
 };
 
 export function folderableActions<T extends IFolder>(): ActionTree<
@@ -63,40 +54,6 @@ export function folderableActions<T extends IFolder>(): ActionTree<
         ...context.state.items.toSpliced(personalIdx, 1),
       ];
       await context.dispatch("mutate", { type: "set", data: sorted });
-    },
-    async startDrafting(context, parentId?: number) {
-      if (context.state.draft) {
-        await context.dispatch("stopDrafting");
-      }
-      // A draft has no id until it is saved, so it doesn't satisfy IFolder yet.
-      // @ts-expect-error
-      const draft: IFolder = {
-        id: null,
-        parentId,
-        name: "Untitled folder",
-      };
-      context.commit("draft", draft);
-      await context.dispatch("mutate", { type: "upsert", data: draft });
-    },
-    async stopDrafting(context) {
-      if (!context.state.draft) {
-        return;
-      }
-      await context.dispatch("mutate", {
-        type: "remove",
-        data: context.state.draft,
-      });
-      context.commit("draft", null);
-    },
-  };
-}
-
-export function folderableMutations<T extends IFolder>(): MutationTree<
-  FolderableState<T>
-> {
-  return {
-    draft(state, draft: T | null) {
-      state.draft = draft;
     },
   };
 }


### PR DESCRIPTION
Folder creation is now handled by sidebar components instead of the vuex module. That way we can prevent the poll() from breaking it.