### PR TITLE
Small improvements: simplify keyboard hints & fix shortcuts modal

### DIFF
--- a/apps/studio/src/assets/styles/app/query-editor.scss
+++ b/apps/studio/src/assets/styles/app/query-editor.scss
@@ -168,13 +168,12 @@
 .shortcut-item {
   display: table-row;
   color: $text-lighter;
-  text-align: right;
   font-size: 95%;
   > div {
     display: table-cell;
     padding: $gutter-h;
     padding-right: ($gutter-h - .2);
-    padding-bottom: ($gutter-h + .2);
+    padding-block: 0.6rem;
   }
   .new {
     margin-right: $gutter-h;

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -69,7 +69,7 @@
     <div class="tab-content">
       <div class="empty-editor-group empty flex-col  expand">
         <div class="expand layout-center">
-          <shortcut-hints />
+          <shortcut-hints type="core-tabs" />
         </div>
       </div>
       <div

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -355,7 +355,7 @@
         class="layout-center expand"
         v-else
       >
-        <shortcut-hints />
+        <shortcut-hints type="query-editor" />
       </div>
       <!-- <span class="expand" v-if="!result"></span> -->
       <!-- STATUS BAR -->

--- a/apps/studio/src/components/TabShell.vue
+++ b/apps/studio/src/components/TabShell.vue
@@ -83,7 +83,7 @@
         class="layout-center expand"
         v-else
       >
-        <shortcut-hints :is-mongo="true" />
+        <shortcut-hints type="query-editor" />
       </div>
       <!-- <span class="expand" v-if="!result"></span> -->
       <!-- STATUS BAR -->

--- a/apps/studio/src/components/common/modals/KeyboardShortcutsModal.vue
+++ b/apps/studio/src/components/common/modals/KeyboardShortcutsModal.vue
@@ -1,79 +1,69 @@
 <template>
-  <portal to="modals">
-    <modal
-      :name="modalName"
-      :class="['vue-dialog', 'beekeeper-modal', 'keyboard-shortcuts-modal']"
-    >
-      <div v-kbd-trap="true">
-        <div class="dialog-content">
-          <div class="dialog-c-title">
-            Keyboard Shortcuts
-          </div>
-          <a class="close-btn btn btn-fab" href="#" @click.prevent="close">
-            <i class="material-icons">clear</i>
-          </a>
-          <div class="search-wrapper">
-            <input
-              type="text"
-              placeholder="Search shortcuts"
-              v-model="searchQuery"
-            >
-            <span
-              v-show="searchQuery"
-              class="clear"
-              @click="searchQuery = ''"
-            >
-              <i class="material-icons">cancel</i>
-            </span>
-          </div>
-          <div class="kbd-content">
+  <base-modal :name="modalName">
+    <template #title>
+      Keyboard Shortcuts
+    </template>
+    <div class="kbd-body">
+      <div class="search-wrapper">
+        <input
+          type="text"
+          placeholder="Search shortcuts"
+          v-model="searchQuery"
+        >
+        <span
+          v-show="searchQuery"
+          class="clear"
+          @click="searchQuery = ''"
+        >
+          <i class="material-icons">cancel</i>
+        </span>
+      </div>
+      <div class="kbd-content">
+        <div
+          v-for="section in filteredSections"
+          :key="section.sectionKey"
+          class="kbd-section"
+        >
+          <h3 class="kbd-section-title">
+            {{ section.label }}
+          </h3>
+          <div class="kbd-list">
             <div
-              v-for="section in filteredSections"
-              :key="section.sectionKey"
-              class="kbd-section"
+              v-for="action in section.actions"
+              :key="action.key"
+              class="kbd-item"
             >
-              <h3 class="kbd-section-title">
-                {{ section.label }}
-              </h3>
-              <div class="kbd-list">
+              <div
+                v-if="action.highlight"
+                class="kbd-label"
+                v-html="action.highlight"
+              />
+              <div v-else class="kbd-label">
+                {{ action.label }}
+              </div>
+              <div class="kbd-keys">
                 <div
-                  v-for="action in section.actions"
-                  :key="action.key"
-                  class="kbd-item"
+                  v-for="(keybinding, kbIdx) in action.keybindings"
+                  :key="kbIdx"
+                  class="kbd-keybinding"
                 >
-                  <div
-                    v-if="action.highlight"
-                    class="kbd-label"
-                    v-html="action.highlight"
-                  />
-                  <div v-else class="kbd-label">
-                    {{ action.label }}
-                  </div>
-                  <div class="kbd-keys">
-                    <div
-                      v-for="(keybinding, kbIdx) in action.keybindings"
-                      :key="kbIdx"
-                      class="kbd-keybinding"
-                    >
-                      <span v-for="(key, keyIdx) in keybinding" :key="keyIdx">{{
-                        key
-                      }}</span>
-                    </div>
-                  </div>
+                  <span v-for="(key, keyIdx) in keybinding" :key="keyIdx">{{
+                    key
+                  }}</span>
                 </div>
               </div>
             </div>
-            <div
-              v-if="!filteredSections.length"
-              class="no-matching-results"
-            >
-              No matching results
-            </div>
           </div>
         </div>
+        <div
+          v-if="!filteredSections.length"
+          class="no-matching-results"
+        >
+          No matching results
+        </div>
       </div>
-    </modal>
-  </portal>
+    </div>
+  </base-modal>
 </template>
 
 <script lang="ts">
@@ -82,6 +72,7 @@ import uFuzzy from "@leeoniya/ufuzzy";
 import { AppEvent } from "@/common/AppEvent";
 import { escapeHtml } from "@shared/lib/tabulator";
 import type { KeybindingSection } from "@/types";
+import BaseModal from "@/components/common/modals/BaseModal.vue";
 
 type SectionAction = KeybindingSection["actions"][number];
 type FilteredAction = SectionAction & { highlight?: string };
@@ -95,6 +86,7 @@ const uf = new uFuzzy({
 });
 
 export default Vue.extend({
+  components: { BaseModal },
   data() {
     return {
       modalName: "keyboard-shortcuts-modal",
@@ -165,15 +157,13 @@ export default Vue.extend({
       this.searchQuery = "";
       this.$modal.show(this.modalName);
     },
-    close() {
-      this.$modal.hide(this.modalName);
-    },
   },
 });
 </script>
 
 <style scoped>
-.dialog-content {
+.kbd-body {
+  --kbd-border-color: color-mix(in srgb, var(--border-color) 40%, transparent);
   height: 70vh;
   display: flex;
   flex-direction: column;
@@ -238,13 +228,13 @@ export default Vue.extend({
   text-transform: uppercase;
   color: var(--text-dark);
   background-color: hsl(from var(--theme-bg) h s calc(l + 1));
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--kbd-border-color);
 }
 
 .kbd-item {
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--kbd-border-color);
   padding-block: 0.65rem;
 }
 

--- a/apps/studio/src/components/editor/ShortcutHints.vue
+++ b/apps/studio/src/components/editor/ShortcutHints.vue
@@ -1,102 +1,86 @@
 <template>
-  <div class="shortcuts">
-    <div class="shortcut-item">
-      <div>Quick Search</div>
-      <shortcut-display-helper shortcut-path="general.openQuickSearch" />
-    </div>
-    <div class="shortcut-item">
-      <div>Autocomplete</div>
-      <div class="shortcut">
-        <span>Ctrl</span><span>Space</span>
+  <div class="shortcut-hints">
+    <div class="shortcuts">
+      <div class="shortcut-item">
+        <div>Quick Search</div>
+        <shortcut-display-helper shortcut-path="general.openQuickSearch" />
       </div>
+      <template v-if="type === 'core-tabs'">
+        <div class="shortcut-item">
+          <div>New Tab</div>
+          <div class="shortcut">
+            <span>{{ $config.isMac ? '⌘' : 'Ctrl' }}</span><span>T</span>
+          </div>
+        </div>
+        <div class="shortcut-item">
+          <div>Reopen Last Closed Tab</div>
+          <shortcut-display-helper shortcut-path="tab.reopenLastClosedTab" />
+        </div>
+        <div class="shortcut-item">
+          <div>Toggle Primary Sidebar</div>
+          <div class="shortcut" v-if="$config.isMac">
+            <span>⌘</span><span>B</span>
+          </div>
+          <div class="shortcut" v-else>
+            <span>Alt</span><span>S</span>
+          </div>
+        </div>
+        <div class="shortcut-item">
+          <div>New Window</div>
+          <div class="shortcut">
+            <span>{{ $config.isMac ? '⌘' : 'Ctrl' }}</span><span>⇧</span><span>N</span>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div class="shortcut-item">
+          <div>Autocomplete</div>
+          <div class="shortcut">
+            <span>Ctrl</span><span>Space</span>
+          </div>
+        </div>
+        <div class="shortcut-item">
+          <div>Format Query</div>
+          <div class="shortcut">
+            <span>{{ $config.isMac ? '⌘' : 'Ctrl' }}</span><span>⇧</span><span>F</span>
+          </div>
+        </div>
+        <div class="shortcut-item">
+          <div>{{ queryActionText(true) }}</div>
+          <shortcut-display-helper shortcut-path="queryEditor.primaryQueryAction" />
+        </div>
+        <div class="shortcut-item">
+          <div>{{ queryActionText(false) }}</div>
+          <shortcut-display-helper shortcut-path="queryEditor.secondaryQueryAction" />
+        </div>
+      </template>
     </div>
-    <div class="shortcut-item">
-      <div>{{ queryActionText(true) }}</div>
-      <shortcut-display-helper shortcut-path="queryEditor.primaryQueryAction" />
-    </div>
-    <div class="shortcut-item">
-      <div>{{ queryActionText(false) }}</div>
-      <shortcut-display-helper shortcut-path="queryEditor.secondaryQueryAction" />
-    </div>
-    <div class="shortcut-item">
-      <div>New Window</div>
-      <div
-        class="shortcut"
-        v-if="$config.isMac"
-      >
-        <span>⌘</span><span>⇧</span><span>N</span>
-      </div>
-      <div
-        class="shortcut"
-        v-else
-      >
-        <span>Ctrl</span><span>⇧</span><span>N</span>
-      </div>
-    </div>
-    <div class="shortcut-item">
-      <div>New Tab</div>
-      <div
-        class="shortcut"
-        v-if="$config.isMac"
-      >
-        <span>⌘</span><span>T</span>
-      </div>
-      <div
-        class="shortcut"
-        v-else
-      >
-        <span>Ctrl</span><span>T</span>
-      </div>
-    </div>
-    <div class="shortcut-item">
-      <div>Reopen Closed Tabs</div>
-      <shortcut-display-helper shortcut-path="tab.reopenLastClosedTab" />
-    </div>
-    <div class="shortcut-item">
-      <div>Close Tab</div>
-      <shortcut-display-helper shortcut-path="tab.closeTab" />
-    </div>
-    <div class="shortcut-item">
-      <div>Find</div>
-      <div
-        v-if="$config.isMac"
-        class="shortcut"
-      >
-        <span>⌘</span><span>F</span>
-      </div>
-      <div
-        v-else
-        class="shortcut"
-      >
-        <span>Ctrl</span><span>F</span>
-      </div>
-    </div>
-    <div v-if="!isMongo" class="shortcut-item">
-      <div>Find and Replace</div>
-      <div
-        class="shortcut"
-        v-if="$config.isMac"
-      >
-        <span>⌘</span><span>R</span>
-      </div>
-      <div
-        class="shortcut"
-        v-else
-      >
-        <span>Ctrl</span><span>R</span>
-      </div>
-    </div>
+    <button
+      class="btn btn-small btn-link btn-view-all"
+      @click="openKeyboardShortcuts"
+    >View all shortcuts ...</button>
   </div>
 </template>
-<script type="text/javascript">
+<script lang="ts">
+import { AppEvent } from '@/common/AppEvent';
 import ShortcutDisplayHelper from './ShortcutDisplayHelper.vue';
 
+type ShortcutHintsType = 'core-tabs' | 'query-editor'
+
   export default {
-    props: ['isMongo'],
+    props: {
+      type: {
+        required: true,
+        type: String as () => ShortcutHintsType
+      }
+    },
     components: {
       ShortcutDisplayHelper
     },
     methods : {
+      openKeyboardShortcuts() {
+        this.trigger(AppEvent.openKeyboardShortcuts)
+      },
       isPrimaryRunCurrentQuery() {
         return this.$bksConfig.ui.queryEditor?.primaryQueryAction.toLowerCase() === 'submitcurrentquery'
       },
@@ -110,3 +94,10 @@ import ShortcutDisplayHelper from './ShortcutDisplayHelper.vue';
     }
   }
 </script>
+<style lang="scss" scoped>
+.btn.btn-view-all {
+  margin-top: 0.5rem;
+  margin-left: -0.25rem;
+  color: var(--text-lighter);
+}
+</style>


### PR DESCRIPTION
**Keyboard Hints**

- Keyboard hints are reduced to 5 + a button that opens a keyboard shortcut modal. Limiting these can make the UI feel less cluttered because it gives more room to breathe.
- The hints are also personalized, so for query editor, it shows Quick Search, Autocomplete, Format Query, Run All, and Run Current.
<img width="931" height="574" alt="image" src="https://github.com/user-attachments/assets/8319848f-2a34-448d-bf38-1be4b1e8fcc3" />

- For empty tab, it shows Quick Search, New Tab, Reopen Last Closed Tab, Toggle Primary Sidebar, and New Window.
<img width="929" height="562" alt="image" src="https://github.com/user-attachments/assets/b236d485-c60b-479a-84d6-c052aa0427eb" />

- The labels are aligned to the left so it's easier to read.

**Shortcuts Modal**

- The shortcuts modal now uses `<base-modal>` so it properly auto focus the search bar, and trap the keyboard navigation.
- The border color is also a bit less contrast for a cleaner look.
<img width="484" height="500" alt="image" src="https://github.com/user-attachments/assets/4b22358a-13ce-466f-8ecb-a9627219fb90" />
 