### PR TITLE
fix(ssh): treat agent errors as non-fatal so publickey auth can proceed

### DIFF
--- a/apps/studio/src/vendor/node-ssh-forward/index.ts
+++ b/apps/studio/src/vendor/node-ssh-forward/index.ts
@@ -232,6 +232,11 @@ class SSHConnection {
       })
 
       connection.on('error', (error) => {
+        // if pageant is not running on windows, we log the message and move on to the next auth method rather than rejecting the connection.
+        if ((error as any).level === 'agent') {
+          this.log.warn(`Ignoring non-fatal SSH agent error: ${error.message}`)
+          return
+        }
         reject(error)
       })
       try {

--- a/apps/studio/tests/unit/vendor/node-ssh-forward.spec.ts
+++ b/apps/studio/tests/unit/vendor/node-ssh-forward.spec.ts
@@ -16,13 +16,17 @@ jest.mock('@/common/platform_info', () => ({
 
 const capturedConfigs: any[] = []
 
+// What the mocked ssh2 Client does once connect() is called. Defaults to a successful connection; individual tests override it to emit errors.
+const mockConnectSuccess = (client: any) => setImmediate(() => client.emit('ready'))
+let mockOnConnect = mockConnectSuccess
+
 jest.mock('ssh2', () => {
   const actual = jest.requireActual('ssh2')
   const { EventEmitter } = require('events')
   class MockClient extends EventEmitter {
     connect(cfg: any) {
       capturedConfigs.push(cfg)
-      setImmediate(() => this.emit('ready'))
+      mockOnConnect(this)
     }
     end() {}
   }
@@ -70,5 +74,46 @@ describe('SSHConnection Windows agent branch', () => {
     expect(cfg.agent).toBeDefined()
     // This is the exact check ssh2's internal isAgent() performs.
     expect(cfg.agent instanceof BaseAgent).toBe(true)
+  })
+})
+
+// Regression tests #4661: when no agent is running (Pageant not started on windows)
+describe('SSHConnection agent error handling', () => {
+  const connectionOptions = {
+    endHost: '127.0.0.1',
+    endPort: 22,
+    username: 'x',
+    skipAutoPrivateKey: true,
+    noReadline: true,
+  }
+
+  afterEach(() => {
+    mockOnConnect = mockConnectSuccess
+  })
+
+  it('ignores a non-fatal agent error and connects', async () => {
+    mockOnConnect = (client: any) => setImmediate(() => {
+      const err: any = new Error('Failed to retrieve identities from agent')
+      err.level = 'agent'
+      client.emit('error', err)
+      setImmediate(() => client.emit('ready'))
+    })
+
+    const conn = new SSHConnection(connectionOptions)
+    await expect(conn.forward({ fromPort: 0, toPort: 22 })).resolves.toBeDefined()
+    await conn.shutdown()
+  })
+
+  it('still rejects when authentication ultimately fails', async () => {
+    mockOnConnect = (client: any) => setImmediate(() => {
+      const err: any = new Error('All configured authentication methods failed')
+      err.level = 'client-authentication'
+      client.emit('error', err)
+    })
+
+    const conn = new SSHConnection(connectionOptions)
+    await expect(conn.forward({ fromPort: 0, toPort: 22 }))
+      .rejects.toThrow('All configured authentication methods failed')
+    await conn.shutdown()
   })
 })


### PR DESCRIPTION
Connecting on Windows with SSH auth set to Automatic fails with "SSH Tunnel Connection Error: Failed to retrieve identities from agent" when no agent is running, even though the key resolved from ~/.ssh/config would authenticate. Starting an empty Pageant works around it.

e8f7b775c made Windows always attempt agent auth (!!socketPath || isWindows) so Pageant users could reach their agent. With no Pageant running, ssh2 cannot read identities and emits an error with level 'agent'. ssh2 treats that as advisory and carries on with the next auth method, but connect() rejected on any error event, aborting a connection that publickey would have completed. Before 6.0.1 the agent was never queried on Windows without SSH_AUTH_SOCK, so this path was unreachable.

Ignore agent-level errors in the connect handler and log them instead. Terminal failures arrive as client-authentication and still reject, so a genuinely unauthenticated connection fails as before.

Fixes #4661