### PR TITLE
fix plugin shortcuts and type errors

### DIFF
--- a/apps/studio/src/services/plugin/web/WebPluginLoader.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginLoader.ts
@@ -31,7 +31,8 @@ type PluginResponseData = {
   };
 }[keyof RequestMap];
 
-type PluginNotificationData = {
+// This should probably be moved to the plugin packge
+export type PluginNotificationData = {
   [K in keyof NotificationMap]: {
     name: K;
     args: NotificationMap[K]["args"];

--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -1,16 +1,15 @@
 import type { UtilityConnection } from "@/lib/utility/UtilityConnection";
 import rawLog from "@bksLogger";
-import { Manifest, OnViewRequestListener, PluginSnapshot } from "../types";
+import { OnViewRequestListener, PluginSnapshot } from "../types";
 import PluginStoreService from "./PluginStoreService";
-import WebPluginLoader from "./WebPluginLoader";
+import WebPluginLoader, { PluginNotificationData } from "./WebPluginLoader";
 import { ContextOption } from "@/plugins/BeekeeperPlugin";
 import { divider } from "@beekeeperstudio/ui-kit";
-import { JsonValue, PluginNotificationData, PluginViewContext } from "@beekeeperstudio/plugin";
+import { JsonValue, PluginViewContext } from "@beekeeperstudio/plugin";
 import { FileHelpers } from "@/types";
 import type Noty from "noty";
 import { AppEvent } from "@/common/AppEvent";
 import { WebPluginCommandExecutor } from "./WebPluginCommandExecutor";
-import { convertToManifestV1, mapViewsAndMenuFromV0ToV1 } from "../utils";
 
 const log = rawLog.scope("WebPluginManager");
 
@@ -286,7 +285,7 @@ export default class WebPluginManager {
         this.pluginStore.appEventBus.emit(
           AppEvent.newCustomTab,
           this.pluginStore.buildPluginTabInit({
-            manifest,
+            manifest: snapshot.manifest,
             viewId,
             command,
             params,


### PR DESCRIPTION
Currently in the app you can't open a plugin tab from a keyboard shortcut as we weren't properly passing the manifest to the function, this fixes that and several type issues