### PR TITLE
Block cloud workspace access for lifetime licenses

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -45,6 +45,7 @@
       <trial-expired-modal />
       <license-expired-modal />
       <lifetime-license-expired-modal />
+      <cloud-workspaces-blocked-modal />
     </template>
     <portal-target
       name="menus"
@@ -84,6 +85,7 @@ import UtilDiedModal from '@/components/UtilDiedModal.vue'
 import TrialExpiredModal from '@/components/license/TrialExpiredModal.vue'
 import LicenseExpiredModal from '@/components/license/LicenseExpiredModal.vue'
 import LifetimeLicenseExpiredModal from '@/components/license/LifetimeLicenseExpiredModal.vue'
+import CloudWorkspacesBlockedModal from '@/components/license/CloudWorkspacesBlockedModal.vue'
 import type { LicenseStatus } from "@/lib/license";
 import { SmartLocalStorage } from '@/common/LocalStorage';
 import PluginManagerModal from '@/components/plugins/PluginManagerModal.vue'
@@ -108,7 +110,8 @@ export default Vue.extend({
     DataManager, UpgradeRequiredModal, ConfirmationModalManager, Dropzone,
     UtilDiedModal, WorkspaceSignInModal, ImportQueriesModal, ImportConnectionsModal,
     EnterLicenseModal, TrialExpiredModal, LicenseExpiredModal,
-    LifetimeLicenseExpiredModal, WorkspaceCreateModal, WorkspaceRenameModal, WorkspaceDeleteModal,
+    LifetimeLicenseExpiredModal, CloudWorkspacesBlockedModal,
+    WorkspaceCreateModal, WorkspaceRenameModal, WorkspaceDeleteModal,
     PluginManagerModal, ConfigurationWarningModal, PluginController, LockManager, KeyboardShortcutsModal,
     InputEphemeralModal, ShareModal, MoveItemModal, MoveFolderModal,
   },

--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -49,6 +49,8 @@ export enum AppEvent {
   backupDatabase = 'backupDatabase',
   restoreDatabase = 'restoreDatabase',
   upgradeModal = 'upgradeModal',
+  /** Triggered when a lifetime (expired subscription) license tries to use cloud workspaces */
+  cloudWorkspacesBlocked = 'cloudWorkspacesBlocked',
   toggleExpandTableList = 'toggleExpandTableList',
   togglePinTableList = 'togglePinTableList',
   dropzoneEnter = 'dropzoneEnter',

--- a/apps/studio/src/components/license/CloudWorkspacesBlockedModal.vue
+++ b/apps/studio/src/components/license/CloudWorkspacesBlockedModal.vue
@@ -1,0 +1,70 @@
+<template>
+  <portal to="modals">
+    <modal class="vue-dialog beekeeper-modal" :name="modalName">
+      <div class="dialog-content">
+        <div class="dialog-c-title">
+          Cloud Workspaces require an active subscription
+        </div>
+        <div>
+          <p>
+            This license includes lifetime access to the app, but the
+            subscription period has ended. Cloud Workspaces are a hosted
+            service, only available while a subscription is active.
+          </p>
+          <p>
+            Existing workspace data (saved queries and connections) can be
+            exported from the account dashboard.
+          </p>
+        </div>
+      </div>
+      <div class="vue-dialog-buttons">
+        <button class="btn btn-flat" type="button" @click.prevent="close">
+          Close
+        </button>
+        <button class="btn btn-flat" type="button" @click.prevent="openDashboard">
+          Open Dashboard
+        </button>
+        <button class="btn btn-primary" type="button" @click.prevent="renew">
+          Renew Subscription
+        </button>
+      </div>
+    </modal>
+  </portal>
+</template>
+
+<script lang="ts">
+import { AppEvent } from "@/common/AppEvent";
+
+export default {
+  computed: {
+    modalName: () => "cloud-workspaces-blocked-modal",
+    rootBindings() {
+      return [
+        { event: AppEvent.cloudWorkspacesBlocked, handler: this.show },
+      ];
+    },
+  },
+  methods: {
+    show() {
+      this.$modal.show(this.modalName);
+    },
+    close() {
+      this.$modal.hide(this.modalName);
+    },
+    openDashboard() {
+      this.close();
+      this.$native.openLink(this.$config.cloudUrl);
+    },
+    renew() {
+      this.close();
+      this.$native.openLink("https://www.beekeeperstudio.io/pricing");
+    },
+  },
+  mounted() {
+    this.registerHandlers(this.rootBindings);
+  },
+  beforeDestroy() {
+    this.unregisterHandlers(this.rootBindings);
+  },
+};
+</script>

--- a/apps/studio/src/components/sidebar/WorkspaceSidebar.vue
+++ b/apps/studio/src/components/sidebar/WorkspaceSidebar.vue
@@ -115,6 +115,10 @@ components: { NewWorkspaceButton, WorkspaceAvatar, AccountStatusButton, ContentP
         this.$root.$emit(AppEvent.upgradeModal, 'Cloud Workspaces')
         return
       }
+      if (!isLocal && this.$store.getters.isLifetime) {
+        this.$root.$emit(AppEvent.cloudWorkspacesBlocked)
+        return
+      }
       await this.$util.send('workspace/setActive', { wId: blob.workspace.id, credentialId: blob.credentialId });
       this.$store.commit('workspaceId', blob.workspace.id)
       this.$store.dispatch('settings/save', {

--- a/apps/studio/src/components/sidebar/connection/NewWorkspaceButton.vue
+++ b/apps/studio/src/components/sidebar/connection/NewWorkspaceButton.vue
@@ -6,7 +6,7 @@
   >
     <x-button class="nav-item" @click="onClick">
       <span class="avatar-btn-link"><i class="material-icons">add</i></span>
-      <x-menu v-if="credentials.length && $store.getters.isUltimate">
+      <x-menu v-if="credentials.length && $store.getters.canAccessCloudWorkspaces">
         <x-menuitem @click.prevent="createWorkspace">
           <x-label>Create a new workspace</x-label>
         </x-menuitem>
@@ -42,6 +42,8 @@ export default Vue.extend({
     onClick() {
       if (this.$store.getters.isCommunity) {
         this.$root.$emit(AppEvent.upgradeModal, 'Cloud Workspaces')
+      } else if (this.$store.getters.isLifetime) {
+        this.$root.$emit(AppEvent.cloudWorkspacesBlocked)
       }
     },
   }

--- a/apps/studio/src/handlers/licenseHandlers.ts
+++ b/apps/studio/src/handlers/licenseHandlers.ts
@@ -41,6 +41,8 @@ export const LicenseHandlers: ILicenseHandlers = {
       isTrial: status.isTrial,
       isValidDateExpired: status.isValidDateExpired,
       isSupportDateExpired: status.isSupportDateExpired,
+      isLifetime: status.isLifetime,
+      canAccessCloudWorkspaces: status.canAccessCloudWorkspaces,
       maxAllowedVersion: status.maxAllowedVersion,
     };
   },

--- a/apps/studio/src/lib/license.ts
+++ b/apps/studio/src/lib/license.ts
@@ -42,6 +42,22 @@ export class LicenseStatus {
     return this.condition.includes("Expired support date");
   }
 
+  /**
+   * A paid license whose subscription (support) period has ended, but which
+   * still grants lifetime usage of app versions released within that period.
+   */
+  get isLifetime() {
+    return this.isSupportDateExpired && !this.isValidDateExpired;
+  }
+
+  /**
+   * Cloud Workspaces are a hosted service and require an active
+   * subscription. Lifetime licenses only cover use of the app itself.
+   */
+  get canAccessCloudWorkspaces() {
+    return this.isUltimate && !this.isLifetime;
+  }
+
   get maxAllowedVersion() {
     return parseVersion(this.license?.maxAllowedAppRelease?.tagName?.slice(1) ?? '0.0.0');
   }

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -308,6 +308,12 @@ const store = new Vuex.Store<State>({
     isTrial(_state, _getters, _rootState, rootGetters) {
       return rootGetters['licenses/isTrial']
     },
+    isLifetime(_state, _getters, _rootState, rootGetters) {
+      return rootGetters['licenses/isLifetime']
+    },
+    canAccessCloudWorkspaces(_state, _getters, _rootState, rootGetters) {
+      return rootGetters['licenses/canAccessCloudWorkspaces']
+    },
     canCreateFolders(_state, getters) {
       return getters.isUltimate || getters.isCloud;
     },

--- a/apps/studio/src/store/modules/CredentialsModule.ts
+++ b/apps/studio/src/store/modules/CredentialsModule.ts
@@ -164,6 +164,10 @@ export const CredentialsModule: Module<State, RootState> = {
         return
       }
 
+      // Licenses on lifetime terms (subscription ended) don't include cloud
+      // workspaces, so don't restore the last-used cloud workspace.
+      if (context.rootGetters['licenses/isLifetime']) return
+
       const match = workspaces.find((v: WSWithClient) => v?.workspace?.id === lastUsedWorkspace)
 
       if (!match) return

--- a/apps/studio/src/store/modules/LicenseModule.ts
+++ b/apps/studio/src/store/modules/LicenseModule.ts
@@ -74,7 +74,16 @@ export const LicenseModule: Module<State, RootState>  = {
       // this means a license with lifetime perms, but is no longer valid for software updates
       // so the user has to use an older version of the app.
       return state.status.isValidDateExpired
-    }
+    },
+    isLifetime(state) {
+      // a paid license past its subscription period, still valid for app usage
+      return state.status.isLifetime
+    },
+    canAccessCloudWorkspaces(state) {
+      // cloud workspaces need an active subscription, lifetime-only licenses
+      // (and community users) don't get them
+      return state.status.canAccessCloudWorkspaces
+    },
   },
   mutations: {
     set(state, licenses: TransportLicenseKey[]) {
@@ -232,6 +241,12 @@ export const LicenseModule: Module<State, RootState>  = {
       context.commit('set', licenses)
       context.commit('setStatus', status)
       context.commit('setNow', new Date())
+      // Licenses on lifetime terms don't include cloud workspaces, so if the
+      // subscription lapsed while a cloud workspace was active, drop back to
+      // the local workspace.
+      if (context.getters.isLifetime && context.rootState.workspaceId !== -1) {
+        context.commit('workspaceId', -1, { root: true })
+      }
     },
   }
 }

--- a/apps/studio/tests/unit/common/appdb/models/license.spec.ts
+++ b/apps/studio/tests/unit/common/appdb/models/license.spec.ts
@@ -189,6 +189,78 @@ describe("License", () => {
       });
     })
 
+    describe("Cloud workspace access", () => {
+      it("Active subscription - allowed", async () => {
+        currentTime("16-Sep-2024");
+        currentVersion(ANY_VERSION);
+        await createLicense({
+          validUntil: "17-Sep-2024",
+          maxAllowedAppRelease: null,
+        });
+        const status = await LicenseKey.getLicenseStatus();
+        expect(status.isLifetime).toBe(false);
+        expect(status.canAccessCloudWorkspaces).toBe(true);
+      });
+
+      it("Active trial - allowed", async () => {
+        currentTime("16-Sep-2024");
+        currentVersion(ANY_VERSION);
+        await LicenseKey.clear();
+        await LicenseKey.createTrialLicense(new Date("17-Sep-2024"));
+        const status = await LicenseKey.getLicenseStatus();
+        expect(status.isLifetime).toBe(false);
+        expect(status.canAccessCloudWorkspaces).toBe(true);
+      });
+
+      it("Lifetime license (support expired, still valid) - blocked", async () => {
+        currentTime("18-Sep-2024");
+        currentVersion(ANY_VERSION);
+        await createLicense({
+          validUntil: "19-Sep-2024",
+          supportUntil: "17-Sep-2024",
+          maxAllowedAppRelease: { tagName: ANY_VERSION_TAG },
+        });
+        const status = await LicenseKey.getLicenseStatus();
+        expect(status.edition).toBe("ultimate");
+        expect(status.isLifetime).toBe(true);
+        expect(status.canAccessCloudWorkspaces).toBe(false);
+      });
+
+      it("Lifetime license without version restriction - blocked", async () => {
+        currentTime("18-Sep-2024");
+        currentVersion(ANY_VERSION);
+        await createLicense({
+          validUntil: "19-Sep-2024",
+          supportUntil: "17-Sep-2024",
+          maxAllowedAppRelease: null,
+        });
+        const status = await LicenseKey.getLicenseStatus();
+        expect(status.edition).toBe("ultimate");
+        expect(status.isLifetime).toBe(true);
+        expect(status.canAccessCloudWorkspaces).toBe(false);
+      });
+
+      it("Fully expired license - blocked", async () => {
+        currentTime("18-Sep-2024");
+        currentVersion(ANY_VERSION);
+        await createLicense({
+          validUntil: "17-Sep-2024",
+          supportUntil: "17-Sep-2024",
+          maxAllowedAppRelease: { tagName: ANY_VERSION_TAG },
+        });
+        const status = await LicenseKey.getLicenseStatus();
+        // an expired license is not on lifetime terms, and is community anyway
+        expect(status.isLifetime).toBe(false);
+        expect(status.canAccessCloudWorkspaces).toBe(false);
+      });
+
+      it("No license - blocked", async () => {
+        const status = await LicenseKey.getLicenseStatus();
+        expect(status.isLifetime).toBe(false);
+        expect(status.canAccessCloudWorkspaces).toBe(false);
+      });
+    });
+
     // Regression tests for version comparison
     it("Should properly compare versions", async () => {
       expect(isVersionLessThanOrEqual(parseVersion("v2.4.6"), parseVersion("v5.7.2"))).toBeTruthy();

--- a/apps/studio/tests/unit/handlers/licenseHandlers.spec.ts
+++ b/apps/studio/tests/unit/handlers/licenseHandlers.spec.ts
@@ -100,4 +100,48 @@ describe("LicenseHandlers", () => {
       expect(result[0].licenseType).toBe("TrialLicense");
     });
   });
+
+  describe("license/getStatus", () => {
+    async function saveLicense(options: { validUntil: Date; supportUntil: Date }) {
+      const license = new LicenseKey();
+      license.email = "fake-email";
+      license.key = "fake-key";
+      license.validUntil = options.validUntil;
+      license.supportUntil = options.supportUntil;
+      license.licenseType = "PersonalLicense";
+      license.maxAllowedAppRelease = null;
+      await license.save();
+    }
+
+    it("includes cloud workspace access flags as own properties for a lifetime license", async () => {
+      // Support period over, license still valid = lifetime terms.
+      await saveLicense({
+        validUntil: new Date(Date.now() + 86_400_000),
+        supportUntil: new Date(Date.now() - 86_400_000),
+      });
+
+      const status = await LicenseHandlers["license/getStatus"]();
+
+      // The status crosses to the renderer via postMessage (structured
+      // clone), which drops prototype getters - the flags must be own
+      // properties of the returned object.
+      expect(Object.getOwnPropertyNames(status)).toEqual(
+        expect.arrayContaining(["isLifetime", "canAccessCloudWorkspaces"])
+      );
+      expect(status.isLifetime).toBe(true);
+      expect(status.canAccessCloudWorkspaces).toBe(false);
+    });
+
+    it("reports cloud workspace access for an active subscription", async () => {
+      await saveLicense({
+        validUntil: new Date(Date.now() + 86_400_000),
+        supportUntil: new Date(Date.now() + 86_400_000),
+      });
+
+      const status = await LicenseHandlers["license/getStatus"]();
+
+      expect(status.isLifetime).toBe(false);
+      expect(status.canAccessCloudWorkspaces).toBe(true);
+    });
+  });
 });

