### PR TITLE
Fix plugin theme does not sync with system theme

### DIFF
--- a/apps/studio/src/components/plugins/PluginController.vue
+++ b/apps/studio/src/components/plugins/PluginController.vue
@@ -8,6 +8,11 @@ export default Vue.extend({
   props: {
     editorFontSize: Number,
   },
+  data() {
+    return {
+      darkMedia: null,
+    };
+  },
   computed: {
     rootBindings() {
       return [
@@ -31,7 +36,7 @@ export default Vue.extend({
     },
   },
   methods: {
-    handleChangedTheme(themeValue: string) {
+    handleChangedTheme() {
       const data: PluginNotificationData = {
         name: "themeChanged",
         args: this.$plugin.pluginStore.getTheme(),
@@ -44,9 +49,12 @@ export default Vue.extend({
   },
   mounted() {
     this.registerHandlers(this.rootBindings);
+    this.darkMedia = window.matchMedia("(prefers-color-scheme: dark)");
+    this.darkMedia.addEventListener("change", this.handleChangedTheme);
   },
   beforeDestroy() {
     this.unregisterHandlers(this.rootBindings);
+    this.darkMedia?.removeEventListener("change", this.handleChangedTheme);
   },
   render() {
     return null;

--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -10,7 +10,6 @@ import { FileHelpers } from "@/types";
 import type Noty from "noty";
 import { AppEvent } from "@/common/AppEvent";
 import { WebPluginCommandExecutor } from "./WebPluginCommandExecutor";
-import { convertToManifestV1, mapViewsAndMenuFromV0ToV1 } from "../utils";
 
 const log = rawLog.scope("WebPluginManager");
 


### PR DESCRIPTION
This happens when the system theme changes while a plugin tab is opened.

To replicate:
1. Open a plugin
2. Go to Devtools >  ⋮ > More tools > Rendering > Emulate CSS media feature prefers-color-scheme
3. Switch it to light or dark

https://github.com/user-attachments/assets/27414063-fdec-4b19-b115-4481316fceaf

We should get this behavior when the theme is `system`. If we pick a different theme, it should keep using that theme just like the app:

https://github.com/user-attachments/assets/49759a57-f9ce-4acf-9a3a-3761c5d77230