### PR TITLE
Vim mode: fix focus, ex commands, and .beekeeper.vimrc

### DIFF
--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -1,7 +1,15 @@
 @import "./text-editor-plugins/partial-read-only.scss";
 
 .BksTextEditor {
-  padding: 0.75rem 0;
+  // The padding belongs on the scroller rather than the root. Codemirror's
+  // panels are siblings of the scroller inside the editor, so padding here
+  // leaves the vim status line floating away from the editor's edges instead
+  // of sitting flush against the toolbar below it.
+  padding: 0;
+
+  .cm-scroller {
+    padding: 0.75rem 0;
+  }
   &.remove-json-root-brackets .CodeMirror-code {
     & > div:first-child, & > div:last-child {
       display: none;

--- a/apps/studio/src/assets/styles/components/text-editor.scss
+++ b/apps/studio/src/assets/styles/components/text-editor.scss
@@ -1,10 +1,8 @@
 @import "./text-editor-plugins/partial-read-only.scss";
 
 .BksTextEditor {
-  // The padding belongs on the scroller rather than the root. Codemirror's
-  // panels are siblings of the scroller inside the editor, so padding here
-  // leaves the vim status line floating away from the editor's edges instead
-  // of sitting flush against the toolbar below it.
+  // On the scroller, not the root: codemirror's panels sit beside the
+  // scroller, so root padding pushes the vim status line off the edge.
   padding: 0;
 
   .cm-scroller {

--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -110,6 +110,10 @@ export enum AppEvent {
    * });
    **/
   openMoveFolderModal = 'openMoveFolderModal',
+  /** Vim's `:w`. Broadcast, so only the active tab should act on it. */
+  vimWrite = 'vimWrite',
+  /** Vim's `:x` and `:wq`. Broadcast, so only the active tab should act. */
+  vimWriteQuit = 'vimWriteQuit',
 }
 
 export type OpenShareModalOptions =  {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1420,10 +1420,13 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.textEditor?.focus()
       },
       handleTextEditorFocus() {
-        // Clicking into the editor is just as much a focus change as asking
-        // for it, so keep both the intent and the actual state in step.
+        // Only reconcile intent. focusingElement drives the is-focused prop,
+        // which the editor treats as a command rather than a report, so
+        // writing an observed focus straight into it makes the editor grab
+        // focus back from whatever legitimately took it. The vim ex prompt
+        // refocuses the editor as it closes, which lands after a modal opened
+        // by the command has focused its own input.
         this.focusElement = 'text-editor'
-        this.focusingElement = 'text-editor'
       },
       handleTextEditorBlur() {
         // An app-initiated blur is waiting on this and updates the state
@@ -1437,7 +1440,14 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         }
       },
       selectTitleInput() {
-        this.$refs.titleInput.select()
+        // Wait a tick: the vim ex prompt hands focus back to the editor while
+        // closing, so claim it after that has settled.
+        this.$nextTick(() => {
+          const input = this.$refs.titleInput
+          if (!input) return
+          input.focus()
+          input.select()
+        })
       },
       selectFirstParameter() {
         if (!this.$refs['paramInput'] || this.$refs['paramInput'].length === 0) return

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -924,9 +924,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           'queryEditor.secondaryQueryAction': this.queryFunctions.secondaryRead
         })
 
-        // Vim is registered ahead of these bindings, so it takes Esc when it
-        // means something there and only a plain normal mode Esc reaches
-        // cancelQuery. Ctrl-Esc stays bound for anyone used to it.
+        // Vim is registered first, so only a plain normal mode Esc gets here.
+        // Ctrl-Esc stays bound for anyone used to it.
         keybindings["Esc"] = this.cancelQuery
         if (this.userKeymap === "vim") {
           keybindings["Ctrl-Esc"] = this.cancelQuery
@@ -1415,9 +1414,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         this.textEditor?.focus()
       },
       handleTextEditorFocus() {
-        // Only reconcile intent. focusingElement drives is-focused, which the
-        // editor treats as a command, so writing observed focus into it makes
-        // the editor grab focus back from whatever legitimately took it.
+        // Set intent only. focusingElement drives is-focused, which the editor
+        // obeys, so echoing focus here steals it back from modals.
         this.focusElement = 'text-editor'
       },
       handleTextEditorBlur() {

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -651,7 +651,6 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         onTextEditorBlur: null,
         wrapText: false,
         vimKeymaps: [],
-        /** The ui-kit editor instance, from bks-initialized. */
         textEditor: null,
         formatterPresets: [],
         selectedFormatter: null,
@@ -925,14 +924,11 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           'queryEditor.secondaryQueryAction': this.queryFunctions.secondaryRead
         })
 
+        // Vim is registered ahead of these bindings, so it takes Esc when it
+        // means something there and only a plain normal mode Esc reaches
+        // cancelQuery. Ctrl-Esc stays bound for anyone used to it.
         keybindings["Esc"] = this.cancelQuery
-
         if (this.userKeymap === "vim") {
-          // The vim keymap is registered ahead of these bindings, so vim takes
-          // Esc whenever it means something there: leaving insert or visual
-          // mode. In plain normal mode vim reports Esc as unhandled, so it
-          // reaches cancelQuery, which does nothing unless a query is running.
-          // Ctrl-Esc stays bound for anyone used to it.
           keybindings["Ctrl-Esc"] = this.cancelQuery
         }
 
@@ -1413,26 +1409,20 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         const data = this.$refs.table.clipboard('md')
       },
       selectEditor() {
+        // The assignment is a no-op if intent was already 'text-editor', so
+        // ask the editor directly too.
         this.focusElement = 'text-editor'
-        // focusElement only drives focus when it changes. If the editor lost
-        // dom focus while the app still believed it had it, the assignment
-        // above is a no-op, so ask the editor directly as well.
         this.textEditor?.focus()
       },
       handleTextEditorFocus() {
-        // Only reconcile intent. focusingElement drives the is-focused prop,
-        // which the editor treats as a command rather than a report, so
-        // writing an observed focus straight into it makes the editor grab
-        // focus back from whatever legitimately took it. The vim ex prompt
-        // refocuses the editor as it closes, which lands after a modal opened
-        // by the command has focused its own input.
+        // Only reconcile intent. focusingElement drives is-focused, which the
+        // editor treats as a command, so writing observed focus into it makes
+        // the editor grab focus back from whatever legitimately took it.
         this.focusElement = 'text-editor'
       },
       handleTextEditorBlur() {
-        // An app-initiated blur is waiting on this and updates the state
-        // itself. Any other blur means the editor no longer has focus, and
-        // leaving focusingElement stale would keep us from ever giving it
-        // back. See #3446.
+        // An app-initiated blur updates the state itself; any other blur means
+        // the editor really lost focus and stale state would strand it (#3446).
         if (this.onTextEditorBlur) {
           this.onTextEditorBlur()
         } else if (this.focusingElement === 'text-editor') {
@@ -1440,8 +1430,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         }
       },
       selectTitleInput() {
-        // Wait a tick: the vim ex prompt hands focus back to the editor while
-        // closing, so claim it after that has settled.
+        // The vim ex prompt refocuses the editor as it closes, so claim the
+        // input after that settles.
         this.$nextTick(() => {
           const input = this.$refs.titleInput
           if (!input) return
@@ -1809,8 +1799,7 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           this.close()
         }
       },
-      // :w and :x are broadcast to every tab, because vim's ex commands are
-      // registered globally. Only the tab in front should act on them.
+      // Broadcast to every tab, so only the active one acts.
       handleVimWrite() {
         if (this.active) this.triggerSave()
       },
@@ -2169,9 +2158,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       })
       this.containerResizeObserver.observe(this.$refs.container)
 
-      // Applying the vimrc reconfigures the editor's keymap, and that rebuilds
-      // the vim extension underneath whatever has focus. Let it land before
-      // focusing rather than after. See #2990.
+      // Reconfiguring the keymap rebuilds the vim extension underneath
+      // whatever has focus, so let it land before focusing (#2990).
       await this.$store.dispatch('vim/load')
       this.vimKeymaps = this.$store.getters['vim/directives']
 

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -85,7 +85,8 @@
         @bks-initialized="handleEditorInitialized"
         @bks-value-change="unsavedText = $event.value"
         @bks-selection-change="handleEditorSelectionChange"
-        @bks-blur="onTextEditorBlur?.()"
+        @bks-focus="handleTextEditorFocus"
+        @bks-blur="handleTextEditorBlur"
         @bks-query-selection-change="handleQuerySelectionChange"
         @bks-apply-preset="applyPreset"
       />
@@ -303,6 +304,7 @@
       <progress-bar
         @cancel="cancelQuery"
         :message="runningText"
+        :cancel-key="userKeymap === 'vim' ? 'Ctrl-Esc' : 'Esc'"
         v-if="running"
       />
       <result-table
@@ -591,7 +593,7 @@
   import { FormatterDialect, dialectFor, formatOptionsFor } from "@shared/lib/dialects/models"
   import { findSqlQueryIdentifierDialect } from "@/lib/editor/CodeMirrorPlugins";
   import { queryMagicExtension } from "@/lib/editor/extensions/queryMagicExtension";
-  import { getVimKeymapsFromVimrc } from "@/lib/editor/vim";
+  import { vimExCommands } from "@/lib/editor/vimExCommands";
   import { monokaiInit } from '@uiw/codemirror-theme-monokai';
   import { SmartLocalStorage } from '@/common/LocalStorage';
   import { IdentifyResult } from 'sql-query-identifier/lib/defines'
@@ -649,6 +651,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
         onTextEditorBlur: null,
         wrapText: false,
         vimKeymaps: [],
+        /** The ui-kit editor instance, from bks-initialized. */
+        textEditor: null,
         formatterPresets: [],
         selectedFormatter: null,
         editHistoryOpen: false,
@@ -703,6 +707,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       rootBindings() {
         return [
           { event: AppEvent.openQueryEditHistory, handler: this.handleOpenQueryEditHistory },
+          { event: AppEvent.vimWrite, handler: this.handleVimWrite },
+          { event: AppEvent.vimWriteQuit, handler: this.handleVimWriteQuit },
         ];
       },
       savedQuery(): ISavedQuery | undefined {
@@ -919,32 +925,21 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           'queryEditor.secondaryQueryAction': this.queryFunctions.secondaryRead
         })
 
-        if(this.userKeymap === "vim") {
+        keybindings["Esc"] = this.cancelQuery
+
+        if (this.userKeymap === "vim") {
+          // The vim keymap is registered ahead of these bindings, so vim takes
+          // Esc whenever it means something there: leaving insert or visual
+          // mode. In plain normal mode vim reports Esc as unhandled, so it
+          // reaches cancelQuery, which does nothing unless a query is running.
+          // Ctrl-Esc stays bound for anyone used to it.
           keybindings["Ctrl-Esc"] = this.cancelQuery
-        } else {
-          keybindings["Esc"] = this.cancelQuery
         }
 
         return keybindings
       },
       vimConfig() {
-        const exCommands = [
-          { name: "write", prefix: "w", handler: this.triggerSave },
-          { name: "quit", prefix: "q", handler: this.close },
-          { name: "qa", prefix: "qa", handler: () => this.$root.$emit(AppEvent.closeAllTabs) },
-          { name: "x", prefix: "x", handler: this.writeQuit },
-          { name: "wq", prefix: "wq", handler: this.writeQuit },
-          { name: "tabnew", prefix: "tabnew", handler: (_cn, params) => {
-            if(params.args && params.args.length > 0){
-              let queryName = params.args[0]
-              this.$root.$emit(AppEvent.newTab,"", queryName)
-              return
-            }
-            this.$root.$emit(AppEvent.newTab)
-          }},
-        ]
-
-        return { exCommands }
+        return vimExCommands(this.trigger)
       },
       editorMarkers() {
         const markers = []
@@ -1321,8 +1316,9 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           this.updateEditorHeight()
         })
       },
-      handleEditorInitialized() {
+      handleEditorInitialized(event) {
         this.editor.initialized = true
+        this.textEditor = event?.detail?.editor ?? event?.editor ?? null
 
         // Setup query magic data providers
         this.queryMagic.setDefaultSchemaGetter(() => this.defaultSchema);
@@ -1418,6 +1414,27 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       },
       selectEditor() {
         this.focusElement = 'text-editor'
+        // focusElement only drives focus when it changes. If the editor lost
+        // dom focus while the app still believed it had it, the assignment
+        // above is a no-op, so ask the editor directly as well.
+        this.textEditor?.focus()
+      },
+      handleTextEditorFocus() {
+        // Clicking into the editor is just as much a focus change as asking
+        // for it, so keep both the intent and the actual state in step.
+        this.focusElement = 'text-editor'
+        this.focusingElement = 'text-editor'
+      },
+      handleTextEditorBlur() {
+        // An app-initiated blur is waiting on this and updates the state
+        // itself. Any other blur means the editor no longer has focus, and
+        // leaving focusingElement stale would keep us from ever giving it
+        // back. See #3446.
+        if (this.onTextEditorBlur) {
+          this.onTextEditorBlur()
+        } else if (this.focusingElement === 'text-editor') {
+          this.focusingElement = 'none'
+        }
       },
       selectTitleInput() {
         this.$refs.titleInput.select()
@@ -1782,6 +1799,14 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
           this.close()
         }
       },
+      // :w and :x are broadcast to every tab, because vim's ex commands are
+      // registered globally. Only the tab in front should act on them.
+      handleVimWrite() {
+        if (this.active) this.triggerSave()
+      },
+      handleVimWriteQuit() {
+        if (this.active) this.writeQuit()
+      },
       async switchPaneFocus(_event?: KeyboardEvent, target?: 'text-editor' | 'table') {
         if (target) {
           this.focusElement = target
@@ -2134,12 +2159,16 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
       })
       this.containerResizeObserver.observe(this.$refs.container)
 
+      // Applying the vimrc reconfigures the editor's keymap, and that rebuilds
+      // the vim extension underneath whatever has focus. Let it land before
+      // focusing rather than after. See #2990.
+      await this.$store.dispatch('vim/load')
+      this.vimKeymaps = this.$store.getters['vim/directives']
+
       if (this.active) {
         await this.$nextTick()
         this.focusElement = 'text-editor'
       }
-
-      this.vimKeymaps = await getVimKeymapsFromVimrc()
 
       // Load formatter presets for context menu
       this.getPresets(this.$bksConfig.ui.queryEditor.defaultFormatter)

