### PR TITLE
ci: never restore node_modules cache in release builds; key caches by runner image

### DIFF
--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -53,7 +53,9 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          # matrix.os keeps caches from different runner images apart:
+          # node_modules holds native modules compiled for one exact image.
+          key: node-modules-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -77,7 +79,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~/AppData/Local/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-smoke-test.yml
+++ b/.github/workflows/e2e-smoke-test.yml
@@ -44,6 +44,13 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
 
+      # ImageOS identifies the runner image (e.g. ubuntu24, win22, macos15), so
+      # caches never cross runner image versions: node_modules holds native
+      # modules compiled for one exact image.
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v5
@@ -53,9 +60,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          # matrix.os keeps caches from different runner images apart:
-          # node_modules holds native modules compiled for one exact image.
-          key: node-modules-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -79,7 +84,7 @@ jobs:
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
             ~/AppData/Local/ms-playwright
-          key: playwright-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      # ImageOS identifies the runner image (e.g. ubuntu22, ubuntu24), so caches
+      # never cross runner image versions: node_modules holds native modules
+      # compiled for one exact image.
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v5
@@ -36,9 +43,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          # The ubuntu-24.04 segment must match this workflow's runs-on:
-          # node_modules holds native modules compiled for that exact image.
-          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -56,7 +61,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -81,6 +86,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Restore node_modules cache
         uses: actions/cache/restore@v5
         with:
@@ -89,14 +98,14 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Restore Playwright browsers cache
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Install Playwright system dependencies

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -36,7 +36,9 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          # The ubuntu-24.04 segment must match this workflow's runs-on:
+          # node_modules holds native modules compiled for that exact image.
+          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -54,7 +56,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'
@@ -87,14 +89,14 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Restore Playwright browsers cache
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          key: playwright-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Install Playwright system dependencies

--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -89,6 +89,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      # ImageOS identifies the runner image (e.g. ubuntu22, win22, macos14), so
+      # caches never cross runner image versions: node_modules holds native
+      # modules compiled for one exact image.
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v5
@@ -98,9 +105,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          # matrix.os keeps caches from different runner images apart:
-          # node_modules holds native modules compiled for one exact image.
-          key: node-modules-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Clean cache
         if: steps.cache-nm.outputs.cache-hit != 'true'

--- a/.github/workflows/studio-build-non-production.yml
+++ b/.github/workflows/studio-build-non-production.yml
@@ -98,7 +98,9 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          # matrix.os keeps caches from different runner images apart:
+          # node_modules holds native modules compiled for one exact image.
+          key: node-modules-${{ matrix.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Clean cache
         if: steps.cache-nm.outputs.cache-hit != 'true'

--- a/.github/workflows/studio-publish.yml
+++ b/.github/workflows/studio-publish.yml
@@ -220,31 +220,19 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Cache node_modules
-        id: cache-nm
-        uses: actions/cache@v5
-        with:
-          path: |
-            node_modules
-            apps/studio/node_modules
-            apps/ui-kit/node_modules
-            apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
-
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v3
         if: matrix.os.type == 'linux'
 
-      - name: Clean cache
-        if: steps.cache-nm.outputs.cache-hit != 'true'
-        run: yarn cache clean --all
-
+      # No node_modules cache here, deliberately. Release builds always install
+      # and compile native modules from scratch so their glibc/libstdc++
+      # requirements match this runner's OS. A cache seeded by a newer-OS job
+      # once shipped binaries that could not load on Ubuntu 22.04/Debian 12 (#4627).
       # FIXME (matthew) Windows needs retries. It sometimes fails to build
       # the native oracledb package.
       # But only sometimes. I cannot figure out why.
       # Someone should at some point.
       - name: yarn install (with retry)
-        if: steps.cache-nm.outputs.cache-hit != 'true'
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 20

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -53,7 +53,9 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          # The ubuntu-24.04 segment must match this workflow's runs-on:
+          # node_modules holds native modules compiled for that exact image.
+          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -87,7 +89,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Lint
@@ -150,7 +152,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Install libaio (for oracle)

--- a/.github/workflows/studio-test.yml
+++ b/.github/workflows/studio-test.yml
@@ -44,6 +44,13 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      # ImageOS identifies the runner image (e.g. ubuntu22, ubuntu24), so caches
+      # never cross runner image versions: node_modules holds native modules
+      # compiled for one exact image.
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Cache node_modules
         id: cache-nm
         uses: actions/cache@v5
@@ -53,9 +60,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          # The ubuntu-24.04 segment must match this workflow's runs-on:
-          # node_modules holds native modules compiled for that exact image.
-          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
         if: steps.cache-nm.outputs.cache-hit != 'true'
@@ -81,6 +86,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Restore node_modules cache
         uses: actions/cache/restore@v5
         with:
@@ -89,7 +98,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Lint
@@ -144,6 +153,10 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Compute runner image cache id
+        shell: bash
+        run: echo "RUNNER_IMAGE_ID=${ImageOS:-unknown}" >> "$GITHUB_ENV"
+
       - name: Restore node_modules cache
         uses: actions/cache/restore@v5
         with:
@@ -152,7 +165,7 @@ jobs:
             apps/studio/node_modules
             apps/ui-kit/node_modules
             apps/sqltools/node_modules
-          key: node-modules-ubuntu-24.04-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
+          key: node-modules-${{ env.RUNNER_IMAGE_ID }}-${{ runner.arch }}-${{ hashFiles('.nvmrc') }}-${{ hashFiles('yarn.lock') }}
           fail-on-cache-miss: true
 
       - name: Install libaio (for oracle)


### PR DESCRIPTION
The release workflow's node_modules cache key (node-modules-Linux-X64-...)
did not include the runner's OS version, and the test/e2e workflows moved to
ubuntu-24.04 in June. For v6.0.0 a 24.04 job seeded the cache, the
ubuntu-22.04 release job restored it and skipped yarn install (and the
electron-builder install-app-deps postinstall), so sqlanywhere.node shipped
compiled with GCC 13.3, requiring GLIBCXX_3.4.32. That symbol version does
not exist on Ubuntu 22.04 or Debian 12, so the utility process crash-looped
at startup and the app never opened (#4627).

- studio-publish.yml: drop the node_modules cache entirely; release builds
  now always run yarn install and compile native modules on the release
  runner itself.
- studio-test.yml / e2e-tests.yml: pin the runner image version
  (ubuntu-24.04) into the node_modules and Playwright cache keys.
- e2e-smoke-test.yml / studio-build-non-production.yml: use the matrix.os
  label in cache keys so different runner images never share caches.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01711KbSuaTsch3k38sncYzp