### PR TITLE
Added cross button hover effect

### DIFF
--- a/apps/studio/src/assets/styles/app/core-tabs.scss
+++ b/apps/studio/src/assets/styles/app/core-tabs.scss
@@ -197,11 +197,27 @@
     }
     .tab-close {
       position: absolute;
-      right: 0;
+      right: 4px;
+      width: 20px;
+      height: 20px;
+      border-radius: 4px;
       display: flex;
       align-items: center;
       justify-content: center;
-      min-width: 24px;
+      cursor: pointer;
+      transition: background 0.15s ease-in-out;
+
+      &:hover {
+        background: rgba($theme-base, 0.12);
+
+        .material-icons {
+          color: $text-dark;
+        }
+      }
+
+      &:active {
+        background: rgba($theme-base, 0.2);
+      }
 
       .close {
         display: none;
@@ -216,7 +232,7 @@
         font-size: 12px;
         font-weight: bold;
         color: $text;
-        transition: none;
+        transition: color 0.15s ease-in-out;
       }
       &.unsaved {
         .unsaved-icon {


### PR DESCRIPTION
On Tabbar cross button I added hover effect on cross button. Previously the hover feedback was absent.

<img width="252" height="43" alt="image" src="https://github.com/user-attachments/assets/a5a44de3-10ab-449e-b3db-8449dca7f25a" />
This is how cross button looks on hover now.