### PR TITLE
Fix phantom tabs when connecting to an unsaved connection

### DIFF
--- a/apps/studio/src/common/appdb/models/used_connection.ts
+++ b/apps/studio/src/common/appdb/models/used_connection.ts
@@ -27,7 +27,17 @@ export class UsedConnection extends DbConnectionBase implements ISimpleConnectio
       this.sslCertFile = other.sslCertFile
       this.sslKeyFile = other.sslKeyFile
       this.readOnlyMode = other.readOnlyMode
-      if (other.id && other.workspaceId) {
+      const explicitConnectionId = (other as Partial<UsedConnection>).connectionId
+      if (!_.isUndefined(explicitConnectionId)) {
+        // an explicit saved_connection reference (possibly null, for
+        // connections that were never saved) always wins over inferring it
+        // from `id` - `id` is only a saved_connection id when the caller
+        // passes a saved connection, never when it passes a used_connection
+        this.connectionId = explicitConnectionId
+        if (other.workspaceId) {
+          this.workspaceId = other.workspaceId
+        }
+      } else if (other.id && other.workspaceId) {
         this.connectionId = other.id
         this.workspaceId = other.workspaceId
       }

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1735,7 +1735,9 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
             excerpt: query.substr(0, 250),
             numberOfRecords: totalRows,
             queryId: this.query?.id,
-            connectionId: this.usedConfig.id
+            // sessions on a never-saved connection have no saved_connection
+            // id; -1 is the column default and cannot collide with one
+            connectionId: this.usedConfig.id ?? -1
           } as any;
 
           if(lastQuery && isDuplicate){

--- a/apps/studio/src/components/sidebar/core/HistoryList.vue
+++ b/apps/studio/src/components/sidebar/core/HistoryList.vue
@@ -101,7 +101,7 @@ import SidebarLoading from '@/components/common/SidebarLoading.vue'
         if(this.showAllHistory){
           return this.history;
         } else {
-          return this.history.filter(item => item.connectionId === this.usedConfig?.id);
+          return this.history.filter(item => item.connectionId === (this.usedConfig?.id ?? -1));
         }
       },
     },

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -555,7 +555,12 @@ const store = new Vuex.Store<State>({
         await context.dispatch('updateRoutines')
         context.dispatch('updateWindowTitle', config)
 
-        await Vue.prototype.$util.send('appdb/tabhistory/clearDeletedTabs', { workspaceId: context.state.usedConfig.workspaceId, connectionId: context.state.usedConfig.id })
+        // no id means the connection was never saved: there is no
+        // per-connection tab history to prune, and a null id must not reach
+        // the delete query
+        if (context.state.usedConfig.id) {
+          await Vue.prototype.$util.send('appdb/tabhistory/clearDeletedTabs', { workspaceId: context.state.usedConfig.workspaceId, connectionId: context.state.usedConfig.id })
+        }
 
         await context.dispatch('checkVersion');
         return true;

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -22,37 +22,63 @@ export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
   actions: utilActionsFor<IConnection>('used', {
     async recordUsed(context, config: IConnection) {
       log.debug("Recording used config for: ", config)
+      // Everything persisted per-connection (open tabs, pins, hidden
+      // entities, tab history) is keyed on the id this action returns, and
+      // that key lives in the saved_connection id space. used_connection has
+      // its own independent id sequence, so a used_connection id must never
+      // escape this action as a config id - it collides with unrelated saved
+      // connections (the "phantom tabs" bug).
+      //
+      // `config` comes in three shapes:
+      // - a saved connection: `id` is a saved_connection id, no
+      //   `connectionId` property
+      // - a brand new, unsaved connection from the connection form: `id` is
+      //   null
+      // - a used_connection row, passed directly by the recent-connections
+      //   list when the connection it came from was never saved (or no
+      //   longer exists): `id` is a used_connection id, and `connectionId`
+      //   holds the saved_connection reference or null
+      const isUsedConfig = !_.isUndefined((config as any).connectionId)
+      const savedConnectionId = isUsedConfig ? (config as any).connectionId : config.id
+
       const lastUsedConnection = context.state.items.find(c => {
-        return config.id &&
+        if (isUsedConfig) {
+          return c.id === config.id
+        }
+        return savedConnectionId &&
           config.workspaceId &&
-          ((!c.connectionId && c.id === config.id) || 
-            (c.connectionId && c.connectionId === config.id)) &&
+          c.connectionId === savedConnectionId &&
           c.workspaceId === config.workspaceId;
       });
       log.debug("Found used config", lastUsedConnection);
       if (lastUsedConnection) {
-        // Overlay the latest connection details from `config` (which is the
-        // saved connection the user is connecting to) onto the existing
-        // used_connection row, so subsequent reads reflect the current
-        // host/port/credentials/etc., not the snapshot from the first connect.
-        //
-        // NOTE: return `config` (the saved connection) unchanged - do NOT swap
-        // it for the used_connection row. Open tabs, pins, and hidden entities
-        // are all persisted keyed on `usedConfig.id`. The saved_connection and
-        // used_connection tables have independent id sequences, so returning
-        // the used_connection here changes that key and orphans everything on
-        // the next launch.
+        // Overlay the latest connection details from `config` onto the
+        // existing used_connection row, so subsequent reads reflect the
+        // current host/port/credentials/etc., not the snapshot from the
+        // first connect.
         await context.dispatch('save', {
           ...config,
           id: lastUsedConnection.id,
-          connectionId: config.id,
+          connectionId: savedConnectionId,
           workspaceId: config.workspaceId,
           createdAt: lastUsedConnection.createdAt,
           updatedAt: new Date(),
         });
       } else {
-        const id = await context.dispatch('save', config);
-        config = context.state.items.find((item) => item.id === id);
+        await context.dispatch('save', {
+          ...config,
+          id: null,
+          connectionId: savedConnectionId,
+        });
+      }
+
+      // Return a config keyed on the saved_connection id. For a connection
+      // that was never saved that key is null, which disables per-connection
+      // persistence for the session (see the usedConfig.id guards in
+      // TabModule and friends) instead of reading/writing some other saved
+      // connection's data.
+      if (isUsedConfig) {
+        return { ..._.omit(config, 'connectionId'), id: savedConnectionId ?? null } as IConnection
       }
       return config;
     },

--- a/apps/studio/tests/unit/store/used_connection/UnsavedConnectionPhantomTabs.spec.ts
+++ b/apps/studio/tests/unit/store/used_connection/UnsavedConnectionPhantomTabs.spec.ts
@@ -15,23 +15,19 @@ const WORKSPACE_ID = -1
 
 const Handlers = { ...AppDbHandlers, ...TabHistoryHandlers }
 
-// Replicates the "phantom tabs" bug: connecting to a connection that was
-// never saved surfaces (and then corrupts) the open tabs of an unrelated
-// *saved* connection.
+// Regression tests for the "phantom tabs" bug: connecting to a connection
+// that was never saved surfaced (and then corrupted) the open tabs of an
+// unrelated *saved* connection.
 //
-// Root cause: for an unsaved config, `recordUsed` returns the new
-// used_connection row, so `usedConfig.id` is a used_connection PK. Tabs,
-// pins, hidden entities, and tab history are all keyed on `usedConfig.id`
-// in a column that normally holds a saved_connection PK. The two tables
-// have independent id sequences, so whenever a used_connection id happens
-// to equal some saved_connection id (very likely - both are small
-// autoincrement ints), the unsaved session reads and writes that saved
-// connection's tabs.
-//
-// These tests are marked `it.failing` because they assert the *correct*
-// behavior, which the current code does not implement. When the bug is
-// fixed they will start reporting "passing test marked failing" - at that
-// point flip them to plain `it(...)`.
+// Root cause: for an unsaved config, `recordUsed` returned the new
+// used_connection row, so `usedConfig.id` was a used_connection PK. Tabs,
+// pins, hidden entities, and tab history are all persisted keyed on
+// `usedConfig.id` in a column that holds saved_connection PKs. The two
+// tables have independent id sequences, so whenever a used_connection id
+// happened to equal some saved_connection id, the unsaved session read and
+// wrote that saved connection's tabs. Sessions on a never-saved connection
+// must have `usedConfig.id` null, which disables per-connection persistence
+// instead of borrowing another connection's key.
 
 function buildSavedConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
   const c = new SavedConnection()
@@ -123,60 +119,71 @@ describe('connecting without saving (phantom tabs)', () => {
     await TestOrmConnection.disconnect()
   })
 
-  // Simulates the exact flow of the root `connect` action for an unsaved
-  // config: recordUsed, then newConnection (store/index.ts:552-553).
-  async function connectUnsaved() {
-    const config = await store.dispatch(
-      'data/usedconnections/recordUsed', await unsavedSnowflakeConfig())
-    store.commit('newConnection', config)
-    return config
+  // Simulates the exact flow of the root `connect` action: recordUsed, then
+  // the newConnection mutation, then pruning old deleted tabs (guarded on
+  // usedConfig.id, as in store/index.ts).
+  async function connectWith(config: any) {
+    const usedConfig = await store.dispatch(
+      'data/usedconnections/recordUsed', config)
+    store.commit('newConnection', usedConfig)
+    if (usedConfig.id) {
+      await Handlers['appdb/tabhistory/clearDeletedTabs']({
+        workspaceId: WORKSPACE_ID,
+        connectionId: usedConfig.id
+      })
+    }
+    await store.dispatch('tabs/load')
+    return usedConfig
   }
 
-  it.failing('does not surface a saved connection\'s tabs in an unsaved-connection session', async () => {
+  async function connectUnsaved() {
+    return await connectWith(await unsavedSnowflakeConfig())
+  }
+
+  it('does not surface a saved connection\'s tabs in an unsaved-connection session', async () => {
     // The user's saved ClickHouse connection, with open tabs.
     const saved = buildSavedConnection()
     await saved.save()
     await openTabFor(saved.id, 'clickhouse query 1')
     await openTabFor(saved.id, 'clickhouse query 2')
 
-    // New Snowflake connection, connected without saving.
+    // New Snowflake connection, connected without saving. Its used_connection
+    // row is the first one, so its PK equals the ClickHouse saved_connection
+    // id - the collision that used to leak the tabs.
     const usedConfig = await connectUnsaved()
 
-    // Documents the collision mechanism: usedConfig.id is the used_connection
-    // PK, which here (first used_connection row vs first saved_connection row)
-    // equals the ClickHouse saved_connection id.
-    expect(usedConfig.id).toBe(saved.id)
-
-    // TabModule.load keys on usedConfig.id, so the Snowflake session gets the
-    // ClickHouse tabs. Correct behavior: no tabs.
-    await store.dispatch('tabs/load')
+    // An unsaved session has no saved_connection id, so no persistence key.
+    expect(usedConfig.id).toBeNull()
     expect((store.state as any).tabs.tabs).toHaveLength(0)
+
+    // It is still recorded for the recent-connections list, unlinked from
+    // any saved connection.
+    const used = await UsedConnection.find()
+    expect(used).toHaveLength(1)
+    expect(used[0].connectionId).toBeNull()
   })
 
-  it.failing('does not write unsaved-session tabs into a saved connection\'s tab set', async () => {
+  it('does not write unsaved-session tabs into a saved connection\'s tab set', async () => {
     const saved = buildSavedConnection()
     await saved.save()
 
     await connectUnsaved()
 
     // User opens a tab while connected to the unsaved Snowflake connection.
-    // TabModule.add persists it with connectionId = usedConfig.id.
     await store.dispatch('tabs/add', {
       item: { tabType: 'query', title: 'snowflake scratch', position: 1 }
     })
 
     // Later: connect to the saved ClickHouse connection.
-    const config = await store.dispatch(
-      'data/usedconnections/recordUsed', await asConfig(saved))
-    store.commit('newConnection', config)
-    await store.dispatch('tabs/load')
+    const config = await connectWith(await asConfig(saved))
+    expect(config.id).toBe(saved.id)
 
-    // Correct behavior: the Snowflake tab does not leak into this session.
+    // The Snowflake tab does not leak into this session.
     const titles = (store.state as any).tabs.tabs.map((t: any) => t.title)
     expect(titles).not.toContain('snowflake scratch')
   })
 
-  it.failing('does not purge a saved connection\'s closed-tab history on unsaved connect', async () => {
+  it('does not purge a saved connection\'s closed-tab history on unsaved connect', async () => {
     const saved = buildSavedConnection()
     await saved.save()
 
@@ -193,20 +200,62 @@ describe('connecting without saving (phantom tabs)', () => {
       .where('id = :id', { id: tab.id })
       .execute()
 
-    const usedConfig = await connectUnsaved()
-
-    // The connect action runs this right after recordUsed
-    // (store/index.ts:564) - with the colliding id it hard-deletes the
-    // ClickHouse connection's history.
-    await Handlers['appdb/tabhistory/clearDeletedTabs']({
-      workspaceId: WORKSPACE_ID,
-      connectionId: usedConfig.id
-    })
+    await connectUnsaved()
 
     const history = await OpenTab.getClosedHistory({
       connectionId: saved.id,
       workspaceId: WORKSPACE_ID
     })
     expect(history).toBeTruthy()
+  })
+
+  it('reconnecting from the recent list to a never-saved connection stays unkeyed', async () => {
+    const saved = buildSavedConnection()
+    await saved.save()
+    await openTabFor(saved.id, 'clickhouse query')
+
+    await connectUnsaved()
+    await store.dispatch('data/usedconnections/load')
+
+    // The recent-connections list passes the used_connection row itself to
+    // `connect` when there is no saved connection to resolve it to
+    // (ConnectionListItem.savedConnection).
+    const recent = (store.state as any)['data/usedconnections'].items[0]
+    expect(recent.connectionId).toBeNull()
+
+    const usedConfig = await connectWith({ ...recent })
+
+    // Its used_connection PK (which equals the ClickHouse saved id here)
+    // must not become the session's persistence key...
+    expect(usedConfig.id).toBeNull()
+    expect((store.state as any).tabs.tabs).toHaveLength(0)
+
+    // ...and the row is updated in place: not duplicated, and not stamped
+    // with its own PK as a saved_connection reference.
+    const used = await UsedConnection.find()
+    expect(used).toHaveLength(1)
+    expect(used[0].connectionId).toBeNull()
+  })
+
+  it('first connect of a saved connection does not hijack an unrelated used_connection row', async () => {
+    // An unsaved session creates used_connection row 1.
+    await connectUnsaved()
+
+    const saved = buildSavedConnection()
+    await saved.save()
+    expect(saved.id).toBe(1) // same small-int id space as the used row
+
+    await store.dispatch('data/usedconnections/load')
+    await connectWith(await asConfig(saved))
+
+    // The saved connection gets its own used_connection row; the Snowflake
+    // row is not overwritten with ClickHouse details or linked to the saved
+    // connection just because the ids coincide.
+    const used = await UsedConnection.find({ order: { id: 'ASC' } })
+    expect(used).toHaveLength(2)
+    expect(used[0].connectionId).toBeNull()
+    expect(used[0].connectionType).toBe('snowflake')
+    expect(used[1].connectionId).toBe(saved.id)
+    expect(used[1].connectionType).toBe('clickhouse')
   })
 })

--- a/apps/studio/tests/unit/store/used_connection/UnsavedConnectionPhantomTabs.spec.ts
+++ b/apps/studio/tests/unit/store/used_connection/UnsavedConnectionPhantomTabs.spec.ts
@@ -1,0 +1,212 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+import { SavedConnection } from '@/common/appdb/models/saved_connection'
+import { UsedConnection } from '@/common/appdb/models/used_connection'
+import { OpenTab } from '@/common/appdb/models/OpenTab'
+import { AppDbHandlers } from '@/handlers/appDbHandlers'
+import { TabHistoryHandlers } from '@/handlers/tabHistoryHandlers'
+import { UtilUsedConnectionModule } from '@/store/modules/data/used_connection/UtilityUsedConnectionModule'
+import { TabModule } from '@/store/modules/TabModule'
+
+Vue.use(Vuex)
+
+const WORKSPACE_ID = -1
+
+const Handlers = { ...AppDbHandlers, ...TabHistoryHandlers }
+
+// Replicates the "phantom tabs" bug: connecting to a connection that was
+// never saved surfaces (and then corrupts) the open tabs of an unrelated
+// *saved* connection.
+//
+// Root cause: for an unsaved config, `recordUsed` returns the new
+// used_connection row, so `usedConfig.id` is a used_connection PK. Tabs,
+// pins, hidden entities, and tab history are all keyed on `usedConfig.id`
+// in a column that normally holds a saved_connection PK. The two tables
+// have independent id sequences, so whenever a used_connection id happens
+// to equal some saved_connection id (very likely - both are small
+// autoincrement ints), the unsaved session reads and writes that saved
+// connection's tabs.
+//
+// These tests are marked `it.failing` because they assert the *correct*
+// behavior, which the current code does not implement. When the bug is
+// fixed they will start reporting "passing test marked failing" - at that
+// point flip them to plain `it(...)`.
+
+function buildSavedConnection(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  const c = new SavedConnection()
+  c.connectionType = 'clickhouse'
+  c.name = 'ClickHouse Prod'
+  c.host = 'clickhouse.example.com'
+  c.port = 8123
+  c.username = 'user'
+  c.defaultDatabase = 'analytics'
+  Object.assign(c, overrides)
+  return c
+}
+
+// What the connection form hands to `connect` when the user fills in a brand
+// new connection and hits Connect without saving: a fresh config (built the
+// same way the connection screen builds one, via appdb/saved/new) with no id.
+async function unsavedSnowflakeConfig() {
+  const fresh = await AppDbHandlers['appdb/saved/new']({ init: null })
+  return {
+    ...fresh,
+    id: null,
+    workspaceId: WORKSPACE_ID,
+    connectionType: 'snowflake',
+    name: null,
+    host: 'account.snowflakecomputing.com',
+    port: 443,
+    username: 'app',
+    defaultDatabase: 'ANALYTICS',
+  }
+}
+
+async function openTabFor(connectionId: number, title: string): Promise<OpenTab> {
+  const tab = new OpenTab()
+  tab.tabType = 'query'
+  tab.title = title
+  tab.connectionId = connectionId
+  tab.workspaceId = WORKSPACE_ID
+  tab.position = 1
+  tab.active = false
+  tab.unsavedQueryText = 'select 1'
+  await tab.save()
+  return tab
+}
+
+// Mirror of production: saved connections reach the renderer as plain objects
+// via transformConn (see UtilUsedConnectionModule.spec.ts for why we can't
+// just spread the entity).
+async function asConfig(saved: SavedConnection) {
+  const fetched = await AppDbHandlers['appdb/saved/findOneBy']({
+    options: { id: saved.id }
+  })
+  return { ...fetched, workspaceId: WORKSPACE_ID }
+}
+
+function buildStore() {
+  return new Vuex.Store({
+    state: { workspaceId: WORKSPACE_ID, usedConfig: null } as any,
+    mutations: {
+      // same shape as the root `newConnection` mutation in store/index.ts
+      newConnection(state: any, config: any) {
+        state.usedConfig = config
+      }
+    },
+    modules: {
+      'data/usedconnections': UtilUsedConnectionModule,
+      tabs: TabModule,
+    }
+  })
+}
+
+describe('connecting without saving (phantom tabs)', () => {
+  let store: ReturnType<typeof buildStore>
+
+  beforeEach(async () => {
+    await TestOrmConnection.connect()
+
+    Vue.prototype.$util = {
+      send: async (channel: string, args: any) => {
+        const handler = (Handlers as any)[channel]
+        if (!handler) throw new Error(`No handler for ${channel}`)
+        return await handler(args)
+      }
+    }
+
+    store = buildStore()
+  })
+
+  afterEach(async () => {
+    await TestOrmConnection.disconnect()
+  })
+
+  // Simulates the exact flow of the root `connect` action for an unsaved
+  // config: recordUsed, then newConnection (store/index.ts:552-553).
+  async function connectUnsaved() {
+    const config = await store.dispatch(
+      'data/usedconnections/recordUsed', await unsavedSnowflakeConfig())
+    store.commit('newConnection', config)
+    return config
+  }
+
+  it.failing('does not surface a saved connection\'s tabs in an unsaved-connection session', async () => {
+    // The user's saved ClickHouse connection, with open tabs.
+    const saved = buildSavedConnection()
+    await saved.save()
+    await openTabFor(saved.id, 'clickhouse query 1')
+    await openTabFor(saved.id, 'clickhouse query 2')
+
+    // New Snowflake connection, connected without saving.
+    const usedConfig = await connectUnsaved()
+
+    // Documents the collision mechanism: usedConfig.id is the used_connection
+    // PK, which here (first used_connection row vs first saved_connection row)
+    // equals the ClickHouse saved_connection id.
+    expect(usedConfig.id).toBe(saved.id)
+
+    // TabModule.load keys on usedConfig.id, so the Snowflake session gets the
+    // ClickHouse tabs. Correct behavior: no tabs.
+    await store.dispatch('tabs/load')
+    expect((store.state as any).tabs.tabs).toHaveLength(0)
+  })
+
+  it.failing('does not write unsaved-session tabs into a saved connection\'s tab set', async () => {
+    const saved = buildSavedConnection()
+    await saved.save()
+
+    await connectUnsaved()
+
+    // User opens a tab while connected to the unsaved Snowflake connection.
+    // TabModule.add persists it with connectionId = usedConfig.id.
+    await store.dispatch('tabs/add', {
+      item: { tabType: 'query', title: 'snowflake scratch', position: 1 }
+    })
+
+    // Later: connect to the saved ClickHouse connection.
+    const config = await store.dispatch(
+      'data/usedconnections/recordUsed', await asConfig(saved))
+    store.commit('newConnection', config)
+    await store.dispatch('tabs/load')
+
+    // Correct behavior: the Snowflake tab does not leak into this session.
+    const titles = (store.state as any).tabs.tabs.map((t: any) => t.title)
+    expect(titles).not.toContain('snowflake scratch')
+  })
+
+  it.failing('does not purge a saved connection\'s closed-tab history on unsaved connect', async () => {
+    const saved = buildSavedConnection()
+    await saved.save()
+
+    // A ClickHouse tab closed 30 days ago (still restorable via
+    // "reopen last closed tab" until clearOldDeletedTabs runs for that
+    // connection).
+    const tab = await openTabFor(saved.id, 'closed clickhouse tab')
+    const thirtyDaysAgo = new Date()
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+    await OpenTab.getRepository()
+      .createQueryBuilder()
+      .update()
+      .set({ deletedAt: thirtyDaysAgo })
+      .where('id = :id', { id: tab.id })
+      .execute()
+
+    const usedConfig = await connectUnsaved()
+
+    // The connect action runs this right after recordUsed
+    // (store/index.ts:564) - with the colliding id it hard-deletes the
+    // ClickHouse connection's history.
+    await Handlers['appdb/tabhistory/clearDeletedTabs']({
+      workspaceId: WORKSPACE_ID,
+      connectionId: usedConfig.id
+    })
+
+    const history = await OpenTab.getClosedHistory({
+      connectionId: saved.id,
+      workspaceId: WORKSPACE_ID
+    })
+    expect(history).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
Fixes the "phantom tabs" bug: connecting to a connection without saving it could surface, pollute, and even purge the open tabs of an unrelated **saved** connection.

**Root cause:** for an unsaved config, `recordUsed` returned the freshly inserted `used_connection` row, so `usedConfig.id` was a `used_connection` PK. Tabs, pins, hidden entities, and tab history are all persisted keyed on `usedConfig.id` in the `saved_connection` id space — and the two tables have independent autoincrement sequences, so whenever a `used_connection` id happened to equal some `saved_connection` id, the unsaved session read and wrote that saved connection's data.

## Changes
- `recordUsed` now only ever returns an id from the `saved_connection` id space: the saved id for saved connections, `null` for connections that were never saved. A null id disables per-connection persistence for the session (all consumers already guard on `usedConfig.id`).
- `used_connection` rows passed back in from the recent-connections list (they carry their saved-connection reference in `connectionId`) are recognized and updated in place instead of being treated as saved connections — this also stops them being stamped with their own PK as a `connectionId`.
- First connect of a saved connection no longer hijacks an unrelated `used_connection` row that shares its id.
- `UsedConnection.withProps` honors an explicit `connectionId` instead of inferring it from `id`.
- The connect action skips `clearDeletedTabs` when there is no saved connection id, so it can't hard-delete another connection's closed-tab history.
- Query history writes use `-1` (the column default) instead of `null` for unsaved sessions, and the history list filters accordingly.

## Tests
New spec `apps/studio/tests/unit/store/used_connection/UnsavedConnectionPhantomTabs.spec.ts` (plain `it()`, fails on the pre-fix code) covering:
1. An unsaved session does not surface a saved connection's tabs
2. Tabs opened in an unsaved session do not leak into a saved connection's tab set
3. Unsaved connect does not purge a saved connection's closed-tab history
4. Reconnecting from the recent list to a never-saved connection stays unkeyed and doesn't duplicate/corrupt the `used_connection` row
5. First connect of a saved connection doesn't hijack an unrelated `used_connection` row with the same id

Full studio unit suite passes locally (90 suites, 3184 tests), plus workspace lint and the CI check scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXqYjLqTpg3hZq1RZ2ktFq