### PR TITLE
Fix missing context menu for AI Shell

### DIFF
--- a/apps/studio/src/assets/styles/components/context-menu.scss
+++ b/apps/studio/src/assets/styles/components/context-menu.scss
@@ -14,27 +14,22 @@ hr {
 
 // ------ Theme Customization ------
 
-.BksContextMenu-list {
-  background: var(--menu-bg);
-  color: $text;
+& {
+  --bks-context-menu-bg-color: var(--menu-bg);
+  --bks-context-menu-fg-color: #{$text};
+  --bks-context-menu-item-fg-color: #{$text-dark};
+  --bks-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
+  --bks-context-menu-item-fg-color-disabled: #{rgba($text-dark, 0.35)};
+  --bks-context-menu-item-bg-color-disabled: transparent;
+  --bks-context-menu-item-shortcut-fg-color: #{rgba($text-dark, 0.5)};
+  --bks-context-menu-divider-border-color: #{$border-color};
 }
 
-.BksContextMenu-item {
-  color: $text-dark;
-  &.disabled {
-    opacity: 0.5;
-    pointer-events: none;
-  }
-  &:hover {
-    background: rgba($theme-base, 0.05);
-  }
-}
-
-.BksContextMenu-item-shortcut {
-  color: $text-dark;
+.BksContextMenu-item.disabled {
   opacity: 0.5;
+  pointer-events: none;
 }
 
-.BksContextMenu-item-divider, hr {
-  border-top: 1px solid $border-color;
+hr {
+  border-top: 1px solid var(--bks-context-menu-divider-border-color);
 }

--- a/apps/studio/src/assets/styles/themes/dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/dark/theme.scss
@@ -219,11 +219,11 @@ $row-handle-selected: color.adjust($query-editor-bg, $lightness: 10%);
   --bks-text-editor-separator-fg-color: #{$text-dark};
   --bks-text-editor-type-fg-color: #{$text-dark};
 
-  --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: 5%)};
-  --bks-text-editor-context-menu-fg-color: #{$text-dark};
-  --bks-text-editor-context-menu-item-bg-color-active: #{color.adjust($theme-secondary, $lightness: -25%)};
-  --bks-text-editor-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
-  --bks-text-editor-context-menu-item-fg-color-active: #ffffff;
+  --bks-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: 5%)};
+  --bks-context-menu-fg-color: #{$text-dark};
+  --bks-context-menu-item-bg-color-active: #{color.adjust($theme-secondary, $lightness: -25%)};
+  --bks-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
+  --bks-context-menu-item-fg-color-active: #ffffff;
 
   --bks-mongo-shell-mongo-prompt-fg: #{$theme-primary};
   --bks-mongo-shell-ansi-output-fg: #{$text-dark};

--- a/apps/studio/src/assets/styles/themes/solarized-dark/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-dark/theme.scss
@@ -6,5 +6,5 @@
 }
 
 & {
-  --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -3%)};
+  --bks-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -3%)};
 }

--- a/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
+++ b/apps/studio/src/assets/styles/themes/solarized-light/theme.scss
@@ -483,9 +483,9 @@ x-buttons {
   --bks-text-editor-cursor-bg-color: #{$text-dark};
   --bks-text-editor-bracket-fg-color: #{$text};
 
-  --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
-  --bks-text-editor-context-menu-item-bg-color-active: #{$brand-info};
-  --bks-text-editor-context-menu-item-fg-color-active: #ffffff;
+  --bks-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
+  --bks-context-menu-item-bg-color-active: #{$brand-info};
+  --bks-context-menu-item-fg-color-active: #ffffff;
 }
 
 .BksTextEditor {
@@ -797,9 +797,9 @@ x-switch {
   --bks-text-editor-panel-bg-color: #{$query-editor-bg};
   --bks-text-editor-panel-fg-color: #{$text-dark};
 
-  --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: 5%)};
-  --bks-text-editor-context-menu-fg-color: #{$text-dark};
-  --bks-text-editor-context-menu-item-bg-color-active: #{color.adjust($theme-secondary, $lightness: -25%)};
-  --bks-text-editor-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
-  --bks-text-editor-context-menu-item-fg-color-active: #ffffff;
+  --bks-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: 5%)};
+  --bks-context-menu-fg-color: #{$text-dark};
+  --bks-context-menu-item-bg-color-active: #{color.adjust($theme-secondary, $lightness: -25%)};
+  --bks-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
+  --bks-context-menu-item-fg-color-active: #ffffff;
 }

