### PR TITLE
fix(json-viewer): escape regex metacharacters when locating keys by path

### DIFF
--- a/apps/studio/src/lib/data/jsonViewer.ts
+++ b/apps/studio/src/lib/data/jsonViewer.ts
@@ -36,7 +36,11 @@ export function findKeyPosition(jsonStr: string, path: (string | number)[]) {
     let found = false;
 
     for (let i = lineSearchOffset; i < lines.length; i++) {
-      const keyMatch = new RegExp(`^\\s{${(pathIdx + 1) * 2}}"${targetKey}":`);
+      // Escape regex metacharacters in the key: JSON keys commonly
+      // contain '.', '+', '(' etc. (URLs, domains, dotted config
+      // names), and an unescaped key would match the wrong line or
+      // fail to match at all.
+      const keyMatch = new RegExp(`^\\s{${(pathIdx + 1) * 2}}"${_.escapeRegExp(targetKey)}":`);
 
       if (keyMatch.test(lines[i])) {
         lineSearchOffset = i + 1;

--- a/apps/studio/tests/unit/lib/data/detail_view.spec.js
+++ b/apps/studio/tests/unit/lib/data/detail_view.spec.js
@@ -24,6 +24,32 @@ describe("Detail View", () => {
     expect(findKeyPosition(jsonStr, ["staff_id", "store_id"])).toBe(64);
   });
 
+  it("should locate keys that contain regex metacharacters", () => {
+    // Regression: the key was interpolated into a RegExp unescaped, so a
+    // key like "a.b" (the "." matched any char) could resolve to a
+    // different sibling line. Dotted/domain-style keys are common in JSON
+    // payloads (URLs, config, hostnames).
+    const dotted = JSON.stringify({ axb: 1, "a.b": 2 }, null, 2);
+    const dottedLines = dotted.split("\n");
+    const dottedPos = findKeyPosition(dotted, ["a.b"]);
+    expect(dottedPos).toBe(dottedLines.findIndex((l) => l.includes('"a.b"')));
+    expect(dottedLines[dottedPos]).toContain('"a.b"');
+
+    // Nested dotted key
+    const nested = JSON.stringify(
+      { config: { "api.example.com": { port: 8080 } } },
+      null,
+      2
+    );
+    const nestedPos = findKeyPosition(nested, ["config", "api.example.com"]);
+    expect(nested.split("\n")[nestedPos]).toContain("api.example.com");
+
+    // "+" is a regex quantifier — must match the literal key, not "aa+b"
+    const plus = JSON.stringify({ ab: 1, "a+b": 2 }, null, 2);
+    const plusPos = findKeyPosition(plus, ["a+b"]);
+    expect(plus.split("\n")[plusPos]).toContain('"a+b"');
+  });
+
   it("should find a value info in a line of JSON text", () => {
     const lines = jsonStr.split("\n");
     expect(findValueInfo(lines[15])).toStrictEqual({


### PR DESCRIPTION
## Summary
- `findKeyPosition` in `apps/studio/src/lib/data/jsonViewer.ts` builds a `RegExp` to locate a JSON key by path, but it interpolated the key into the pattern without escaping it.
- Keys containing regex metacharacters are common in real JSON payloads (dots in URLs / hostnames such as `api.example.com`, plus signs, parentheses in dotted config names). An unescaped key matched the wrong line or failed to match: with both `axb` and `a.b` present, asking for `a.b` resolved to the `axb` line because the unescaped `.` matched any character.
- This drives expand/collapse and path navigation in the JSON detail view (`JsonViewer.vue`, `persistJsonFold`), so dotted keys would expand/highlight the wrong node.
- Escape the key with lodash's `escapeRegExp` (already imported in the module) so the match is literal.

## Test plan
- [x] Added a regression case to `apps/studio/tests/unit/lib/data/detail_view.spec.js` covering a dotted key (`a.b`) that collides with a regex-wildcard sibling (`axb`), a nested dotted key (`api.example.com`), and a `+` key (a regex quantifier).
- [x] Confirmed the new test fails against the old code (resolves to the wrong line) and passes with the fix; the pre-existing `findKeyPosition` cases still pass.
- [x] `npx eslint src/lib/data/jsonViewer.ts tests/unit/lib/data/detail_view.spec.js` — clean.
- [x] `yarn workspace beekeeper-studio test:unit -- tests/unit/lib/data/detail_view.spec.js` — 12 passed.

Co-Authored-By: Claude <noreply@anthropic.com>