--- a/apps/studio/tests/unit/store/CredentialsModule.spec.ts
+++ b/apps/studio/tests/unit/store/CredentialsModule.spec.ts
@@ -1,0 +1,89 @@
+import Vuex from 'vuex'
+import Vue from 'vue'
+import { CredentialsModule } from '@/store/modules/CredentialsModule'
+import { LocalWorkspace } from '@/common/interfaces/IWorkspace'
+
+Vue.use(Vuex)
+
+jest.mock('@/lib/cloud/CloudClient')
+
+const mockSend = jest.fn()
+Vue.prototype.$util = { send: mockSend }
+
+function buildStore(options: { isLifetime: boolean, lastUsedWorkspace: number }) {
+  return new Vuex.Store({
+    state: { workspaceId: LocalWorkspace.id },
+    mutations: {
+      workspaceId(state: any, id: number) {
+        state.workspaceId = Number(id)
+      },
+    },
+    modules: {
+      credentials: CredentialsModule,
+      licenses: {
+        namespaced: true,
+        getters: {
+          isLifetime: () => options.isLifetime,
+        },
+      },
+      settings: {
+        namespaced: true,
+        getters: {
+          lastUsedWorkspace: () => ({ value: String(options.lastUsedWorkspace) }),
+        },
+      },
+    },
+  })
+}
+
+function seedCloudWorkspace(store: ReturnType<typeof buildStore>) {
+  store.commit('credentials/add', {
+    id: 1,
+    credential: { id: 1, appId: 'beekeeper-app-x', email: 'user@example.com', token: 'token' },
+    client: null,
+    workspaces: [{ id: 42, name: 'Team Workspace' }],
+  })
+}
+
+describe('CredentialsModule', () => {
+  beforeEach(() => {
+    mockSend.mockReset()
+    mockSend.mockResolvedValue(null)
+  })
+
+  describe('setUserWorkspace', () => {
+    it('restores the last used cloud workspace on an active subscription', async () => {
+      const store = buildStore({ isLifetime: false, lastUsedWorkspace: 42 })
+      seedCloudWorkspace(store)
+
+      await store.dispatch('credentials/setUserWorkspace')
+
+      expect(mockSend).toHaveBeenCalledWith('workspace/setActive', {
+        wId: 42,
+        credentialId: 1,
+      })
+      expect(store.state.workspaceId).toBe(42)
+    })
+
+    it('does not restore a cloud workspace on a lifetime license', async () => {
+      const store = buildStore({ isLifetime: true, lastUsedWorkspace: 42 })
+      seedCloudWorkspace(store)
+
+      await store.dispatch('credentials/setUserWorkspace')
+
+      expect(mockSend).not.toHaveBeenCalled()
+      expect(store.state.workspaceId).toBe(LocalWorkspace.id)
+    })
+
+    it('still restores the local workspace on a lifetime license', async () => {
+      const store = buildStore({ isLifetime: true, lastUsedWorkspace: LocalWorkspace.id })
+      seedCloudWorkspace(store)
+
+      await store.dispatch('credentials/setUserWorkspace')
+
+      expect(mockSend).toHaveBeenCalledWith('workspace/setActive', {
+        wId: LocalWorkspace.id,
+      })
+    })
+  })
+})