--- a/apps/studio/src/services/plugin/web/cssVars.ts
+++ b/apps/studio/src/services/plugin/web/cssVars.ts
@@ -132,10 +132,16 @@ export const cssVars = [
   "--bks-text-editor-sql-alias-fg-color",
   "--bks-text-editor-sql-field-fg-color",
 
-  // BksTextEditor context menu
-  "--bks-text-editor-context-menu-bg-color",
-  "--bks-text-editor-context-menu-fg-color",
-  "--bks-text-editor-context-menu-item-bg-color-active",
-  "--bks-text-editor-context-menu-item-fg-color-active",
-  "--bks-text-editor-context-menu-item-bg-color-hover",
+  // BksContextMenu
+  "--bks-context-menu-bg-color",
+  "--bks-context-menu-fg-color",
+  "--bks-context-menu-border-color",
+  "--bks-context-menu-item-fg-color",
+  "--bks-context-menu-item-bg-color-active",
+  "--bks-context-menu-item-fg-color-active",
+  "--bks-context-menu-item-bg-color-hover",
+  "--bks-context-menu-item-fg-color-disabled",
+  "--bks-context-menu-item-bg-color-disabled",
+  "--bks-context-menu-item-shortcut-fg-color",
+  "--bks-context-menu-divider-border-color",
 ] as const;

--- a/apps/ui-kit/lib/components/context-menu/ContextMenuRoot.vue
+++ b/apps/ui-kit/lib/components/context-menu/ContextMenuRoot.vue
@@ -6,7 +6,7 @@
       :options="options"
       :event="event"
       :item="item"
-      @close="$emit('close')"
+      @close="hideContextMenu"
     />
   </teleport>
 </template>
@@ -16,6 +16,7 @@ import ContextMenu from "./ContextMenu.vue";
 import Teleport from "vue2-teleport"
 import Vue from 'vue'
 import { getContextMenuContainer } from "../../config/context-menu";
