### PR TITLE
fix(editor): show hours field at exactly one hour in query elapsed timer

### DIFF
--- a/apps/studio/src/lib/time/formatSeconds.ts
+++ b/apps/studio/src/lib/time/formatSeconds.ts
@@ -2,5 +2,5 @@ export default (seconds: number) => {
   const h = Math.floor(seconds / 3600).toString().padStart(2, '0');
   const m = Math.floor((seconds % 3600) / 60).toString().padStart(2, '0');
   const s = (seconds % 60).toString().padStart(2, '0');
-  return `${seconds > 3600 ? `${h}:` : ''}${m}:${s}`;
+  return `${seconds >= 3600 ? `${h}:` : ''}${m}:${s}`;
 }

--- a/apps/studio/tests/unit/lib/time/formatSeconds.spec.ts
+++ b/apps/studio/tests/unit/lib/time/formatSeconds.spec.ts
@@ -1,0 +1,22 @@
+import formatSeconds from "@/lib/time/formatSeconds"
+
+describe("formatSeconds", () => {
+  it("formats sub-minute and sub-hour durations as mm:ss", () => {
+    expect(formatSeconds(0)).toBe("00:00")
+    expect(formatSeconds(5)).toBe("00:05")
+    expect(formatSeconds(59)).toBe("00:59")
+    expect(formatSeconds(60)).toBe("01:00")
+    expect(formatSeconds(95)).toBe("01:35")
+    expect(formatSeconds(3599)).toBe("59:59")
+  })
+
+  it("shows the hours field starting exactly at one hour", () => {
+    // Regression: the threshold used to be `seconds > 3600`, so at
+    // exactly 3600s (1h) the hours prefix was dropped and the timer
+    // briefly rendered "00:00" instead of "01:00:00".
+    expect(formatSeconds(3600)).toBe("01:00:00")
+    expect(formatSeconds(3601)).toBe("01:00:01")
+    expect(formatSeconds(3661)).toBe("01:01:01")
+    expect(formatSeconds(7384)).toBe("02:03:04")
+  })
+})


### PR DESCRIPTION
## Summary
- The query elapsed-time formatter (`apps/studio/src/lib/time/formatSeconds.ts`) used a strict `seconds > 3600` check to decide whether to render the `HH:` prefix.
- At exactly 3600 seconds (1 hour) the prefix was dropped, so the timer on the query status bar briefly rendered `00:00` before flipping to `01:00:01` one tick later.
- Changed the bound to `>=` so the one-hour boundary renders as `01:00:00`. The elapsed counter in `TabQueryEditor.vue` increments by whole seconds, so this only ever received integers; the off-by-one was purely the inclusive-vs-exclusive bound.

## Test plan
- [x] Added `apps/studio/tests/unit/lib/time/formatSeconds.spec.ts` covering sub-minute, sub-hour, and the one-hour boundary.
- [x] Confirmed the new test fails against the old code (`formatSeconds(3600)` returned `00:00`) and passes with the fix.
- [x] `npx eslint src/lib/time/formatSeconds.ts tests/unit/lib/time/formatSeconds.spec.ts` — clean.
- [x] `yarn workspace beekeeper-studio test:unit -- tests/unit/lib/time/formatSeconds.spec.ts` — 2 passed.

Co-Authored-By: Claude <noreply@anthropic.com>