### PR TITLE
fix(sidebar): drag-and-drop reordering is discarded on the next render

### DIFF
--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -469,29 +469,12 @@ export default {
       return this.connectionsPollError || this.foldersPollError || null
     },
     sortedItemNodes() {
-      // Cloud has no sort buttons — drag and drop is the only way to reorder,
-      // and it lands in `position`.
-      if (this.isCloud) {
-        return _.sortBy(this.itemNodes, 'ref.position')
-      }
-      let result = []
-      if (this.sort.field === 'labelColor') {
-        const mappings = {
-          default: -1,
-          red: 0,
-          orange: 1,
-          yellow: 2,
-          green: 3,
-          blue: 4,
-          purple: 5,
-          pink: 6
-        }
-        result = _.orderBy(this.itemNodes, (n) => mappings[n.ref.labelColor])
-      } else {
-        result = _.orderBy(this.itemNodes, `ref.${this.sort.field}`)
-      }
-      if (this.sort.order === 'desc') result = result.reverse()
-      return result;
+      // Rendered order always comes from `position`. The sort buttons are a
+      // one-shot action: `reorderBySort` rewrites `position` for every
+      // connection and offers an undo. Deriving the rendered order from
+      // `sort.field` here instead would permanently outrank `position`, so a
+      // drag would save but never show.
+      return _.sortBy(this.itemNodes, (n) => n.ref.position ?? 0)
     },
     errorList() {
       return Object.values(this.errors);

--- a/apps/studio/src/components/sidebar/core/FavoriteList.vue
+++ b/apps/studio/src/components/sidebar/core/FavoriteList.vue
@@ -297,12 +297,10 @@ export default {
       return this.expandedFolderIds.map((id) => `folder-${id}`);
     },
     sortedItemNodes() {
-      // Cloud has no sort buttons — drag and drop is the only way to reorder,
-      // and it lands in `position`.
-      if (this.isCloud) {
-        return _.sortBy(this.itemNodes, 'ref.position')
-      }
-      return _.sortBy(this.itemNodes, 'ref.title')
+      // Drag and drop is the only way to reorder queries, and it lands in
+      // `position`. Sorting by title here would outrank it, so a drag would
+      // save but never show.
+      return _.sortBy(this.itemNodes, (n) => n.ref.position ?? 0)
     },
     searching() {
       return !!this.filterQuery;

--- a/apps/studio/tests/unit/components/sidebar/SidebarRenderOrder.spec.ts
+++ b/apps/studio/tests/unit/components/sidebar/SidebarRenderOrder.spec.ts
@@ -1,0 +1,84 @@
+import ConnectionSidebar from '@/components/sidebar/ConnectionSidebar.vue'
+import FavoriteList from '@/components/sidebar/core/FavoriteList.vue'
+
+/**
+ * Drag and drop writes `position`, so `position` is what the sidebars must
+ * render by. Ordering the rendered list by a sort field instead silently
+ * outranks it: the drop saves, and the next render throws it away.
+ */
+
+function itemNode(id: number, position: number, ref: Record<string, unknown> = {}) {
+  return {
+    id: `item-${id}`,
+    parentId: null,
+    type: 'item',
+    parentIdKey: 'connectionFolderId',
+    ref: { id, position, ...ref },
+  }
+}
+
+/** The computed reads only `itemNodes`, so it needs no mounted component. */
+function renderOrder(component: any, itemNodes: unknown[]) {
+  return component.computed.sortedItemNodes.call({ itemNodes })
+}
+
+describe('ConnectionSidebar render order', () => {
+  it('orders by position, not alphabetically by name', () => {
+    const nodes = [
+      itemNode(1, 3, { name: 'alpha' }),
+      itemNode(2, 1, { name: 'zulu' }),
+      itemNode(3, 2, { name: 'mike' }),
+    ]
+
+    const names = renderOrder(ConnectionSidebar, nodes).map((n: any) => n.ref.name)
+
+    expect(names).toEqual(['zulu', 'mike', 'alpha'])
+  })
+
+  it('keeps a dragged connection where it was dropped, whatever its color', () => {
+    // A red connection dragged below a blue one must stay below it. Ranking by
+    // label color here would pull red back above blue.
+    const nodes = [
+      itemNode(1, 1, { name: 'blue one', labelColor: 'blue' }),
+      itemNode(2, 2, { name: 'red one', labelColor: 'red' }),
+    ]
+
+    const names = renderOrder(ConnectionSidebar, nodes).map((n: any) => n.ref.name)
+
+    expect(names).toEqual(['blue one', 'red one'])
+  })
+
+  it('treats a missing position as first rather than dropping the item', () => {
+    const nodes = [itemNode(1, 2, { name: 'second' }), itemNode(2, undefined, { name: 'unset' })]
+
+    const names = renderOrder(ConnectionSidebar, nodes).map((n: any) => n.ref.name)
+
+    expect(names).toEqual(['unset', 'second'])
+  })
+
+  it('preserves input order when positions tie', () => {
+    const nodes = [
+      itemNode(1, 1, { name: 'first' }),
+      itemNode(2, 1, { name: 'second' }),
+      itemNode(3, 1, { name: 'third' }),
+    ]
+
+    const names = renderOrder(ConnectionSidebar, nodes).map((n: any) => n.ref.name)
+
+    expect(names).toEqual(['first', 'second', 'third'])
+  })
+})
+
+describe('FavoriteList render order', () => {
+  it('orders by position, not alphabetically by title', () => {
+    const nodes = [
+      itemNode(1, 3, { title: 'alpha' }),
+      itemNode(2, 1, { title: 'zulu' }),
+      itemNode(3, 2, { title: 'mike' }),
+    ]
+
+    const titles = renderOrder(FavoriteList, nodes).map((n: any) => n.ref.title)
+
+    expect(titles).toEqual(['zulu', 'mike', 'alpha'])
+  })
+})


### PR DESCRIPTION
Dragging a connection or saved query in the sidebar looks like it does nothing — the item lifts, you drop it, and it snaps back.

The drop actually saves fine; `reorder` writes the new `position` to the database. The trouble is that `sortedItemNodes` builds the rendered list from `sort.field` instead:

```js
result = _.orderBy(this.itemNodes, `ref.${this.sort.field}`)
```

`position` never gets a say, so the order you just saved is thrown away on the next render. Cloud workspaces already sorted by `position`, so this only shows up locally.

### Why it broke

Sorting here has always been a one-shot action rather than a live view sort — `reorderBySort` rewrites `position` for every connection and offers an Undo. The order on screen was `position`.

Before the tree rewrite, the old `sortedConnections` computed had a single consumer, and that consumer re-sorted by `position` anyway, so its ordering was never actually used. When `67d8043a1` wired it into the tree as `sortedItemNodes`, that unused ordering quietly became the real one.

### The fix

Render by `position` in both sidebars.

Sorting by Colour still works — the colour map it needs lives in `applySortOrder`, which is what `reorderBySort` calls. The copy removed here was a duplicate. Cloud behaviour is unchanged, since it already sorted by `position`.

### One thing to watch

With sort set to Name, the list now shows saved `position` order instead of re-alphabetizing on every render. That's how it worked before 6.0, but if someone's stored positions are stale, the list may not look alphabetical until they pick a sort again.

### Testing

Added `SidebarRenderOrder.spec.ts` covering position vs name/title, position vs colour rank, missing positions, and ties. I checked these actually catch the bug — putting the old code back fails all four connection cases. Full suite passes (88 suites, 3158 tests).
