### PR TITLE
fix ssh attempting to parse encrypted default keys

### DIFF
--- a/apps/studio/src/lib/db/tunnel.ts
+++ b/apps/studio/src/lib/db/tunnel.ts
@@ -10,7 +10,7 @@ import { IDbConnectionServerConfig, IDbConnectionServerSSHConfig } from './types
 import { resolveHomePathToAbsolute } from '@/handlers/utils';
 import { IDbSshTunnel } from './backendTypes';
 import os from 'os';
-import { loadAllowedPublicKeys } from '@/lib/ssh/sshKeyUtils';
+import { canParseKey, loadAllowedPublicKeys } from '@/lib/ssh/sshKeyUtils';
 import { createFilteringAgent } from '@/lib/ssh/identitiesOnlyAgent';
 import type { AuthenticationType, BaseAgent } from 'ssh2';
 
@@ -28,7 +28,7 @@ function findDefaultIdentityFile(): string | undefined {
   const sshDir = path.join(os.homedir(), '.ssh');
   for (const name of DEFAULT_IDENTITY_FILES) {
     const candidate = path.join(sshDir, name);
-    if (fs.existsSync(candidate)) return candidate;
+    if (fs.existsSync(candidate) && canParseKey(candidate)) return candidate;
   }
   return undefined;
 }
@@ -42,6 +42,12 @@ function tryReadKeyFile(candidate: string): Buffer | undefined {
     log.warn(`Skipping IdentityFile that does not exist: ${resolved}`);
     return undefined;
   }
