### PR TITLE
only save persistence data if data has changed

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -834,6 +834,8 @@ export default Vue.extend({
       }
 
       const serialized = JSON.stringify(data);
+      if (serialized === this.persistenceRow.data) return;
+
       const existingId = this.persistenceRow?.id;
       this.persistenceRow = { id: existingId, data: serialized };
       try {

--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -834,7 +834,7 @@ export default Vue.extend({
       }
 
       const serialized = JSON.stringify(data);
-      if (serialized === this.persistenceRow.data) return;
+      if (serialized === this.persistenceRow?.data) return;
 
       const existingId = this.persistenceRow?.id;
       this.persistenceRow = { id: existingId, data: serialized };


### PR DESCRIPTION
Tabulator tries to write persistence data a lot apparently, so before we send the request to the backend, check if the data has actually changed