### PR TITLE
Add per-path checkboxes to release publishing dispatch

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -13,7 +13,8 @@ name: Release - Publish Channels
 # slack_production_alerts_webhook, one incoming-webhook URL per channel).
 #
 # workflow_dispatch re-runs any of it idempotently for a given tag - use it to
-# backfill the mirror or heal a partial run.
+# backfill the mirror or heal a partial run. The checkboxes select which
+# publish paths run; a release event always runs all of them.
 
 permissions:
   contents: read
@@ -26,6 +27,18 @@ on:
       tag:
         description: "Release tag to publish (e.g. v5.4.2)"
         required: true
+      mirror:
+        description: "Mirror downloads to R2 + refresh latest.json"
+        type: boolean
+        default: true
+      repositories:
+        description: "Publish deb/rpm repositories"
+        type: boolean
+        default: true
+      snap:
+        description: "Publish snap to the store"
+        type: boolean
+        default: true
 
 # Serialize near-simultaneous publishes. The mirror script's latest-release
 # guard makes any completion order converge on GitHub's canonical latest.
@@ -66,6 +79,7 @@ jobs:
         run: bash ./.github/scripts/extract_channel.sh "${TAG#v}"
 
   mirror_downloads:
+    if: github.event_name == 'release' || inputs.mirror
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Git repository
@@ -103,7 +117,7 @@ jobs:
 
   publish_repositories:
     needs: identify_channel
-    if: needs.identify_channel.outputs.channel == 'latest'
+    if: (github.event_name == 'release' || inputs.repositories) && needs.identify_channel.outputs.channel == 'latest'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out Git repository
@@ -178,6 +192,7 @@ jobs:
 
   publish_snapcraft:
     needs: identify_channel
+    if: github.event_name == 'release' || inputs.snap
     runs-on: ubuntu-latest
     env:
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}


### PR DESCRIPTION
## Summary

Follow-up to #4629. The manual "Run workflow" form for `release-published.yml` now has three boolean inputs (all default on) selecting which publish paths run:

- **mirror** — Mirror downloads to R2 + refresh latest.json
- **repositories** — Publish deb/rpm repositories
- **snap** — Publish snap to the store

This allows re-running a single path for a given tag — e.g. just the R2 mirror without touching the apt/rpm repos or the snap store.

## Behavior

- Release-published events ignore the inputs and always run every path (`github.event_name == 'release' || inputs.<path>` gates).
- Deselected jobs report as `skipped`, which the Slack result notification already counts as success (same handling as the beta-release repository skip).
- The `repositories` checkbox composes with the existing stable-channel gate — beta tags still never publish deb/rpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLJ3hsY7SBCCAnM5neCAY1

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLJ3hsY7SBCCAnM5neCAY1)_