### PR TITLE
feat(editor): Add active line background feedback and active line number highlighting

### DIFF
--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -189,6 +189,8 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   // --bks-badge-bg: #{$badge-bg};
 
   --bks-text-editor-bg-color: #{$query-editor-bg};
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.05)};
+  --bks-text-editor-activeline-gutter-bg-color: transparent;
   --bks-text-editor-error-bg-color: #{rgba($brand-danger, 0.1)};
   --bks-text-editor-error-fg-color: #{$brand-danger};
   --bks-text-editor-fg-color: #{$text-dark};
@@ -206,6 +208,7 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   --bks-text-editor-variable-2-fg-color: #{$brand-secondary};
   --bks-text-editor-selected-bg-color: #{rgba($theme-base, 0.25)};
   --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.15)};
+  --bks-text-editor-linenumber-active-fg-color: #{$text-dark};
   --bks-text-editor-number-fg-color: #{$brand-primary};
   --bks-text-editor-string-fg-color: #{$brand-primary};
   --bks-text-editor-cursor-bg-color: #{$text-dark};

--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -189,8 +189,8 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   // --bks-badge-bg: #{$badge-bg};
 
   --bks-text-editor-bg-color: #{$query-editor-bg};
-  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.05)};
-  --bks-text-editor-activeline-gutter-bg-color: transparent;
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.08)};
+  --bks-text-editor-activeline-gutter-bg-color: #{rgba($theme-base, 0.08)};
   --bks-text-editor-error-bg-color: #{rgba($brand-danger, 0.1)};
   --bks-text-editor-error-fg-color: #{$brand-danger};
   --bks-text-editor-fg-color: #{$text-dark};

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -566,8 +566,8 @@ x-switch {
 }
 
 & {
-  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.04)};
-  --bks-text-editor-activeline-gutter-bg-color: transparent;
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.08)};
+  --bks-text-editor-activeline-gutter-bg-color: #{rgba($theme-base, 0.08)};
   --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.25)};
   --bks-text-editor-linenumber-active-fg-color: #{$text-dark};
 }

--- a/apps/studio/src/assets/styles/themes/light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/light/theme.scss
@@ -565,6 +565,13 @@ x-switch {
   }
 }
 
+& {
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.04)};
+  --bks-text-editor-activeline-gutter-bg-color: transparent;
+  --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.25)};
+  --bks-text-editor-linenumber-active-fg-color: #{$text-dark};
+}
+
 .BksTextEditor {
   font-weight: 500;
 }

--- a/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
@@ -762,8 +762,8 @@ x-switch {
   --bks-table-icon-color: #{$theme-primary};
 
   --bks-text-editor-bg-color: #{$query-editor-bg};
-  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.06)};
-  --bks-text-editor-activeline-gutter-bg-color: transparent;
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.08)};
+  --bks-text-editor-activeline-gutter-bg-color: #{rgba($theme-base, 0.08)};
   --bks-text-editor-error-bg-color: #{rgba($brand-danger, 0.1)};
   --bks-text-editor-error-fg-color: #{$brand-danger};
   --bks-text-editor-fg-color: #{$text-dark};

--- a/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
@@ -37,9 +37,9 @@ $editor-statusbar:         $theme-base;
   background: $theme-bg;
   color: $text;
 }
-.material-icons {
-  // font-weight: 600;
-}
+// .material-icons {
+//   font-weight: 600;
+// }
 select {
   background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='8' height='8' fill='rgba(0,0,0, 0.87)'><polygon points='0,0 8,0 4,4'/></svg>") no-repeat scroll 98% 60% transparent !important;
   option {
@@ -762,6 +762,8 @@ x-switch {
   --bks-table-icon-color: #{$theme-primary};
 
   --bks-text-editor-bg-color: #{$query-editor-bg};
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.06)};
+  --bks-text-editor-activeline-gutter-bg-color: transparent;
   --bks-text-editor-error-bg-color: #{rgba($brand-danger, 0.1)};
   --bks-text-editor-error-fg-color: #{$brand-danger};
   --bks-text-editor-fg-color: #{$text-dark};
@@ -779,6 +781,7 @@ x-switch {
   --bks-text-editor-variable-2-fg-color: #{$brand-secondary};
   --bks-text-editor-selected-bg-color: #{rgba($theme-base, 0.25)};
   --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.15)};
