### PR TITLE
feat: show how long ago a date cell was

### DIFF
--- a/apps/studio/src/mixins/data_mutators.ts
+++ b/apps/studio/src/mixins/data_mutators.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { Mutators } from '../lib/data/tools'
 import { TabulatorFormatterParams } from '@/common/tabulator'
 import helpers, { escapeHtml } from '@shared/lib/tabulator'
+import { isDateDataType, normalizeDataType } from '@/common/utils'
 export const NULL = '(NULL)'
 import {CellComponent} from 'tabulator-tables'
 
@@ -65,7 +66,26 @@ export default {
       }
       
       const nullValue = emptyResult(cellValue)
-      return nullValue ? nullValue : escapeHtml(this.niceString(cellValue, true))
+      if (nullValue) return nullValue
+
+      const tooltip = escapeHtml(this.niceString(cellValue, true))
+      const relative = this.relativeTimeFor(
+        cell.getColumn().getDefinition().dataType,
+        cell.getValue()
+      )
+      return relative ? `${tooltip}<br>${escapeHtml(relative)}` : tooltip
+    },
+    relativeTimeFor(dataType: string | undefined, value: unknown): string | null {
+      // dataType is absent for query results that aren't backed by a table
+      if (!dataType || _.isNil(value)) return null
+      if (!isDateDataType(dataType)) return null
+      // Intervals are durations, not points in time -- nothing to compare to now.
+      if (normalizeDataType(dataType).startsWith('interval')) return null
+
+      const date = value instanceof Date ? value : new Date(String(value))
+      if (isNaN(date.getTime())) return null
+
+      return this.$bks.timeAgo(date)
     },
     cellFormatter(
       cell: CellComponent,

--- a/apps/studio/tests/unit/mixins/data_mutators.spec.js
+++ b/apps/studio/tests/unit/mixins/data_mutators.spec.js
@@ -64,3 +64,31 @@ describe("cellFormatter", () => {
   })
 
 })
+
+describe("relativeTimeFor", () => {
+  // $bks.timeAgo is provided app-wide by BeekeeperPlugin
+  const ctx = { $bks: { timeAgo: () => '3 days ago' } }
+  const relativeTimeFor = (dt, v) => mutators.methods.relativeTimeFor.call(ctx, dt, v)
+
+  it("should describe date columns relative to now", () => {
+    expect(relativeTimeFor('timestamp with time zone', '2026-08-09T14:30:00Z')).toBe('3 days ago')
+    expect(relativeTimeFor('date', new Date('2026-08-09'))).toBe('3 days ago')
+  })
+
+  it("should ignore non-date columns", () => {
+    expect(relativeTimeFor('text', '2026-08-09')).toBe(null)
+    expect(relativeTimeFor('int4', 123)).toBe(null)
+  })
+
+  // Intervals are durations, not points in time
+  it("should ignore intervals", () => {
+    expect(relativeTimeFor('interval', '1 day')).toBe(null)
+    expect(relativeTimeFor('interval year to month', '1 year')).toBe(null)
+  })
+
+  it("should handle missing or unparseable values", () => {
+    expect(relativeTimeFor(undefined, '2026-08-09')).toBe(null)
+    expect(relativeTimeFor('date', null)).toBe(null)
+    expect(relativeTimeFor('date', 'not a date')).toBe(null)
+  })
+})


### PR DESCRIPTION
Hovering a date or timestamp cell now shows a relative time ("3 days ago") under the exact value. Lives in the `cellTooltip` mixin, so the table view and query results grid both get it; intervals and unparseable values are skipped.

<img width="277" height="98" alt="image" src="https://github.com/user-attachments/assets/11121794-fdfc-4e52-8710-aeb35c694fed" />