+import props from "./props";
 
 export default Vue.extend({
   name: 'ContextMenuRoot',
@@ -23,7 +24,7 @@ export default Vue.extend({
     Teleport,
     ContextMenu,
   },
-  props: ['options', 'event', 'item', 'targetElement'],
+  props,
   data() {
     return {
       menuWidth: null,
@@ -33,7 +34,7 @@ export default Vue.extend({
   },
   methods: {
     hideContextMenu() {
-      this.$emit('close')
+      this.$destroy()
     },
     onEscKeyRelease(event) {
       if (event.keyCode === 27) {
@@ -57,6 +58,9 @@ export default Vue.extend({
   beforeDestroy() {
     document.removeEventListener('mousedown', this.maybeHideMenu)
     document.removeEventListener('keyup', this.onEscKeyRelease);
-  }
+  },
+  destroyed() {
+    this.$emit("bks-destroyed");
+  },
 })
 </script>

--- a/apps/ui-kit/lib/components/context-menu/context-menu.scss
+++ b/apps/ui-kit/lib/components/context-menu/context-menu.scss
@@ -4,6 +4,20 @@
 @use "../../styles/variables" as *;
 @use "../../styles/mixins" as *;
 
+:root {
+  --bks-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: 5%)};
+  --bks-context-menu-fg-color: #{$text};
+  --bks-context-menu-border-color: transparent;
+  --bks-context-menu-item-fg-color: #{$text-dark};
+  --bks-context-menu-item-bg-color-active: #{$brand-info};
+  --bks-context-menu-item-fg-color-active: #ffffff;
+  --bks-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
+  --bks-context-menu-item-fg-color-disabled: #{rgba($text-dark, 0.35)};
+  --bks-context-menu-item-bg-color-disabled: transparent;
+  --bks-context-menu-item-shortcut-fg-color: #{rgba($text-dark, 0.5)};
+  --bks-context-menu-divider-border-color: #{$border-color};
+}
+
 .BksContextMenu-list {
   top: 0;
   left: 0;
@@ -13,8 +27,8 @@
   list-style: none;
   position: absolute;
   z-index: 1000000;
-  background-color: color.adjust($theme-bg, $lightness: 5%);
-  color: $text;
+  background-color: var(--bks-context-menu-bg-color);
+  color: var(--bks-context-menu-fg-color);
   padding: ($gutter-h * 0.75) 0;
   border-radius: 6px;
   box-shadow: var(--elevation-5);
@@ -43,18 +57,18 @@
   padding: 0 $gutter-w;
   font-size: 0.9rem;
   min-height: 28px;
-  color: $text-dark;
+  color: var(--bks-context-menu-item-fg-color);
   cursor: pointer;
   align-items: center;
 
   &:hover {
-    background-color: rgba($theme-base, 0.05);
+    background-color: var(--bks-context-menu-item-bg-color-hover);
   }
 
   &.BksContextMenu-item-disabled {
     pointer-events: none;
-    color: color.adjust($text-dark, $lightness: -25%);
-    background-color: color.adjust(rgba($theme-base, 0.05), $lightness: -25%);
+    color: var(--bks-context-menu-item-fg-color-disabled);
+    background-color: var(--bks-context-menu-item-bg-color-disabled);
   }
 }
 
@@ -65,7 +79,7 @@
 .BksContextMenu-item-shortcut {
   font-size: 0.9rem;
   line-height: 1;
-  color: rgba($text-dark, 0.5);
+  color: var(--bks-context-menu-item-shortcut-fg-color);
   margin-left: 0.4rem;
 }
 
@@ -92,7 +106,7 @@
   box-sizing: border-box;
   background-color: transparent;
   border: 0;
-  border-top: 1px solid $border-color;
+  border-top: 1px solid var(--bks-context-menu-divider-border-color);
   pointer-events: none;
 
   &:last-child {

--- a/apps/ui-kit/lib/components/context-menu/define.ts
+++ b/apps/ui-kit/lib/components/context-menu/define.ts
@@ -1,0 +1,3 @@
+import { ContextMenuElement } from "./index";
+
+window.customElements.define("bks-context-menu", ContextMenuElement);

--- a/apps/ui-kit/lib/components/context-menu/index.ts
+++ b/apps/ui-kit/lib/components/context-menu/index.ts
@@ -1,4 +1,16 @@
-import ContextMenu from "./ContextMenuRoot.vue";
+import Vue from "vue";
+import wrap from "@vue/web-component-wrapper";
+import Component from "./ContextMenuRoot.vue";
+import props from "./props";
+import { PropsToType, VueWrapper } from "../utilTypes";
+import { ContextMenuEventMap } from "./types";
 
-export { ContextMenu };
-export * from "./menu";
+export interface ContextMenuElement
+  extends PropsToType<typeof props>,
+    VueWrapper<ContextMenuElement, ContextMenuEventMap> {}
+
+// @ts-ignore - Third param is valid in our fork
+export const ContextMenuElement = wrap(Vue, Component, {
+  disableShadowDom: true,
+  exposeMethods: [],
+}) as unknown as ContextMenuElement;

--- a/apps/ui-kit/lib/components/context-menu/menu.ts
+++ b/apps/ui-kit/lib/components/context-menu/menu.ts
@@ -45,13 +45,7 @@ export const divider: DividerItem = { type: 'divider', id: 'divider' }
 export function openMenu<Item>(args: MenuProps<Item>) {
   if (isEmpty(args.options)) return
   const ContextComponent = Vue.extend(ContextMenu)
-  const cMenu = new ContextComponent({
-    propsData: args
-  })
-  cMenu.$on('close', () => {
-    cMenu.$off()
-    cMenu.$destroy()
-  })
+  const cMenu = new ContextComponent({ propsData: args })
   cMenu.$mount()
 }
 

--- a/apps/ui-kit/lib/components/context-menu/props.ts
+++ b/apps/ui-kit/lib/components/context-menu/props.ts
@@ -1,0 +1,17 @@
+import { PropType } from "vue";
+import { MenuItem } from "./menu";
+
+const props = {
+  options: {
+    type: Array as PropType<MenuItem[]>,
+    default: () => [],
+  },
+  event: {
+    type: Event,
+    required: true,
+  },
+  item: null as unknown as PropType<unknown>,
+  targetElement: String,
+};
+
+export default props;

--- a/apps/ui-kit/lib/components/context-menu/types.ts
+++ b/apps/ui-kit/lib/components/context-menu/types.ts
@@ -1,0 +1,3 @@
+export interface ContextMenuEventMap extends HTMLElementEventMap {
+  "bks-destroyed": CustomEvent;
+}

--- a/apps/ui-kit/lib/components/define.ts
+++ b/apps/ui-kit/lib/components/define.ts
@@ -3,3 +3,4 @@ import "./text-editor/define";
 import "./sql-text-editor/define";
 import "./table/define";
 import "./entity-list/define";
+import "./context-menu/define";

--- a/apps/ui-kit/lib/components/index.ts
+++ b/apps/ui-kit/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./context-menu";
+export * from "./context-menu/menu";
 export * from "./text-editor";
 export * from "./sql-text-editor";
 export * from "./table";

--- a/apps/ui-kit/lib/components/mongo-shell/props.ts
+++ b/apps/ui-kit/lib/components/mongo-shell/props.ts
@@ -1,6 +1,6 @@
 import { PropType } from "vue";
 import { Keybindings, Keymap } from "../text-editor";
-import { CustomMenuItems } from "../context-menu";
+import { CustomMenuItems } from "../context-menu/menu";
 import { Clipboard, Config } from "../text-editor/extensions/vim";
 import { Extension } from "@codemirror/state";
 

--- a/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
+++ b/apps/ui-kit/lib/components/sql-text-editor/SqlTextEditor.vue
@@ -11,7 +11,7 @@ import {
   ContextMenuExtension,
   InternalContextItem,
   divider,
-} from "../context-menu";
+} from "../context-menu/menu";
 import { format, formatDialect } from "sql-formatter";
 import ProxyEmit from "../mixins/ProxyEmit";
 import Vue from "vue";

--- a/apps/ui-kit/lib/components/surreal-text-editor/SurrealTextEditor.vue
+++ b/apps/ui-kit/lib/components/surreal-text-editor/SurrealTextEditor.vue
@@ -7,7 +7,7 @@ import Vue from "vue";
 import mixin from "../text-editor/mixin";
 import props from "./props";
 import ProxyEmit from "../mixins/ProxyEmit";
-import { ContextMenuExtension, divider, InternalContextItem } from "../context-menu";
+import { ContextMenuExtension, divider, InternalContextItem } from "../context-menu/menu";
 import { SurrealTextEditor } from "./SurrealTextEditor";
 import { Entity } from "../types";
 import { SurrealTextEditorMenuContext } from "./types";

--- a/apps/ui-kit/lib/components/text-editor/extensions/index.ts
+++ b/apps/ui-kit/lib/components/text-editor/extensions/index.ts
@@ -292,13 +292,13 @@ export function extensions(config: ExtensionConfiguration = {}) {
       },
       // Autocomplete hints
       ".cm-tooltip": {
-        backgroundColor: "var(--bks-text-editor-context-menu-bg-color)",
-        color: "var(--bks-text-editor-context-menu-fg-color)",
-        borderColor: "var(--bks-text-editor-context-menu-border-color)",
+        backgroundColor: "var(--bks-context-menu-bg-color)",
+        color: "var(--bks-context-menu-fg-color)",
+        borderColor: "var(--bks-context-menu-border-color)",
       },
       ".cm-tooltip-autocomplete ul li[aria-selected]": {
-        backgroundColor: "var(--bks-text-editor-context-menu-item-bg-color-active)",
-        color: "var(--bks-text-editor-context-menu-item-fg-color-active)",
+        backgroundColor: "var(--bks-context-menu-item-bg-color-active)",
+        color: "var(--bks-context-menu-item-fg-color-active)",
         padding: "0.2rem 0.4rem",
       },
     }),

--- a/apps/ui-kit/lib/components/text-editor/mixin.ts
+++ b/apps/ui-kit/lib/components/text-editor/mixin.ts
@@ -5,7 +5,7 @@ import {
   divider,
   InternalContextItem,
   openMenu,
-} from "../context-menu";
+} from "../context-menu/menu";
 import { readClipboard, writeClipboard } from "../../utils";
 import { TextEditorBlurEvent, TextEditorFocusEvent, TextEditorInitializedEvent, TextEditorLSPReadyEvent, TextEditorMenuContext, TextEditorSelectionChangeEvent, TextEditorValueChangeEvent } from "./types";
 

--- a/apps/ui-kit/lib/components/text-editor/props.ts
+++ b/apps/ui-kit/lib/components/text-editor/props.ts
@@ -1,4 +1,4 @@
-import type { CustomMenuItems } from "../context-menu";
+import type { CustomMenuItems } from "../context-menu/menu";
 import { PropType } from "vue";
 import { Keybindings, Keymap, LanguageServerConfiguration, EditorMarker, LineGutter } from "./types";
 import { Extension } from "@codemirror/state";

--- a/apps/ui-kit/lib/components/text-editor/text-editor.scss
+++ b/apps/ui-kit/lib/components/text-editor/text-editor.scss
@@ -112,14 +112,6 @@
   // Not --bks-text-editor-font-size, which tracks the user's font size setting.
   --bks-text-editor-vim-panel-font-size: 0.875rem;
   --bks-text-editor-vim-panel-border: 1px solid rgba(128, 128, 128, 0.35);
-
-  // Context Menu
-  --bks-text-editor-context-menu-bg-color: #{color.adjust($theme-bg, $lightness: -5%)};
-  --bks-text-editor-context-menu-fg-color: #{$text-dark};
-  --bks-text-editor-context-menu-border-color: transparent;
-  --bks-text-editor-context-menu-item-bg-color-active: #{$brand-info};
-  --bks-text-editor-context-menu-item-fg-color-active: #ffffff;
-  --bks-text-editor-context-menu-item-bg-color-hover: #{rgba($theme-base, 0.05)};
 }
 
 .BksTextEditor {
@@ -308,7 +300,7 @@
     cursor: pointer;
 
     &:hover:not([aria-selected]) {
-      background-color: var(--bks-text-editor-context-menu-item-bg-color-hover);
+      background-color: var(--bks-context-menu-item-bg-color-hover);
     }
 
     // Option type-based styling

--- a/apps/ui-kit/lib/index.ts
+++ b/apps/ui-kit/lib/index.ts
@@ -2,5 +2,5 @@ import "./style.scss"
 
 export type * from "./components"
 export { setClipboard } from "./utils/clipboard";
-export { divider, openMenu } from "./components/context-menu";
+export { divider, openMenu } from "./components/context-menu/menu";
 export { formatDisplayKeybinding } from "./utils/formatDisplayKeybinding";

--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -7,7 +7,7 @@
     "url": "https://beekeeperstudio.io"
   },
   "private": false,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/beekeeper-studio/beekeeper-studio.git",

--- a/apps/ui-kit/package.json
+++ b/apps/ui-kit/package.json
@@ -19,45 +19,118 @@
   "homepage": "https://beekeeperstudio.io",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "lib/components/text-editor/extensions/redisCommands.json"
   ],
   "main": "./dist/index.js",
   "style": "./dist/style.css",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./style.css": "./dist/style.css",
-    "./table": "./dist/table.js",
-    "./entity-list": "./dist/entity-list.js",
-    "./sql-text-editor": "./dist/sql-text-editor.js",
-    "./text-editor": "./dist/text-editor.js",
+    "./table": {
+      "types": "./dist/components/table/index.d.ts",
+      "import": "./dist/table.js"
+    },
+    "./entity-list": {
+      "types": "./dist/components/entity-list/index.d.ts",
+      "import": "./dist/entity-list.js"
+    },
+    "./sql-text-editor": {
+      "types": "./dist/components/sql-text-editor/index.d.ts",
+      "import": "./dist/sql-text-editor.js"
+    },
+    "./text-editor": {
+      "types": "./dist/components/text-editor/index.d.ts",
+      "import": "./dist/text-editor.js"
+    },
+    "./data-editor": {
+      "types": "./dist/components/data-editor/index.d.ts",
+      "import": "./dist/data-editor.js"
+    },
     "./lib/components/text-editor/extensions/redisCommands.json": "./lib/components/text-editor/extensions/redisCommands.json",
-    "./mongo-shell": "./dist/mongo-shell.js",
-    "./mongo-shell/state": "./dist/mongo-shell/state.js",
-    "./super-formatter": "./dist/super-formatter.js",
-    "./surreal-text-editor": "./dist/surreal-text-editor.js",
-    "./merge-text-editor": "./dist/merge-text-editor.js",
-    "./tree": "./dist/tree.js",
-    "./vue/table": "./dist/vue/table.js",
-    "./vue/entity-list": "./dist/vue/entity-list.js",
-    "./vue/sql-text-editor": "./dist/vue/sql-text-editor.js",
-    "./vue/data-editor": "./dist/vue/data-editor.js",
-    "./vue/text-editor": "./dist/vue/text-editor.js",
-    "./vue/mongo-shell": "./dist/vue/mongo-shell.js",
-    "./vue/super-formatter": "./dist/vue/super-formatter.js",
-    "./vue/surreal-text-editor": "./dist/vue/surreal-text-editor.js",
-    "./vue/merge-text-editor": "./dist/vue/merge-text-editor.js",
-    "./vue/tree": "./dist/vue/tree.js",
-    "./config/context-menu": "./dist/config/context-menu.js"
+    "./mongo-shell": {
+      "types": "./dist/components/mongo-shell/index.d.ts",
+      "import": "./dist/mongo-shell.js"
+    },
+    "./mongo-shell/state": {
+      "types": "./dist/components/mongo-shell/state.d.ts",
+      "import": "./dist/mongo-shell/state.js"
+    },
+    "./super-formatter": {
+      "types": "./dist/components/super-formatter/index.d.ts",
+      "import": "./dist/super-formatter.js"
+    },
+    "./surreal-text-editor": {
+      "types": "./dist/components/surreal-text-editor/index.d.ts",
+      "import": "./dist/surreal-text-editor.js"
+    },
+    "./merge-text-editor": {
+      "types": "./dist/components/merge-text-editor/index.d.ts",
+      "import": "./dist/merge-text-editor.js"
+    },
+    "./tree": {
+      "types": "./dist/components/tree/index.d.ts",
+      "import": "./dist/tree.js"
+    },
+    "./context-menu": {
+      "types": "./dist/components/context-menu/index.d.ts",
+      "import": "./dist/context-menu.js"
+    },
+    "./vue/table": {
+      "types": "./dist/components/table/index.d.ts",
+      "import": "./dist/vue/table.js"
+    },
+    "./vue/entity-list": {
+      "types": "./dist/components/entity-list/index.d.ts",
+      "import": "./dist/vue/entity-list.js"
+    },
+    "./vue/sql-text-editor": {
+      "types": "./dist/components/sql-text-editor/index.d.ts",
+      "import": "./dist/vue/sql-text-editor.js"
+    },
+    "./vue/data-editor": {
+      "types": "./dist/components/data-editor/index.d.ts",
+      "import": "./dist/vue/data-editor.js"
+    },
+    "./vue/text-editor": {
+      "types": "./dist/components/text-editor/index.d.ts",
+      "import": "./dist/vue/text-editor.js"
+    },
+    "./vue/mongo-shell": {
+      "types": "./dist/components/mongo-shell/index.d.ts",
+      "import": "./dist/vue/mongo-shell.js"
+    },
+    "./vue/super-formatter": {
+      "types": "./dist/components/super-formatter/index.d.ts",
+      "import": "./dist/vue/super-formatter.js"
+    },
+    "./vue/surreal-text-editor": {
+      "types": "./dist/components/surreal-text-editor/index.d.ts",
+      "import": "./dist/vue/surreal-text-editor.js"
+    },
+    "./vue/merge-text-editor": {
+      "types": "./dist/components/merge-text-editor/index.d.ts",
+      "import": "./dist/vue/merge-text-editor.js"
+    },
+    "./vue/tree": {
+      "types": "./dist/components/tree/index.d.ts",
+      "import": "./dist/vue/tree.js"
+    },
+    "./config/context-menu": {
+      "types": "./dist/config/context-menu.d.ts",
+      "import": "./dist/config/context-menu.js"
+    }
   },
   "scripts": {
     "dev": "vite -c vite.config.dev.ts",
-    "lib:dev": "vite build -c vite.config.ts --watch --mode development",
+    "lib:dev": "concurrently \"vite build -c vite.config.ts --watch --mode development\" \"vite build -c vite.config.vue.ts --watch --mode development\"",
     "lib:types": "tsc -p ./tsconfig.types.json",
     "test": "vitest run",
-    "build": "vite build -c vite.config.ts --mode production && yarn lib:types",
+    "build": "vite build -c vite.config.ts --mode production && vite build -c vite.config.vue.ts --mode production && yarn lib:types",
     "preview": "vite preview"
   },
   "peerDependencies": {
@@ -95,19 +168,23 @@
     "@codemirror/view": "^6.36.2",
     "@lezer/highlight": "^1.2.1",
     "@marimo-team/codemirror-languageserver": "^1.15.25",
+    "@open-rpc/client-js": "^1.8.1",
     "@replit/codemirror-emacs": "^6.1.0",
     "@replit/codemirror-indentation-markers": "^6.5.3",
     "@replit/codemirror-vim": "^6.3.0",
     "@surrealdb/codemirror": "^1.0.0-beta.21",
+    "@types/tabulator-tables": "^6.3.4",
     "ansi-to-html": "^0.7.2",
-    "highlight.js": "^11.11.1"
+    "highlight.js": "^11.11.1",
+    "sql-formatter": "15.7.3",
+    "sql-query-identifier": "^3.2.0",
+    "tabulator-tables": "^6.5.0",
+    "vscode-languageserver-protocol": "^3.17.5"
   },
   "devDependencies": {
-    "@open-rpc/client-js": "^1.8.1",
     "@pdanpdan/vue-keyboard-trap": "^1.0.19",
     "@types/codemirror": "^0.0.97",
     "@types/lodash": "^4.14.159",
-    "@types/tabulator-tables": "^6.3.4",
     "@vue/web-component-wrapper": "beekeeper-studio/vue-web-component-wrapper#635e4b427b90e199c273b194cf9db6b744d63e95",
     "codemirror": "^5.63.1",
     "concurrently": "^8.2.2",
@@ -121,9 +198,6 @@
     "sass": "~1.77.1",
     "scrollyfills": "^1.0.0",
     "split.js": "^1.5.11",
-    "sql-formatter": "15.7.3",
-    "sql-query-identifier": "^3.2.0",
-    "tabulator-tables": "^6.5.0",
     "tinyduration": "^3.2.4",
     "typescript": "~5.8.3",
     "vite": "^8.0.8",
@@ -135,5 +209,11 @@
     "vue-virtual-scroll-list": "^2.3.5",
     "vue2-teleport": "^1.1.4",
     "vuedraggable": "^2.24.2"
-  }
+  },
+  "peerDependenciesMeta": {
+    "vue": {
+      "optional": true
+    }
+  },
+  "types": "./dist/index.d.ts"
 }