+  --bks-text-editor-linenumber-active-fg-color: #{$text-dark};
   --bks-text-editor-number-fg-color: #{$brand-primary};
   --bks-text-editor-string-fg-color: #{$brand-primary};
   --bks-text-editor-cursor-bg-color: #{$text-dark};

--- a/apps/studio/src/components/TabQueryEditor.vue
+++ b/apps/studio/src/components/TabQueryEditor.vue
@@ -1029,6 +1029,8 @@ import { KeybindingPath } from '@/common/bksConfig/BksConfigProvider'
               settings: {
                 selection: "",
                 selectionMatch: "",
+                lineHighlight: "",
+                gutterActiveForeground: "",
               },
             }),
             this.queryMagic.extensions,

--- a/apps/studio/src/components/editor/QueryEditHistory.vue
+++ b/apps/studio/src/components/editor/QueryEditHistory.vue
@@ -500,7 +500,14 @@ export default Vue.extend({
     replaceExtensions(extensions: Extension): Extension[] {
       return [
         extensions,
-        monokaiInit({ settings: { selection: "", selectionMatch: "" } }),
+        monokaiInit({
+          settings: {
+            selection: "",
+            selectionMatch: "",
+            lineHighlight: "",
+            gutterActiveForeground: "",
+          },
+        }),
       ];
     },
   },

--- a/apps/studio/src/components/sidebar/JsonViewer.vue
+++ b/apps/studio/src/components/sidebar/JsonViewer.vue
@@ -393,6 +393,8 @@ export default Vue.extend({
           settings: {
             selection: "",
             selectionMatch: "",
+            lineHighlight: "",
+            gutterActiveForeground: "",
           },
         }),
         this.persistJsonFold.extensions,

--- a/apps/studio/src/components/tableview/EditorModal.vue
+++ b/apps/studio/src/components/tableview/EditorModal.vue
@@ -281,6 +281,8 @@ export default Vue.extend({
           settings: {
             selection: "",
             selectionMatch: "",
+            lineHighlight: "",
+            gutterActiveForeground: "",
           },
         }),
       ]

