### PR TITLE
feat: edit json/jsonb cells in a side drawer

### DIFF
--- a/apps/studio/src/assets/styles/components/_all.scss
+++ b/apps/studio/src/assets/styles/components/_all.scss
@@ -7,5 +7,6 @@
 @import "dropzone.scss";
 @import "text-editor.scss";
 @import "json-viewer.scss";
+@import "json-cell-drawer.scss";
 @import './upsell/upgrade-panel.scss';
 @import './upsell/ai-shell-upsell.scss';

--- a/apps/studio/src/assets/styles/components/json-cell-drawer.scss
+++ b/apps/studio/src/assets/styles/components/json-cell-drawer.scss
@@ -1,0 +1,105 @@
+.json-cell-drawer {
+  --hoz-gutter: 1rem;
+
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-width: 100%;
+  min-width: 10rem;
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    min-height: 2.35rem;
+    padding-left: var(--hoz-gutter);
+    padding-right: var(--hoz-gutter);
+
+    .header-group {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 0;
+    }
+
+    // Actions keep full width; the column name truncates instead.
+    .header-group.actions {
+      flex-shrink: 0;
+    }
+
+    .column-name {
+      font-weight: bold;
+      color: $text-dark;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      min-width: 0;
+    }
+
+    // Matches the flattened treatment the same badge gets in the table headers
+    // (see .tabulator-col .badge) rather than the global pill.
+    .column-data-type {
+      flex-shrink: 0;
+      background: transparent;
+      color: $text-lighter;
+      padding: 0;
+      margin: 0;
+    }
+
+    .read-only-hint {
+      color: $text-light;
+      font-size: 0.85rem;
+    }
+  }
+
+  .text-editor-wrapper {
+    flex: 1 1 auto;
+    height: 100%;
+    position: relative;
+
+    .BksTextEditor {
+      position: absolute;
+      inset: 0;
+      height: 100%;
+      width: 100%;
+      padding-left: 1rem;
+
+      --bks-text-editor-bg-color: #{$theme-bg};
+      --bks-text-editor-gutter-bg-color: #{$theme-bg};
+    }
+  }
+
+  // Own row above the buttons: sharing one pushes them out of a narrow sidebar.
+  .error-message {
+    display: block;
+    padding: 0.35rem var(--hoz-gutter) 0;
+    color: $brand-danger;
+    font-size: 0.85rem;
+    line-height: 1.35;
+    // Parse errors are one long unbroken string.
+    overflow-wrap: anywhere;
+  }
+
+  .footer {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem var(--hoz-gutter);
+
+    .expand {
+      flex: 1 1 auto;
+    }
+
+    .btn {
+      margin: 0;
+      flex-shrink: 0;
+    }
+  }
+
+  .empty-text {
+    padding: 0.5rem var(--hoz-gutter);
+    color: $text-light;
+  }
+}

