### PR TITLE
fix save connection form showing up on new connection screen

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -57,7 +57,7 @@
                   </option>
                 </select>
               </div>
-              <div v-if="!shouldUpsell">
+              <div v-if="config.connectionType && !shouldUpsell">
                 <!-- INDIVIDUAL DB CONFIGS -->
                 <postgres-form
                   v-if="config.connectionType === 'cockroachdb'"


### PR DESCRIPTION
Save connection form should not show up until a connection type has been chosen:

<img width="634" height="548" alt="image" src="https://github.com/user-attachments/assets/09501ec4-981f-40e6-bfbf-f4dc5d3f03cf" />
