### PR TITLE
skip .git folder in import

### DIFF
--- a/apps/studio/src/handlers/workspaceHandlers.ts
+++ b/apps/studio/src/handlers/workspaceHandlers.ts
@@ -18,6 +18,8 @@ const log = rawLog.scope("workspaceHandlers")
 const MAX_SQL_FILE_BYTES = 4 * 2_000_000;
 const SQL_FILE_EXTENSIONS = new Set(['.sql', '.txt']);
 
+const SKIP_DIR_NAMES = new Set(['.git']);
+
 // I am just assuming that big batches might be an issue, so we have the ability to cap here
 // as well as cap the amount of rows so we don't piss off the active record transaction
 // I'm also not sure what size the cloud can actually handle
@@ -202,14 +204,18 @@ async function importDirectory(funcs: ImportFunctions, dir: string, parentId: nu
     const childDirNames = await getDirChildren(dir, true);
 
     for (const child of childDirNames) {
-      const dirPath = path.join(dir, child);
+      if (!SKIP_DIR_NAMES.has(child)) {
+        const dirPath = path.join(dir, child);
 
-      const childStats = await importDirectory(funcs, dirPath, parentId);
+        const childStats = await importDirectory(funcs, dirPath, parentId);
 
-      stats.queries += childStats.queries;
-      stats.directories += childStats.directories;
-      if (childStats.warnings.length) {
-        stats.warnings.push(...childStats.warnings);
+        stats.queries += childStats.queries;
+        stats.directories += childStats.directories;
+        if (childStats.warnings.length) {
+          stats.warnings.push(...childStats.warnings);
+        }
+      } else {
+        stats.warnings.push(`Skipping folder: ${child}`);
       }
     }
   }

--- a/bin/allowed-console-logs.txt
+++ b/bin/allowed-console-logs.txt
@@ -16,7 +16,6 @@ apps/studio/src/components/data/DataManager.vue::console.log("DataManager checki
 apps/studio/src/components/data/DataManager.vue::console.log("DataManager --> registering", module.path)
 apps/studio/src/components/data/DataManager.vue::console.log("DataManager --> unregistering", module.path)
 apps/studio/src/components/data/DataManager.vue::console.log('mount and refresh: ', this.workspace)
-apps/studio/src/components/data/ImportConnectionsModal.vue::console.log("opening modal!")
 apps/studio/src/components/data/WorkspaceSignInModal.vue::console.log("open modal with ", email)
 apps/studio/src/components/editor/MergeManager.vue::console.log("Apply Patch", this.unsavedText, patch)
 apps/studio/src/components/editor/MergeManager.vue::console.log("Make Patch: ", this.originalText, this.query.text)


### PR DESCRIPTION
Just manually skip folders named `.git` as this will most likely be present in popsql exports and nothing inside will be importable anyways