--- a/apps/ui-kit/tsconfig.types.json
+++ b/apps/ui-kit/tsconfig.types.json
@@ -21,7 +21,9 @@
     "lib/components/sql-text-editor/types.ts",
     "lib/components/data-editor/types.ts",
     "lib/components/surreal-text-editor/types.ts",
-    "lib/components/tree/types.ts"
+    "lib/components/tree/types.ts",
+    "lib/config/context-menu.ts",
+    "lib/components/mongo-shell/state.ts"
   ],
   "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts", "lib/components/sql-text-editor/define.ts"]
 }

--- a/apps/ui-kit/vite.config.ts
+++ b/apps/ui-kit/vite.config.ts
@@ -7,7 +7,6 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      // Aliasing `vue` here would defeat the external below.
       "@": resolve('./lib'),
     },
     dedupe: ["@codemirror/state", "@codemirror/view"],
@@ -18,34 +17,7 @@ export default defineConfig({
   define: process.env.VITEST ? {} : { global: 'navigator' },
   build: {
     lib: {
-      entry: resolve(__dirname, "lib/index.ts"),
-      name: "BksUiKit",
-      formats: ["es"],
-      fileName: () => `[name].js`,
-      // Vite 8 names the merged lib CSS bundle after the package ("ui-kit.css")
-      // by default. Keep emitting "style.css" so the package exports map and
-      // consumers importing "@beekeeperstudio/ui-kit/style.css" keep working.
-      cssFileName: "style",
-    },
-    rollupOptions: {
-      external: [
-        // A second copy of Vue makes $store undefined in host components.
-        "vue",
-        "@codemirror/state",
-        "@codemirror/view",
-        "@codemirror/language",
-        "@codemirror/commands",
-        "@codemirror/search",
-        "@codemirror/lint",
-        "@codemirror/lang-sql",
-        "@codemirror/autocomplete",
-        "@codemirror/merge",
-        "@replit/codemirror-emacs",
-        "@replit/codemirror-vim",
-        "@marimo-team/codemirror-languageserver",
-      ],
-      input: {
-        index: resolve(__dirname, "lib/index.ts"),
+      entry: {
         table: resolve(__dirname, "lib/components/table/define.ts"),
         "entity-list": resolve(
           __dirname,
@@ -84,42 +56,37 @@ export default defineConfig({
           "lib/components/merge-text-editor/define.ts"
         ),
         tree: resolve(__dirname, "lib/components/tree/define.ts"),
-        "vue/table": resolve(__dirname, "lib/components/table/Table.vue"),
-        "vue/entity-list": resolve(
+        "context-menu": resolve(
           __dirname,
-          "lib/components/entity-list/EntityList.vue"
+          "lib/components/context-menu/define.ts"
         ),
-        "vue/sql-text-editor": resolve(
-          __dirname,
-          "lib/components/sql-text-editor/SqlTextEditor.vue"
-        ),
-        "vue/mongo-shell": resolve(
-          __dirname,
-          "lib/components/mongo-shell/MongoShell.vue"
-        ),
-        "vue/data-editor": resolve(
-          __dirname,
-          "lib/components/data-editor/DataEditor.vue"
-        ),
-        "vue/text-editor": resolve(
-          __dirname,
-          "lib/components/text-editor/TextEditor.vue"
-        ),
-        "vue/surreal-text-editor": resolve(
-          __dirname,
-          "lib/components/surreal-text-editor/SurrealTextEditor.vue"
-        ),
-        "vue/merge-text-editor": resolve(
-          __dirname,
-          "lib/components/merge-text-editor/MergeTextEditor.vue"
-        ),
-        "vue/super-formatter": resolve(
-          __dirname,
-          "lib/components/super-formatter/SuperFormatter.vue"
-        ),
-        "vue/tree": resolve(__dirname, "lib/vue/tree.ts"),
         "config/context-menu": resolve(__dirname, "lib/config/context-menu.ts"),
       },
+      formats: ["es"],
+      fileName: () => `[name].js`,
+      cssFileName: "web-components-style",
+    },
+    rollupOptions: {
+      external: [
+        // Externalize this because @codemirror/state uses instanceof checks.
+        "@codemirror/state",
+        "@codemirror/view",
+        "@codemirror/language",
+        "@codemirror/commands",
+        "@codemirror/search",
+        "@codemirror/lint",
+        "@codemirror/lang-sql",
+        "@codemirror/lang-html",
+        "@codemirror/lang-javascript",
+        "@codemirror/lang-json",
+        "@lezer/highlight",
+        "@surrealdb/codemirror",
+        "@codemirror/autocomplete",
+        "@codemirror/merge",
+        "@replit/codemirror-emacs",
+        "@replit/codemirror-vim",
+        "@marimo-team/codemirror-languageserver",
+      ],
     },
     outDir: "dist",
     sourcemap: true,

--- a/apps/ui-kit/vite.config.vue.ts
+++ b/apps/ui-kit/vite.config.vue.ts
@@ -1,0 +1,91 @@
+import { defineConfig } from "vite";
+import vue from "vite-ng-plugin-vue2";
+import { resolve } from "path";
+
+// The entries a Vue 2 host imports directly: the root (openMenu mounts with the
+// host's Vue) and ./vue/*. A second Vue makes $store undefined in host components.
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      // Aliasing `vue` here would defeat the external below.
+      "@": resolve("./lib"),
+    },
+    dedupe: ["@codemirror/state", "@codemirror/view"],
+  },
+  optimizeDeps: {
+    include: ["@codemirror/state", "@codemirror/view"],
+  },
+  define: process.env.VITEST ? {} : { global: "navigator" },
+  build: {
+    // vite.config.ts runs first and clears dist; this pass adds to it.
+    emptyOutDir: false,
+    lib: {
+      entry: {
+        index: resolve(__dirname, "lib/index.ts"),
+        "vue/table": resolve(__dirname, "lib/components/table/Table.vue"),
+        "vue/entity-list": resolve(
+          __dirname,
+          "lib/components/entity-list/EntityList.vue"
+        ),
+        "vue/sql-text-editor": resolve(
+          __dirname,
+          "lib/components/sql-text-editor/SqlTextEditor.vue"
+        ),
+        "vue/mongo-shell": resolve(
+          __dirname,
+          "lib/components/mongo-shell/MongoShell.vue"
+        ),
+        "vue/data-editor": resolve(
+          __dirname,
+          "lib/components/data-editor/DataEditor.vue"
+        ),
+        "vue/text-editor": resolve(
+          __dirname,
+          "lib/components/text-editor/TextEditor.vue"
+        ),
+        "vue/surreal-text-editor": resolve(
+          __dirname,
+          "lib/components/surreal-text-editor/SurrealTextEditor.vue"
+        ),
+        "vue/merge-text-editor": resolve(
+          __dirname,
+          "lib/components/merge-text-editor/MergeTextEditor.vue"
+        ),
+        "vue/super-formatter": resolve(
+          __dirname,
+          "lib/components/super-formatter/SuperFormatter.vue"
+        ),
+        "vue/tree": resolve(__dirname, "lib/vue/tree.ts"),
+      },
+      formats: ["es"],
+      fileName: () => `[name].js`,
+      cssFileName: "style",
+    },
+    rollupOptions: {
+      external: [
+        "vue",
+        // A second copy of @codemirror/state breaks instanceof checks.
+        "@codemirror/state",
+        "@codemirror/view",
+        "@codemirror/language",
+        "@codemirror/commands",
+        "@codemirror/search",
+        "@codemirror/lint",
+        "@codemirror/lang-sql",
+        "@codemirror/lang-html",
+        "@codemirror/lang-javascript",
+        "@codemirror/lang-json",
+        "@lezer/highlight",
+        "@surrealdb/codemirror",
+        "@codemirror/autocomplete",
+        "@codemirror/merge",
+        "@replit/codemirror-emacs",
+        "@replit/codemirror-vim",
+        "@marimo-team/codemirror-languageserver",
+      ],
+    },
+    outDir: "dist",
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
- Export context menu component so AI Shell can use it
- Fix build setup

UI Kit has been externalizing `vue` since https://github.com/beekeeper-studio/beekeeper-studio/pull/4502. Because of that, AI Shell cannot upgrade this package right now because AI Shell uses vue 3, and UI Kit uses vue 2. To make this work, this PR separates the vite config into two types; vue component and web component.

If you use a vue component, it will share the same vue instance that the project uses:

```ts
// TabQueryEditor.vue
import SqlTextEditor from "@beekeeperstudio/ui-kit/vue/sql-text-editor";
```

If you use a web component, which is what AI Shell does, it will not share the same vue instance, and will create its own vue internally:

```ts
// main.ts
import "@beekeeperstudio/ui-kit/sql-text-editor";
```