### PR TITLE
fix(tabletable): make Add row reachable via right-click when table is full

### DIFF
--- a/apps/studio/src/components/tableview/TableTable.vue
+++ b/apps/studio/src/components/tableview/TableTable.vue
@@ -1257,6 +1257,14 @@ export default Vue.extend({
       }
       return [
         {
+          label: createMenuItem(
+            "Add row",
+            this.$bksConfig.getKeybindings("context-menu", "general.addRow"),
+          ),
+          action: this.cellAddRow.bind(this),
+          disabled: !this.editable,
+        },
+        {
           label: createMenuItem(`Clone ${rowRangeLabel}`, "Control+D"),
           action: this.cellCloneRow.bind(this),
           disabled: !this.editable,


### PR DESCRIPTION
Follow-up to #4503 (thanks @mazzoccantelorenzo, nice feature!) — turns out it only works when the table has empty space below the last row.

**The problem**

The right-click menu bails out whenever the click lands inside an existing row:

```js
if (target.closest('.tabulator-row, .tabulator-header, .tabulator-row-header, .tabulator-corner')) {
  return;
}
```

That empty space below the last row only exists when the table doesn't have enough records to fill the viewport. As soon as a table has enough rows to fill the screen (which is most real tables), every right-click lands inside `.tabulator-row`, so the menu never opens. In practice the feature was unreachable for most tables people actually work with.

**The fix**

Instead of relying on finding empty space, "Add row" is now added to `rowActionsMenu`, the context menu builder already shared by both the per-cell context menu and the row-header context menu. Right-clicking any existing row or cell now shows "Add row" next to "Clone row"/"Delete row", regardless of how full the table is. The empty-space menu from #4503 is untouched and still works for small/empty tables.

**Screenshot**

Right-clicking a data row in a full table now shows "Add row" (see comment below).
<img width="1358" height="1376" alt="image" src="https://github.com/user-attachments/assets/df66ac88-59e7-43ab-ae68-3acdca62593d" />