--- a/apps/studio/src/services/plugin/web/cssVars.ts
+++ b/apps/studio/src/services/plugin/web/cssVars.ts
@@ -69,6 +69,7 @@ export const cssVars = [
   "--bks-text-editor-indent-marker-active-bg-color",
   "--bks-text-editor-keyword-fg-color",
   "--bks-text-editor-linenumber-fg-color",
+  "--bks-text-editor-linenumber-active-fg-color",
   "--bks-text-editor-link-fg-color",
   "--bks-text-editor-matchingbracket-fg-color",
   "--bks-text-editor-matchingbracket-bg-color",

--- a/apps/ui-kit/docs/text-editor.md
+++ b/apps/ui-kit/docs/text-editor.md
@@ -74,8 +74,8 @@ You can customize the appearance of the Text Editor by overriding the CSS variab
 
 ```css
 .BksTextEditor {
-  --bks-text-editor-activeline-bg-color: rgba(0, 0, 0, 0.03);
-  --bks-text-editor-activeline-gutter-bg-color: rgba(0, 0, 0, 0.03);
+  --bks-text-editor-activeline-bg-color: rgba(0, 0, 0, 0.08);
+  --bks-text-editor-activeline-gutter-bg-color: rgba(0, 0, 0, 0.08);
   --bks-text-editor-atom-fg-color: #ae81ff;
   --bks-text-editor-bg-color: white;
   --bks-text-editor-bracket-fg-color: rgba(0, 0, 0, 0.67);

--- a/apps/ui-kit/docs/text-editor.md
+++ b/apps/ui-kit/docs/text-editor.md
@@ -96,6 +96,7 @@ You can customize the appearance of the Text Editor by overriding the CSS variab
   --bks-text-editor-header-fg-color: #ae81ff;
   --bks-text-editor-keyword-fg-color: #ff00f0;
   --bks-text-editor-linenumber-fg-color: rgba(0, 0, 0, 0.25);
+  --bks-text-editor-linenumber-active-fg-color: rgba(0, 0, 0, 0.87);
   --bks-text-editor-link-fg-color: #ae81ff;
   --bks-text-editor-matchingbracket-fg-color: #999977;
   --bks-text-editor-matchingbracket-bg-color: rgba(153, 153, 119, 0.2);

--- a/apps/ui-kit/lib/components/mongo-shell/MongoShell.vue
+++ b/apps/ui-kit/lib/components/mongo-shell/MongoShell.vue
@@ -175,6 +175,8 @@ export default {
             settings: {
               selection: "",
               selectionMatch: "",
+              lineHighlight: "",
+              gutterActiveForeground: "",
             },
           }),
           protectPrompt,

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -203,6 +203,9 @@ export function extensions(config: ExtensionConfiguration = {}) {
       ".cm-lineNumbers .cm-gutterElement": {
         color: "var(--bks-text-editor-linenumber-fg-color)",
       },
+      ".cm-lineNumbers .cm-activeLineGutter": {
+        color: "var(--bks-text-editor-linenumber-active-fg-color)",
+      },
       // Focused state
       "&.cm-focused": {
         outlineColor: "var(--bks-text-editor-focused-outline-color)",

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -4,8 +4,8 @@
 @use 'sass:color';
 
 :root {
-  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.03)};
-  --bks-text-editor-activeline-gutter-bg-color: #{rgba($theme-base, 0.03)};
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.04)};
+  --bks-text-editor-activeline-gutter-bg-color: transparent;
   --bks-text-editor-atom-fg-color: #ae81ff;
   --bks-text-editor-bg-color: #{$query-editor-bg};
   --bks-text-editor-bracket-fg-color: #{$text};
@@ -34,6 +34,7 @@
   --bks-text-editor-indent-marker-active-bg-color: #{rgba($theme-base, 0.2)};
   --bks-text-editor-keyword-fg-color: #{$brand-pink};
   --bks-text-editor-linenumber-fg-color: #{rgba($theme-base, 0.25)};
+  --bks-text-editor-linenumber-active-fg-color: #{$text-dark};
   --bks-text-editor-link-fg-color: #ae81ff;
   --bks-text-editor-matchingbracket-fg-color: #999977;
   --bks-text-editor-matchingbracket-bg-color: rgba(153, 153, 119, 0.2);
@@ -138,6 +139,18 @@
     outline: none;
     font-family: $font-family-mono;
     font-size: var(--bks-text-editor-font-size, 0.875rem);
+  }
+
+  .cm-activeLine {
+    background-color: var(--bks-text-editor-activeline-bg-color);
+  }
+
+  .cm-activeLineGutter {
+    background-color: var(--bks-text-editor-activeline-gutter-bg-color);
+  }
+
+  .cm-lineNumbers .cm-activeLineGutter {
+    color: var(--bks-text-editor-linenumber-active-fg-color);
   }
 
   // Semantic token styles for v2 - using distinct colors in 6-digit hex format

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -4,8 +4,8 @@
 @use 'sass:color';
 
 :root {
-  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.04)};
-  --bks-text-editor-activeline-gutter-bg-color: transparent;
+  --bks-text-editor-activeline-bg-color: #{rgba($theme-base, 0.08)};
+  --bks-text-editor-activeline-gutter-bg-color: #{rgba($theme-base, 0.08)};
   --bks-text-editor-atom-fg-color: #ae81ff;
   --bks-text-editor-bg-color: #{$query-editor-bg};
   --bks-text-editor-bracket-fg-color: #{$text};


### PR DESCRIPTION
### Summary of Changes

- **Active Line Feedback**: Added `--bks-text-editor-activeline-bg-color` to subtly change the background of the currently active line across Dark, Light, Solarized Light, and Solarized Dark themes.
- **Active Line Number Highlight**: Added `--bks-text-editor-linenumber-active-fg-color` and styled `.cm-lineNumbers .cm-activeLineGutter` so the active line number is distinctly highlighted compared to inactive line numbers.
- **Theme Consistency**: Updated `monokaiInit` settings in editor views (`TabQueryEditor`, `JsonViewer`, `EditorModal`, `QueryEditHistory`, `MongoShell`) to allow theme CSS variables to govern active line styling without conflict.