### PR TITLE
fix(cassandra): render UUIDs nested inside user defined types

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -15,6 +15,7 @@ import { identify } from "sql-query-identifier";
 import { errors } from "@/lib/errors";
 import { dataTypesToMatchTypeCode, CassandraData as D } from "@shared/lib/dialects/cassandra";
 import { CassandraCursor } from "./cassandra/CassandraCursor";
+import { convertValueByType } from "./cassandra/valueConverter";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import _ from "lodash";
 import { IdentifyResult } from "sql-query-identifier/lib/defines";
@@ -808,55 +809,9 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
 
     return rows?.map((row) => {
       Object.keys(row).forEach((key) => {
-        const value = row[key];
-        const typeCode = typeByColumn[key].code;
-
-        if (typeCode == cassandra.types.dataTypes.list || typeCode == cassandra.types.dataTypes.set) {
-          row[key] = value?.map((v) => this.convertValueByType(v, typeByColumn[key].info.code));
-          return;
-        }
-
-        if (typeCode == cassandra.types.dataTypes.map) {
-          const [keyType, valueType] = typeByColumn[key].info;
-          const converted = {};
-          if (value) {
-            Object.entries(value).forEach(([k, v]) => {
-              const convertedKey = this.convertValueByType(k, keyType.code);
-              converted[convertedKey as string] = this.convertValueByType(v, valueType.code);
-            });
-          }
-          row[key] = converted;
-          return;
-        }
-
-        row[key] = this.convertValueByType(value, typeCode);
+        row[key] = convertValueByType(row[key], typeByColumn[key]);
       });
       return row;
     });
-  }
-
-  private convertValueByType(value, type) {
-    if (value == null || value === undefined) {
-      return null;
-    }
-
-    switch (type) {
-      case cassandra.types.dataTypes.bigint:
-        return String(value);
-      case cassandra.types.dataTypes.timestamp:
-        return value ? value.toISOString() : null;
-      case cassandra.types.dataTypes.time:
-      case cassandra.types.dataTypes.date:
-        return value ? String(value) : null;
-      case cassandra.types.dataTypes.uuid:
-      case cassandra.types.dataTypes.timeuuid:
-        return value?.buffer
-          ? new cassandra.types.Uuid(Buffer.from(value.buffer)).toString()
-          : value;
-      case cassandra.types.dataTypes.inet:
-        return value ? value.toString() : null;
-      default:
-        return value;
-    }
   }
 }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
@@ -1,0 +1,92 @@
+import * as cassandra from 'cassandra-driver';
+
+/**
+ * A column/field type descriptor as handed to us by the driver.
+ *
+ * The shape of `info` depends on `code`:
+ *  - list/set:  a single nested descriptor (the element type)
+ *  - map:       a two element tuple, [keyType, valueType]
+ *  - tuple:     an array of descriptors, one per position
+ *  - udt:       { name, keyspace, fields: [{ name, type }] }
+ *  - scalars:   unused
+ */
+export type CassandraType = {
+  code: number;
+  info?: any;
+};
+
+const dataTypes = cassandra.types.dataTypes;
+
+function convertScalar(value: any, code: number) {
+  switch (code) {
+    case dataTypes.bigint:
+      return String(value);
+    case dataTypes.timestamp:
+      // Map keys reach us already coerced to strings: the driver builds plain
+      // object maps with `map[key] = value`, which stringifies a Date key.
+      return typeof value.toISOString === 'function' ? value.toISOString() : String(value);
+    case dataTypes.time:
+    case dataTypes.date:
+      return String(value);
+    case dataTypes.uuid:
+    case dataTypes.timeuuid:
+      return value?.buffer
+        ? new cassandra.types.Uuid(Buffer.from(value.buffer)).toString()
+        : value;
+    case dataTypes.inet:
+      return value.toString();
+    default:
+      return value;
+  }
+}
+
+/**
+ * Convert a driver-decoded value into something that survives the trip to the
+ * renderer and reads sensibly in the grid.
+ *
+ * Driver types like Uuid, Long and InetAddress are class instances, so once
+ * they cross the process boundary they arrive as their raw internals - a UUID
+ * turns into `{ buffer: { type: "Buffer", data: [...] } }`. Containers are
+ * walked recursively so a driver type is converted no matter how deeply it is
+ * nested: set<frozen<udt>>, a udt holding a list, a udt inside a udt, and so on.
+ */
+export function convertValueByType(value: any, type: CassandraType) {
+  if (value == null) {
+    return null;
+  }
+
+  const { code, info } = type ?? {};
+
+  if (code === dataTypes.list || code === dataTypes.set) {
+    return Array.from(value).map((v) => convertValueByType(v, info));
+  }
+
+  if (code === dataTypes.map) {
+    const [keyType, valueType] = info ?? [];
+    const entries = value instanceof Map ? value.entries() : Object.entries(value);
+    const converted = {};
+    for (const [k, v] of entries) {
+      const convertedKey = convertValueByType(k, keyType);
+      converted[convertedKey as string] = convertValueByType(v, valueType);
+    }
+    return converted;
+  }
+
+  if (code === dataTypes.udt) {
+    const converted = {};
+    (info?.fields ?? []).forEach((field) => {
+      converted[field.name] = convertValueByType(value[field.name], field.type);
+    });
+    return converted;
+  }
+
+  if (code === dataTypes.tuple) {
+    // A driver Tuple is not iterable and exposes no indexed properties, so
+    // Array.from(tuple) yields a same-length array of undefined. Read the
+    // backing array instead.
+    const elements = value.elements ?? value;
+    return Array.from(elements).map((v, i) => convertValueByType(v, info?.[i]));
+  }
+
+  return convertScalar(value, code);
+}

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -170,4 +170,73 @@ describe("Cassandra Tests", () => {
     expect(typeof row.text_uuid_map).toBe('object')
     expect(row.text_uuid_map.first).toBe(textVal)
   })
