### PR TITLE
Respect column visibility when generating table queries

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1888,7 +1888,12 @@ export default Vue.extend({
       ];
       const limit = this.tabulator.getPageSize() ?? this.limit;
       const offset = (this.tabulator.getPage() - 1) * limit;
-      const selects = ["*"];
+      // column hiding and reordering are front-end only, so bake the
+      // displayed columns into the generated query
+      const visibleColumns = this.columnsWithFilterAndOrder
+        .filter((c) => c.filter)
+        .map((c) => c.name);
+      const selects = visibleColumns.length ? visibleColumns : ["*"];
 
       // like if you change a filter
       if (page && page !== this.page) {


### PR DESCRIPTION
## Summary
Modified the table view query generation to respect column visibility settings. Previously, all queries used `SELECT *` regardless of which columns were hidden or reordered by the user. Now the query explicitly selects only the visible columns.

## Changes
- Updated `TableTable.vue` to extract visible columns from `columnsWithFilterAndOrder` before generating the SELECT clause
- The query now includes only columns that pass the visibility filter, falling back to `SELECT *` only when no columns are visible
- Added clarifying comment explaining that column hiding and reordering are front-end only operations

## Implementation Details
- Visible columns are determined by filtering `columnsWithFilterAndOrder` and extracting column names
- If visible columns exist, they're used in the SELECT clause; otherwise defaults to `SELECT *` to maintain backward compatibility
- This ensures the API response only includes data for displayed columns, improving query efficiency and consistency between the UI and backend

https://claude.ai/code/session_0199P1Nz9cLF9V8vy9w5P5fJ