### PR TITLE
Load saved connections that are tied to used connections

### DIFF
--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -685,7 +685,7 @@ export default Vue.extend({
 })
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .connection-heading {
   display: flex;
 

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -36,23 +36,28 @@ const log = rawLog.scope('Appdb handlers');
 const pluralKeys = [
   'connectionFolderIds',
   'queryFolderIds',
-  'parentIds'
+  'parentIds',
+  'ids'
 ]
 
-function paramsToWhere(params: Record<string, any>): FindOptionsWhere<any> {
-  const where = {};
-  for (const key of pluralKeys) {
-    if (key in params) {
-      const singular = key.replace(/Ids$/, 'Id');
-      if (params[key] && params[key].length > 0) {
-        where[singular] = In(params[key]);
-      } else {
-        where[singular] = IsNull();
+function paramsToWhere(params: Record<string, any> | Array<Record<string, any>>): FindOptionsWhere<any>[] {
+  params = _.isArray(params) ? params : [params];
+
+  return params.map((p: Record<string, any>) => {
+    const where = {};
+    for (const key of pluralKeys) {
+      if (key in p) {
+        const singular = key.replace(/Ids$/, 'Id').replace(/ids$/, 'id');
+        if (p[key] && p[key].length > 0) {
+          where[singular] = In(p[key]);
+        } else {
+          where[singular] = IsNull();
+        }
       }
     }
-  }
 
-  return where;
+    return where;
+  })
 }
 
 async function defaultTransform<T extends Transport>(obj: T, cls: any) {

--- a/apps/studio/src/handlers/appDbHandlers.ts
+++ b/apps/studio/src/handlers/appDbHandlers.ts
@@ -38,7 +38,14 @@ const pluralKeys = [
   'queryFolderIds',
   'parentIds',
   'ids'
-]
+];
+
+const pluralToSingular = {
+  'connectionFolderIds': 'connectionFolderId',
+  'queryFolderIds': 'queryFolderId',
+  'parentIds': 'parentId',
+  'ids': 'id'
+};
 
 function paramsToWhere(params: Record<string, any> | Array<Record<string, any>>): FindOptionsWhere<any>[] {
   params = _.isArray(params) ? params : [params];
@@ -47,7 +54,7 @@ function paramsToWhere(params: Record<string, any> | Array<Record<string, any>>)
     const where = {};
     for (const key of pluralKeys) {
       if (key in p) {
-        const singular = key.replace(/Ids$/, 'Id').replace(/ids$/, 'id');
+        const singular = pluralToSingular[key] ?? '';
         if (p[key] && p[key].length > 0) {
           where[singular] = In(p[key]);
         } else {

--- a/apps/studio/src/store/modules/data/DataModuleBase.ts
+++ b/apps/studio/src/store/modules/data/DataModuleBase.ts
@@ -193,7 +193,6 @@ export function utilActionsFor<T extends Transport>(type: string, other: any = {
           ...(options.params ? { params: options.params } : {})
         };
         const items = await Vue.prototype.$util.send(`appdb/${type}/find`, { options: findOpts });
-        log.info(`Util loaded ${items.length} items`)
         await context.dispatch('mutate', { type: 'upsert', data: items });
       }, options.onError)
     },

--- a/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
@@ -39,13 +39,10 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
     ...actionsFor<ICloudSavedConnection>('connections', {}),
     ...accessGrantActions('connections'),
     ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, false, { field: 'linkedSavedConnectionIds', update: 'loadLinkedSavedConnectionIds' }),
-    async initialize(context) {
-      await context.dispatch('loadLinkedSavedConnectionIds');
+    initialize() {
     },
     async poll(context) {
       if (!context.rootState.connected) {
-        await context.dispatch('loadLinkedSavedConnectionIds');
-
         const expandedFolderIds = context.rootState.sidebar.connections.expandedIds
         const result = await context.dispatch('loadByParentIds', expandedFolderIds)
         if (result.error) {

--- a/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
@@ -6,7 +6,9 @@ import { FolderFetchModule, treeActions } from "@/store/modules/data/tree/treeSt
 import { ItemNodeModule } from "@/store/modules/data/tree/ItemNodeModule";
 import _ from "lodash";
 
-type State = DataState<ICloudSavedConnection>;
+type State = DataState<ICloudSavedConnection> & {
+  linkedSavedConnectionIds: number[]
+};
 
 export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
   namespaced: true,
@@ -18,10 +20,14 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
     filter: undefined,
     pendingSaveIds: [],
     searching: false,
+    linkedSavedConnectionIds: []
   },
   mutations: mutationsFor<ICloudSavedConnection>({
     connectionFilter(state: State, str: string) {
       state.filter = str;
+    },
+    linkedSavedConnectionIds(state: State, conns: number[]) {
+      state.linkedSavedConnectionIds = conns;
     },
     ...accessGrantMutations(),
   }, { field: 'name', direction: 'asc'}),
@@ -32,12 +38,14 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
   actions: {
     ...actionsFor<ICloudSavedConnection>('connections', {}),
     ...accessGrantActions('connections'),
-    ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }),
-    async initialize() {
-      // noop
+    ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, false, { field: 'linkedSavedConnectionIds', update: 'loadLinkedSavedConnectionIds' }),
+    async initialize(context) {
+      await context.dispatch('loadLinkedSavedConnectionIds');
     },
     async poll(context) {
       if (!context.rootState.connected) {
+        await context.dispatch('loadLinkedSavedConnectionIds');
+
         const expandedFolderIds = context.rootState.sidebar.connections.expandedIds
         const result = await context.dispatch('loadByParentIds', expandedFolderIds)
         if (result.error) {
@@ -142,6 +150,14 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
         // Clear pending status
         context.commit('removePendingSave', item.id)
       }
+    },
+    async loadLinkedSavedConnectionIds(context) {
+      const used = context.rootGetters['data/usedconnections/orderedUsedConfigs'];
+      if (!used) return;
+
+      const ids = used.map((u) => u.connectionId);
+
+      context.commit('linkedSavedConnectionIds', ids);
     }
   },
   getters: {

--- a/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
@@ -38,7 +38,7 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
   actions: {
     ...actionsFor<ICloudSavedConnection>('connections', {}),
     ...accessGrantActions('connections'),
-    ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, false, { field: 'linkedSavedConnectionIds', update: 'loadLinkedSavedConnectionIds' }),
+    ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, false),
     initialize() {
     },
     async poll(context) {
@@ -155,6 +155,28 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
       const ids = used.map((u) => u.connectionId);
 
       context.commit('linkedSavedConnectionIds', ids);
+    },
+    async loadByParentIds(context, parentIds: number[]) {
+      if (context.state.linkedSavedConnectionIds.length === 0) {
+        await context.dispatch('loadLinkedSavedConnectionIds');
+      }
+
+      let persistentIds = [];
+      if (!_.isNil(context.state.linkedSavedConnectionIds)) {
+        persistentIds = context.state.linkedSavedConnectionIds;
+      }
+
+      return await context.dispatch('loadWithOptions', {
+        parentIds,
+        persistentIds
+      });
+    },
+    async unloadByParentIds(context, parentIds: number[]) {
+      const persistentIds = context.state.linkedSavedConnectionIds ?? [];
+      return context.dispatch('unloadWithOptions', {
+        parentIds,
+        persistentIds
+      });
     }
   },
   getters: {

--- a/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
@@ -157,7 +157,7 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
       context.commit('linkedSavedConnectionIds', ids);
     },
     async loadByParentIds(context, parentIds: number[]) {
-      if (context.state.linkedSavedConnectionIds.length === 0) {
+      if (context.state.linkedSavedConnectionIds?.length === 0) {
         await context.dispatch('loadLinkedSavedConnectionIds');
       }
 

--- a/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/CloudConnectionModule.ts
@@ -39,7 +39,7 @@ export const CloudConnectionModule: DataStore<ICloudSavedConnection, State> = {
     ...actionsFor<ICloudSavedConnection>('connections', {}),
     ...accessGrantActions('connections'),
     ...treeActions<ICloudSavedConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, false),
-    initialize() {
+    async initialize() {
     },
     async poll(context) {
       if (!context.rootState.connected) {

--- a/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
@@ -39,7 +39,7 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
   actions: {
     ...utilActionsFor<IConnection>('saved', {}),
     ...accessGrantActions('connections'),
-    ...treeActions<IConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, true, { field: 'linkedSavedConnectionIds', update: 'loadLinkedSavedConnectionIds' }),
+    ...treeActions<IConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, true),
     async initialize() {
       // no-op
     },
@@ -127,6 +127,28 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
       const ids = used.map((u) => u.connectionId);
 
       context.commit('linkedSavedConnectionIds', ids);
+    },
+    async loadByParentIds(context, parentIds: number[]) {
+      if (context.state.linkedSavedConnectionIds.length === 0) {
+        await context.dispatch('loadLinkedSavedConnectionIds');
+      }
+
+      let persistentIds = [];
+      if (!_.isNil(context.state.linkedSavedConnectionIds)) {
+        persistentIds = context.state.linkedSavedConnectionIds;
+      }
+
+      return await context.dispatch('loadWithOptions', {
+        parentIds,
+        persistentIds
+      });
+    },
+    async unloadByParentIds(context, parentIds: number[]) {
+      const persistentIds = context.state.linkedSavedConnectionIds ?? [];
+      return context.dispatch('unloadWithOptions', {
+        parentIds,
+        persistentIds
+      });
     }
   },
   getters: {

--- a/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
@@ -129,7 +129,7 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
       context.commit('linkedSavedConnectionIds', ids);
     },
     async loadByParentIds(context, parentIds: number[]) {
-      if (context.state.linkedSavedConnectionIds.length === 0) {
+      if (context.state.linkedSavedConnectionIds?.length === 0) {
         await context.dispatch('loadLinkedSavedConnectionIds');
       }
 

--- a/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/connection/UtilityConnectionModule.ts
@@ -6,7 +6,9 @@ import { ItemNodeModule } from "@/store/modules/data/tree/ItemNodeModule";
 import _ from "lodash";
 import Vue from "vue";
 
-type State = DataState<IConnection>
+type State = DataState<IConnection> & {
+  linkedSavedConnectionIds: number[]
+}
 
 export const UtilConnectionModule: DataStore<IConnection, State> = {
   namespaced: true,
@@ -18,11 +20,15 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
       pollError: null,
       filter: undefined,
       pendingSaveIds: [],
+      linkedSavedConnectionIds: []
     }
   },
   mutations: mutationsFor<IConnection>({
     connectionFilter(state: DataState<IConnection>, str: string) {
       state.filter = str;
+    },
+    linkedSavedConnectionIds(state: State, conns: number[]) {
+      state.linkedSavedConnectionIds = conns;
     },
     ...accessGrantMutations(),
   }),
@@ -33,8 +39,8 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
   actions: {
     ...utilActionsFor<IConnection>('saved', {}),
     ...accessGrantActions('connections'),
-    ...treeActions<IConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, true),
-    initialize() {
+    ...treeActions<IConnection>({ plural: 'connectionFolderIds', singular: 'connectionFolderId' }, true, { field: 'linkedSavedConnectionIds', update: 'loadLinkedSavedConnectionIds' }),
+    async initialize() {
       // no-op
     },
     async afterMutate(context, { type, data }) {
@@ -114,6 +120,13 @@ export const UtilConnectionModule: DataStore<IConnection, State> = {
       }
 
       return item.id
+    },
+    async loadLinkedSavedConnectionIds(context) {
+      const used = context.rootGetters['data/usedconnections/orderedUsedConfigs'];
+      if (!used) return;
+      const ids = used.map((u) => u.connectionId);
+
+      context.commit('linkedSavedConnectionIds', ids);
     }
   },
   getters: {

--- a/apps/studio/src/store/modules/data/tree/treeStore.ts
+++ b/apps/studio/src/store/modules/data/tree/treeStore.ts
@@ -64,10 +64,16 @@ export type TreeState<T> = {
 /**
  * Actions for models that support tree structure or nested folders.
  **/
-export function treeActions<T extends HasId>(parentKeys: {
-  plural: "connectionFolderIds" | "queryFolderIds" | "parentIds",
-  singular: "connectionFolderId" | "queryFolderId" | "parentId"
-}, local: boolean = false): ActionTree<TreeState<T>, RootState> {
+export function treeActions<T extends HasId>(
+  parentKeys: {
+    plural: "connectionFolderIds" | "queryFolderIds" | "parentIds",
+    singular: "connectionFolderId" | "queryFolderId" | "parentId"
+  },
+  local: boolean = false,
+  extraIdsInfo: {
+    field: string,
+    update: string
+  } = null): ActionTree<TreeState<T>, RootState> {
   return {
     async refresh(context, parentIds: number[]) {
       await context.dispatch("resetTree");
@@ -84,6 +90,15 @@ export function treeActions<T extends HasId>(parentKeys: {
         return { error: null };
       }
 
+      if (!_.isNil(extraIdsInfo)) {
+        await context.dispatch(extraIdsInfo.update);
+      }
+
+      let extraIds = undefined;
+      if (!_.isNil(extraIdsInfo) && !_.isNil(context.state[extraIdsInfo.field])) {
+        extraIds = context.state[extraIdsInfo.field];
+      }
+
       context.commit("folders/fetchingIds", [
         ...context.state.folders.fetchingIds,
         ...parentIds,
@@ -91,9 +106,13 @@ export function treeActions<T extends HasId>(parentKeys: {
 
       let error: ClientError | null = null;
 
+      let params = local ?
+        [ { [parentKeys.plural]: parentIds }, { ids: extraIds } ] :
+        { [parentKeys.plural]: parentIds, ids: extraIds };
+
       try {
         await context.dispatch("load", {
-          params: { [parentKeys.plural]: parentIds },
+          params,
           replaceIf(item: T) {
             return parentIds.includes(item[parentKeys.singular]);
           },
@@ -116,8 +135,12 @@ export function treeActions<T extends HasId>(parentKeys: {
         return;
       }
 
+      const linkedIds = extraIdsInfo?.field ?
+        context.state[extraIdsInfo.field] :
+        [];
+
       const stale = context.state.items.filter((item) =>
-        parentIds.includes(item[parentKeys.singular])
+        parentIds.includes(item[parentKeys.singular]) && !linkedIds.includes(item.id)
       );
 
       if (stale.length === 0) {

--- a/apps/studio/src/store/modules/data/tree/treeStore.ts
+++ b/apps/studio/src/store/modules/data/tree/treeStore.ts
@@ -107,7 +107,7 @@ export function treeActions<T extends HasId>(
 
       let error: ClientError | null = null;
 
-      let params = local ?
+      const params = local ?
         [ { [parentKeys.plural]: parentIds }, { [parentKeys.plural]: []}, { ids: persistentIds } ] :
         { [parentKeys.plural]: parentIds, ids: persistentIds };
 

--- a/apps/studio/src/store/modules/data/tree/treeStore.ts
+++ b/apps/studio/src/store/modules/data/tree/treeStore.ts
@@ -61,6 +61,11 @@ export type TreeState<T> = {
   folders: FolderFetchState;
 };
 
+interface LoadOptions {
+  parentIds: number[],
+  persistentIds: number[]
+}
+
 /**
  * Actions for models that support tree structure or nested folders.
  **/
@@ -70,10 +75,7 @@ export function treeActions<T extends HasId>(
     singular: "connectionFolderId" | "queryFolderId" | "parentId"
   },
   local: boolean = false,
-  extraIdsInfo: {
-    field: string,
-    update: string
-  } = null): ActionTree<TreeState<T>, RootState> {
+): ActionTree<TreeState<T>, RootState> {
   return {
     async refresh(context, parentIds: number[]) {
       await context.dispatch("resetTree");
@@ -84,19 +86,18 @@ export function treeActions<T extends HasId>(
       context.commit("folders/reset");
     },
     async loadByParentIds(context, parentIds: number[]) {
+      return await context.dispatch('loadWithOptions', {
+        parentIds,
+        extraIds: []
+      });
+    },
+    async loadWithOptions(context, options: LoadOptions) {
+      let parentIds = options.parentIds;
+      const persistentIds = options.persistentIds ?? [];
       parentIds = _.difference(parentIds, context.state.folders.fetchingIds);
 
       if (parentIds.length === 0 && !local) {
         return { error: null };
-      }
-
-      if (!_.isNil(extraIdsInfo) && context.state[extraIdsInfo.field].length === 0) {
-        await context.dispatch(extraIdsInfo.update);
-      }
-
-      let extraIds = undefined;
-      if (!_.isNil(extraIdsInfo) && !_.isNil(context.state[extraIdsInfo.field])) {
-        extraIds = context.state[extraIdsInfo.field];
       }
 
       context.commit("folders/fetchingIds", [
@@ -107,14 +108,15 @@ export function treeActions<T extends HasId>(
       let error: ClientError | null = null;
 
       let params = local ?
-        [ { [parentKeys.plural]: parentIds }, { [parentKeys.plural]: []}, { ids: extraIds } ] :
-        { [parentKeys.plural]: parentIds, ids: extraIds };
+        [ { [parentKeys.plural]: parentIds }, { [parentKeys.plural]: []}, { ids: persistentIds } ] :
+        { [parentKeys.plural]: parentIds, ids: persistentIds };
 
       try {
         await context.dispatch("load", {
           params,
           replaceIf(item: T) {
-            return parentIds.includes(item[parentKeys.singular]);
+            const itemParentId = item[parentKeys.singular];
+            return parentIds.includes(itemParentId) || persistentIds.includes(item.id);
           },
           onError(fetchError: ClientError) {
             error = fetchError;
@@ -129,18 +131,22 @@ export function treeActions<T extends HasId>(
 
       return { error };
     },
-    /** Drops a collapsed folder's children so the next expand refetches them. */
     async unloadByParentIds(context, parentIds: number[]) {
+      return await context.dispatch('unloadWithOptions', {
+        parentIds,
+        persistentIds: []
+      })
+    },
+    /** Drops a collapsed folder's children so the next expand refetches them. */
+    async unloadWithOptions(context, options: LoadOptions) {
+      const parentIds = options.parentIds;
+      const persistentIds = options.persistentIds ?? [];
       if (parentIds.length === 0) {
         return;
       }
 
-      const linkedIds = extraIdsInfo?.field ?
-        context.state[extraIdsInfo.field] :
-        [];
-
       const stale = context.state.items.filter((item) =>
-        parentIds.includes(item[parentKeys.singular]) && !linkedIds.includes(item.id)
+        parentIds.includes(item[parentKeys.singular]) && !persistentIds.includes(item.id)
       );
 
       if (stale.length === 0) {

--- a/apps/studio/src/store/modules/data/tree/treeStore.ts
+++ b/apps/studio/src/store/modules/data/tree/treeStore.ts
@@ -90,7 +90,7 @@ export function treeActions<T extends HasId>(
         return { error: null };
       }
 
-      if (!_.isNil(extraIdsInfo)) {
+      if (!_.isNil(extraIdsInfo) && context.state[extraIdsInfo.field].length === 0) {
         await context.dispatch(extraIdsInfo.update);
       }
 
@@ -107,7 +107,7 @@ export function treeActions<T extends HasId>(
       let error: ClientError | null = null;
 
       let params = local ?
-        [ { [parentKeys.plural]: parentIds }, { ids: extraIds } ] :
+        [ { [parentKeys.plural]: parentIds }, { [parentKeys.plural]: []}, { ids: extraIds } ] :
         { [parentKeys.plural]: parentIds, ids: extraIds };
 
       try {

--- a/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
+++ b/apps/studio/src/store/modules/data/used_connection/UtilityUsedConnectionModule.ts
@@ -11,11 +11,13 @@ type State = DataState<IConnection>;
 // NOTE (@day): may need to add a custom action for removeUsedConfig that also deletes the tokencache?
 export const UtilUsedConnectionModule: DataStore<IConnection, State> = {
   namespaced: true,
-  state: {
-    items: [],
-    loading: false,
-    error: null,
-    pollError: null
+  state() {
+    return {
+      items: [],
+      loading: false,
+      error: null,
+      pollError: null
+    }
   },
   mutations: mutationsFor<IConnection>(),
   actions: utilActionsFor<IConnection>('used', {


### PR DESCRIPTION
Load saved connections that are tied to used connections show that their info can be used in the recent list, regardless of whether their parent has been expanded or not.

** PENDING CLOUD PR: https://github.com/beekeeper-studio/cloud/pull/184**