--- a/apps/studio/tests/unit/store/LicenseModule.spec.ts
+++ b/apps/studio/tests/unit/store/LicenseModule.spec.ts
@@ -14,6 +14,12 @@ Vue.prototype.$util = { send: mockSend }
 
 function buildStore() {
   return new Vuex.Store({
+    state: { workspaceId: -1 },
+    mutations: {
+      workspaceId(state: any, id: number) {
+        state.workspaceId = Number(id)
+      },
+    },
     modules: { licenses: LicenseModule },
   })
 }
@@ -124,6 +130,54 @@ describe('LicenseModule', () => {
       expect((CloudClient.getLicense as jest.Mock)).not.toHaveBeenCalled()
       const saveCalls = mockSend.mock.calls.filter(([ch]) => ch === 'appdb/license/save')
       expect(saveCalls).toHaveLength(0)
+    })
+  })
+
+  describe('sync action', () => {
+    function mockStatus(status: Record<string, unknown>) {
+      mockSend.mockImplementation(async (channel: string) => {
+        if (channel === 'license/getStatus') return status
+        if (channel === 'license/get') return []
+        return null
+      })
+    }
+
+    it('drops back to the local workspace when the license is on lifetime terms', async () => {
+      store.commit('workspaceId', 42)
+      mockStatus({
+        edition: 'ultimate',
+        condition: ['Expired support date', 'App version allowed'],
+        isUltimate: true,
+        isCommunity: false,
+        isTrial: false,
+        isValidDateExpired: false,
+        isSupportDateExpired: true,
+        isLifetime: true,
+        canAccessCloudWorkspaces: false,
+      })
+
+      await store.dispatch('licenses/sync')
+
+      expect(store.state.workspaceId).toBe(-1)
+    })
+
+    it('stays in the cloud workspace with an active subscription', async () => {
+      store.commit('workspaceId', 42)
+      mockStatus({
+        edition: 'ultimate',
+        condition: ['No app version restriction'],
+        isUltimate: true,
+        isCommunity: false,
+        isTrial: false,
+        isValidDateExpired: false,
+        isSupportDateExpired: false,
+        isLifetime: false,
+        canAccessCloudWorkspaces: true,
+      })
+
+      await store.dispatch('licenses/sync')
+
+      expect(store.state.workspaceId).toBe(42)
     })
   })
 


