### PR TITLE
fix: show empty state and disable 'more' in connection switch popover

### DIFF
--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -701,3 +701,19 @@
   flex-grow: 1;
   max-height: calc(50vh - 70px);
 }
+
+.quick-switcher-empty {
+  padding: 12px 6px;
+  color: $text-lighter;
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+.quick-switcher-item:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+
+  &:hover {
+    background: none;
+  }
+}

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -154,9 +154,19 @@
               {{ conn.name }}
             </button>
           </div>
+          <div
+            v-if="displayedConnections.length === 0"
+            class="quick-switcher-empty"
+          >
+            No other connections to switch to
+          </div>
         </div>
         <div class="quick-switcher-footer">
-          <button class="quick-switcher-item more" @click.stop="toggleMore">
+          <button
+            class="quick-switcher-item more"
+            :disabled="!hasMoreConnections"
+            @click.stop="toggleMore"
+          >
             <span class="label">{{ showingMore ? 'less' : 'more' }}</span>
             <span style="font-size: 22px;">
               {{ showingMore ? '‹' : '›' }}
@@ -220,6 +230,17 @@ export default {
       return connections.filter(conn =>
         conn.id !== this.config.id || conn.workspaceId !== this.config.workspaceId
       );
+    },
+
+    hasMoreConnections() {
+      if (this.showingMore) {
+        return true;
+      }
+      const recentCount = this.displayedConnections.length;
+      const savedCount = this.savedConnections.filter(conn =>
+        conn.id !== this.config.id || conn.workspaceId !== this.config.workspaceId
+      ).length;
+      return savedCount > recentCount;
     },
     classes() {
       const result = {


### PR DESCRIPTION
## Summary
Fixes #4150.

The "Switch Connection" popover (the quick switcher opened from the connection button menu) had two rough edges:

- When there are no other connections to switch to, the list was just blank. This adds a friendly empty-state message instead.
- The "more" button (which toggles between recent and all saved connections) stayed clickable even when there was nothing more to reveal. It is now disabled in that case.

## Changes
- `ConnectionButton.vue`: render a `quick-switcher-empty` element when `displayedConnections` is empty, and bind `:disabled` on the "more" button to a new `hasMoreConnections` computed property.
- `sidebar.scss`: add styling for `.quick-switcher-empty` and the disabled state of `.quick-switcher-item`.

## How to test
1. Open the connection menu on a tab and choose **Switch Connection**.
2. With only the current connection available, the popover shows "No other connections to switch to" and the "more" button is disabled.
3. With additional saved connections, the list shows them and "more" toggles to the full saved list as before.