+
+  it("Should convert UUIDs nested inside user defined types to strings", async () => {
+    const keyspace = 'uuid_udt_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    // a udt with a uuid field, used both as a bare column and as the element
+    // type of a collection, plus a udt nested inside another udt
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.item_ref (
+        id UUID,
+        position INT
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.wrapper_type (
+        label TEXT,
+        inner FROZEN<item_ref>
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.nested_udt (
+        username TEXT PRIMARY KEY,
+        single FROZEN<item_ref>,
+        item_list SET<FROZEN<item_ref>>,
+        nested FROZEN<wrapper_type>
+      )
+    `)
+
+    const singleId = '660e8400-e29b-41d4-a716-446655440000'
+    const setIdA = '660e8400-e29b-41d4-a716-446655440001'
+    const setIdB = '660e8400-e29b-41d4-a716-446655440002'
+    const nestedId = '660e8400-e29b-41d4-a716-446655440003'
+
+    await connection.executeQuery(`
+      INSERT INTO ${keyspace}.nested_udt (username, single, item_list, nested)
+      VALUES (
+        'test_user',
+        {id: ${singleId}, position: 1},
+        {{id: ${setIdA}, position: 2}, {id: ${setIdB}, position: 3}},
+        {label: 'wrapped', inner: {id: ${nestedId}, position: 4}}
+      )
+    `)
+
+    const results = await connection.executeQuery(
+      `SELECT * FROM ${keyspace}.nested_udt WHERE username = 'test_user'`
+    )
+    expect(results[0].rows).toHaveLength(1)
+    const row = results[0].rows[0]
+
+    // bare FROZEN<udt> column
+    expect(row.single).toEqual({ id: singleId, position: 1 })
+    expect(typeof row.single.id).toBe('string')
+
+    // SET<FROZEN<udt>> (order is not guaranteed)
+    expect(Array.isArray(row.item_list)).toBe(true)
+    expect([...row.item_list].sort((a, b) => a.position - b.position)).toEqual([
+      { id: setIdA, position: 2 },
+      { id: setIdB, position: 3 },
+    ])
+
+    // udt nested inside a udt
+    expect(row.nested).toEqual({ label: 'wrapped', inner: { id: nestedId, position: 4 } })
+
+    // nothing driver-internal survives the structured clone the IPC boundary
+    // performs on its way to the renderer
+    expect(structuredClone(row)).toEqual(row)
+  })
 })

--- a/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
@@ -1,0 +1,188 @@
+import * as cassandra from "cassandra-driver"
+import { convertValueByType } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
+
+const dataTypes = cassandra.types.dataTypes
+
+const uuid = (code = dataTypes.uuid) => ({ code })
+const text = { code: dataTypes.text }
+const int = { code: dataTypes.int }
+const boolean = { code: dataTypes.boolean }
+
+const list = (info) => ({ code: dataTypes.list, info })
+const set = (info) => ({ code: dataTypes.set, info })
+const map = (keyType, valueType) => ({ code: dataTypes.map, info: [keyType, valueType] })
+const tuple = (...info) => ({ code: dataTypes.tuple, info })
+const udt = (name, fields) => ({
+  code: dataTypes.udt,
+  info: {
+    name,
+    keyspace: "mtm",
+    fields: Object.entries(fields).map(([fieldName, type]) => ({ name: fieldName, type })),
+  },
+})
+
+// The driver hands back Uuid instances. Once they cross the process boundary
+// they arrive as their raw internals, which is what the grid used to render.
+const driverUuid = (value: string) => cassandra.types.Uuid.fromString(value)
+
+const ID_A = "b7e4e35c-1a05-4c93-8a3f-9d2fd6a1f001"
+const ID_B = "0f2b6c1e-9d4a-4e21-8b70-3c1a5e7d2002"
+
+describe("cassandra valueConverter", () => {
+  describe("scalars", () => {
+    it("converts a top level uuid to a string", () => {
+      expect(convertValueByType(driverUuid(ID_A), uuid())).toBe(ID_A)
+    })
+
+    it("converts a timeuuid to a string", () => {
+      const value = cassandra.types.TimeUuid.now()
+      expect(convertValueByType(value, uuid(dataTypes.timeuuid))).toBe(value.toString())
+    })
+
+    it("converts a bigint to a string", () => {
+      expect(convertValueByType(cassandra.types.Long.fromString("9007199254740993"), { code: dataTypes.bigint }))
+        .toBe("9007199254740993")
+    })
+
+    it("converts a timestamp to an ISO string", () => {
+      const date = new Date("2026-08-28T10:11:12.000Z")
+      expect(convertValueByType(date, { code: dataTypes.timestamp })).toBe("2026-08-28T10:11:12.000Z")
+    })
+
+    it("leaves plain types alone", () => {
+      expect(convertValueByType("hello", text)).toBe("hello")
+      expect(convertValueByType(7, int)).toBe(7)
+      expect(convertValueByType(false, boolean)).toBe(false)
+    })
+
+    it("returns null for null and undefined", () => {
+      expect(convertValueByType(null, uuid())).toBeNull()
+      expect(convertValueByType(undefined, uuid())).toBeNull()
+    })
+  })
+
+  describe("collections", () => {
+    it("converts uuids in a list", () => {
+      expect(convertValueByType([driverUuid(ID_A), driverUuid(ID_B)], list(uuid())))
+        .toEqual([ID_A, ID_B])
+    })
+
+    it("converts uuids in a set", () => {
+      expect(convertValueByType([driverUuid(ID_A), driverUuid(ID_B)], set(uuid())))
+        .toEqual([ID_A, ID_B])
+    })
+
+    it("converts uuid keys and values in a map", () => {
+      const value = { [ID_A]: driverUuid(ID_B) }
+      expect(convertValueByType(value, map(uuid(), uuid()))).toEqual({ [ID_A]: ID_B })
+    })
+
+    it("converts a map decoded as an ES6 Map", () => {
+      const value = new Map([[ID_A, driverUuid(ID_B)]])
+      expect(convertValueByType(value, map(uuid(), uuid()))).toEqual({ [ID_A]: ID_B })
+    })
+
+    it("converts values in a tuple position by position", () => {
+      // A real driver Tuple, not a plain array: Tuple is not iterable and has no
+      // indexed properties, so Array.from(tuple) silently yields [undefined, ...]
+      const value = cassandra.types.Tuple.fromArray([driverUuid(ID_A), 3])
+      expect(convertValueByType(value, tuple(uuid(), int))).toEqual([ID_A, 3])
+    })
+
+    it("converts a tuple nested inside a collection", () => {
+      const value = [cassandra.types.Tuple.fromArray([driverUuid(ID_A), 1])]
+      expect(convertValueByType(value, list(tuple(uuid(), int))))
+        .toEqual([[ID_A, 1]])
+    })
+
+    it("does not stringify an already stringified timestamp map key", () => {
+      // The driver builds plain object maps with `map[key] = value`, so a Date
+      // key arrives as a string and must not be handed toISOString()
+      const key = new Date("2026-08-28T10:11:12.000Z").toString()
+      const value = { [key]: driverUuid(ID_A) }
+
+      expect(convertValueByType(value, map({ code: dataTypes.timestamp }, uuid())))
+        .toEqual({ [key]: ID_A })
+    })
+  })
+
+  describe("user defined types", () => {
+    // a udt with a uuid field: the shape at the heart of this bug
+    const itemRef = udt("item_ref", { id: uuid(), position: int })
+
+    it("converts a uuid inside a bare udt column", () => {
+      const ownerRef = udt("owner_ref", { id: uuid(), name: text, description: text })
+      const value = { id: driverUuid(ID_A), name: "Acme", description: null }
+
+      expect(convertValueByType(value, ownerRef))
+        .toEqual({ id: ID_A, name: "Acme", description: null })
+    })
+
+    it("converts uuids inside a set of udts", () => {
+      const value = [
+        { id: driverUuid(ID_A), position: 1 },
+        { id: driverUuid(ID_B), position: 2 },
+      ]
+
+      expect(convertValueByType(value, set(itemRef))).toEqual([
+        { id: ID_A, position: 1 },
+        { id: ID_B, position: 2 },
+      ])
+    })
+
+    it("converts uuids inside a list of udts", () => {
+      const value = [{ id: driverUuid(ID_A), position: 1 }]
+      expect(convertValueByType(value, list(itemRef))).toEqual([{ id: ID_A, position: 1 }])
+    })
+
+    it("converts a collection nested inside a udt", () => {
+      const memberType = udt("member_type", { username: text, roles: set(text), blocked: boolean })
+      const value = { username: "test_user", roles: ["admin", "editor"], blocked: false }
+
+      expect(convertValueByType(value, memberType))
+        .toEqual({ username: "test_user", roles: ["admin", "editor"], blocked: false })
+    })
+
+    it("converts a uuid in a udt nested inside a udt inside a list", () => {
+      // a udt holding another udt, inside a list
+      const meta = udt("note_meta_type", { authorId: uuid() })
+      const comment = udt("note_type", { id: uuid(), meta })
+      const value = [{ id: driverUuid(ID_A), meta: { authorId: driverUuid(ID_B) } }]
+
+      expect(convertValueByType(value, list(comment)))
+        .toEqual([{ id: ID_A, meta: { authorId: ID_B } }])
+    })
+
+    it("converts uuids in a map whose values are udts", () => {
+      const value = { first: { id: driverUuid(ID_A), position: 1 } }
+      expect(convertValueByType(value, map(text, itemRef)))
+        .toEqual({ first: { id: ID_A, position: 1 } })
+    })
+
+    it("keeps null udt fields null", () => {
+      expect(convertValueByType({ id: null, position: null }, itemRef))
+        .toEqual({ id: null, position: null })
+    })
+
+    it("returns null for a null udt column", () => {
+      expect(convertValueByType(null, itemRef)).toBeNull()
+    })
+
+    it("returns null for a null element inside a collection of udts", () => {
+      expect(convertValueByType([null], list(itemRef))).toEqual([null])
+    })
+  })
+
+  it("does not leave driver internals anywhere in a nested value", () => {
+    const itemRef = udt("item_ref", { id: uuid(), position: int })
+    const converted = convertValueByType(
+      [{ id: driverUuid(ID_A), position: 1 }],
+      set(itemRef)
+    )
+
+    // The bug: an unconverted Uuid instance survives the structured clone the
+    // IPC boundary performs and reaches the grid as { buffer: ... }.
+    // (JSON.stringify would hide this - Uuid defines toJSON.)
+    expect(structuredClone(converted)).toEqual([{ id: ID_A, position: 1 }])
+  })
+})


### PR DESCRIPTION
Follow-up to #4220, which fixed UUIDs inside `list`/`set`/`map`. The same symptom appears one level deeper, inside user defined types:

```cql
CREATE TYPE item_ref (id uuid, position int);
CREATE TABLE items (
    name text,
    refs set<frozen<item_ref>>,
    PRIMARY KEY (name)
);
```

The grid and CSV export show `[{"id":{"buffer":{"0":15,"1":190,…}},"position":1}]` instead of `[{"id":"3f1a…","position":1}]`.

### Why

`parseRows` branched on the column's top-level type code and handled `list`/`set`, `map`, and scalars. For a set it mapped elements through `convertValueByType(v, info.code)`, but that only switched on *scalar* codes — a `udt` element (code 48) hit `default:` and came back untouched.

Untouched values are driver class instances. `decodeUdt` decodes each field with the same decoder used for top-level columns, so a `uuid` field is a `types.Uuid`. Rows then cross from the utility process to the renderer over IPC, which uses structured clone — that strips the prototype and leaves raw `{ buffer: … }` behind. `JSON.stringify` hides this since `Uuid` defines `toJSON`; only the clone exposes it.

Bare `frozen<udt>` columns were broken the same way, as were tuples and anything nested deeper, e.g. `list<frozen<udt>>` where the udt holds another udt.

### What changed

Replaced the shape-specific branching with a recursive converter taking the full type descriptor (`{ code, info }`) instead of a bare type code, moved to `clients/cassandra/valueConverter.ts`. It walks `list`/`set`, `map`, `udt`, and `tuple`, converting scalars with the existing switch. `parseRows` is now a one-liner and no container shape can fall through again.

Two things surfaced while testing it:

- `Array.from()` on a driver `Tuple` returns a same-length array of `undefined` — `Tuple` isn't iterable and exposes no indexed properties, only `.get()`, `.values()`, `.elements`. Reads `.elements` now.
- `map<timestamp, …>` keys threw. The driver builds plain object maps via `map[key] = value`, stringifying a `Date` key before we see it, so `toISOString()` was called on a string. Guarded.

### Testing

23 unit tests covering udt, tuple, map, and collection nesting in both directions, plus nulls at each level. Assertions go through `structuredClone` rather than `JSON.stringify` so they reproduce the actual IPC boundary — the JSON version passes even on unconverted values.

Integration test added alongside the existing UUID-collection one, verified against a Cassandra 4.1 container.