--- a/apps/studio/src/components/TabShell.vue
+++ b/apps/studio/src/components/TabShell.vue
@@ -417,10 +417,11 @@ export default Vue.extend({
     },
     updateTextEditorFocus(focused: boolean) {
       if (focused) {
-        // Clicking into the editor is just as much a focus change as asking
-        // for it, so keep both the intent and the actual state in step.
+        // Only reconcile intent. focusingElement drives the is-focused prop,
+        // which the editor treats as a command, so writing an observed focus
+        // into it makes the editor grab focus back from whatever legitimately
+        // took it.
         this.focusElement = 'text-editor'
-        this.focusingElement = 'text-editor'
         return
       }
       // An app-initiated blur is waiting on this callback and updates the

--- a/apps/studio/src/components/TabShell.vue
+++ b/apps/studio/src/components/TabShell.vue
@@ -230,21 +230,17 @@ export default Vue.extend({
    keybindings() {
       const keybindings: any = {}
 
+      // Vim is registered ahead of these bindings, so only a plain normal
+      // mode Esc reaches cancelQuery. Ctrl-Esc stays bound too.
       keybindings["Esc"] = this.cancelQuery
-
       if (this.userKeymap === "vim") {
-        // Vim is registered ahead of these bindings, so it takes Esc whenever
-        // it means something there. In plain normal mode vim reports Esc as
-        // unhandled and it reaches cancelQuery. Ctrl-Esc stays bound for
-        // anyone used to it.
         keybindings["Ctrl-Esc"] = this.cancelQuery
       }
 
       return keybindings
     },
     vimConfig() {
-      // The same table every tab registers. A shell tab has nothing to save,
-      // so it simply never listens for AppEvent.vimWrite.
+      // A shell tab has nothing to save, so it never listens for vimWrite.
       return vimExCommands(this.trigger)
     },
     showResultTable() {
@@ -417,17 +413,13 @@ export default Vue.extend({
     },
     updateTextEditorFocus(focused: boolean) {
       if (focused) {
-        // Only reconcile intent. focusingElement drives the is-focused prop,
-        // which the editor treats as a command, so writing an observed focus
-        // into it makes the editor grab focus back from whatever legitimately
-        // took it.
+        // Only reconcile intent; focusingElement drives is-focused, which the
+        // editor treats as a command rather than a report.
         this.focusElement = 'text-editor'
         return
       }
-      // An app-initiated blur is waiting on this callback and updates the
-      // state itself. Any other blur means the editor really has lost focus,
-      // and leaving focusingElement stale would stop us ever handing it
-      // back. See #3446.
+      // An app-initiated blur updates the state itself; any other blur means
+      // the editor really lost focus and stale state would strand it (#3446).
       if (this.onTextEditorBlur) {
         this.onTextEditorBlur()
       } else if (this.focusingElement === 'text-editor') {
@@ -478,9 +470,8 @@ export default Vue.extend({
     })
     this.containerResizeObserver.observe(this.$refs.container)
 
-    // Applying the vimrc reconfigures the editor's keymap, which rebuilds the
-    // vim extension underneath whatever has focus. Let it land before
-    // focusing rather than after. See #2990.
+    // Reconfiguring the keymap rebuilds the vim extension underneath whatever
+    // has focus, so let it land before focusing (#2990).
     await this.$store.dispatch('vim/load');
     this.vimKeymaps = this.$store.getters['vim/directives'];
 

--- a/apps/studio/src/components/TabShell.vue
+++ b/apps/studio/src/components/TabShell.vue
@@ -12,6 +12,7 @@
         v-bind.sync="editor"
         :vim-config="vimConfig"
         :vim-keymaps="vimKeymaps"
+        :clipboard="$native.clipboard"
         :keymap="userKeymap"
         :output="mongoOutputResult"
         :is-focused="focusingElement === 'text-editor'"
@@ -123,7 +124,7 @@ import MergeManager from '@/components/editor/MergeManager.vue'
 import { AppEvent } from '@/common/AppEvent'
 import { PropType } from 'vue'
 import { TransportOpenTab } from '@/common/transport/TransportOpenTab'
-import { getVimKeymapsFromVimrc } from '@/lib/editor/vim';
+import { vimExCommands } from '@/lib/editor/vimExCommands';
 
 const log = rawlog.scope('query-editor')
 
@@ -229,29 +230,22 @@ export default Vue.extend({
    keybindings() {
       const keybindings: any = {}
 
-      if(this.userKeymap === "vim") {
+      keybindings["Esc"] = this.cancelQuery
+
+      if (this.userKeymap === "vim") {
+        // Vim is registered ahead of these bindings, so it takes Esc whenever
+        // it means something there. In plain normal mode vim reports Esc as
+        // unhandled and it reaches cancelQuery. Ctrl-Esc stays bound for
+        // anyone used to it.
         keybindings["Ctrl-Esc"] = this.cancelQuery
-      } else {
-        keybindings["Esc"] = this.cancelQuery
       }
 
       return keybindings
     },
     vimConfig() {
-      const exCommands = [
-        { name: "quit", prefix: "q", handler: this.close },
-        { name: "qa", prefix: "qa", handler: () => this.$root.$emit(AppEvent.closeAllTabs) },
-        { name: "tabnew", prefix: "tabnew", handler: (_cn, params) => {
-          if(params.args && params.args.length > 0){
-            let queryName = params.args[0]
-            this.$root.$emit(AppEvent.newTab,"", queryName)
-            return
-          }
-          this.$root.$emit(AppEvent.newTab)
-        }},
-      ]
-
-      return { exCommands }
+      // The same table every tab registers. A shell tab has nothing to save,
+      // so it simply never listens for AppEvent.vimWrite.
+      return vimExCommands(this.trigger)
     },
     showResultTable() {
       return this.rowCount > 0
@@ -422,8 +416,21 @@ export default Vue.extend({
       }
     },
     updateTextEditorFocus(focused: boolean) {
-      if (!focused) {
-        this.onTextEditorBlur?.()
+      if (focused) {
+        // Clicking into the editor is just as much a focus change as asking
+        // for it, so keep both the intent and the actual state in step.
+        this.focusElement = 'text-editor'
+        this.focusingElement = 'text-editor'
+        return
+      }
+      // An app-initiated blur is waiting on this callback and updates the
+      // state itself. Any other blur means the editor really has lost focus,
+      // and leaving focusingElement stale would stop us ever handing it
+      // back. See #3446.
+      if (this.onTextEditorBlur) {
+        this.onTextEditorBlur()
+      } else if (this.focusingElement === 'text-editor') {
+        this.focusingElement = 'none'
       }
     },
     async switchPaneFocus(_event?: KeyboardEvent, target?: 'text-editor' | 'table') {
@@ -470,12 +477,16 @@ export default Vue.extend({
     })
     this.containerResizeObserver.observe(this.$refs.container)
 
+    // Applying the vimrc reconfigures the editor's keymap, which rebuilds the
+    // vim extension underneath whatever has focus. Let it land before
+    // focusing rather than after. See #2990.
+    await this.$store.dispatch('vim/load');
+    this.vimKeymaps = this.$store.getters['vim/directives'];
+
     if (this.active) {
       await this.$nextTick()
       this.focusElement = 'text-editor'
     }
-
-    this.vimKeymaps = await getVimKeymapsFromVimrc();
   },
   beforeDestroy() {
     if(this.split) {

--- a/apps/studio/src/components/editor/ProgressBar.vue
+++ b/apps/studio/src/components/editor/ProgressBar.vue
@@ -24,10 +24,7 @@
         required: false,
         default: true
       },
-      /**
-       * In vim mode Esc only reaches cancel from normal mode, so Ctrl-Esc is
-       * the key that always works and the one worth advertising.
-       */
+      /** In vim mode Esc only cancels from normal mode, so advertise Ctrl-Esc. */
       cancelKey: {
         type: String,
         required: false,

--- a/apps/studio/src/components/editor/ProgressBar.vue
+++ b/apps/studio/src/components/editor/ProgressBar.vue
@@ -5,7 +5,7 @@
       <a
         v-if="canCancel"
         @click.prevent="$emit('cancel')"
-        title="Cancel Query Execution (Esc)"
+        :title="`Cancel Query Execution (${cancelKey})`"
         class="cancel-query btn btn-flat"
       >Cancel</a>
     </div>
@@ -23,6 +23,15 @@
         type: Boolean,
         required: false,
         default: true
+      },
+      /**
+       * In vim mode Esc only reaches cancel from normal mode, so Ctrl-Esc is
+       * the key that always works and the one worth advertising.
+       */
+      cancelKey: {
+        type: String,
+        required: false,
+        default: 'Esc'
       }
     }
   }

--- a/apps/studio/src/lib/editor/vim.ts
+++ b/apps/studio/src/lib/editor/vim.ts
@@ -1,186 +1,237 @@
-import Vue from "vue";
+export type VimMode = "normal" | "insert" | "visual";
 
+/**
+ * A directive parsed out of `.beekeeper.vimrc`. The shapes match the
+ * `vimKeymaps` prop of the ui-kit text editor, which applies them in order.
+ */
 export type IMapping = {
+  type?: "map";
   mappingMode: string;
   lhs: string;
   rhs: string;
-  mode: string;
+  mode?: VimMode;
+  /** `noremap` and friends: don't re-expand the rhs through other mappings. */
+  noremap?: boolean;
 };
 
-interface Config {
-  exCommands?: { name: string, prefix: string, handler: () => void }[];
+export type IUnmapping = {
+  type: "unmap";
+  lhs: string;
+  mode?: VimMode;
+};
+
+export type IMapClear = {
+  type: "mapclear";
+  mode?: VimMode;
+};
+
+export type IVimOption = {
+  type: "set";
+  name: string;
+  value: string | boolean;
+};
+
+export type VimDirective = IMapping | IUnmapping | IMapClear | IVimOption;
+
+export interface VimrcParseError {
+  /** 1-based, so it lines up with what an editor shows. */
+  line: number;
+  text: string;
+  reason: string;
 }
 
-export function applyConfig(codeMirrorVimInstance: any, config: Config) {
-  const { exCommands } = config;
-  if (exCommands) {
-    exCommands.forEach(({ name, prefix, handler }) => {
-      codeMirrorVimInstance.defineEx(name, prefix, handler);
-    });
+export interface VimrcParseResult {
+  directives: VimDirective[];
+  errors: VimrcParseError[];
+}
+
+const MAP_COMMANDS: Record<string, { mode?: VimMode; noremap: boolean }> = {
+  map: { noremap: false },
+  nmap: { mode: "normal", noremap: false },
+  imap: { mode: "insert", noremap: false },
+  vmap: { mode: "visual", noremap: false },
+  noremap: { noremap: true },
+  nnoremap: { mode: "normal", noremap: true },
+  inoremap: { mode: "insert", noremap: true },
+  vnoremap: { mode: "visual", noremap: true },
+};
+
+const UNMAP_COMMANDS: Record<string, VimMode | undefined> = {
+  unmap: undefined,
+  nunmap: "normal",
+  iunmap: "insert",
+  vunmap: "visual",
+};
+
+const MAPCLEAR_COMMANDS: Record<string, VimMode | undefined> = {
+  mapclear: undefined,
+  nmapclear: "normal",
+  imapclear: "insert",
+  vmapclear: "visual",
+};
+
+const DEFAULT_LEADER = "\\";
+const MAPLEADER = /^let\s+(?:g:)?mapleader\s*=\s*(.+)$/;
+const LEADER = /<leader>/gi;
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  if ((quote === '"' || quote === "'") && trimmed.endsWith(quote) && trimmed.length > 1) {
+    return trimmed.slice(1, -1);
   }
+  return trimmed;
 }
 
-async function readVimrc(): Promise<string[]> {
-  const data: string | null = await Vue.prototype.$util.send('config/readVimrc');
-  if (data == null) return [];
-  return data.split("\n");
-}
-
-export async function getVimKeymapsFromVimrc(): Promise<IMapping[]> {
-  const potentialCommands = await readVimrc();
-
-  if (potentialCommands.length === 0) {
-    return [];
+function parseSet(token: string): IVimOption | string {
+  if (token.endsWith("!") || token.startsWith("inv")) {
+    return "toggling an option is not supported, set it explicitly instead";
   }
 
-  return createVimCommands(potentialCommands);
-}
-
-export async function setKeybindingsFromVimrc(codeMirrorVimInstance: any): Promise<void> {
-  const mappings = await getVimKeymapsFromVimrc();
-
-  for (let j = 0; j < mappings.length; j++) {
-    codeMirrorVimInstance.map(
-      mappings[j].lhs,
-      mappings[j].rhs,
-      mappings[j].mode
-    );
+  const equals = token.indexOf("=");
+  if (equals > 0) {
+    return { type: "set", name: token.slice(0, equals), value: token.slice(equals + 1) };
   }
+
+  if (token.startsWith("no") && token.length > 2) {
+    return { type: "set", name: token.slice(2), value: false };
+  }
+
+  return { type: "set", name: token, value: true };
 }
 
-export function createVimCommands(vimrcContents: string[]): IMapping[] {
-  const keyMappingModes = ["nmap", "imap", "vmap"];
-  const mappings: IMapping[] = [];
+/**
+ * Parse the contents of a `.beekeeper.vimrc`, one entry per line.
+ *
+ * Anything unrecognised is collected in `errors` rather than thrown, so a
+ * single bad line never costs the user the rest of their config.
+ */
+export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
+  const directives: VimDirective[] = [];
+  const errors: VimrcParseError[] = [];
+  let leader = DEFAULT_LEADER;
 
-  vimrcContents.forEach((line: string) => {
-    if (!line) {
+  const fail = (line: number, text: string, reason: string) =>
+    errors.push({ line, text, reason });
+
+  vimrcContents.forEach((rawLine, index) => {
+    const line = index + 1;
+    const text = (rawLine ?? "").trim();
+
+    // Blank lines and vim comments, which start with a double quote. A quote
+    // anywhere else on the line is part of the mapping (e.g. the "* register).
+    if (!text || text.startsWith('"')) return;
+
+    const mapleader = text.match(MAPLEADER);
+    if (mapleader) {
+      leader = unquote(mapleader[1]);
       return;
     }
 
-    const words = line.split(" ");
-    let newCommand: IMapping;
-    if (words.length > 3) {
-      newCommand = {
-        mappingMode: words[0],
-        lhs: words[1],
-        rhs: words.slice(2).join(" "),
-        mode:
-          words[0] === "nmap"
-            ? "normal"
-            : words[0] === "imap"
-            ? "insert"
-            : "visual",
-      };
-    } else if (words.length !== 3) {
-      console.error(`Unable to parse this command: ${line}.`);
-      return;
-    } else {
-      newCommand = {
-        mappingMode: words[0],
-        lhs: words[1],
-        rhs: words[2],
-        mode:
-          words[0] === "nmap"
-            ? "normal"
-            : words[0] === "imap"
-            ? "insert"
-            : "visual",
-      };
-    }
+    const [command, ...args] = text.split(/\s+/);
 
-    if (keyMappingModes.includes(newCommand.mappingMode) === false) {
-      console.error(
-        `Sorry, ${newCommand.mappingMode} type is invalid and needs to be one of the following: ${keyMappingModes.join(
-          ", "
-        )}`
-      );
+    if (MAP_COMMANDS[command]) {
+      const { mode, noremap } = MAP_COMMANDS[command];
+      if (args.length < 2) {
+        fail(line, text, `${command} expects a key to map and something to map it to`);
+        return;
+      }
+
+      const lhs = args[0].replace(LEADER, leader);
+      const rhs = args.slice(1).join(" ");
+
+      // A recursive mapping whose rhs contains its own lhs expands forever.
+      // Vim has the same problem, which is what the noremap family is for.
+      if (!noremap && rhs.includes(lhs)) {
+        fail(
+          line,
+          text,
+          `${lhs} maps to itself, which repeats without end. Use ${command.replace("map", "noremap")} instead`
+        );
+        return;
+      }
+
+      directives.push({ mappingMode: command, lhs, rhs, mode, noremap });
       return;
     }
 
-    const currEntry = mappings.find((mapping) => mapping.lhs === newCommand.lhs && mapping.mappingMode === newCommand.mappingMode)
-    if (currEntry) {
-      const index = mappings.indexOf(currEntry)
-      mappings[index] = newCommand
-    } else {
-      mappings.push(newCommand);
+    if (command in UNMAP_COMMANDS) {
+      if (args.length !== 1) {
+        fail(line, text, `${command} expects exactly one key`);
+        return;
+      }
+      directives.push({
+        type: "unmap",
+        lhs: args[0].replace(LEADER, leader),
+        mode: UNMAP_COMMANDS[command],
+      });
+      return;
     }
+
+    if (command in MAPCLEAR_COMMANDS) {
+      if (args.length > 0) {
+        fail(line, text, `${command} takes no arguments`);
+        return;
+      }
+      directives.push({ type: "mapclear", mode: MAPCLEAR_COMMANDS[command] });
+      return;
+    }
+
+    if (command === "set" || command === "se") {
+      if (args.length === 0) {
+        fail(line, text, "set expects an option name");
+        return;
+      }
+      args.forEach((token) => {
+        const option = parseSet(token);
+        if (typeof option === "string") {
+          fail(line, text, option);
+        } else {
+          directives.push(option);
+        }
+      });
+      return;
+    }
+
+    fail(line, text, `${command} is not a supported command`);
   });
 
-  return mappings;
+  return { directives: dedupeMappings(directives), errors };
 }
 
-type Clipboard = {
-  writeText(text: string, notify?: boolean): void
-  readText(): string
-}
+/**
+ * Later mappings win, matching how sourcing a vimrc twice behaves. The
+ * survivor keeps the later position so that an unmap written between the two
+ * still runs first. Only plain mappings collapse: unmap, mapclear and set are
+ * order-sensitive and stay exactly as written.
+ */
+function dedupeMappings(directives: VimDirective[]): VimDirective[] {
+  const result: VimDirective[] = [];
 
-export class Register {
-  keyBuffer: string[];
-  insertModeChanges: Array<any> = [];
-  searchQueries: Array<any> = []
-  linewise = false;
-  blockwise = false;
-  clipboard: Clipboard;
-
-  constructor(clipboard: Clipboard) {
-    this.clipboard = clipboard;
-    this.clear();
-    this.keyBuffer = [''];
-  }
-
-  setText(text: string, linewise: boolean, blockwise: boolean) {
-    this.keyBuffer = [text || ''];
-    this.linewise = !!linewise;
-    this.blockwise = !!blockwise;
-    this.clipboard.writeText(text, false);
-  }
-
-  pushText(text: string, linewise: boolean) {
-    if (linewise) {
-      if (!this.linewise) {
-        this.keyBuffer.push('\n');
-      }
-      this.linewise = true;
+  directives.forEach((directive) => {
+    if ("type" in directive && directive.type) {
+      result.push(directive);
+      return;
     }
-    this.keyBuffer.push(text);
-    this.clipboard.writeText(this.keyBuffer.join(' '), false)
-  }
 
-  pushInsertModeChanges(changes: any) {
-    this.insertModeChanges.push(this.createInsertModeChanges(changes))
-  }
+    const mapping = directive as IMapping;
+    const superseded = result.findIndex(
+      (candidate) =>
+        !("type" in candidate && candidate.type) &&
+        (candidate as IMapping).lhs === mapping.lhs &&
+        (candidate as IMapping).mappingMode === mapping.mappingMode
+    );
 
-  pushSearchQuery(query: string) {
-    this.searchQueries.push(query);
-  }
-
-  clear() {
-    this.keyBuffer = [];
-    this.insertModeChanges = [];
-    this.searchQueries = [];
-    this.linewise = false;
-  }
-
-  toString() {
-    return this.clipboard.readText();
-    // return this.keyBuffer.join('');
-  }
-
-  private createInsertModeChanges(c: any) {
-    if (c) {
-      // Copy construction
-      return {
-        changes: c.changes,
-        expectCursorActivityForChange: c.expectCursorActivityForChange
-      };
+    if (superseded !== -1) {
+      result.splice(superseded, 1);
     }
-    return {
-      // Change list
-      changes: [],
-      // Set to true on change, false on cursorActivity.
-      expectCursorActivityForChange: false
-    };
-  }
+    result.push(mapping);
+  });
+
+  return result;
 }
 
-
+/** @deprecated Use `parseVimrc`, which also reports what it could not parse. */
+export function createVimCommands(vimrcContents: string[]): VimDirective[] {
+  return parseVimrc(vimrcContents).directives;
+}

--- a/apps/studio/src/lib/editor/vim.ts
+++ b/apps/studio/src/lib/editor/vim.ts
@@ -1,16 +1,12 @@
 export type VimMode = "normal" | "insert" | "visual";
 
-/**
- * A directive parsed out of `.beekeeper.vimrc`. The shapes match the
- * `vimKeymaps` prop of the ui-kit text editor, which applies them in order.
- */
+/** Directives match the ui-kit editor's `vimKeymaps` prop, applied in order. */
 export type IMapping = {
   type?: "map";
   mappingMode: string;
   lhs: string;
   rhs: string;
   mode?: VimMode;
-  /** `noremap` and friends: don't re-expand the rhs through other mappings. */
   noremap?: boolean;
 };
 
@@ -34,7 +30,7 @@ export type IVimOption = {
 export type VimDirective = IMapping | IUnmapping | IMapClear | IVimOption;
 
 export interface VimrcParseError {
-  /** 1-based, so it lines up with what an editor shows. */
+  /** 1-based. */
   line: number;
   text: string;
   reason: string;
@@ -101,10 +97,8 @@ function parseSet(token: string): IVimOption | string {
 }
 
 /**
- * Parse the contents of a `.beekeeper.vimrc`, one entry per line.
- *
- * Anything unrecognised is collected in `errors` rather than thrown, so a
- * single bad line never costs the user the rest of their config.
+ * Parse a `.beekeeper.vimrc`. Unrecognised lines land in `errors` rather than
+ * throwing, so one bad line does not cost the user the rest of their config.
  */
 export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
   const directives: VimDirective[] = [];
@@ -118,8 +112,8 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
     const line = index + 1;
     const text = (rawLine ?? "").trim();
 
-    // Blank lines and vim comments, which start with a double quote. A quote
-    // anywhere else on the line is part of the mapping (e.g. the "* register).
+    // Only a leading quote is a comment; elsewhere it is part of the mapping,
+    // as in the "* register.
     if (!text || text.startsWith('"')) return;
 
     const mapleader = text.match(MAPLEADER);
@@ -140,8 +134,7 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
       const lhs = args[0].replace(LEADER, leader);
       const rhs = args.slice(1).join(" ");
 
-      // A recursive mapping whose rhs contains its own lhs expands forever.
-      // Vim has the same problem, which is what the noremap family is for.
+      // A recursive mapping containing its own lhs expands forever.
       if (!noremap && rhs.includes(lhs)) {
         fail(
           line,
@@ -200,10 +193,9 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
 }
 
 /**
- * Later mappings win, matching how sourcing a vimrc twice behaves. The
- * survivor keeps the later position so that an unmap written between the two
- * still runs first. Only plain mappings collapse: unmap, mapclear and set are
- * order-sensitive and stay exactly as written.
+ * Later mappings win, and keep the later position so an unmap written between
+ * the two still runs first. Only plain mappings collapse; unmap, mapclear and
+ * set are order-sensitive.
  */
 function dedupeMappings(directives: VimDirective[]): VimDirective[] {
   const result: VimDirective[] = [];
@@ -229,9 +221,4 @@ function dedupeMappings(directives: VimDirective[]): VimDirective[] {
   });
 
   return result;
-}
-
-/** @deprecated Use `parseVimrc`, which also reports what it could not parse. */
-export function createVimCommands(vimrcContents: string[]): VimDirective[] {
-  return parseVimrc(vimrcContents).directives;
 }

--- a/apps/studio/src/lib/editor/vim.ts
+++ b/apps/studio/src/lib/editor/vim.ts
@@ -3,7 +3,6 @@ export type VimMode = "normal" | "insert" | "visual";
 /** Directives match the ui-kit editor's `vimKeymaps` prop, applied in order. */
 export type IMapping = {
   type?: "map";
-  mappingMode: string;
   lhs: string;
   rhs: string;
   mode?: VimMode;
@@ -97,8 +96,8 @@ function parseSet(token: string): IVimOption | string {
 }
 
 /**
- * Parse a `.beekeeper.vimrc`. Unrecognised lines land in `errors` rather than
- * throwing, so one bad line does not cost the user the rest of their config.
+ * Unrecognised lines go to `errors` instead of throwing, so one bad line
+ * doesn't cost the user the rest of their config.
  */
 export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
   const directives: VimDirective[] = [];
@@ -112,8 +111,8 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
     const line = index + 1;
     const text = (rawLine ?? "").trim();
 
-    // Only a leading quote is a comment; elsewhere it is part of the mapping,
-    // as in the "* register.
+    // Only a leading quote starts a comment. Elsewhere it's part of the
+    // mapping, as in the "* register.
     if (!text || text.startsWith('"')) return;
 
     const mapleader = text.match(MAPLEADER);
@@ -144,7 +143,7 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
         return;
       }
 
-      directives.push({ mappingMode: command, lhs, rhs, mode, noremap });
+      directives.push({ lhs, rhs, mode, noremap });
       return;
     }
 
@@ -193,9 +192,8 @@ export function parseVimrc(vimrcContents: string[]): VimrcParseResult {
 }
 
 /**
- * Later mappings win, and keep the later position so an unmap written between
- * the two still runs first. Only plain mappings collapse; unmap, mapclear and
- * set are order-sensitive.
+ * Later mappings win, and take the later position so an unmap written between
+ * the two still runs first. Only mappings collapse; the rest stay in order.
  */
 function dedupeMappings(directives: VimDirective[]): VimDirective[] {
   const result: VimDirective[] = [];
@@ -211,7 +209,7 @@ function dedupeMappings(directives: VimDirective[]): VimDirective[] {
       (candidate) =>
         !("type" in candidate && candidate.type) &&
         (candidate as IMapping).lhs === mapping.lhs &&
-        (candidate as IMapping).mappingMode === mapping.mappingMode
+        (candidate as IMapping).mode === mapping.mode
     );
 
     if (superseded !== -1) {

--- a/apps/studio/src/lib/editor/vimExCommands.ts
+++ b/apps/studio/src/lib/editor/vimExCommands.ts
@@ -13,10 +13,8 @@ export interface VimExCommandConfig {
 type Trigger = (event: AppEvent, ...args: any[]) => void;
 
 /**
- * Ex commands live on a process-global vim singleton, so handlers cannot close
- * over a tab -- each mount would overwrite the last, and `:w` would save the
- * wrong tab (#1930). Emitting keeps the table identical everywhere and lets
- * the active tab decide. Tabs that don't support a command don't listen.
+ * Ex commands are global, so a handler that captured a tab would be overwritten
+ * by the next tab to mount and `:w` would save the wrong one (#1930).
  */
 export function vimExCommands(trigger: Trigger): VimExCommandConfig {
   return {
@@ -49,13 +47,11 @@ export function vimExCommands(trigger: Trigger): VimExCommandConfig {
 }
 
 /**
- * Vim binds <C-p> to "up", swallowing quick search (#3446). Mapped rather than
- * unmapped, because removing a built-in breaks mapclear and noremap. Applied
- * ahead of the user's vimrc, so `nnoremap <C-p> k` takes the key back.
+ * Vim binds <C-p> to "up", which swallowed quick search (#3446). Mapped rather
+ * than unmapped, because removing a built-in breaks mapclear and noremap.
  */
 export const DEFAULT_VIM_MAPPINGS = [
   {
-    mappingMode: "nmap",
     lhs: "<C-p>",
     rhs: ":bksquicksearch<CR>",
     mode: "normal" as const,

--- a/apps/studio/src/lib/editor/vimExCommands.ts
+++ b/apps/studio/src/lib/editor/vimExCommands.ts
@@ -1,0 +1,73 @@
+import { AppEvent } from "@/common/AppEvent";
+
+export interface VimExCommand {
+  name: string;
+  prefix: string;
+  handler: (...args: any[]) => void;
+}
+
+export interface VimExCommandConfig {
+  exCommands: VimExCommand[];
+}
+
+type Trigger = (event: AppEvent, ...args: any[]) => void;
+
+/**
+ * Ex commands live on a process-global vim singleton, so their handlers can't
+ * close over a tab: every tab that mounts overwrites the previous tab's
+ * handlers, and `:w` ends up saving whichever tab mounted last rather than the
+ * one being typed in. Emitting instead keeps the table identical for every
+ * tab, and the tab that is actually active decides what to do.
+ *
+ * Tabs that don't support a command simply don't listen for it, which is how
+ * the shell tab stays without `:w`.
+ */
+export function vimExCommands(trigger: Trigger): VimExCommandConfig {
+  return {
+    exCommands: [
+      { name: "write", prefix: "w", handler: () => trigger(AppEvent.vimWrite) },
+      { name: "quit", prefix: "q", handler: () => trigger(AppEvent.closeTab) },
+      { name: "qa", prefix: "qa", handler: () => trigger(AppEvent.closeAllTabs) },
+      { name: "x", prefix: "x", handler: () => trigger(AppEvent.vimWriteQuit) },
+      { name: "wq", prefix: "wq", handler: () => trigger(AppEvent.vimWriteQuit) },
+      // Reached from the default <C-p> mapping below rather than typed.
+      {
+        name: "bksquicksearch",
+        prefix: "bksquicksearch",
+        handler: () => trigger(AppEvent.quickSearch),
+      },
+      {
+        name: "tabnew",
+        prefix: "tabnew",
+        handler: (_cm, params) => {
+          const name = params?.args?.[0];
+          if (name) {
+            trigger(AppEvent.newTab, "", name);
+          } else {
+            trigger(AppEvent.newTab);
+          }
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * Vim binds <C-p> to "up" in every mode, which swallowed the app's quick
+ * search shortcut once the editor moved to codemirror 6 (#3446). Rather than
+ * unmapping it -- codemirror derives which keymap entries are user defined by
+ * subtracting the length it recorded at startup, so removing a built-in
+ * breaks mapclear and noremap -- point it at the app action instead.
+ *
+ * These are applied ahead of the user's vimrc, so `nnoremap <C-p> k` in
+ * `.beekeeper.vimrc` takes the key back.
+ */
+export const DEFAULT_VIM_MAPPINGS = [
+  {
+    mappingMode: "nmap",
+    lhs: "<C-p>",
+    rhs: ":bksquicksearch<CR>",
+    mode: "normal" as const,
+    noremap: false,
+  },
+];

--- a/apps/studio/src/lib/editor/vimExCommands.ts
+++ b/apps/studio/src/lib/editor/vimExCommands.ts
@@ -13,14 +13,10 @@ export interface VimExCommandConfig {
 type Trigger = (event: AppEvent, ...args: any[]) => void;
 
 /**
- * Ex commands live on a process-global vim singleton, so their handlers can't
- * close over a tab: every tab that mounts overwrites the previous tab's
- * handlers, and `:w` ends up saving whichever tab mounted last rather than the
- * one being typed in. Emitting instead keeps the table identical for every
- * tab, and the tab that is actually active decides what to do.
- *
- * Tabs that don't support a command simply don't listen for it, which is how
- * the shell tab stays without `:w`.
+ * Ex commands live on a process-global vim singleton, so handlers cannot close
+ * over a tab -- each mount would overwrite the last, and `:w` would save the
+ * wrong tab (#1930). Emitting keeps the table identical everywhere and lets
+ * the active tab decide. Tabs that don't support a command don't listen.
  */
 export function vimExCommands(trigger: Trigger): VimExCommandConfig {
   return {
@@ -30,7 +26,7 @@ export function vimExCommands(trigger: Trigger): VimExCommandConfig {
       { name: "qa", prefix: "qa", handler: () => trigger(AppEvent.closeAllTabs) },
       { name: "x", prefix: "x", handler: () => trigger(AppEvent.vimWriteQuit) },
       { name: "wq", prefix: "wq", handler: () => trigger(AppEvent.vimWriteQuit) },
-      // Reached from the default <C-p> mapping below rather than typed.
+      // Reached from the default <C-p> mapping below, not typed.
       {
         name: "bksquicksearch",
         prefix: "bksquicksearch",
@@ -53,14 +49,9 @@ export function vimExCommands(trigger: Trigger): VimExCommandConfig {
 }
 
 /**
- * Vim binds <C-p> to "up" in every mode, which swallowed the app's quick
- * search shortcut once the editor moved to codemirror 6 (#3446). Rather than
- * unmapping it -- codemirror derives which keymap entries are user defined by
- * subtracting the length it recorded at startup, so removing a built-in
- * breaks mapclear and noremap -- point it at the app action instead.
- *
- * These are applied ahead of the user's vimrc, so `nnoremap <C-p> k` in
- * `.beekeeper.vimrc` takes the key back.
+ * Vim binds <C-p> to "up", swallowing quick search (#3446). Mapped rather than
+ * unmapped, because removing a built-in breaks mapclear and noremap. Applied
+ * ahead of the user's vimrc, so `nnoremap <C-p> k` takes the key back.
  */
 export const DEFAULT_VIM_MAPPINGS = [
   {

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -40,6 +40,7 @@ import { PopupMenuModule } from './modules/PopupMenuModule'
 import { WebPluginManagerStatus } from '@/services/plugin'
 import { MenuBarModule } from './modules/MenuBarModule'
 import { PluginsModule, PluginsState } from './modules/plugins'
+import { VimStoreModule } from './modules/VimStoreModule'
 import { pluralize } from '@/vendor/pluralize'
 
 
@@ -154,6 +155,7 @@ const store = new Vuex.Store<State>({
     popupMenu: PopupMenuModule,
     menuBar: MenuBarModule,
     plugins: PluginsModule,
+    vim: VimStoreModule,
   },
   state: {
     connection: new ElectronUtilityConnectionClient(),

--- a/apps/studio/src/store/modules/VimStoreModule.ts
+++ b/apps/studio/src/store/modules/VimStoreModule.ts
@@ -15,7 +15,7 @@ interface State {
   directives: VimDirective[];
   errors: VimrcParseError[];
   loaded: boolean;
-  /** Held so concurrent callers share one read rather than racing. */
+  /** Shared so concurrent callers don't race. */
   loading: Promise<void> | null;
 }
 
@@ -25,10 +25,7 @@ async function readVimrc(): Promise<string[]> {
   return data.split("\n");
 }
 
-/**
- * A single line gets its reason spelled out; several would make the
- * notification unreadable, so those just get located.
- */
+/** One line gets its reason; several would be unreadable, so those get located. */
 function describeErrors(errors: VimrcParseError[]): string {
   if (errors.length === 1) {
     return `.beekeeper.vimrc line ${errors[0].line}: ${errors[0].reason}`;
@@ -38,9 +35,7 @@ function describeErrors(errors: VimrcParseError[]): string {
 }
 
 /**
- * The user's `.beekeeper.vimrc`, read once per app run rather than once per
- * editor tab. Mappings are applied to a global vim singleton, so re-reading
- * the file for every tab did redundant io and re-applied the same mappings.
+ * The user's `.beekeeper.vimrc`, read once per app run rather than per tab.
  */
 export const VimStoreModule: Module<State, RootState> = {
   namespaced: true,
@@ -51,10 +46,7 @@ export const VimStoreModule: Module<State, RootState> = {
     loading: null,
   }),
   getters: {
-    /**
-     * The app's own defaults first, so anything in the user's vimrc that
-     * touches the same key is applied afterwards and wins.
-     */
+    /** App defaults first, so the user's vimrc is applied after and wins. */
     directives(state) {
       return [...DEFAULT_VIM_MAPPINGS, ...state.directives];
     },
@@ -73,7 +65,7 @@ export const VimStoreModule: Module<State, RootState> = {
     },
   },
   actions: {
-    /** Resolves once the vimrc is available. Safe to await from every tab. */
+    /** Safe to await from every tab. */
     async load(context): Promise<void> {
       if (context.state.loaded) return;
       if (context.state.loading) return context.state.loading;

--- a/apps/studio/src/store/modules/VimStoreModule.ts
+++ b/apps/studio/src/store/modules/VimStoreModule.ts
@@ -1,0 +1,102 @@
+import Vue from "vue";
+import { Module } from "vuex";
+import rawLog from "@bksLogger";
+import { State as RootState } from "../index";
+import {
+  VimDirective,
+  VimrcParseError,
+  parseVimrc,
+} from "@/lib/editor/vim";
+import { DEFAULT_VIM_MAPPINGS } from "@/lib/editor/vimExCommands";
+
+const log = rawLog.scope("vim");
+
+interface State {
+  directives: VimDirective[];
+  errors: VimrcParseError[];
+  loaded: boolean;
+  /** Held so concurrent callers share one read rather than racing. */
+  loading: Promise<void> | null;
+}
+
+async function readVimrc(): Promise<string[]> {
+  const data: string | null = await Vue.prototype.$util.send("config/readVimrc");
+  if (data == null) return [];
+  return data.split("\n");
+}
+
+/**
+ * A single line gets its reason spelled out; several would make the
+ * notification unreadable, so those just get located.
+ */
+function describeErrors(errors: VimrcParseError[]): string {
+  if (errors.length === 1) {
+    return `.beekeeper.vimrc line ${errors[0].line}: ${errors[0].reason}`;
+  }
+  const lines = errors.map((e) => e.line).join(", ");
+  return `.beekeeper.vimrc: ${errors.length} lines could not be parsed (lines ${lines})`;
+}
+
+/**
+ * The user's `.beekeeper.vimrc`, read once per app run rather than once per
+ * editor tab. Mappings are applied to a global vim singleton, so re-reading
+ * the file for every tab did redundant io and re-applied the same mappings.
+ */
+export const VimStoreModule: Module<State, RootState> = {
+  namespaced: true,
+  state: () => ({
+    directives: [],
+    errors: [],
+    loaded: false,
+    loading: null,
+  }),
+  getters: {
+    /**
+     * The app's own defaults first, so anything in the user's vimrc that
+     * touches the same key is applied afterwards and wins.
+     */
+    directives(state) {
+      return [...DEFAULT_VIM_MAPPINGS, ...state.directives];
+    },
+    errors(state) {
+      return state.errors;
+    },
+  },
+  mutations: {
+    setResult(state, { directives, errors }) {
+      state.directives = directives;
+      state.errors = errors;
+      state.loaded = true;
+    },
+    setLoading(state, loading: Promise<void> | null) {
+      state.loading = loading;
+    },
+  },
+  actions: {
+    /** Resolves once the vimrc is available. Safe to await from every tab. */
+    async load(context): Promise<void> {
+      if (context.state.loaded) return;
+      if (context.state.loading) return context.state.loading;
+
+      const loading = (async () => {
+        try {
+          const { directives, errors } = parseVimrc(await readVimrc());
+          context.commit("setResult", { directives, errors });
+
+          if (errors.length > 0) {
+            log.warn("Could not parse every line of .beekeeper.vimrc", errors);
+            Vue.prototype.$noty.warning(describeErrors(errors));
+          }
+        } catch (e) {
+          log.error("Could not read .beekeeper.vimrc", e);
+          context.commit("setResult", { directives: [], errors: [] });
+        } finally {
+          context.commit("setLoading", null);
+        }
+      })();
+
+      context.commit("setLoading", loading);
+      return loading;
+    },
+  },
+};

--- a/apps/studio/tests/unit/lib/editor/vimExCommands.spec.ts
+++ b/apps/studio/tests/unit/lib/editor/vimExCommands.spec.ts
@@ -1,0 +1,88 @@
+import { AppEvent } from "@/common/AppEvent";
+import { vimExCommands, DEFAULT_VIM_MAPPINGS } from "@/lib/editor/vimExCommands";
+
+function commandsByPrefix(trigger: jest.Mock) {
+  const { exCommands } = vimExCommands(trigger as any);
+  return Object.fromEntries(exCommands.map((c) => [c.prefix, c]));
+}
+
+describe("vim ex commands", () => {
+  let trigger: jest.Mock;
+
+  beforeEach(() => {
+    trigger = jest.fn();
+  });
+
+  // https://github.com/beekeeper-studio/beekeeper-studio/issues/1930
+  // Ex commands are registered on a global vim singleton, so a handler that
+  // captured a tab would act on whichever tab mounted last. These broadcast
+  // instead, leaving the active tab to decide.
+  it("broadcasts rather than capturing a tab", () => {
+    const commands = commandsByPrefix(trigger);
+
+    commands["w"].handler();
+    expect(trigger).toHaveBeenCalledWith(AppEvent.vimWrite);
+
+    commands["q"].handler();
+    expect(trigger).toHaveBeenCalledWith(AppEvent.closeTab);
+
+    commands["qa"].handler();
+    expect(trigger).toHaveBeenCalledWith(AppEvent.closeAllTabs);
+  });
+
+  it("treats :x and :wq the same", () => {
+    const commands = commandsByPrefix(trigger);
+
+    commands["x"].handler();
+    commands["wq"].handler();
+
+    expect(trigger.mock.calls).toEqual([
+      [AppEvent.vimWriteQuit],
+      [AppEvent.vimWriteQuit],
+    ]);
+  });
+
+  it("passes a name through to :tabnew, and copes without one", () => {
+    const commands = commandsByPrefix(trigger);
+
+    commands["tabnew"].handler({}, { args: ["reports"] });
+    expect(trigger).toHaveBeenCalledWith(AppEvent.newTab, "", "reports");
+
+    commands["tabnew"].handler({}, {});
+    expect(trigger).toHaveBeenCalledWith(AppEvent.newTab);
+
+    commands["tabnew"].handler({}, { args: [] });
+    expect(trigger).toHaveBeenCalledTimes(3);
+  });
+
+  it("builds an identical table every time, so tabs cannot clobber each other", () => {
+    const a = vimExCommands(trigger as any).exCommands.map((c) => [c.name, c.prefix]);
+    const b = vimExCommands(jest.fn() as any).exCommands.map((c) => [c.name, c.prefix]);
+
+    expect(a).toEqual(b);
+  });
+});
+
+describe("default vim mappings", () => {
+  // https://github.com/beekeeper-studio/beekeeper-studio/issues/3446
+  it("routes ctrl-p to quick search through an ex command", () => {
+    const mapping = DEFAULT_VIM_MAPPINGS.find((m) => m.lhs === "<C-p>");
+
+    expect(mapping).toBeDefined();
+    expect(mapping.mode).toEqual("normal");
+
+    const trigger = jest.fn();
+    const commands = commandsByPrefix(trigger);
+    const exName = mapping.rhs.replace(/^:/, "").replace(/<CR>$/, "");
+
+    expect(commands[exName]).toBeDefined();
+    commands[exName].handler();
+    expect(trigger).toHaveBeenCalledWith(AppEvent.quickSearch);
+  });
+
+  it("does not unmap anything", () => {
+    // Removing a built-in shrinks codemirror's keymap below the length it
+    // recorded at startup, which breaks mapclear and noremap lookups.
+    expect(DEFAULT_VIM_MAPPINGS.every((m) => !("type" in m))).toBe(true);
+  });
+});

--- a/apps/studio/tests/unit/mixins/vimrc.spec.js
+++ b/apps/studio/tests/unit/mixins/vimrc.spec.js
@@ -1,4 +1,4 @@
-import { parseVimrc, createVimCommands } from "../../../../studio/src/lib/editor/vim"
+import { parseVimrc } from "../../../../studio/src/lib/editor/vim"
 
 const mapping = (mappingMode, lhs, rhs, mode, noremap = false) =>
   ({ mappingMode, lhs, rhs, mode, noremap })
@@ -41,12 +41,6 @@ describe("Vimrc parsing", () => {
     ])
 
     expect(directives).toHaveLength(2)
-  })
-
-  it("still exposes createVimCommands", () => {
-    expect(createVimCommands(["nmap gl $"])).toEqual([
-      mapping("nmap", "gl", "$", "normal"),
-    ])
   })
 })
 

--- a/apps/studio/tests/unit/mixins/vimrc.spec.js
+++ b/apps/studio/tests/unit/mixins/vimrc.spec.js
@@ -1,7 +1,6 @@
 import { parseVimrc } from "../../../../studio/src/lib/editor/vim"
 
-const mapping = (mappingMode, lhs, rhs, mode, noremap = false) =>
-  ({ mappingMode, lhs, rhs, mode, noremap })
+const mapping = (lhs, rhs, mode, noremap = false) => ({ lhs, rhs, mode, noremap })
 
 describe("Vimrc parsing", () => {
   it("parses the map commands into directives", () => {
@@ -16,12 +15,12 @@ describe("Vimrc parsing", () => {
 
     expect(errors).toEqual([])
     expect(directives).toEqual([
-      mapping("nmap", "gl", "$", "normal"),
-      mapping("nmap", "gh", "^", "normal"),
-      mapping("nmap", "Y", "y$", "normal"),
-      mapping("nmap", "J", ":tabp", "normal"),
-      mapping("nmap", "K", ":tabn", "normal"),
-      mapping("vmap", "K", ":m '<-2gv=gv", "visual"),
+      mapping("gl", "$", "normal"),
+      mapping("gh", "^", "normal"),
+      mapping("Y", "y$", "normal"),
+      mapping("J", ":tabp", "normal"),
+      mapping("K", ":tabn", "normal"),
+      mapping("K", ":m '<-2gv=gv", "visual"),
     ])
   })
 
@@ -31,7 +30,16 @@ describe("Vimrc parsing", () => {
       "nmap gl $",
     ])
 
-    expect(directives).toEqual([mapping("nmap", "gl", "$", "normal")])
+    expect(directives).toEqual([mapping("gl", "$", "normal")])
+  })
+
+  it("lets a later noremap supersede an earlier map for the same key", () => {
+    const { directives } = parseVimrc([
+      "nmap gl ^",
+      "nnoremap gl $",
+    ])
+
+    expect(directives).toEqual([mapping("gl", "$", "normal", true)])
   })
 
   it("treats the same key in different modes as separate mappings", () => {
@@ -55,7 +63,7 @@ describe("Vimrc parsing: whitespace and comments", () => {
     ])
 
     expect(errors).toEqual([])
-    expect(directives).toEqual([mapping("nmap", "gl", "$", "normal")])
+    expect(directives).toEqual([mapping("gl", "$", "normal")])
   })
 
   it("accepts tabs and runs of spaces as separators", () => {
@@ -67,9 +75,9 @@ describe("Vimrc parsing: whitespace and comments", () => {
 
     expect(errors).toEqual([])
     expect(directives).toEqual([
-      mapping("nmap", "gl", "$", "normal"),
-      mapping("nmap", "gh", "^", "normal"),
-      mapping("nmap", "Y", "y$", "normal"),
+      mapping("gl", "$", "normal"),
+      mapping("gh", "^", "normal"),
+      mapping("Y", "y$", "normal"),
     ])
   })
 
@@ -77,7 +85,7 @@ describe("Vimrc parsing: whitespace and comments", () => {
     const { directives, errors } = parseVimrc(['nnoremap y "*y'])
 
     expect(errors).toEqual([])
-    expect(directives).toEqual([mapping("nnoremap", "y", '"*y', "normal", true)])
+    expect(directives).toEqual([mapping("y", '"*y', "normal", true)])
   })
 })
 
@@ -92,10 +100,10 @@ describe("Vimrc parsing: noremap", () => {
 
     expect(errors).toEqual([])
     expect(directives).toEqual([
-      mapping("noremap", "gl", "$", undefined, true),
-      mapping("nnoremap", "gh", "^", "normal", true),
-      mapping("inoremap", "jk", "<Esc>", "insert", true),
-      mapping("vnoremap", "p", "P", "visual", true),
+      mapping("gl", "$", undefined, true),
+      mapping("gh", "^", "normal", true),
+      mapping("jk", "<Esc>", "insert", true),
+      mapping("p", "P", "visual", true),
     ])
   })
 
@@ -152,7 +160,7 @@ describe("Vimrc parsing: unmap and mapclear", () => {
 
     expect(directives).toEqual([
       { type: "unmap", lhs: "gl", mode: "normal" },
-      mapping("nmap", "gl", "^", "normal"),
+      mapping("gl", "^", "normal"),
     ])
   })
 
@@ -202,7 +210,7 @@ describe("Vimrc parsing: leader", () => {
   it("expands <leader> to a backslash by default", () => {
     const { directives } = parseVimrc(["nmap <leader>w :w<CR>"])
 
-    expect(directives).toEqual([mapping("nmap", "\\w", ":w<CR>", "normal")])
+    expect(directives).toEqual([mapping("\\w", ":w<CR>", "normal")])
   })
 
   it("honours mapleader", () => {
@@ -211,7 +219,7 @@ describe("Vimrc parsing: leader", () => {
       "nmap <leader>w :w<CR>",
     ])
 
-    expect(directives).toEqual([mapping("nmap", ",w", ":w<CR>", "normal")])
+    expect(directives).toEqual([mapping(",w", ":w<CR>", "normal")])
   })
 
   it("honours g:mapleader and an unspaced assignment", () => {
@@ -220,7 +228,7 @@ describe("Vimrc parsing: leader", () => {
       "nmap <Leader>w :w<CR>",
     ])
 
-    expect(directives).toEqual([mapping("nmap", " w", ":w<CR>", "normal")])
+    expect(directives).toEqual([mapping(" w", ":w<CR>", "normal")])
   })
 
   it("only applies mapleader to mappings that follow it", () => {

--- a/apps/studio/tests/unit/mixins/vimrc.spec.js
+++ b/apps/studio/tests/unit/mixins/vimrc.spec.js
@@ -1,85 +1,267 @@
-import { createVimCommands } from "../../../../studio/src/lib/editor/vim"
+import { parseVimrc, createVimCommands } from "../../../../studio/src/lib/editor/vim"
 
-describe("Vimrc Parsing", () => {
-  it("Should parse all the commands here, and supply all the IMapping commands to be sent into the setKeybindingsFromVimrc.", () => {
-    const vimrcSampleContent = [
+const mapping = (mappingMode, lhs, rhs, mode, noremap = false) =>
+  ({ mappingMode, lhs, rhs, mode, noremap })
+
+describe("Vimrc parsing", () => {
+  it("parses the map commands into directives", () => {
+    const { directives, errors } = parseVimrc([
       "nmap gl $",
       "nmap gh ^",
       "nmap Y y$",
       "nmap J :tabp",
       "nmap K :tabn",
-      "vmap K :m '<-2gv=gv"
-    ];
+      "vmap K :m '<-2gv=gv",
+    ])
 
-    const expected = {
-      nmapgl: { mappingMode: "nmap", lhs: "gl", rhs: "$", mode: "normal" },
-      nmapgh: { mappingMode: "nmap", lhs: "gh", rhs: "^", mode: "normal" },
-      nmapY: { mappingMode: "nmap", lhs: "Y", rhs: "y$", mode: "normal" },
-      nmapJ: { mappingMode: "nmap", lhs: "J", rhs: ":tabp", mode: "normal" },
-      nmapK: { mappingMode: "nmap", lhs: "K", rhs: ":tabn", mode: "normal" },
-      vmapK: { mappingMode: "vmap", lhs: "K", rhs: ":m '<-2gv=gv", mode: "visual" },
-    }
-
-    const commands = createVimCommands(vimrcSampleContent);
-
-    commands.forEach((command) => {
-      expect(command).toEqual(expected[command.mappingMode + command.lhs])
-    });
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      mapping("nmap", "gl", "$", "normal"),
+      mapping("nmap", "gh", "^", "normal"),
+      mapping("nmap", "Y", "y$", "normal"),
+      mapping("nmap", "J", ":tabp", "normal"),
+      mapping("nmap", "K", ":tabn", "normal"),
+      mapping("vmap", "K", ":m '<-2gv=gv", "visual"),
+    ])
   })
-})
 
-describe("Vimrc Parsing", () => {
-  it("register two of the same command and same mapping mode, take the last one created and ignore the other", () => {
-    const vimrcSampleContent = [
+  it("keeps the last of two mappings for the same key and mode", () => {
+    const { directives } = parseVimrc([
       "nmap gl ^",
       "nmap gl $",
-    ];
+    ])
 
-    const expected = {
-      nmapgl: { mappingMode: "nmap", lhs: "gl", rhs: "$", mode: "normal" },
-    }
+    expect(directives).toEqual([mapping("nmap", "gl", "$", "normal")])
+  })
 
-    const commands = createVimCommands(vimrcSampleContent);
+  it("treats the same key in different modes as separate mappings", () => {
+    const { directives } = parseVimrc([
+      "nmap gl ^",
+      "vmap gl $",
+    ])
 
-    expect(commands.length).toEqual(1);
-    commands.forEach((command) => {
-      expect(command).toEqual(expected[command.mappingMode + command.lhs])
-    });
+    expect(directives).toHaveLength(2)
+  })
+
+  it("still exposes createVimCommands", () => {
+    expect(createVimCommands(["nmap gl $"])).toEqual([
+      mapping("nmap", "gl", "$", "normal"),
+    ])
   })
 })
 
-describe("Vimrc Parsing", () => {
-  it("Should parse all the commands here, and skip the invalid ones, and supply all the IMapping commands to be sent into the setKeybindingsFromVimrc.", () => {
-    const vimrcSampleContent = [
+describe("Vimrc parsing: whitespace and comments", () => {
+  it("skips blank lines and comments", () => {
+    const { directives, errors } = parseVimrc([
+      "",
+      '" go to the end of the line',
+      "   ",
       "nmap gl $",
-      "nmap gh ^",
-      "nmap Y y$",
-      "i l :test", //Not a valid command because i is not a valid mapping mode
-      "nnoremap <leader>l :test", //Not a valid command because nnoremap is not a current valid mapping mode, but it should be in the future.
-    ];
+      '"nmap gh ^',
+    ])
 
-    const expected = {
-      gl: { mappingMode: "nmap", lhs: "gl", rhs: "$", mode: "normal" },
-      gh: { mappingMode: "nmap", lhs: "gh", rhs: "^", mode: "normal" },
-      Y: { mappingMode: "nmap", lhs: "Y", rhs: "y$", mode: "normal" },
-    }
+    expect(errors).toEqual([])
+    expect(directives).toEqual([mapping("nmap", "gl", "$", "normal")])
+  })
 
-    const commands = createVimCommands(vimrcSampleContent);
+  it("accepts tabs and runs of spaces as separators", () => {
+    const { directives, errors } = parseVimrc([
+      "nmap\tgl\t$",
+      "nmap    gh    ^",
+      "  nmap Y y$  ",
+    ])
 
-    commands.forEach((command) => {
-      expect(command).toEqual(expected[command.lhs])
-    });
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      mapping("nmap", "gl", "$", "normal"),
+      mapping("nmap", "gh", "^", "normal"),
+      mapping("nmap", "Y", "y$", "normal"),
+    ])
+  })
+
+  it("does not mistake a quote inside a mapping for a comment", () => {
+    const { directives, errors } = parseVimrc(['nnoremap y "*y'])
+
+    expect(errors).toEqual([])
+    expect(directives).toEqual([mapping("nnoremap", "y", '"*y', "normal", true)])
   })
 })
 
-describe("Vimrc Parsing", () => {
-  it("Should parse all the commands here, and return no valid commands.", () => {
-    const vimrcSampleContent = [
-      "i l :test", //Not a valid command because i is not a valid mapping mode
-      "nnoremap <leader>l :test", //Not a valid command because nnoremap is not a current valid mapping mode, but it should be in the future.
-    ];
+describe("Vimrc parsing: noremap", () => {
+  it("marks the noremap family as non-recursive", () => {
+    const { directives, errors } = parseVimrc([
+      "noremap gl $",
+      "nnoremap gh ^",
+      "inoremap jk <Esc>",
+      "vnoremap p P",
+    ])
 
-    const commands = createVimCommands(vimrcSampleContent);
-    expect(commands.length).toEqual(0);
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      mapping("noremap", "gl", "$", undefined, true),
+      mapping("nnoremap", "gh", "^", "normal", true),
+      mapping("inoremap", "jk", "<Esc>", "insert", true),
+      mapping("vnoremap", "p", "P", "visual", true),
+    ])
+  })
+
+  // https://github.com/beekeeper-studio/beekeeper-studio/issues/2953
+  it("rejects a recursive mapping that contains its own key", () => {
+    const { directives, errors } = parseVimrc(['nmap y "*y'])
+
+    expect(directives).toEqual([])
+    expect(errors).toHaveLength(1)
+    expect(errors[0].line).toEqual(1)
+    expect(errors[0].reason).toContain("nnoremap")
+  })
+
+  it("allows the same mapping when it is declared non-recursive", () => {
+    const { errors } = parseVimrc(['nnoremap y "*y'])
+    expect(errors).toEqual([])
+  })
+})
+
+describe("Vimrc parsing: unmap and mapclear", () => {
+  it("parses the unmap family", () => {
+    const { directives, errors } = parseVimrc([
+      "unmap <C-p>",
+      "nunmap gl",
+      "iunmap jk",
+      "vunmap p",
+    ])
+
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      { type: "unmap", lhs: "<C-p>", mode: undefined },
+      { type: "unmap", lhs: "gl", mode: "normal" },
+      { type: "unmap", lhs: "jk", mode: "insert" },
+      { type: "unmap", lhs: "p", mode: "visual" },
+    ])
+  })
+
+  it("parses the mapclear family", () => {
+    const { directives, errors } = parseVimrc(["mapclear", "nmapclear"])
+
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      { type: "mapclear", mode: undefined },
+      { type: "mapclear", mode: "normal" },
+    ])
+  })
+
+  it("keeps unmap in the order it was written", () => {
+    const { directives } = parseVimrc([
+      "nmap gl $",
+      "nunmap gl",
+      "nmap gl ^",
+    ])
+
+    expect(directives).toEqual([
+      { type: "unmap", lhs: "gl", mode: "normal" },
+      mapping("nmap", "gl", "^", "normal"),
+    ])
+  })
+
+  it("reports unmap without a key", () => {
+    const { errors } = parseVimrc(["unmap"])
+    expect(errors).toHaveLength(1)
+  })
+})
+
+describe("Vimrc parsing: set", () => {
+  it("parses boolean, negated and valued options", () => {
+    const { directives, errors } = parseVimrc([
+      "set ignorecase",
+      "set nonumber",
+      "set tabstop=4",
+    ])
+
+    expect(errors).toEqual([])
+    expect(directives).toEqual([
+      { type: "set", name: "ignorecase", value: true },
+      { type: "set", name: "number", value: false },
+      { type: "set", name: "tabstop", value: "4" },
+    ])
+  })
+
+  it("accepts several options on one line", () => {
+    const { directives } = parseVimrc(["set ignorecase smartcase"])
+
+    expect(directives).toEqual([
+      { type: "set", name: "ignorecase", value: true },
+      { type: "set", name: "smartcase", value: true },
+    ])
+  })
+
+  it("reports a toggle it cannot express", () => {
+    const { errors } = parseVimrc(["set ignorecase!"])
+    expect(errors).toHaveLength(1)
+  })
+
+  it("reports set with no option", () => {
+    const { errors } = parseVimrc(["set"])
+    expect(errors).toHaveLength(1)
+  })
+})
+
+describe("Vimrc parsing: leader", () => {
+  it("expands <leader> to a backslash by default", () => {
+    const { directives } = parseVimrc(["nmap <leader>w :w<CR>"])
+
+    expect(directives).toEqual([mapping("nmap", "\\w", ":w<CR>", "normal")])
+  })
+
+  it("honours mapleader", () => {
+    const { directives } = parseVimrc([
+      'let mapleader = ","',
+      "nmap <leader>w :w<CR>",
+    ])
+
+    expect(directives).toEqual([mapping("nmap", ",w", ":w<CR>", "normal")])
+  })
+
+  it("honours g:mapleader and an unspaced assignment", () => {
+    const { directives } = parseVimrc([
+      "let g:mapleader=' '",
+      "nmap <Leader>w :w<CR>",
+    ])
+
+    expect(directives).toEqual([mapping("nmap", " w", ":w<CR>", "normal")])
+  })
+
+  it("only applies mapleader to mappings that follow it", () => {
+    const { directives } = parseVimrc([
+      "nmap <leader>a :qa<CR>",
+      'let mapleader = ","',
+      "nmap <leader>b :q<CR>",
+    ])
+
+    expect(directives.map((d) => d.lhs)).toEqual(["\\a", ",b"])
+  })
+})
+
+describe("Vimrc parsing: errors", () => {
+  it("reports an unknown command and keeps the rest", () => {
+    const { directives, errors } = parseVimrc([
+      "nmap gl $",
+      "colorscheme gruvbox",
+      "nmap gh ^",
+    ])
+
+    expect(directives).toHaveLength(2)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].line).toEqual(2)
+    expect(errors[0].text).toEqual("colorscheme gruvbox")
+  })
+
+  it("reports a mapping that is missing its right hand side", () => {
+    const { directives, errors } = parseVimrc(["nmap gl"])
+
+    expect(directives).toEqual([])
+    expect(errors).toHaveLength(1)
+  })
+
+  it("does not throw on malformed input", () => {
+    expect(() => parseVimrc([null, undefined, "", "!!!"])).not.toThrow()
   })
 })

--- a/apps/ui-kit/docs/api/text-editor.md
+++ b/apps/ui-kit/docs/api/text-editor.md
@@ -17,13 +17,48 @@
 | `lsConfig`          | `LanguageServerConfiguration`                             | Configure the Language Server Protocol integration. See [Language Server Configuration](#language-server-configuration) below.                                                                                                            | `undefined` | ✅     |
 | `replaceExtensions` | `Extension[] \| (extensions: Extension[]) => Extension[]` | Replace or modify the default CodeMirror extensions used by the editor. Accepts either a full list of extensions or a function to transform the default list.                                                                             | `undefined` | ✅     |
 | `vimConfig`         | `object`                                                  | Configure vim mode.                                                                                                                                                                                                                       | `undefined` | ⚠️     |
-| `vimKeymaps`        | `array`                                                   | Configure custom key mappings in vim. See documentation in `texteditor/mixin.ts` for more details.                                                                                                                                        | `undefined` | ⚠️     |
+| `vimKeymaps`        | `VimDirective[]`                                          | Configure vim from the host app: mappings (recursive or `noremap`), `unmap`, `mapclear` and `set`. See [Vim Directives](#vim-directives) below.                                                                                           | `undefined` | ⚠️     |
 | `foldGutter`        | `boolean`                                                 | Enable code folding in the editor.                                                                                                                                                                                                        | `false`     | ⚠️     |
 | `clipboard`         | `Clipboard`                                               | Custom clipboard handler for the editor used in vim. If provided, it must implement a `write` method to copy text to the clipboard. See [MDN Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) for more details. | `undefined` | ⚠️     |
 | `height`            | `number`                                                  | **[Deprecated]** Use CSS to control the editor height instead.                                                                                                                                                                            | `undefined` | ❌     |
 
 <!-- Not sure if autofocus should be here, see https://github.com/beekeeper-studio/beekeeper-studio/issues/3051 -->
 <!-- | `autoFocus`         | `boolean`                                                 | Automatically focus the editor when it regains window focus after blur.                                                                                                                                                                   | `false`     | ⚠️     | -->
+
+### Vim Directives
+
+`vimKeymaps` takes a list of directives, applied in order. Anything without a
+`type` is a mapping.
+
+| Directive | Fields | Vim equivalent |
+| --- | --- | --- |
+| mapping | `lhs`, `rhs`, `mode?`, `noremap?` | `map` / `nmap` / `nnoremap` / … |
+| `type: 'unmap'` | `lhs`, `mode?` | `unmap` / `nunmap` / … |
+| `type: 'mapclear'` | `mode?` | `mapclear` / `nmapclear` / … |
+| `type: 'set'` | `name`, `value` | `set name`, `set noname`, `set name=value` |
+
+`mode` is `'normal'`, `'insert'` or `'visual'`; leaving it out means every
+mode. Set `noremap` whenever the `rhs` contains the `lhs`, which would
+otherwise expand without end.
+
+```js
+const vimKeymaps = [
+  { lhs: ';', rhs: ':' },
+  { lhs: 'y', rhs: '"*y', mode: 'normal', noremap: true },
+  { type: 'set', name: 'ignorecase', value: true },
+]
+```
+
+Note that vim mappings are registered on a process-global vim instance shared
+by every editor on the page, so the last configuration applied wins.
+
+### Vim Status Line
+
+With `keymap="vim"` the editor renders CodeMirror's vim status panel along the
+bottom: the current mode, pending keys, and the `:` and `/` input lines. Style
+it with the `.cm-vim-panel` class or the
+`--bks-text-editor-vim-panel-bg-color` and
+`--bks-text-editor-vim-panel-fg-color` variables.
 
 ### Language Server Configuration
 

--- a/apps/ui-kit/docs/api/text-editor.md
+++ b/apps/ui-kit/docs/api/text-editor.md
@@ -55,10 +55,14 @@ by every editor on the page, so the last configuration applied wins.
 ### Vim Status Line
 
 With `keymap="vim"` the editor renders CodeMirror's vim status panel along the
-bottom: the current mode, pending keys, and the `:` and `/` input lines. Style
-it with the `.cm-vim-panel` class or the
-`--bks-text-editor-vim-panel-bg-color` and
-`--bks-text-editor-vim-panel-fg-color` variables.
+bottom: the current mode, pending keys, and the `:` and `/` input lines.
+
+Recolour it with `--bks-text-editor-vim-panel-bg-color` and
+`--bks-text-editor-vim-panel-fg-color`, which default to the editor's own
+background and foreground. Overriding the `.cm-vim-panel` class from a
+stylesheet is not reliable: CodeMirror injects both its own panel defaults and
+the ones `@replit/codemirror-vim` ships as themes, and those outrank plain
+selectors. The variables are applied from the editor's theme so they win.
 
 ### Language Server Configuration
 

--- a/apps/ui-kit/docs/api/text-editor.md
+++ b/apps/ui-kit/docs/api/text-editor.md
@@ -57,9 +57,13 @@ by every editor on the page, so the last configuration applied wins.
 With `keymap="vim"` the editor renders CodeMirror's vim status panel along the
 bottom: the current mode, pending keys, and the `:` and `/` input lines.
 
-Recolour it with `--bks-text-editor-vim-panel-bg-color` and
-`--bks-text-editor-vim-panel-fg-color`, which default to the editor's own
-background and foreground. Overriding the `.cm-vim-panel` class from a
+Adjust it with `--bks-text-editor-vim-panel-bg-color` and
+`--bks-text-editor-vim-panel-fg-color`, which default to `inherit` so the bar
+follows whatever theme you hand CodeMirror, plus
+`--bks-text-editor-vim-panel-font-size` and
+`--bks-text-editor-vim-panel-border`. The font size is deliberately its own
+variable rather than `--bks-text-editor-font-size`, so the bar does not grow
+with the editor's font size setting. Overriding the `.cm-vim-panel` class from a
 stylesheet is not reliable: CodeMirror injects both its own panel defaults and
 the ones `@replit/codemirror-vim` ships as themes, and those outrank plain
 selectors. The variables are applied from the editor's theme so they win.

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -231,6 +231,53 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-query-editor-bg)",
         color: "var(--bks-text-dark)",
       },
+      // codemirror's base theme paints the panel container #f5f5f5 with black
+      // text whenever the editor is not flagged as a dark theme, which shows
+      // straight through the vim status line because its input inherits the
+      // background. Set it explicitly instead of relying on that default.
+      ".cm-panels": {
+        backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
+        color: "var(--bks-text-editor-vim-panel-fg-color)",
+      },
+      ".cm-panels-bottom": {
+        borderTop: "1px solid var(--bks-border-color)",
+      },
+      // Vim's status line: current mode, pending keys, and the ':' and '/'
+      // inputs. These live here rather than in the stylesheet so they outrank
+      // the base theme @replit/codemirror-vim ships.
+      ".cm-panels .cm-vim-panel": {
+        backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
+        color: "var(--bks-text-editor-vim-panel-fg-color)",
+        fontFamily: "var(--bks-text-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)",
+        fontSize: "var(--bks-text-editor-font-size, 0.875rem)",
+        // The mode label and the ':' input swap places in here, so pin the
+        // metrics to stop the bar changing height as you type a command.
+        boxSizing: "border-box",
+        alignItems: "center",
+        gap: "0.5rem",
+        padding: "2px 10px",
+        minHeight: "0",
+        lineHeight: "1.5",
+      },
+      ".cm-panels .cm-vim-panel input, .cm-panels .cm-vim-panel button": {
+        boxSizing: "border-box",
+        height: "auto",
+        margin: "0",
+        padding: "0",
+        border: "none",
+        outline: "none",
+        background: "transparent",
+        color: "inherit",
+        font: "inherit",
+        lineHeight: "inherit",
+      },
+      ".cm-panels .cm-vim-panel input": {
+        flex: "1",
+        minWidth: "0",
+      },
+      ".cm-panels .cm-vim-panel button": {
+        cursor: "default",
+      },
       // Autocomplete hints
       ".cm-tooltip": {
         backgroundColor: "var(--bks-text-editor-context-menu-bg-color)",

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -231,42 +231,29 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-query-editor-bg)",
         color: "var(--bks-text-dark)",
       },
-      // Every EditorView.theme gets its own generated scope class, and they
-      // all sit at the same specificity, so a plain ".cm-panels" rule is
-      // decided purely by which theme mounted last -- and the app appends its
-      // own theme after this one. Qualifying with & lifts these above any
-      // single-class rule so the outcome does not depend on mount order.
-      //
-      // The panel container is a direct child of .cm-editor, so inheriting
-      // picks up whatever background the host app themed the editor with.
-      // codemirror's own base theme would otherwise paint it #f5f5f5 with
-      // black text, which shows straight through the vim status line because
-      // its input inherits the background.
+      // Panels inherit from .cm-editor so they follow whatever theme the host
+      // app gave codemirror; otherwise codemirror's base theme paints them
+      // #f5f5f5 on black. The & qualifier matters: every EditorView.theme gets
+      // one generated scope class, so an unqualified ".cm-panels" ties on
+      // specificity and loses to whichever theme mounted last.
       "&.cm-editor .cm-panels": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
       },
       "&.cm-editor .cm-panels-bottom": {
-        // Neutral and translucent so it reads against a light or a dark
-        // editor. --bks-border-color would fall into the same trap as the
-        // colours above and resolve against the light defaults.
         borderTop: "var(--bks-text-editor-vim-panel-border)",
       },
-      // Vim's status line: current mode, pending keys, and the ':' and '/'
-      // inputs. These live here rather than in the stylesheet so they outrank
-      // the base theme @replit/codemirror-vim ships.
-      // Note this element also carries the generic .cm-panel class, whose rule
-      // above resolves to white, so this needs to outrank it.
+      // The vim status line. Here rather than in the stylesheet so it outranks
+      // both the base theme @replit/codemirror-vim ships and the .cm-panel
+      // rule above, which resolves to white.
       "&.cm-editor .cm-panels .cm-panel.cm-vim-panel": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
         fontFamily: "var(--bks-text-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)",
         fontSize: "var(--bks-text-editor-vim-panel-font-size)",
-        // Matches the top border, so the bar reads as its own strip rather
-        // than running into the toolbar underneath the editor.
         borderBottom: "var(--bks-text-editor-vim-panel-border)",
-        // The mode label and the ':' input swap places in here, so pin the
-        // metrics to stop the bar changing height as you type a command.
+        // The mode label and the ':' input swap places here, so pin the
+        // metrics to stop the bar resizing as you type a command.
         boxSizing: "border-box",
         alignItems: "center",
         gap: "0.5rem",

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -231,16 +231,22 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-query-editor-bg)",
         color: "var(--bks-text-dark)",
       },
+      // Every EditorView.theme gets its own generated scope class, and they
+      // all sit at the same specificity, so a plain ".cm-panels" rule is
+      // decided purely by which theme mounted last -- and the app appends its
+      // own theme after this one. Qualifying with & lifts these above any
+      // single-class rule so the outcome does not depend on mount order.
+      //
       // The panel container is a direct child of .cm-editor, so inheriting
       // picks up whatever background the host app themed the editor with.
       // codemirror's own base theme would otherwise paint it #f5f5f5 with
       // black text, which shows straight through the vim status line because
       // its input inherits the background.
-      ".cm-panels": {
+      "&.cm-editor .cm-panels": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
       },
-      ".cm-panels-bottom": {
+      "&.cm-editor .cm-panels-bottom": {
         // Neutral and translucent so it reads against a light or a dark
         // editor. --bks-border-color would fall into the same trap as the
         // colours above and resolve against the light defaults.
@@ -251,7 +257,7 @@ export function extensions(config: ExtensionConfiguration = {}) {
       // the base theme @replit/codemirror-vim ships.
       // Note this element also carries the generic .cm-panel class, whose rule
       // above resolves to white, so this needs to outrank it.
-      ".cm-panels .cm-panel.cm-vim-panel": {
+      "&.cm-editor .cm-panels .cm-panel.cm-vim-panel": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
         fontFamily: "var(--bks-text-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)",
@@ -265,7 +271,7 @@ export function extensions(config: ExtensionConfiguration = {}) {
         minHeight: "0",
         lineHeight: "1.5",
       },
-      ".cm-panels .cm-vim-panel input, .cm-panels .cm-vim-panel button": {
+      "&.cm-editor .cm-panels .cm-vim-panel input, &.cm-editor .cm-panels .cm-vim-panel button": {
         boxSizing: "border-box",
         height: "auto",
         margin: "0",
@@ -277,11 +283,11 @@ export function extensions(config: ExtensionConfiguration = {}) {
         font: "inherit",
         lineHeight: "inherit",
       },
-      ".cm-panels .cm-vim-panel input": {
+      "&.cm-editor .cm-panels .cm-vim-panel input": {
         flex: "1",
         minWidth: "0",
       },
-      ".cm-panels .cm-vim-panel button": {
+      "&.cm-editor .cm-panels .cm-vim-panel button": {
         cursor: "default",
       },
       // Autocomplete hints

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -231,21 +231,27 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-query-editor-bg)",
         color: "var(--bks-text-dark)",
       },
-      // codemirror's base theme paints the panel container #f5f5f5 with black
-      // text whenever the editor is not flagged as a dark theme, which shows
-      // straight through the vim status line because its input inherits the
-      // background. Set it explicitly instead of relying on that default.
+      // The panel container is a direct child of .cm-editor, so inheriting
+      // picks up whatever background the host app themed the editor with.
+      // codemirror's own base theme would otherwise paint it #f5f5f5 with
+      // black text, which shows straight through the vim status line because
+      // its input inherits the background.
       ".cm-panels": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
       },
       ".cm-panels-bottom": {
-        borderTop: "1px solid var(--bks-border-color)",
+        // Neutral and translucent so it reads against a light or a dark
+        // editor. --bks-border-color would fall into the same trap as the
+        // colours above and resolve against the light defaults.
+        borderTop: "1px solid rgba(128, 128, 128, 0.35)",
       },
       // Vim's status line: current mode, pending keys, and the ':' and '/'
       // inputs. These live here rather than in the stylesheet so they outrank
       // the base theme @replit/codemirror-vim ships.
-      ".cm-panels .cm-vim-panel": {
+      // Note this element also carries the generic .cm-panel class, whose rule
+      // above resolves to white, so this needs to outrank it.
+      ".cm-panels .cm-panel.cm-vim-panel": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
         fontFamily: "var(--bks-text-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)",

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -250,7 +250,7 @@ export function extensions(config: ExtensionConfiguration = {}) {
         // Neutral and translucent so it reads against a light or a dark
         // editor. --bks-border-color would fall into the same trap as the
         // colours above and resolve against the light defaults.
-        borderTop: "1px solid rgba(128, 128, 128, 0.35)",
+        borderTop: "var(--bks-text-editor-vim-panel-border)",
       },
       // Vim's status line: current mode, pending keys, and the ':' and '/'
       // inputs. These live here rather than in the stylesheet so they outrank
@@ -261,7 +261,10 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
         fontFamily: "var(--bks-text-editor-font-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace)",
-        fontSize: "var(--bks-text-editor-font-size, 0.875rem)",
+        fontSize: "var(--bks-text-editor-vim-panel-font-size)",
+        // Matches the top border, so the bar reads as its own strip rather
+        // than running into the toolbar underneath the editor.
+        borderBottom: "var(--bks-text-editor-vim-panel-border)",
         // The mode label and the ':' input swap places in here, so pin the
         // metrics to stop the bar changing height as you type a command.
         boxSizing: "border-box",

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -231,11 +231,8 @@ export function extensions(config: ExtensionConfiguration = {}) {
         backgroundColor: "var(--bks-query-editor-bg)",
         color: "var(--bks-text-dark)",
       },
-      // Panels inherit from .cm-editor so they follow whatever theme the host
-      // app gave codemirror; otherwise codemirror's base theme paints them
-      // #f5f5f5 on black. The & qualifier matters: every EditorView.theme gets
-      // one generated scope class, so an unqualified ".cm-panels" ties on
-      // specificity and loses to whichever theme mounted last.
+      // Inherit so panels follow the app's codemirror theme, or codemirror
+      // paints them #f5f5f5. The & is what outranks the app's own theme.
       "&.cm-editor .cm-panels": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
@@ -243,9 +240,8 @@ export function extensions(config: ExtensionConfiguration = {}) {
       "&.cm-editor .cm-panels-bottom": {
         borderTop: "var(--bks-text-editor-vim-panel-border)",
       },
-      // The vim status line. Here rather than in the stylesheet so it outranks
-      // both the base theme @replit/codemirror-vim ships and the .cm-panel
-      // rule above, which resolves to white.
+      // Here rather than the stylesheet so it outranks the vim package's own
+      // theme and the .cm-panel rule above, which resolves to white.
       "&.cm-editor .cm-panels .cm-panel.cm-vim-panel": {
         backgroundColor: "var(--bks-text-editor-vim-panel-bg-color)",
         color: "var(--bks-text-editor-vim-panel-fg-color)",
@@ -253,7 +249,7 @@ export function extensions(config: ExtensionConfiguration = {}) {
         fontSize: "var(--bks-text-editor-vim-panel-font-size)",
         borderBottom: "var(--bks-text-editor-vim-panel-border)",
         // The mode label and the ':' input swap places here, so pin the
-        // metrics to stop the bar resizing as you type a command.
+        // metrics or the bar resizes as you type a command.
         boxSizing: "border-box",
         alignItems: "center",
         gap: "0.5rem",

--- a/apps/ui-kit/lib/components/text-editor/extensions/keymap.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/keymap.ts
@@ -4,7 +4,7 @@ import { emacs } from "@replit/codemirror-emacs";
 import { vim } from "@replit/codemirror-vim";
 import * as VimLib from "@replit/codemirror-vim";
 import { Keymap } from "../types";
-import { Clipboard, Config, extendVimOnCodeMirror, IMapping } from "./vim";
+import { Clipboard, Config, extendVimOnCodeMirror, VimDirective } from "./vim";
 
 const Vim = VimLib.Vim;
 
@@ -32,7 +32,7 @@ export function applyKeymap(view: EditorView, keymap: Keymap, options: VimOption
 
 export interface VimOptions {
   config?: Config;
-  keymaps?: IMapping[];
+  keymaps?: VimDirective[];
   clipboard?: Clipboard;
 }
 
@@ -40,7 +40,9 @@ function buildKeymap(keymap: Keymap, options: VimOptions = {}): Extension {
   let extension: Extension = [];
 
   if (keymap === "vim") {
-    extension = vim();
+    // status renders codemirror's own bottom panel: the current mode, any
+    // pending keys, and the : and / input lines.
+    extension = vim({ status: true });
     extendVimOnCodeMirror(Vim, options.config, options.keymaps, options.clipboard);
   } else if (keymap === "emacs") {
     extension = emacs();

--- a/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
@@ -6,11 +6,7 @@ export type IMapping = {
   rhs: string;
   /** 'normal', 'insert' or 'visual'. Omitted means every mode. */
   mode?: string;
-  /**
-   * When true the mapping is non-recursive, i.e. `nnoremap` rather than
-   * `nmap`. Recursive mappings whose rhs contains their own lhs loop forever,
-   * so anything referencing a register or the lhs itself wants this.
-   */
+  /** `nnoremap` rather than `nmap`. */
   noremap?: boolean;
 };
 
@@ -28,15 +24,10 @@ export type IMapClear = {
 export type IVimOption = {
   type: "set";
   name: string;
-  /** `true`/`false` for boolean options, a string for `set name=value`. */
   value: string | boolean;
 };
 
-/**
- * One entry of the `vimKeymaps` prop. A bare mapping object (no `type`) is
- * treated as a `map`, so callers written against the older array-of-mappings
- * shape keep working unchanged.
- */
+/** A bare mapping (no `type`) is a `map`, keeping the older prop shape valid. */
 export type VimDirective =
   | (IMapping & { type?: "map" })
   | IUnmapping
@@ -56,9 +47,8 @@ export function applyConfig(codeMirrorVimInstance: any, config: Config) {
   }
 }
 
+// codemirror distinguishes "every mode" from an explicit one by argument count.
 function modeArgs(mode?: string): string[] {
-  // codemirror's map/unmap treat a missing context as "every mode", and it
-  // distinguishes that from an explicit one by argument count.
   return mode ? [mode] : [];
 }
 
@@ -172,30 +162,18 @@ export class Register {
   }
 }
 
-/**
- * Mappings live on the global Vim singleton, not on an editor instance, and
- * every mapping is pushed onto one shared keymap. Applying the same config on
- * each keymap reconfigure would stack duplicates, so remember what is already
- * applied and only touch the singleton when it actually changes.
- */
+// Mappings live on the global Vim singleton and stack up, so only touch it
+// when the config actually changes.
 let appliedKeymapSignature: string | null = null;
 let appliedMappings: { lhs: string; mode?: string }[] = [];
-
-/** Exported for tests. */
-export function resetAppliedKeymaps(): void {
-  appliedKeymapSignature = null;
-  appliedMappings = [];
-}
 
 function applyKeymaps(vim: any, directives: VimDirective[]): void {
   const signature = JSON.stringify(directives);
   if (signature === appliedKeymapSignature) return;
 
-  // Undo only the mappings added here. codemirror records its keymap's length
-  // once at startup and derives "which entries are user defined" by
-  // subtracting it, so removing anything that was there originally leaves that
-  // arithmetic negative and breaks both mapclear and noremap lookups.
-  // mapclear() is unusable for the same reason.
+  // Only ever remove mappings added here. Codemirror derives "user defined"
+  // by subtracting the keymap length it recorded at startup, so removing a
+  // built-in makes that negative and breaks mapclear and noremap lookups.
   appliedMappings.forEach(({ lhs, mode }) => {
     try {
       vim.unmap(lhs, ...modeArgs(mode));
@@ -234,16 +212,13 @@ export function extendVimOnCodeMirror(
     console.error("vimKeymaps must be an array");
   }
 
-  // The * register is global and can only be defined once: codemirror throws
-  // on a second attempt and the first definition sticks for the rest of the
-  // session. Registering without a clipboard would therefore leave "*y and
-  // "*p permanently broken for every editor on the page, so wait for an
-  // editor that actually has one.
+  // The * register is global and sticks to whoever defines it first, so wait
+  // for an editor that actually has a clipboard.
   if (clipboard) {
     try {
       codeMirrorVimInstance.defineRegister("*", new Register(clipboard));
     } catch (e) {
-      // Already defined, which is the common case on the second editor.
+      // Already defined.
     }
   }
 }

--- a/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
@@ -1,14 +1,50 @@
 import _ from "lodash";
 
 export type IMapping = {
-  mappingMode: string;
+  mappingMode?: string;
   lhs: string;
   rhs: string;
-  mode: string;
+  /** 'normal', 'insert' or 'visual'. Omitted means every mode. */
+  mode?: string;
+  /**
+   * When true the mapping is non-recursive, i.e. `nnoremap` rather than
+   * `nmap`. Recursive mappings whose rhs contains their own lhs loop forever,
+   * so anything referencing a register or the lhs itself wants this.
+   */
+  noremap?: boolean;
 };
 
+export type IUnmapping = {
+  type: "unmap";
+  lhs: string;
+  mode?: string;
+};
+
+export type IMapClear = {
+  type: "mapclear";
+  mode?: string;
+};
+
+export type IVimOption = {
+  type: "set";
+  name: string;
+  /** `true`/`false` for boolean options, a string for `set name=value`. */
+  value: string | boolean;
+};
+
+/**
+ * One entry of the `vimKeymaps` prop. A bare mapping object (no `type`) is
+ * treated as a `map`, so callers written against the older array-of-mappings
+ * shape keep working unchanged.
+ */
+export type VimDirective =
+  | (IMapping & { type?: "map" })
+  | IUnmapping
+  | IMapClear
+  | IVimOption;
+
 export interface Config {
-  exCommands?: { name: string, prefix: string, handler: () => void }[];
+  exCommands?: { name: string, prefix: string, handler: (...args: any[]) => void }[];
 }
 
 export function applyConfig(codeMirrorVimInstance: any, config: Config) {
@@ -20,13 +56,46 @@ export function applyConfig(codeMirrorVimInstance: any, config: Config) {
   }
 }
 
-export function setKeybindings(codeMirrorVimInstance: any, mappings: IMapping[]): void {
-  for (let j = 0; j < mappings.length; j++) {
-    codeMirrorVimInstance.map(
-      mappings[j].lhs,
-      mappings[j].rhs,
-      mappings[j].mode
-    );
+function modeArgs(mode?: string): string[] {
+  // codemirror's map/unmap treat a missing context as "every mode", and it
+  // distinguishes that from an explicit one by argument count.
+  return mode ? [mode] : [];
+}
+
+function applyDirective(vim: any, directive: VimDirective): void {
+  const type = ("type" in directive && directive.type) || "map";
+
+  switch (type) {
+    case "map": {
+      const mapping = directive as IMapping;
+      const fn = mapping.noremap ? vim.noremap : vim.map;
+      fn.call(vim, mapping.lhs, mapping.rhs, ...modeArgs(mapping.mode));
+      break;
+    }
+    case "unmap": {
+      const unmapping = directive as IUnmapping;
+      vim.unmap(unmapping.lhs, ...modeArgs(unmapping.mode));
+      break;
+    }
+    case "mapclear":
+      vim.mapclear(...modeArgs((directive as IMapClear).mode));
+      break;
+    case "set": {
+      const option = directive as IVimOption;
+      vim.setOption(option.name, option.value);
+      break;
+    }
+  }
+}
+
+export function setKeybindings(codeMirrorVimInstance: any, directives: VimDirective[]): void {
+  for (const directive of directives) {
+    try {
+      applyDirective(codeMirrorVimInstance, directive);
+    } catch (e) {
+      // One bad directive must not take the rest of the vimrc down with it.
+      console.error("Could not apply vim directive", directive, e);
+    }
   }
 }
 
@@ -84,7 +153,6 @@ export class Register {
 
   toString() {
     return this.clipboard.readText();
-    // return this.keyBuffer.join('');
   }
 
   private createInsertModeChanges(c: any) {
@@ -104,28 +172,78 @@ export class Register {
   }
 }
 
-export function extendVimOnCodeMirror(codeMirrorVimInstance: any, vimConfig?: Config, vimKeymaps: IMapping[] = [], clipboard?: Clipboard) {
+/**
+ * Mappings live on the global Vim singleton, not on an editor instance, and
+ * every mapping is pushed onto one shared keymap. Applying the same config on
+ * each keymap reconfigure would stack duplicates, so remember what is already
+ * applied and only touch the singleton when it actually changes.
+ */
+let appliedKeymapSignature: string | null = null;
+let appliedMappings: { lhs: string; mode?: string }[] = [];
+
+/** Exported for tests. */
+export function resetAppliedKeymaps(): void {
+  appliedKeymapSignature = null;
+  appliedMappings = [];
+}
+
+function applyKeymaps(vim: any, directives: VimDirective[]): void {
+  const signature = JSON.stringify(directives);
+  if (signature === appliedKeymapSignature) return;
+
+  // Undo only the mappings added here. codemirror records its keymap's length
+  // once at startup and derives "which entries are user defined" by
+  // subtracting it, so removing anything that was there originally leaves that
+  // arithmetic negative and breaks both mapclear and noremap lookups.
+  // mapclear() is unusable for the same reason.
+  appliedMappings.forEach(({ lhs, mode }) => {
+    try {
+      vim.unmap(lhs, ...modeArgs(mode));
+    } catch (e) {
+      console.error("Could not remove vim mapping", lhs, e);
+    }
+  });
+
+  setKeybindings(vim, directives);
+
+  appliedMappings = directives
+    .filter((directive): directive is IMapping => !("type" in directive && directive.type))
+    .map(({ lhs, mode }) => ({ lhs, mode }));
+
+  appliedKeymapSignature = signature;
+}
+
+export function extendVimOnCodeMirror(
+  codeMirrorVimInstance: any,
+  vimConfig?: Config,
+  vimKeymaps: VimDirective[] = [],
+  clipboard?: Clipboard
+) {
   if (!codeMirrorVimInstance) {
     console.error("Could not find code mirror vim instance");
+    return;
+  }
+
+  if (vimConfig) {
+    applyConfig(codeMirrorVimInstance, vimConfig);
+  }
+
+  if (_.isArray(vimKeymaps)) {
+    applyKeymaps(codeMirrorVimInstance, vimKeymaps);
   } else {
-    if (vimConfig) {
-      applyConfig(codeMirrorVimInstance, vimConfig);
-    }
+    console.error("vimKeymaps must be an array");
+  }
 
-    if (_.isArray(vimKeymaps)) {
-      setKeybindings(codeMirrorVimInstance, vimKeymaps);
-    } else {
-      console.error("vimKeymaps must be an array");
-    }
-
-    // cm throws if this is already defined, we don't need to handle that case
+  // The * register is global and can only be defined once: codemirror throws
+  // on a second attempt and the first definition sticks for the rest of the
+  // session. Registering without a clipboard would therefore leave "*y and
+  // "*p permanently broken for every editor on the page, so wait for an
+  // editor that actually has one.
+  if (clipboard) {
     try {
-      codeMirrorVimInstance.defineRegister(
-        "*",
-        new Register(clipboard)
-      );
+      codeMirrorVimInstance.defineRegister("*", new Register(clipboard));
     } catch (e) {
-      // nothing
+      // Already defined, which is the common case on the second editor.
     }
   }
 }

--- a/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/vim.ts
@@ -1,7 +1,6 @@
 import _ from "lodash";
 
 export type IMapping = {
-  mappingMode?: string;
   lhs: string;
   rhs: string;
   /** 'normal', 'insert' or 'visual'. Omitted means every mode. */
@@ -171,9 +170,8 @@ function applyKeymaps(vim: any, directives: VimDirective[]): void {
   const signature = JSON.stringify(directives);
   if (signature === appliedKeymapSignature) return;
 
-  // Only ever remove mappings added here. Codemirror derives "user defined"
-  // by subtracting the keymap length it recorded at startup, so removing a
-  // built-in makes that negative and breaks mapclear and noremap lookups.
+  // Only remove mappings added here. Codemirror spots user mappings by
+  // keymap length, so removing a built-in breaks mapclear and noremap.
   appliedMappings.forEach(({ lhs, mode }) => {
     try {
       vim.unmap(lhs, ...modeArgs(mode));

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -119,9 +119,7 @@ export default {
     },
     applyKeymap() {
       this.textEditor.setKeymap(this.keymap, this.vimOptions);
-      // Reconfiguring the keymap compartment rebuilds the vim extension, and
-      // that can leave the editor without dom focus. Put it back if the editor
-      // is meant to have it.
+      // Rebuilding the vim extension can drop dom focus.
       if (this.isFocused) {
         this.textEditor.focus();
       }
@@ -211,12 +209,17 @@ export default {
             this.textEditor.execCommand("findAndReplace")
           }
         },
-        {
-          key: "Mod-r",
-          run: () => {
-            this.textEditor.execCommand("findAndReplace")
+        // Mod-r is vim's redo. Vim is registered ahead of this keymap so it
+        // should win anyway, but claiming the key at all leaves nothing
+        // between a precedence change and silently breaking redo.
+        ...(this.keymap === "vim" ? [] : [
+          {
+            key: "Mod-r",
+            run: () => {
+              this.textEditor.execCommand("findAndReplace")
+            }
           }
-        },
+        ]),
         ...this.internalActionsKeymap
       ]
 

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -119,6 +119,12 @@ export default {
     },
     applyKeymap() {
       this.textEditor.setKeymap(this.keymap, this.vimOptions);
+      // Reconfiguring the keymap compartment rebuilds the vim extension, and
+      // that can leave the editor without dom focus. Put it back if the editor
+      // is meant to have it.
+      if (this.isFocused) {
+        this.textEditor.focus();
+      }
     },
     applyLineWrapping() {
       this.textEditor.setLineWrapping(this.lineWrapping);

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -209,9 +209,8 @@ export default {
             this.textEditor.execCommand("findAndReplace")
           }
         },
-        // Mod-r is vim's redo. Vim is registered ahead of this keymap so it
-        // should win anyway, but claiming the key at all leaves nothing
-        // between a precedence change and silently breaking redo.
+        // Mod-r is vim's redo, and duplicates Mod-f above. Vim should win on
+        // precedence anyway, but claiming it risks silently breaking redo.
         ...(this.keymap === "vim" ? [] : [
           {
             key: "Mod-r",

--- a/apps/ui-kit/lib/components/text-editor/props.ts
+++ b/apps/ui-kit/lib/components/text-editor/props.ts
@@ -2,7 +2,7 @@ import type { CustomMenuItems } from "../context-menu";
 import { PropType } from "vue";
 import { Keybindings, Keymap, LanguageServerConfiguration, EditorMarker, LineGutter } from "./types";
 import { Extension } from "@codemirror/state";
-import { Config } from "./extensions/vim";
+import { Clipboard, Config, VimDirective } from "./extensions/vim";
 
 export default {
   value: {
@@ -83,11 +83,15 @@ export default {
   /** Unfold all folds in the editor. */
   unfoldAll: null,
   /**
-   * Configure custom key mappings in vim. `vimKeymaps` accepts an array of
-   * objects that contain the following properties:
+   * Configure vim from the host application. `vimKeymaps` accepts an array of
+   * directives, applied in order. A directive with no `type` is a mapping:
    * - lhs: The key you want to map
    * - rhs: The key you want to map to
-   * - mode: (optional) The mode in which you want to map the key ('normal', 'visual', 'insert')
+   * - mode: (optional) The mode to map in ('normal', 'visual', 'insert').
+   *   Omitted means every mode.
+   * - noremap: (optional) Map non-recursively, i.e. `nnoremap` rather than
+   *   `nmap`. Required whenever the rhs contains the lhs, which would
+   *   otherwise expand forever.
    *
    * For example, to map `;` to `:`, you can do:
    *
@@ -98,7 +102,11 @@ export default {
    * ```
    *
    * In vim, that would be `:map ; :`.
+   *
+   * The other directives mirror their vim commands:
+   * `{ type: 'unmap', lhs, mode? }`, `{ type: 'mapclear', mode? }`, and
+   * `{ type: 'set', name, value }` where value is a string or a boolean.
    */
-  vimKeymaps: Array,
+  vimKeymaps: Array as PropType<VimDirective[]>,
   clipboard: Object as PropType<Clipboard>
 };

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -103,6 +103,10 @@
   --bks-text-editor-panel-bg-color: var(--bks-query-editor-bg);
   --bks-text-editor-panel-fg-color: var(--bks-text-dark);
 
+  // Vim status line
+  --bks-text-editor-vim-panel-bg-color: var(--bks-text-editor-panel-bg-color);
+  --bks-text-editor-vim-panel-fg-color: var(--bks-text-editor-panel-fg-color);
+
   // Context Menu
   --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
   --bks-text-editor-context-menu-fg-color: #{$text-dark};
@@ -221,6 +225,39 @@
     background-image: none; // reset cm style
     background-color: var(--bks-text-editor-button-bg-color);
     text-transform: capitalize;
+  }
+
+  // Vim's status line: the current mode, any pending keys, and the ':' ex
+  // and '/' search inputs. Rendered by @replit/codemirror-vim as a codemirror
+  // panel, so it only carries layout styles of its own.
+  .cm-vim-panel {
+    border-top: 1px solid var(--bks-border-color);
+    background-color: var(--bks-text-editor-vim-panel-bg-color);
+    color: var(--bks-text-editor-vim-panel-fg-color);
+    font-family: $font-family-mono;
+    font-size: 12px;
+    align-items: center;
+    gap: 0.5rem;
+
+    input {
+      flex: 1;
+      min-width: 0;
+      padding: 0;
+      border: none;
+      outline: none;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+    }
+
+    button {
+      padding: 0;
+      border: none;
+      background: none;
+      color: inherit;
+      font: inherit;
+      cursor: default;
+    }
   }
 
   .cm-panel.cm-search {

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -103,15 +103,11 @@
   --bks-text-editor-panel-bg-color: var(--bks-query-editor-bg);
   --bks-text-editor-panel-fg-color: var(--bks-text-dark);
 
-  // Vim status line. Inherited from the editor by default, so the bar tracks
-  // whatever theme the host app applies to codemirror. Naming a colour here
-  // instead would break every app that themes the editor through codemirror
-  // rather than through these variables: the --bks-text-editor-* defaults all
-  // resolve to $query-editor-bg, which is white.
+  // Vim status line. Inherit, so the bar follows whatever theme the host app
+  // gave codemirror; naming a colour would resolve to $query-editor-bg (white).
   --bks-text-editor-vim-panel-bg-color: inherit;
   --bks-text-editor-vim-panel-fg-color: inherit;
-  // Deliberately not --bks-text-editor-font-size: that follows the user's
-  // editor font size setting, which makes the status line grow with it.
+  // Not --bks-text-editor-font-size, which tracks the user's font size setting.
   --bks-text-editor-vim-panel-font-size: 0.875rem;
   --bks-text-editor-vim-panel-border: 1px solid rgba(128, 128, 128, 0.35);
 

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -103,11 +103,13 @@
   --bks-text-editor-panel-bg-color: var(--bks-query-editor-bg);
   --bks-text-editor-panel-fg-color: var(--bks-text-dark);
 
-  // Vim status line. Based on the editor's own background rather than
-  // --bks-text-editor-panel-bg-color, whose --bks-query-editor-bg default is
-  // white and so leaves the bar light inside a dark editor.
-  --bks-text-editor-vim-panel-bg-color: var(--bks-text-editor-bg-color);
-  --bks-text-editor-vim-panel-fg-color: var(--bks-text-editor-fg-color);
+  // Vim status line. Inherited from the editor by default, so the bar tracks
+  // whatever theme the host app applies to codemirror. Naming a colour here
+  // instead would break every app that themes the editor through codemirror
+  // rather than through these variables: the --bks-text-editor-* defaults all
+  // resolve to $query-editor-bg, which is white.
+  --bks-text-editor-vim-panel-bg-color: inherit;
+  --bks-text-editor-vim-panel-fg-color: inherit;
 
   // Context Menu
   --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -103,9 +103,11 @@
   --bks-text-editor-panel-bg-color: var(--bks-query-editor-bg);
   --bks-text-editor-panel-fg-color: var(--bks-text-dark);
 
-  // Vim status line
-  --bks-text-editor-vim-panel-bg-color: var(--bks-text-editor-panel-bg-color);
-  --bks-text-editor-vim-panel-fg-color: var(--bks-text-editor-panel-fg-color);
+  // Vim status line. Based on the editor's own background rather than
+  // --bks-text-editor-panel-bg-color, whose --bks-query-editor-bg default is
+  // white and so leaves the bar light inside a dark editor.
+  --bks-text-editor-vim-panel-bg-color: var(--bks-text-editor-bg-color);
+  --bks-text-editor-vim-panel-fg-color: var(--bks-text-editor-fg-color);
 
   // Context Menu
   --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
@@ -225,39 +227,6 @@
     background-image: none; // reset cm style
     background-color: var(--bks-text-editor-button-bg-color);
     text-transform: capitalize;
-  }
-
-  // Vim's status line: the current mode, any pending keys, and the ':' ex
-  // and '/' search inputs. Rendered by @replit/codemirror-vim as a codemirror
-  // panel, so it only carries layout styles of its own.
-  .cm-vim-panel {
-    border-top: 1px solid var(--bks-border-color);
-    background-color: var(--bks-text-editor-vim-panel-bg-color);
-    color: var(--bks-text-editor-vim-panel-fg-color);
-    font-family: $font-family-mono;
-    font-size: 12px;
-    align-items: center;
-    gap: 0.5rem;
-
-    input {
-      flex: 1;
-      min-width: 0;
-      padding: 0;
-      border: none;
-      outline: none;
-      background: transparent;
-      color: inherit;
-      font: inherit;
-    }
-
-    button {
-      padding: 0;
-      border: none;
-      background: none;
-      color: inherit;
-      font: inherit;
-      cursor: default;
-    }
   }
 
   .cm-panel.cm-search {

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -110,6 +110,10 @@
   // resolve to $query-editor-bg, which is white.
   --bks-text-editor-vim-panel-bg-color: inherit;
   --bks-text-editor-vim-panel-fg-color: inherit;
+  // Deliberately not --bks-text-editor-font-size: that follows the user's
+  // editor font size setting, which makes the status line grow with it.
+  --bks-text-editor-vim-panel-font-size: 0.875rem;
+  --bks-text-editor-vim-panel-border: 1px solid rgba(128, 128, 128, 0.35);
 
   // Context Menu
   --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};

--- a/docs/user_guide/sql_editor/editor.es.md
+++ b/docs/user_guide/sql_editor/editor.es.md
@@ -110,13 +110,44 @@ Puedes ajustar el tamano de fuente del editor SQL desde el menu `View`:
 ## Modo Vim
 Junto con el editor de consultas predeterminado, Beekeeper soporta el modo Vim, que te permite escribir consultas en un editor de texto tipo Vim.
 
-Para habilitar esto, puedes hacer clic en el engranaje en la esquina inferior izquierda del editor de consultas:
+Para habilitar esto, puedes hacer clic en el engranaje en la esquina inferior derecha del editor de consultas:
 
 ![seleccion de modo de editor](../../assets/images/using-the-sql-editor-155.png)
 
 Y luego estas listo para usar un editor vim en Beekeeper!
 
 El editor que prefieras se preservara en todas las conexiones/reinicios/etc.
+
+### La linea de estado
+
+En modo vim el editor muestra una linea de estado en la parte inferior con el
+modo actual, las teclas pendientes de completar un comando y el prefijo de
+repeticion. Tambien es donde se escriben los comandos `:` y las busquedas `/`.
+
+### Comandos ex
+
+| Comando | Efecto |
+| --- | --- |
+| `:w`, `:write` | Guarda la consulta actual |
+| `:q`, `:quit` | Cierra la pestana actual |
+| `:qa` | Cierra todas las pestanas |
+| `:x`, `:wq` | Guarda y luego cierra la pestana |
+| `:tabnew [nombre]` | Abre una pestana nueva, opcionalmente con nombre |
+
+Actuan sobre la pestana en la que estas escribiendo.
+
+### Cancelar una consulta en ejecucion
+
+`Esc` cancela una consulta en ejecucion. En modo vim solo lo hace desde el modo
+normal y sin nada pendiente, de forma que salir del modo insercion o visual
+sigue funcionando como corresponde. `Ctrl-Esc` cancela una consulta desde
+cualquier modo.
+
+### Ctrl+P
+
+Vim asigna `Ctrl+P` a "subir" en todos los modos. En Beekeeper Studio se
+mantiene en la busqueda rapida, ya que `k` tambien sube. Para recuperarlo,
+agrega `nnoremap <C-p> k` a tu `.beekeeper.vimrc`.
 
 ### Personalizacion
 Tambien puedes agregar tus propios atajos de teclado y movimientos al editor vim colocando un archivo `.beekeeper.vimrc` en el `userDirectory` de Beekeeper Studio y escribiendo tus mapeos personalizados.
@@ -135,4 +166,30 @@ nmap gh ^
 
 Estos comandos agregan movimientos para `gl` para ir al final de una linea, y `gh` para ir al inicio de una linea
 
-Actualmente solo soportamos los comandos `nmap`, `imap` y `vmap`, pero esperamos introducir mas en el futuro!
+Las lineas que empiezan con `"` son comentarios, y las lineas vacias se
+ignoran. Comandos soportados:
+
+| Comando | Notas |
+| --- | --- |
+| `map`, `nmap`, `imap`, `vmap` | Mapeos recursivos |
+| `noremap`, `nnoremap`, `inoremap`, `vnoremap` | Mapeos no recursivos |
+| `unmap`, `nunmap`, `iunmap`, `vunmap` | Elimina un mapeo |
+| `mapclear`, `nmapclear`, `imapclear`, `vmapclear` | Elimina todos los mapeos propios |
+| `set` | Opciones de vim, por ejemplo `set ignorecase`, `set nonumber`, `set tabstop=4` |
+| `let mapleader` | A que se expande `<leader>`. Por defecto `\` |
+
+Lo que no se pueda interpretar se informa en una notificacion que indica la
+linea, y el resto del archivo se sigue aplicando.
+
+#### Copiar al portapapeles del sistema
+
+El registro `*` esta conectado al portapapeles del sistema, asi que `"*y` y
+`"*p` funcionan como en vim. Para que una `y` sola lo use, el mapeo tiene que
+ser no recursivo:
+
+```
+nnoremap y "*y
+```
+
+Escrito como `nmap y "*y`, la `y` de la derecha se vuelve a expandir en el
+propio mapeo, sin fin. Ese caso se informa como error en lugar de aplicarse.

--- a/docs/user_guide/sql_editor/editor.md
+++ b/docs/user_guide/sql_editor/editor.md
@@ -165,6 +165,36 @@ And then you're off to the races with a vim editor in Beekeeper!
 
 Whichever editor you prefer will be preserved across all connections/restarts/etc.
 
+### The status line
+
+In vim mode the editor shows a status line along the bottom with the current
+mode, any keys waiting on the rest of a command, and the count prefix. It is
+also where `:` commands and `/` searches are typed.
+
+### Ex commands
+
+| Command | Effect |
+| --- | --- |
+| `:w`, `:write` | Save the current query |
+| `:q`, `:quit` | Close the current tab |
+| `:qa` | Close every tab |
+| `:x`, `:wq` | Save, then close the tab |
+| `:tabnew [name]` | Open a new tab, optionally with a name |
+
+These act on the tab you are typing in.
+
+### Cancelling a running query
+
+`Esc` cancels a running query. In vim mode it only does that from normal mode
+with nothing pending, so leaving insert or visual mode behaves as it should.
+`Ctrl-Esc` cancels a query from any mode.
+
+### Ctrl+P
+
+Vim binds `Ctrl+P` to "move up" in every mode. In Beekeeper Studio it stays on
+quick search instead, since `k` already moves up. To take it back, add
+`nnoremap <C-p> k` to your `.beekeeper.vimrc`.
+
 ### Customisation
 
 You can also add your own keybindings and motions to the vim editor by placing a `.beekeeper.vimrc` file in the `userDirectory` for Beekeeper Studio and writing out your custom mappings.
@@ -184,4 +214,30 @@ nmap gh ^
 
 These commands add motions for `gl` to go to the end of a line, and `gh` to go to the beginning of a line
 
-We currently only support the `nmap`, `imap`, and `vmap` commands, but we hope to introduce more in the future!
+Lines beginning with `"` are comments, and blank lines are skipped. Supported
+commands:
+
+| Command | Notes |
+| --- | --- |
+| `map`, `nmap`, `imap`, `vmap` | Recursive mappings |
+| `noremap`, `nnoremap`, `inoremap`, `vnoremap` | Non-recursive mappings |
+| `unmap`, `nunmap`, `iunmap`, `vunmap` | Remove a mapping |
+| `mapclear`, `nmapclear`, `imapclear`, `vmapclear` | Remove every custom mapping |
+| `set` | Vim options, e.g. `set ignorecase`, `set nonumber`, `set tabstop=4` |
+| `let mapleader` | What `<leader>` expands to. Defaults to `\` |
+
+Anything that cannot be parsed is reported in a notification naming the line,
+and the rest of the file still applies.
+
+#### Yanking to the system clipboard
+
+The `*` register is connected to the system clipboard, so `"*y` and `"*p` work
+as they would in vim. To make a plain `y` use it, the mapping has to be
+non-recursive:
+
+```
+nnoremap y "*y
+```
+
+Written as `nmap y "*y` the `y` on the right expands back into the mapping
+itself, without end. That case is reported as an error instead of applied.


### PR DESCRIPTION
Vim mode has collected a few issues over the years, and the CodeMirror 6 migration added some more. This fixes the open ones and fills in some gaps.

**This needs hands-on testing.** The vimrc parser has unit tests, but the app itself could not be run where this was written, so nothing below has been confirmed in a real session. If you use vim mode, please work through the list and say which of these actually hold.

## Things that were broken

- **The editor no longer goes dead after you run a query.** Run a query, then tap `Esc` a few times in normal mode. It used to stop accepting keys entirely — the cursor turned into a hollow outline and you had to click back into the editor to recover. (#3446)
- **A new tab is ready to type in immediately.** Press `Cmd/Ctrl+T` and start typing. Vim mode used to need a click first, and the known workaround was opening a second tab and closing it again. Worth checking on the very first tab after a cold start, which was the worst case. (#2990)
- **`:w` saves the tab you are actually in.** Open two tabs with unsaved text and `:w` in the first one. It used to save whichever tab was opened most recently. (#1930)
- **`Ctrl+P` opens quick search again from normal mode.** Vim binds `Ctrl+P` to "move up", which took the shortcut over during the CodeMirror 6 move. `k` still moves up. If you would rather have vim's binding back, `nnoremap <C-p> k` in your `.beekeeper.vimrc` reclaims it. (#3446)
- **`"*y` and `"*p` should work consistently**, including in the Mongo shell tab where they previously did nothing at all.

## New

- **The editor has a status line along the bottom.** It shows `--NORMAL--` / `--INSERT--` / `--VISUAL--`, any keys waiting on the rest of a command, and count prefixes. `:` commands and `/` searches are typed there now too. Please flag if it looks wrong in your theme.
- **`Esc` cancels a running query again.** Only from normal mode with nothing pending — `Esc` out of insert or visual mode just returns you to normal mode, as it should. `Ctrl-Esc` still cancels from any mode.

## `.beekeeper.vimrc`

- **`noremap`, `nnoremap`, `inoremap` and `vnoremap` now work.** `nnoremap y "*y` is the supported way to make a plain `y` use the system clipboard. Written as `nmap y "*y` it used to emit thousands of errors; that mistake is now reported as a single message instead. (#2953)
- **Comments and ordinary whitespace no longer break the file.** Lines starting with `"` are comments, and tabs or runs of spaces between fields are fine. Previously anything other than a single space was rejected, and a comment line was treated as a broken mapping.
- **`unmap`, `nunmap`, `iunmap`, `vunmap` and the `mapclear` family are supported.**
- **`set` is supported** — `set ignorecase`, `set nonumber`, `set tabstop=4`.
- **`<leader>` is supported**, with `let mapleader = ","` (or `g:mapleader`). Defaults to `\`.
- **A line that cannot be parsed now tells you so**, in a notification naming the line number. It used to fail silently unless you had the developer console open. The rest of the file still applies.
- **Your vimrc is read once at startup** rather than re-read for every tab you open.

## Ex commands

These already existed but were never written down: `:w`, `:q`, `:qa`, `:x`, `:wq`, `:tabnew [name]`. They are in the docs now.

## Please poke at

- Focus generally — clicking between the editor and the results grid, switching tabs, `Ctrl+L`. The focus fix is the largest behavioural change here.
- **Non-vim users too:** the focus fix applies to the default keymap as well, so it is worth a sanity check with vim mode off.
- Whether the status line is readable in both light and dark themes.
- Whether `Esc` ever cancels a query when you did not mean it to.
- Anything in your existing `.beekeeper.vimrc` that behaves differently.

Docs: `docs/user_guide/sql_editor/editor.md`.

Closes #3446, #2990, #1930, #2953

---
_Generated by [Claude Code](https://claude.ai/code/session_016tFqRXyPEpgUJYGMU83wjF)_