### PR TITLE
Fix for being unable to close tabs

### DIFF
--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -1089,9 +1089,15 @@ export default Vue.extend({
       if (this.closingTab) return; // prevent close modals queueing
 
       if (tab.unsavedChanges && !options?.ignoreUnsavedChanges) {
+        let confirmed = false
         this.closingTab = tab
-        const confirmed = await this.$confirmById(this.confirmModalId);
-        this.closingTab = null
+        try {
+          confirmed = await this.$confirmById(this.confirmModalId);
+        } finally {
+          // Never leave this set - it gates every close, so a stuck value
+          // silently disables tab closing for the rest of the session.
+          this.closingTab = null
+        }
         if (!confirmed) return
       }
 

--- a/apps/studio/src/components/common/modals/ConfirmationModal.vue
+++ b/apps/studio/src/components/common/modals/ConfirmationModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <base-modal :name="id" @submit="confirm">
+  <base-modal
+    :name="id"
+    @submit="confirm"
+    @closed="reportClose(false)"
+  >
     <template #title>
       <slot name="title">Are you sure?</slot>
     </template>
@@ -36,20 +40,25 @@ export default Vue.extend({
     },
   },
   methods: {
-    confirm() {
+    /**
+     * Whoever opened this modal is likely awaiting a promise that only settles
+     * on this event, so every way out has to report an outcome - including the
+     * ones we don't control (the header close button, Escape, clicking the
+     * overlay), which only reach us as `closed`. `closed` also fires after an
+     * explicit confirm/cancel; the manager ignores the second report.
+     */
+    reportClose(confirmed: boolean) {
       this.trigger(MODAL_CLOSE_EVENT, {
         modalId: this.id,
-        confirmed: true,
+        confirmed,
       } as ModalCloseEventData);
-
+    },
+    confirm() {
+      this.reportClose(true);
       this.$modal.hide(this.id);
     },
     cancel() {
-      this.trigger(MODAL_CLOSE_EVENT, {
-        modalId: this.id,
-        confirmed: false,
-      } as ModalCloseEventData);
-
+      this.reportClose(false);
       this.$modal.hide(this.id);
     },
   },

--- a/apps/studio/src/components/common/modals/ConfirmationModalManager.vue
+++ b/apps/studio/src/components/common/modals/ConfirmationModalManager.vue
@@ -76,6 +76,11 @@ export default Vue.extend({
   methods: {
     onModalClose(event: ModalCloseEventData) {
       const idx: number = this.modals.findIndex((modal: ModalContext) => modal.id === event.modalId)
+      // Modals we aren't tracking still broadcast on this root event - ignore
+      // them rather than throwing, which would strand any modal whose handler
+      // runs after ours.
+      if (idx === -1) return;
+
       const modal: ModalContext = this.modals[idx];
 
       if (event.confirmed) modal.onConfirm();

--- a/apps/studio/tests/unit/components/CoreTabsClose.spec.ts
+++ b/apps/studio/tests/unit/components/CoreTabsClose.spec.ts
@@ -1,0 +1,72 @@
+import CoreTabs from "@/components/CoreTabs.vue";
+
+// `close` gates every tab close on `closingTab`, so if it's ever left set the
+// ✕ button, ctrl+w and File > Close Tab all become silent no-ops. Exercise the
+// method directly - mounting CoreTabs would drag in the whole tab surface.
+const close = (CoreTabs as any).options.methods.close;
+
+function context(overrides: Record<string, any> = {}) {
+  return {
+    closingTab: null,
+    confirmModalId: "core-tabs-close-confirmation",
+    activeTab: null,
+    selectedSidebarItem: null,
+    trigger: jest.fn(),
+    $store: { dispatch: jest.fn().mockResolvedValue(undefined), commit: jest.fn() },
+    $confirmById: jest.fn().mockResolvedValue(true),
+    lastTab: null,
+    previousTab: jest.fn(),
+    nextTab: jest.fn(),
+    ...overrides,
+  };
+}
+
+const dirtyTab = () => ({ unsavedChanges: true, title: "Query #1" });
+const cleanTab = () => ({ unsavedChanges: false, title: "Query #2" });
+
+describe("CoreTabs close", () => {
+  it("removes a tab with no unsaved changes", async () => {
+    const vm = context();
+    const tab = cleanTab();
+
+    await close.call(vm, tab);
+
+    expect(vm.$store.dispatch).toHaveBeenCalledWith("tabs/remove", tab);
+  });
+
+  it("removes a tab with unsaved changes once confirmed", async () => {
+    const vm = context();
+    const tab = dirtyTab();
+
+    await close.call(vm, tab);
+
+    expect(vm.$confirmById).toHaveBeenCalledWith(vm.confirmModalId);
+    expect(vm.$store.dispatch).toHaveBeenCalledWith("tabs/remove", tab);
+    expect(vm.closingTab).toBeNull();
+  });
+
+  it("keeps the tab and clears closingTab when the confirmation is declined", async () => {
+    const vm = context({ $confirmById: jest.fn().mockResolvedValue(false) });
+
+    await close.call(vm, dirtyTab());
+
+    expect(vm.$store.dispatch).not.toHaveBeenCalled();
+    expect(vm.closingTab).toBeNull();
+  });
+
+  // A confirmation that blows up used to leave `closingTab` pinned, which
+  // disabled tab closing entirely until the app was restarted.
+  it("clears closingTab when the confirmation rejects", async () => {
+    const vm = context({
+      $confirmById: jest.fn().mockRejectedValue(new Error("modal is gone")),
+    });
+
+    await expect(close.call(vm, dirtyTab())).rejects.toThrow("modal is gone");
+    expect(vm.closingTab).toBeNull();
+
+    // ...and the next close still works.
+    const tab = cleanTab();
+    await close.call(vm, tab);
+    expect(vm.$store.dispatch).toHaveBeenCalledWith("tabs/remove", tab);
+  });
+});

--- a/apps/studio/tests/unit/components/modals/ConfirmationModal.spec.ts
+++ b/apps/studio/tests/unit/components/modals/ConfirmationModal.spec.ts
@@ -1,0 +1,156 @@
+import { mount, createLocalVue } from "@vue/test-utils";
+import Vue from "vue";
+import { AppEvent, AppEventMixin } from "@/common/AppEvent";
+import BaseModal from "@/components/common/modals/BaseModal.vue";
+import ConfirmationModal from "@/components/common/modals/ConfirmationModal.vue";
+import ConfirmationModalManager from "@/components/common/modals/ConfirmationModalManager.vue";
+import { MODAL_CLOSE_EVENT } from "@/components/common/modals/utils";
+
+// The app installs this globally in renderer.ts. Both the manager and the
+// modal rely on `trigger` / `registerHandlers` from it.
+Vue.mixin(AppEventMixin);
+
+const MODAL_ID = "test-close-confirmation";
+
+describe("ConfirmationModal.vue", () => {
+  let wrapper;
+  let modalMock;
+
+  // Mirrors how CoreTabs uses this: the manager lives in App.vue, and the
+  // <confirmation-modal> with a fixed id is declared in the consumer's
+  // template. `$confirmById` then shows that existing modal by id.
+  const Harness = {
+    components: { ConfirmationModalManager, ConfirmationModal },
+    template: `
+      <div>
+        <confirmation-modal-manager />
+        <confirmation-modal :id="modalId" />
+      </div>
+    `,
+    data() {
+      return { modalId: MODAL_ID };
+    },
+  };
+
+  function mountHarness() {
+    modalMock = { show: jest.fn(), hide: jest.fn() };
+    return mount(Harness, {
+      localVue: createLocalVue(),
+      // <modal> (vue-js-modal) and <portal> (portal-vue) are globally
+      // registered in the app but not in the test environment.
+      stubs: { modal: true, portal: true, "x-progressbar": true },
+      mocks: { $modal: modalMock },
+    });
+  }
+
+  // This is what `$confirmById` (BeekeeperPlugin) does.
+  function confirmById(id: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      wrapper.vm.$root.$emit(AppEvent.showConfirmModal, {
+        id,
+        onConfirm: () => resolve(true),
+        onCancel: () => resolve(false),
+      });
+    });
+  }
+
+  /** Resolves to `settled` if the promise settles, `pending` otherwise. */
+  function settlesWith(promise: Promise<unknown>) {
+    return Promise.race([
+      promise.then((v) => ({ settled: true, value: v })),
+      Promise.resolve().then(() => ({ settled: false, value: undefined })),
+    ]);
+  }
+
+  beforeEach(() => {
+    wrapper = mountHarness();
+  });
+
+  afterEach(() => {
+    wrapper.destroy();
+  });
+
+  // The bug: dismissing the modal via the header ✕, Escape, or an overlay
+  // click only calls `$modal.hide()`. Nothing fires MODAL_CLOSE_EVENT, so the
+  // promise handed back by `$confirmById` never settles. In CoreTabs that
+  // leaves `closingTab` pinned forever and every later tab close becomes a
+  // silent no-op.
+  it("settles a pending confirmation as cancelled when dismissed without a button", async () => {
+    const pending = confirmById(MODAL_ID);
+    await wrapper.vm.$nextTick();
+
+    // vue-js-modal emits `closed` however the modal was dismissed, and
+    // BaseModal forwards it.
+    wrapper.findComponent(BaseModal).vm.$emit("closed");
+    await wrapper.vm.$nextTick();
+
+    await expect(settlesWith(pending)).resolves.toEqual({
+      settled: true,
+      value: false,
+    });
+  });
+
+  it("resolves true when confirmed", async () => {
+    const pending = confirmById(MODAL_ID);
+    await wrapper.vm.$nextTick();
+
+    wrapper.findComponent(ConfirmationModal).vm.confirm();
+    await wrapper.vm.$nextTick();
+
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it("resolves false when cancelled", async () => {
+    const pending = confirmById(MODAL_ID);
+    await wrapper.vm.$nextTick();
+
+    wrapper.findComponent(ConfirmationModal).vm.cancel();
+    await wrapper.vm.$nextTick();
+
+    await expect(pending).resolves.toBe(false);
+  });
+
+  // `confirm()` fires the event and then hides the modal, which makes
+  // vue-js-modal emit `closed`. That must not report a second, contradictory
+  // cancel for the same confirmation.
+  it("does not report a cancel after confirming", async () => {
+    const onConfirm = jest.fn();
+    const onCancel = jest.fn();
+    wrapper.vm.$root.$emit(AppEvent.showConfirmModal, {
+      id: MODAL_ID,
+      onConfirm,
+      onCancel,
+    });
+    await wrapper.vm.$nextTick();
+
+    wrapper.findComponent(ConfirmationModal).vm.confirm();
+    wrapper.findComponent(BaseModal).vm.$emit("closed");
+    await wrapper.vm.$nextTick();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  // A second confirmation on the same modal id must work after the first one
+  // was dismissed.
+  it("can be reused after a dismissal", async () => {
+    const first = confirmById(MODAL_ID);
+    await wrapper.vm.$nextTick();
+    wrapper.findComponent(BaseModal).vm.$emit("closed");
+    await expect(first).resolves.toBe(false);
+
+    const second = confirmById(MODAL_ID);
+    await wrapper.vm.$nextTick();
+    wrapper.findComponent(ConfirmationModal).vm.confirm();
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("ignores close events for modals it isn't tracking", async () => {
+    expect(() => {
+      wrapper.vm.$root.$emit(MODAL_CLOSE_EVENT, {
+        modalId: "not-a-modal-we-know-about",
+        confirmed: false,
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
- getting a tab close confirmation then dismissing with esc didn't clear the 'closing' flag
- This meant that no tab could be closed
- We now properly track confirmation modal state