--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -69,6 +69,8 @@ export enum AppEvent {
   updateJsonViewerSidebar = 'updateJsonViewerSidebar',
   jsonViewerSidebarExpandPath = 'jsonViewerSidebarExpandPath',
   jsonViewerSidebarValueChange = 'jsonViewerSidebarValueChange',
+  /** Open the json/jsonb cell drawer. First argument is the cell payload. */
+  openJsonCellDrawer = 'openJsonCellDrawer',
   /** A tab is about to be switched. First argument is the tab. */
   switchingTab = 'switchingTab',
   /** A tab has been switched. First argument is the tab. */

--- a/apps/studio/src/common/utils.ts
+++ b/apps/studio/src/common/utils.ts
@@ -357,6 +357,13 @@ export function isDateDataType (dataType) {
   return dateLikeStarts.some(t => base.startsWith(t))
 }
 
+export function isJsonDataType (dataType) {
+  // dataType is frequently absent for query results that aren't backed by a table
+  if (!dataType) return false
+  const base = normalizeDataType(dataType)
+  return base === 'json' || base === 'jsonb'
+}
+
 export function isNumericDataType (dataType) {
   if (isDateDataType(dataType)) return false
   const base = normalizeDataType(dataType)

--- a/apps/studio/src/components/editor/ResultTable.vue
+++ b/apps/studio/src/components/editor/ResultTable.vue
@@ -61,6 +61,7 @@
   import { escapeHtml, FormatterParams } from '@shared/lib/tabulator'
   import { dialectFor, formatOptionsFor } from '@shared/lib/dialects/models'
   import { FkLinkMixin } from '@/mixins/fk_click'
+  import { JsonCellDrawerMixin } from '@/mixins/json_cell_drawer'
   import MagicColumnBuilder from '@/lib/magic/MagicColumnBuilder'
   import Papa from 'papaparse'
   import { mapState, mapGetters } from 'vuex'
@@ -79,7 +80,7 @@
   import { FieldDescriptor, FieldEditData, FieldReadOnlyReasonStr, NgQueryResult, TableUpdate } from '@/lib/db/models'
   import { CellComponent, RangeComponent, RowComponent } from 'tabulator-tables'
   import { PropType } from 'vue'
-  import { safeSqlFormat } from '@/common/utils'
+  import { safeSqlFormat, isJsonDataType } from '@/common/utils'
 import { stringToTypedArray } from '@/common/utils'
 
   const log = rawLog.scope('ResultTable');
@@ -102,7 +103,7 @@ import { stringToTypedArray } from '@/common/utils'
 
   export default {
     components: { EditorModal },
-    mixins: [Converter, Mutators, FkLinkMixin],
+    mixins: [Converter, Mutators, FkLinkMixin, JsonCellDrawerMixin],
     data() {
       return {
         tabulator: null,
@@ -378,6 +379,7 @@ import { stringToTypedArray } from '@/common/utils'
         const eventParams = { cell, isReadOnly };
         this.$refs.editorModal.openModal(cell.getValue(), undefined, eventParams)
       },
+
       onSaveEditorModal(content: string, _l: any, cell: CellComponent){
         const editData = this.editData?.get(cell.getField());
         const isBinary = editData?.bksField?.bksType === 'BINARY' || _.isTypedArray(cell.getValue());
@@ -533,6 +535,15 @@ import { stringToTypedArray } from '@/common/utils'
           ...magicStuff
         }
 
+        // Don't touch `editable` here -- paste uses it as its permission check
+        // (see setCellValue in lib/menu/tableMenu).
+        if (isJsonDataType(editData?.dataType)) {
+          result['cellDblClick'] = (_e, cell: CellComponent) => this.openJsonCellDrawer(cell, {
+            dataType: editData?.dataType,
+            readOnly: !this.cellEditCheck(cell),
+          })
+        }
+
         if (column.dataType === 'INTERVAL') {
           // add interval sorter
           result['sorter'] = this.intervalSorter;
@@ -572,10 +583,11 @@ import { stringToTypedArray } from '@/common/utils'
       editorType(dataType: string) {
         const ne = vueEditor(NullableInputEditorVue)
 
+        // No inline editor: json/jsonb open the cell drawer on double click.
+        if (isJsonDataType(dataType)) return false
+
         switch (dataType?.toLowerCase() ?? '') {
           case 'text':
-          case 'json':
-          case 'jsonb':
           case 'tsvector':
             return 'textarea'
           case 'bool':

--- a/apps/studio/src/components/sidebar/JsonCellDrawer.vue
+++ b/apps/studio/src/components/sidebar/JsonCellDrawer.vue
@@ -1,0 +1,233 @@
+<template>
+  <div class="json-cell-drawer">
+    <template v-if="hasCell">
+      <div class="header">
+        <div class="header-group">
+          <span class="column-name truncate" :title="columnName">{{ columnName }}</span>
+          <span class="badge column-data-type" v-if="dataType">{{ dataType }}</span>
+        </div>
+        <div class="header-group actions">
+          <span class="read-only-hint" v-if="readOnly">Read-only</span>
+          <x-button
+            class="menu-btn btn btn-fab"
+            tabindex="0"
+          >
+            <i class="material-icons">more_vert</i>
+            <x-menu style="--target-align:right;">
+              <x-menuitem @click.prevent="reformat(2)">
+                <x-label>Format</x-label>
+              </x-menuitem>
+              <x-menuitem @click.prevent="reformat()">
+                <x-label>Minify</x-label>
+              </x-menuitem>
+              <x-menuitem togglable :toggled="wrapText" @click.prevent="wrapText = !wrapText">
+                <x-label>Wrap Text</x-label>
+              </x-menuitem>
+              <x-menuitem @click.prevent="copy">
+                <x-label>Copy</x-label>
+              </x-menuitem>
+            </x-menu>
+          </x-button>
+        </div>
+      </div>
+
+      <div class="text-editor-wrapper">
+        <text-editor
+          language-id="json"
+          :value="content"
+          :read-only="readOnly"
+          :line-wrapping="wrapText"
+          :force-initialize="reinitializeTextEditor"
+          :replace-extensions="replaceExtensions"
+          :fold-gutters="true"
+          :line-numbers="false"
+          @bks-value-change="handleValueChange"
+        />
+      </div>
+
+      <span class="error-message" v-if="error">{{ error }}</span>
+
+      <div class="footer">
+        <span class="expand" />
+        <button
+          class="btn btn-flat btn-sm"
+          @click.prevent="revert"
+          :disabled="!dirty"
+        >
+          Revert
+        </button>
+        <button
+          class="btn btn-primary btn-sm"
+          @click.prevent="apply"
+          :disabled="readOnly || error || !dirty"
+        >
+          Apply
+        </button>
+      </div>
+    </template>
+
+    <div class="empty-text" v-else>
+      Double-click a JSON cell to edit it here
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+/**
+ * Edits a single json/jsonb cell as the root document, rather than showing the
+ * whole row like JsonViewer does. Applying writes back through the cell's
+ * setValue so it joins the normal pending-changes flow.
+ */
+import Vue from "vue";
+import _ from "lodash";
+import TextEditor from "@beekeeperstudio/ui-kit/vue/text-editor";
+import { AppEvent } from "@/common/AppEvent";
+import { monokaiInit } from "@uiw/codemirror-theme-monokai";
+import { typedArrayToString } from "@/common/utils";
+import { Languages } from "@/lib/editor/languageData";
+
+const JsonLanguage = Languages.find((lang) => lang.name === "json");
+
+export default Vue.extend({
+  name: "JsonCellDrawer",
+  components: { TextEditor },
+  data() {
+    return {
+      hasCell: false,
+      columnName: "",
+      dataType: "",
+      readOnly: false,
+      content: "",
+      dirty: false,
+      error: null,
+      wrapText: false,
+      reinitializeTextEditor: 0,
+    };
+  },
+  computed: {
+    rootBindings() {
+      return [
+        { event: AppEvent.openJsonCellDrawer, handler: this.open },
+        { event: AppEvent.switchingTab, handler: this.reset },
+        { event: AppEvent.closingTab, handler: this.reset },
+      ];
+    },
+  },
+  created() {
+    // Non-reactive on purpose: Vue 2 deep observes data(), and a CellComponent
+    // transitively holds the row, column and whole table. Only setValue() is
+    // ever called on it, so observing it is pure cost.
+    this.cell = null;
+    this.originalContent = "";
+  },
+  methods: {
+    async open(payload) {
+      this.cell = payload.cell;
+      this.hasCell = true;
+      this.columnName = payload.columnName;
+      this.dataType = payload.dataType;
+      this.readOnly = payload.readOnly;
+      this.setContent(this.stringify(payload.value));
+      // The sidebar pane is expanding as this fires, so the editor would
+      // otherwise measure itself inside a zero-width container.
+      await this.$nextTick();
+      this.reinitializeTextEditor++;
+    },
+    reset() {
+      this.cell = null;
+      this.hasCell = false;
+      this.columnName = "";
+      this.dataType = "";
+      this.readOnly = false;
+      this.setContent("");
+    },
+    setContent(text: string) {
+      this.originalContent = text;
+      this.content = text;
+      this.dirty = false;
+      this.error = null;
+    },
+    handleValueChange(event) {
+      this.content = event.value;
+      this.dirty = this.content !== this.originalContent;
+      this.validate();
+    },
+    // Debounced, not a computed: parsing a multi-MB document on every keystroke
+    // would lock the editor. apply() re-checks before writing.
+    validate: _.debounce(function () {
+      // An empty editor means NULL, which is valid.
+      if (this.content.trim() === "") {
+        this.error = null;
+        return;
+      }
+      try {
+        JSON.parse(this.content);
+        this.error = null;
+      } catch (e) {
+        // Not isValid(): it discards the parser's line/column.
+        this.error = e.message;
+      }
+    }, 250),
+    // jsonb often arrives already parsed, json usually as a string. Unparseable
+    // values fall through as-is so bad data stays visible rather than lost.
+    stringify(value) {
+      if (value == null) return "";
+      if (_.isTypedArray(value)) {
+        value = typedArrayToString(value, this.$bksConfig.ui.general.binaryEncoding);
+      }
+      if (typeof value !== "string") return JSON.stringify(value, null, 2);
+      try {
+        return JsonLanguage.beautify(value);
+      } catch {
+        return value;
+      }
+    },
+    /** Pass an indent to format, omit it to minify. */
+    reformat(indent?: number) {
+      try {
+        this.content = indent
+          ? JsonLanguage.beautify(this.content)
+          : JsonLanguage.minify(this.content);
+        this.dirty = this.content !== this.originalContent;
+        this.reinitializeTextEditor++;
+      } catch {
+        // Invalid content stays put; the error message explains why.
+      }
+    },
+    copy() {
+      this.$native.clipboard.writeText(this.content);
+      this.$noty.success("Copied the data to your clipboard!");
+    },
+    revert() {
+      this.setContent(this.originalContent);
+      this.reinitializeTextEditor++;
+    },
+    apply() {
+      if (this.readOnly || this.error || !this.cell) return;
+      // An empty editor means NULL rather than an empty string, matching what
+      // "Set as NULL" does elsewhere.
+      const trimmed = this.content.trim();
+      this.cell.setValue(trimmed === "" ? null : trimmed);
+      this.setContent(this.content);
+    },
+    replaceExtensions(extensions) {
+      return [
+        extensions,
+        monokaiInit({
+          settings: {
+            selection: "",
+            selectionMatch: "",
+          },
+        }),
+      ];
+    },
+  },
+  mounted() {
+    this.registerHandlers(this.rootBindings);
+  },
+  beforeDestroy() {
+    this.validate.cancel();
+    this.unregisterHandlers(this.rootBindings);
+  },
+});
+</script>

--- a/apps/studio/src/components/sidebar/SecondarySidebar.vue
+++ b/apps/studio/src/components/sidebar/SecondarySidebar.vue
@@ -26,6 +26,12 @@
             :key="tab.id"
           />
         </template>
+        <template v-else-if="tab.id === 'json-cell'">
+          <json-cell-drawer
+            v-show="secondaryActiveTabId === 'json-cell'"
+            :key="tab.id"
+          />
+        </template>
         <isolated-plugin-view
           v-else
           :visible="secondaryActiveTabId === tab.id"
@@ -43,6 +49,7 @@
 import Vue from "vue";
 import { mapState, mapActions } from "vuex";
 import JsonViewerSidebar from "./JsonViewerSidebar.vue";
+import JsonCellDrawer from "./JsonCellDrawer.vue";
 import { AppEvent } from "@/common/AppEvent";
 import IsolatedPluginView from "@/components/plugins/IsolatedPluginView.vue";
 
@@ -54,7 +61,7 @@ interface SidebarTab {
 
 export default Vue.extend({
   name: "SecondarySidebar",
-  components: { JsonViewerSidebar, IsolatedPluginView },
+  components: { JsonViewerSidebar, JsonCellDrawer, IsolatedPluginView },
   data() {
     return {
       reloaders: {},

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -321,6 +321,7 @@ import { ColumnComponent, CellComponent, RangeComponent, RowComponent } from 'ta
 import data_converter from "../../mixins/data_converter";
 import DataMutators from '../../mixins/data_mutators'
 import { FkLinkMixin } from '@/mixins/fk_click'
+import { JsonCellDrawerMixin } from '@/mixins/json_cell_drawer'
 import Statusbar from '../common/StatusBar.vue'
 import RowFilterBuilder from './RowFilterBuilder.vue'
 import ColumnFilterModal from './ColumnFilterModal.vue'
@@ -337,7 +338,7 @@ import TableLength from '@/components/common/TableLength.vue'
 import { mapGetters, mapState } from 'vuex';
 import { TableUpdate, TableUpdateResult, ExtendedTableColumn } from '@/lib/db/models';
 import { dialectFor, formatOptionsFor, TableKey } from '@shared/lib/dialects/models'
-import { normalizeFilters, safeSqlFormat, createTableFilter, isNumericDataType, isDateDataType, rowHeaderField, joinFilters } from '@/common/utils'
+import { normalizeFilters, safeSqlFormat, createTableFilter, isNumericDataType, isDateDataType, isJsonDataType, rowHeaderField, joinFilters } from '@/common/utils'
 import { TableFilter } from '@/lib/db/models';
 import { LanguageData } from '../../lib/editor/languageData'
 import { escapeHtml, FormatterParams } from '@shared/lib/tabulator';
@@ -355,7 +356,7 @@ let draftFilters: TableFilter[] | string | null;
 
 export default Vue.extend({
   components: { Statusbar, ColumnFilterModal, TableLength, RowFilterBuilder, EditorModal, LoadingSpinner },
-  mixins: [data_converter, DataMutators, FkLinkMixin],
+  mixins: [data_converter, DataMutators, FkLinkMixin, JsonCellDrawerMixin],
   props: ["active", 'tab', 'table'],
   data() {
     return {
@@ -1045,6 +1046,15 @@ export default Vue.extend({
         },
       }
 
+      // Don't touch `editable` here -- paste uses it as its permission check
+      // (see setCellValue in lib/menu/tableMenu).
+      if (isJsonDataType(column.dataType)) {
+        result['cellDblClick'] = (_e, cell: CellComponent) => this.openJsonCellDrawer(cell, {
+          dataType: column.dataType,
+          readOnly: this.isEditorMenuDisabled(cell),
+        })
+      }
+
       if (column.dataType && /^(bool|boolean)$/i.test(column.dataType)) {
         const values = [
           { label: 'false', value: this.dialectData.boolean?.false ?? false },
@@ -1457,10 +1467,11 @@ export default Vue.extend({
       //   return vueEditor(DateTimePickerEditorVue)
       // }
 
+      // No inline editor: json/jsonb open the cell drawer on double click.
+      if (isJsonDataType(dt)) return false
+
       switch (dt?.toLowerCase() ?? '') {
         case 'text':
-        case 'json':
-        case 'jsonb':
         case 'tsvector':
           return 'textarea'
         case 'bool':

--- a/apps/studio/src/mixins/json_cell_drawer.ts
+++ b/apps/studio/src/mixins/json_cell_drawer.ts
@@ -1,0 +1,33 @@
+import { CellComponent } from 'tabulator-tables'
+import { AppEvent } from '@/common/AppEvent'
+
+export interface JsonCellDrawerPayload {
+  cell: CellComponent
+  columnName: string
+  dataType?: string
+  value: unknown
+  readOnly: boolean
+}
+
+/**
+ * Opens the JSON cell drawer in the secondary sidebar. Shared by the table view
+ * and the query results grid.
+ */
+export const JsonCellDrawerMixin = {
+  methods: {
+    openJsonCellDrawer(
+      cell: CellComponent,
+      options: { dataType?: string; readOnly: boolean }
+    ) {
+      this.trigger(AppEvent.toggleSecondarySidebar, true)
+      this.trigger(AppEvent.selectSecondarySidebarTab, 'json-cell')
+      this.trigger(AppEvent.openJsonCellDrawer, {
+        cell,
+        columnName: cell.getField(),
+        dataType: options.dataType,
+        value: cell.getValue(),
+        readOnly: options.readOnly,
+      } as JsonCellDrawerPayload)
+    },
+  },
+}

--- a/apps/studio/src/store/modules/SidebarModule.ts
+++ b/apps/studio/src/store/modules/SidebarModule.ts
@@ -63,6 +63,10 @@ export const SidebarModule: Module<State, RootState> = {
         id: "json-viewer",
         label: "JSON Viewer",
       },
+      {
+        id: "json-cell",
+        label: "JSON Editor",
+      },
     ],
 
     // PRIMARY SIDEBAR

--- a/apps/studio/tests/unit/common/utils.spec.js
+++ b/apps/studio/tests/unit/common/utils.spec.js
@@ -1,4 +1,4 @@
-import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType } from "@/common/utils"
+import { checkEmptyFilters, isBlank, removeUnsortableColumnsFromSortBy, isNumericDataType, isDateDataType, isJsonDataType } from "@/common/utils"
 import { PostgresData } from '@/shared/lib/dialects/postgresql'
 import { MysqlData } from '@/shared/lib/dialects/mysql'
 import { SqliteData } from '@/shared/lib/dialects/sqlite'
@@ -204,6 +204,29 @@ describe("isNumericDataType", () => {
     expect(isNumericDataType('interval')).toBe(false)
     expect(isNumericDataType('INTERVAL')).toBe(false)
     expect(isNumericDataType('interval year to month')).toBe(false)
+  })
+})
+
+describe("isJsonDataType", () => {
+  it("should all be json types", () => {
+    expect(isJsonDataType('json')).toBe(true)
+    expect(isJsonDataType('jsonb')).toBe(true)
+    expect(isJsonDataType('JSONB')).toBe(true)
+    expect(isJsonDataType(' json ')).toBe(true)
+  })
+
+  it("should not be json types", () => {
+    expect(isJsonDataType('text')).toBe(false)
+    expect(isJsonDataType('varchar(255)')).toBe(false)
+    expect(isJsonDataType('jsonpath')).toBe(false)
+    expect(isJsonDataType('_json')).toBe(false)
+  })
+
+  // dataType is absent for query results that aren't backed by a table
+  it("should handle a missing data type", () => {
+    expect(isJsonDataType(undefined)).toBe(false)
+    expect(isJsonDataType(null)).toBe(false)
+    expect(isJsonDataType('')).toBe(false)
   })
 })
 


### PR DESCRIPTION
Double-clicking a json/jsonb cell previously opened Tabulator’s inline textarea, which was too cramped for anything beyond trivial values.

It now opens a drawer in the secondary sidebar displaying the cell’s value as the root JSON document. The drawer supports folding, formatting/minifying, live validation, and explicit Revert / Apply actions.

When applied, the updated value goes through cell.setValue(), ensuring that edits follow the normal pending-changes flow.

This has been wired into both the table view and the query results grid.

Related to #2972.

Notes for review

* json/jsonb now return false from editorType() instead of having their editor overridden after the fact.
* The column’s editable flag is deliberately left untouched, as paste relies on it for its permission check (setCellValue in lib/menu/tableMenu.ts).

<img width="469" height="916" alt="image" src="https://github.com/user-attachments/assets/d1412bd9-ab93-467f-92c2-1bbaec63043e" />