+
+  if (!canParseKey(resolved)) {
+    log.warn(`Skipping unparseable IdentityFile ${resolved}`);
+    return undefined;
+  }
+
   try {
     return fs.readFileSync(resolved);
   } catch (err) {

--- a/apps/studio/src/lib/ssh/sshKeyUtils.ts
+++ b/apps/studio/src/lib/ssh/sshKeyUtils.ts
@@ -26,6 +26,22 @@ export function loadAllowedPublicKeys(
   return result;
 }
 
+export function canParseKey(keyPath: string): boolean {
+  try {
+    const data = fs.readFileSync(keyPath);
+    const parsed = ssh2Utils.parseKey(data);
+    if (parsed instanceof Error) {
+      log.warn(`Could not parse ${keyPath}: ${parsed.message}`);
+      return false;
+    }
+  } catch (err) {
+    log.warn(`Error checking key file ${keyPath}: ${err.message}`);
+    return false;
+  }
+
+  return true;
+}
+
 function readPublicKeyBlob(
   filePath: string,
   passphrase?: string

--- a/apps/studio/tests/integration/lib/db/clients/ssh-agent-encrypted-identity.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/ssh-agent-encrypted-identity.spec.js
@@ -1,0 +1,157 @@
+// Regression test for the encrypted default IdentityFile case.
+//
+// In agent mode with no IdentityFile configured, tunnel.ts falls back to the
+// OpenSSH default identity files (~/.ssh/id_ed25519, etc). If that default key
+// is passphrase-protected, it must NOT be loaded as sshConfig.privateKey: ssh2
+// parses privateKey at connect() time and throws ("Encrypted private OpenSSH
+// key detected, but no passphrase given") before any auth method runs, aborting
+// the whole connection. The unlocked key already lives in the ssh-agent, so the
+// encrypted default file should be skipped and authentication left to the agent.
+//
+// This test sets up that exact scenario:
+//   - ~/.ssh/id_ed25519 exists but is ENCRYPTED (has a passphrase) and is NOT
+//     authorized on the server,
+//   - a separate, unencrypted key is loaded into a real ssh-agent and authorized
+//     on the server,
+//   - agent mode with no ~/.ssh/config IdentityFile entries.
+// Beekeeper must skip the encrypted default key and authenticate via the agent.
+
+import { execSync } from 'child_process'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { DockerComposeEnvironment, Wait } from 'testcontainers'
+import { dbtimeout } from '../../../../lib/db'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+
+// findDefaultIdentityFile() (tunnel.ts) resolves ~/.ssh via os.homedir(). In
+// this electron test runtime os.homedir() ignores a runtime $HOME override, so
+// mock it to point at a throwaway fake home instead of the real ~/.ssh.
+// var (not let): testcontainers calls os.homedir() at import time, before this
+// initializes — var is hoisted as undefined so the mock falls back to the real
+// homedir until the test assigns the fake one.
+var mockHomedir
+jest.mock('os', () => {
+  const actual = jest.requireActual('os')
+  return {
+    ...actual,
+    homedir: () => mockHomedir || actual.homedir(),
+  }
+})
+
+let mockSshAuthSock
+jest.mock('@/common/platform_info', () => {
+  const actual = jest.requireActual('@/common/platform_info')
+  return {
+    __esModule: true,
+    default: new Proxy(actual.default, {
+      get(target, prop) {
+        if (prop === 'sshAuthSock') return mockSshAuthSock
+        return target[prop]
+      },
+    }),
+  }
+})
+
+const ConnectionProvider = require('@commercial/backend/lib/connection-provider').default
+
+describe('SSH Tunnel Tests (skip encrypted default IdentityFile in agent mode)', () => {
+  jest.setTimeout(dbtimeout)
+
+  let environment
+  let container
+  let database
+  let connection
+  let workDir
+  let agentPid
+
+  beforeAll(async () => {
+    await TestOrmConnection.connect()
+
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bks-ssh-enc-id-'))
+
+    // The good identity: an unencrypted key loaded into the agent and authorized
+    // on the server. This is what the agent authenticates with.
+    const agentKeyPath = path.join(workDir, 'agent_key')
+    execSync(`ssh-keygen -t ed25519 -f "${agentKeyPath}" -N "" -q`)
+    const agentPublicKey = fs.readFileSync(`${agentKeyPath}.pub`, 'utf-8').trim()
+
+    const sock = path.join(workDir, 'agent.sock')
+    const agentOut = execSync(`ssh-agent -a "${sock}"`).toString()
+    const m = agentOut.match(/SSH_AGENT_PID=(\d+)/)
+    if (!m) throw new Error(`Failed to start ssh-agent: ${agentOut}`)
+    agentPid = Number(m[1])
+    mockSshAuthSock = sock
+
+    execSync(`ssh-add "${agentKeyPath}"`, {
+      env: { ...process.env, SSH_AUTH_SOCK: sock },
+      stdio: 'pipe',
+    })
+
+    // Fake home whose ~/.ssh/id_ed25519 is the OpenSSH default identity file but
+    // is passphrase-protected. There is no ssh config, so no IdentityFile is
+    // configured and tunnel.ts falls back to this default key. It is NOT
+    // authorized on the server; it must be skipped rather than loaded as
+    // privateKey (which would make connect() throw on the encrypted key).
+    const fakeHome = path.join(workDir, 'home')
+    fs.mkdirSync(path.join(fakeHome, '.ssh'), { recursive: true })
+    const defaultKeyPath = path.join(fakeHome, '.ssh', 'id_ed25519')
+    execSync(`ssh-keygen -t ed25519 -f "${defaultKeyPath}" -N "hunter2-passphrase" -q`)
+    mockHomedir = fakeHome
+
+    environment = await new DockerComposeEnvironment('tests/docker', 'ssh.yml')
+      .withWaitStrategy('test_ssh_postgres', Wait.forLogMessage('database system is ready to accept connections', 2))
+      .withWaitStrategy('test_ssh', Wait.forListeningPorts())
+      .up(['postgres', 'ssh'])
+
+    container = environment.getContainer('test_ssh')
+
+    await container.exec([
+      'sh',
+      '-c',
+      `mkdir -p /config/.ssh && echo '${agentPublicKey}' >> /config/.ssh/authorized_keys && chmod 700 /config/.ssh && chmod 600 /config/.ssh/authorized_keys && chown -R abc:abc /config/.ssh`,
+    ])
+
+    const config = {
+      connectionType: 'postgresql',
+      host: 'postgres',
+      port: 5432,
+      username: 'postgres',
+      password: 'example',
+      sshEnabled: true,
+      sshMode: 'agent',
+      sshHost: container.getHost(),
+      sshPort: container.getMappedPort(2222),
+      sshUsername: 'beekeeper',
+    }
+
+    connection = ConnectionProvider.for(config)
+    database = connection.createConnection('integration_test')
+    await database.connect()
+  })
+
+  describe('Can SSH via agent and run a query', () => {
+    it('should skip the encrypted default identity file and authenticate via the agent', async () => {
+      const query = await database.query('select 1')
+      await query.execute()
+    })
+  })
+
+  afterAll(async () => {
+    // Guard each step: when the connection fails (the bug under test)
+    // disconnect() throws, and the agent/containers still need tearing down.
+    if (database) {
+      try { await database.disconnect() } catch (_e) { /* ignore */ }
+    }
+    if (environment) {
+      try { await environment.stop() } catch (_e) { /* ignore */ }
+    }
+    if (agentPid) {
+      try { process.kill(agentPid) } catch (_e) { /* ignore */ }
+    }
+    if (workDir && fs.existsSync(workDir)) {
+      try { fs.rmSync(workDir, { recursive: true, force: true }) } catch (_e) { /* ignore */ }
+    }
+    await TestOrmConnection.disconnect()
+  })
+})

--- a/apps/studio/tests/unit/lib/db/tunnel.spec.ts
+++ b/apps/studio/tests/unit/lib/db/tunnel.spec.ts
@@ -11,6 +11,22 @@ const mockSshConnectionForward = jest.fn().mockResolvedValue({});
 const mockSshConnectionCtor = jest.fn();
 let lastSshConfig: any;
 
+// A real, unencrypted ed25519 private key. Agent mode now validates identity
+// files with ssh2's parseKey (canParseKey) and skips anything unparseable, so
+// the buffer returned for an accepted key must actually parse. See tunnel.ts.
+const VALID_KEY = Buffer.from(
+  [
+    "-----BEGIN OPENSSH PRIVATE KEY-----",
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW",
+    "QyNTUxOQAAACBY86eOOX4ODJ4v/x6h/LiJ/3GyKEJt4DwXoA9o5GDhzQAAAJAlAC4fJQAu",
+    "HwAAAAtzc2gtZWQyNTUxOQAAACBY86eOOX4ODJ4v/x6h/LiJ/3GyKEJt4DwXoA9o5GDhzQ",
+    "AAAEBWkR2A+4+w8egvJcxeXHXcrlpXwq2/zowS4xn4wmItt1jzp445fg4Mni//HqH8uIn/",
+    "cbIoQm3gPBegD2jkYOHNAAAAC3R1bm5lbC10ZXN0AQI=",
+    "-----END OPENSSH PRIVATE KEY-----",
+    "",
+  ].join("\n")
+);
+
 jest.mock("fs", () => {
   const actual = jest.requireActual("fs");
   return { ...actual, readFileSync: (...args: any[]) => mockReadFileSync(...args) };
@@ -141,6 +157,10 @@ describe("connectTunnel SSH agent handling (#4193)", () => {
     fs.writeFileSync(goodKey, "PRIVATE KEY DATA");
     const badKey = path.join(dir, "missing_key");
 
+    // Agent mode validates each candidate with parseKey before using it, so the
+    // accepted key must be a real, parseable key.
+    mockReadFileSync.mockReturnValue(VALID_KEY);
+
     // connection-provider copies the first IdentityFile into privateKey and
     // passes the full ordered list as identityFiles.
     const ssh = buildSsh({
@@ -152,11 +172,12 @@ describe("connectTunnel SSH agent handling (#4193)", () => {
 
     await connectTunnel(buildConfig(ssh));
 
-    // The missing entry is skipped; only the existing key is read.
-    expect(mockReadFileSync).toHaveBeenCalledTimes(1);
-    expect(mockReadFileSync.mock.calls[0][0]).toContain(goodKey);
-    expect(mockReadFileSync.mock.calls[0][0]).not.toContain("missing_key");
-    expect(lastSshConfig.privateKey).toEqual(Buffer.from("KEY"));
+    // The missing entry is skipped entirely (never read). The existing key is
+    // read twice: once by canParseKey to validate it, once to load its bytes.
+    expect(mockReadFileSync).toHaveBeenCalledTimes(2);
+    expect(mockReadFileSync.mock.calls.every((c) => String(c[0]).includes(goodKey))).toBe(true);
+    expect(mockReadFileSync.mock.calls.every((c) => !String(c[0]).includes("missing_key"))).toBe(true);
+    expect(lastSshConfig.privateKey).toEqual(VALID_KEY);
     expect(lastSshConfig.authHandler).toEqual(["none", "agent", "publickey"]);
 
     fs.rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
fix #4594 

Our ssh system will attempt to read default keys when connecting in automatic mode. In the case of encrypted default ssh keys (which is quite common) this means that we are passing an encrypted payload to the ssh module with no passphrase, which causes errors. This makes it so we test if we can parse any keys taken from the ssh config or the default keys, and if we can't we just ignore them.