### PR DESCRIPTION
## Summary

Implements licensing restrictions for cloud workspaces, preventing users with lifetime licenses (expired subscriptions) from accessing cloud workspaces while allowing active subscribers and trial users to continue using them.

## Key Changes

- **License Status Model**: Added `isLifetime` and `canAccessCloudWorkspaces` computed properties to `LicenseStatus` class to determine cloud workspace eligibility
  - `isLifetime`: Identifies paid licenses whose subscription period has ended but still grant lifetime app usage
  - `canAccessCloudWorkspaces`: Returns true only for Ultimate edition with active subscriptions

- **Store Integration**: 
  - Added getters to `LicenseModule` for `isLifetime` and `canAccessCloudWorkspaces`
  - Exposed these getters at root store level for component access
  - Updated `LicenseModule.sync()` to drop users back to local workspace (-1) when license transitions to lifetime terms

- **Credentials Module**: Modified `setUserWorkspace()` action to skip cloud workspace restoration for lifetime licenses

- **UI Components**:
  - Created `CloudWorkspacesBlockedModal` to inform users why cloud workspaces are unavailable
  - Updated `WorkspaceSidebar` to emit `cloudWorkspacesBlocked` event when lifetime license attempts cloud workspace access
  - Updated `NewWorkspaceButton` to check `canAccessCloudWorkspaces` instead of just `isUltimate`

- **License Handlers**: Updated `license/getStatus` handler to include `isLifetime` and `canAccessCloudWorkspaces` as own properties (required for structured clone serialization to renderer)

- **App Events**: Added `cloudWorkspacesBlocked` event to `AppEvent` enum

## Testing

- Added comprehensive test suite for `CredentialsModule.setUserWorkspace()` covering active subscriptions, lifetime licenses, and local workspace restoration
- Added test coverage in `LicenseModule` for workspace fallback behavior
- Added license status tests validating cloud workspace access rules for various license states (active subscription, trial, lifetime, expired, no license)
- Added handler tests verifying status object structure for serialization

https://claude.ai/code/session_01Qc86ikWVPj5hWK3StMNUcD