### PR TITLE
Send plugin events to renderer

### DIFF
--- a/apps/studio/src-commercial/backend/handlers/pluginHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/pluginHandlers.ts
@@ -1,9 +1,9 @@
 import { EncryptedPluginData } from "@/common/appdb/models/EncryptedPluginData";
 import { PluginData } from "@/common/appdb/models/PluginData";
 import { Manifest, PluginSnapshot, PluginManager, PluginRegistryEntry, PluginRepository } from "@/services/plugin";
-import { PluginSystemError } from "@/lib/errors";
 
 interface IPluginHandlers {
+  "plugin/initialized": () => Promise<boolean>
   "plugin/plugins": () => Promise<PluginSnapshot[]>
   "plugin/entries": ({ clearCache }: { clearCache: boolean }) => Promise<{ official: PluginRegistryEntry[], community: PluginRegistryEntry[] }>
   "plugin/repository": ({ id }: { id: string }) => Promise<PluginRepository>
@@ -23,29 +23,8 @@ interface IPluginHandlers {
 }
 
 export const PluginHandlers: (pluginManager: PluginManager) => IPluginHandlers = (pluginManager) => ({
-  "plugin/waitForInit": async () => {
-    if (pluginManager.isInitialized) {
-      return;
-    }
-
-    return new Promise<void>((resolve, reject) => {
-      let duration = 0;
-      const interval = setInterval(() => {
-        duration += 100;
-        if (pluginManager.isInitialized) {
-          clearInterval(interval);
-          resolve();
-        } else if (duration > 30_000) {
-          clearInterval(interval);
-          reject(
-            new PluginSystemError(
-              "INIT_TIMEOUT",
-              "Plugin initialization timed out"
-            )
-          );
-        }
-      }, 100);
-    });
+  "plugin/initialized": async () => {
+    return pluginManager.isInitialized;
   },
   "plugin/plugins": async () => {
     return await pluginManager.getPlugins();

--- a/apps/studio/src-commercial/backend/plugin-system/modules/BundledPluginModule.ts
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/BundledPluginModule.ts
@@ -26,7 +26,7 @@ export class BundledPluginModule extends Module {
   constructor(options: ModuleOptions) {
     super(options);
 
-    this.hook("before-initialize", this.installBundledPlugins);
+    this.hook("beforeInitialize", this.installBundledPlugins);
   }
 
   private async installBundledPlugins() {

--- a/apps/studio/src-commercial/backend/plugin-system/modules/ConfigurationModule.ts
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/ConfigurationModule.ts
@@ -37,8 +37,8 @@ export class ConfigurationModule extends Module {
       this.manager.registry.communityDisabled = true;
     }
 
-    this.hook("before-install-plugin", this.validatePluginInstall);
-    this.hook("plugin-snapshots", this.applyConfig);
+    this.hook("beforeInstallPlugin", this.validatePluginInstall);
+    this.hook("pluginSnapshots", this.applyConfig);
   }
 
   static with(options: ConfigurationOptions) {

--- a/apps/studio/src-commercial/backend/plugin-system/modules/NotificationModule.ts
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/NotificationModule.ts
@@ -1,0 +1,41 @@
+import { states } from "@/handlers/handlerState";
+import { NotificationMap, NotificationType } from "@/lib/utility/notifications";
+import { Module, type ModuleOptions } from "@/services/plugin/Module";
+import rawLog from "@bksLogger";
+
+const log = rawLog.scope("NotificationModule");
+
+/**
+ * A plugin system module that forwards plugin manager events to the windows as
+ * notifications.
+ *
+ * @example
+ *
+ * ```ts
+ * const manager = new PluginManager();
+ * manager.registerModule(NotificationModule);
+ * await manager.initialize();
+ * ```
+ **/
+export class NotificationModule extends Module {
+  constructor(options: ModuleOptions) {
+    super(options);
+
+    this.hook("afterInitialize", (...args) =>
+      this.broadcast("afterInitializePluginManager", args)
+    );
+  }
+
+  broadcast<T extends NotificationType>(type: T, payload?: NotificationMap[T]) {
+    for (const [id, state] of states) {
+      if (!state.port) {
+        continue;
+      }
+      try {
+        state.port.postMessage({ type, input: payload });
+      } catch (e) {
+        log.warn(`Failed to broadcast "${type}" to session ${id}`, e);
+      }
+    }
+  }
+}

--- a/apps/studio/src-commercial/backend/plugin-system/modules/README.md
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/README.md
@@ -56,5 +56,3 @@ export interface ModuleHookMap {
 ```
 
 Both side-effect and waterfall hooks coexist in the same `ModuleHookMap`. The difference is how the `PluginManager` calls them: `notify` for side-effect hooks (typically `void`), `pipe` for waterfall hooks (typically returns a type).
-
-A side-effect hook that the windows need to know about is forwarded by `NotificationModule`; add it there and to `ForwardedHook` in `src/lib/utility/notifications.ts`.

--- a/apps/studio/src-commercial/backend/plugin-system/modules/README.md
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/README.md
@@ -49,10 +49,12 @@ Add the hook signature to `ModuleHookMap` in `src/services/plugin/Module.ts`:
 
 ```typescript
 export interface ModuleHookMap {
- "before-install-plugin": (pluginId: string) => void | Promise<void>;
- "plugin-snapshots": (snapshots: PluginSnapshot[]) => PluginSnapshot[] | Promise<PluginSnapshot[]>;
+ beforeInstallPlugin: (pluginId: string) => void | Promise<void>;
+ pluginSnapshots: (snapshots: PluginSnapshot[]) => PluginSnapshot[] | Promise<PluginSnapshot[]>;
  "my-new-hook": (data: SomeType) => SomeType | Promise<SomeType>;
 }
 ```
 
-Both side-effect and waterfall hooks coexist in the same `ModuleHookMap`. The difference is how the `PluginManager` calls them: `callHook` for side-effect hooks (typically `void`), `applyHook` for waterfall hooks (typically returns a type).
+Both side-effect and waterfall hooks coexist in the same `ModuleHookMap`. The difference is how the `PluginManager` calls them: `notify` for side-effect hooks (typically `void`), `pipe` for waterfall hooks (typically returns a type).
+
+A side-effect hook that the windows need to know about is forwarded by `NotificationModule`; add it there and to `ForwardedHook` in `src/lib/utility/notifications.ts`.

--- a/apps/studio/src-commercial/backend/plugin-system/modules/index.ts
+++ b/apps/studio/src-commercial/backend/plugin-system/modules/index.ts
@@ -1,2 +1,3 @@
 export { ConfigurationModule } from "./ConfigurationModule";
 export { BundledPluginModule } from "./BundledPluginModule";
+export { NotificationModule } from "./NotificationModule";

--- a/apps/studio/src-commercial/entrypoints/utility.ts
+++ b/apps/studio/src-commercial/entrypoints/utility.ts
@@ -36,6 +36,7 @@ import _ from 'lodash';
 import {
   ConfigurationModule,
   BundledPluginModule,
+  NotificationModule,
 } from '@commercial/backend/plugin-system/modules';
 import { PluginErrorCode, PluginSystemErrorCode } from '@/lib/errors';
 
@@ -55,6 +56,7 @@ const pluginManager = new PluginManager({
 });
 pluginManager.registerModule(ConfigurationModule.with({ config: BksConfig }));
 pluginManager.registerModule(BundledPluginModule);
+pluginManager.registerModule(NotificationModule);
 
 const driverDepManager = new DriverDepManager({
   fileManager: new DriverDepFileManager({

--- a/apps/studio/src/common/globals.ts
+++ b/apps/studio/src/common/globals.ts
@@ -36,6 +36,14 @@ export default {
       { id: "bks-ai-shell", pkg: "@beekeeperstudio/bks-ai-shell" },
       { id: "bks-er-diagram", pkg: "@beekeeperstudio/bks-er-diagram" },
     ],
+
+    /**
+     * How long the renderer waits for the backend's plugin manager to
+     * initialize before timing out.
+     *
+     * @see `ReadyState` in src/services/plugin/web/ReadyState.ts
+     **/
+    initTimeout: 30 * 1000, // 30 seconds
   }
 }
 

--- a/apps/studio/src/handlers/handlerState.ts
+++ b/apps/studio/src/handlers/handlerState.ts
@@ -11,8 +11,6 @@ import { MessagePortMain } from "electron";
 import { FSWatcher } from "fs";
 import fs from "fs";
 import tmp from 'tmp';
-import rawLog from "@bksLogger";
-import type { NotificationMap, NotificationType } from "@/lib/utility/notifications";
 
 export interface TempFile {
   fileObject: tmp.FileResult,

--- a/apps/studio/src/handlers/handlerState.ts
+++ b/apps/studio/src/handlers/handlerState.ts
@@ -11,6 +11,8 @@ import { MessagePortMain } from "electron";
 import { FSWatcher } from "fs";
 import fs from "fs";
 import tmp from 'tmp';
+import rawLog from "@bksLogger";
+import type { NotificationMap, NotificationType } from "@/lib/utility/notifications";
 
 export interface TempFile {
   fileObject: tmp.FileResult,
@@ -50,7 +52,7 @@ class State {
   tempFiles: Map<string, TempFile> = new Map();
 }
 
-const states = new Map<string, State>();
+export const states = new Map<string, State>();
 
 // I kinda hate this tbh. modifying could be scary
 export function state(id: string): State {

--- a/apps/studio/src/lib/utility/UtilityConnection.ts
+++ b/apps/studio/src/lib/utility/UtilityConnection.ts
@@ -2,10 +2,13 @@ import { uuidv4 } from "../uuid";
 import rawLog from '@bksLogger';
 import _ from 'lodash';
 import { PluginError, PluginSystemError } from "../errors";
+import type { NotificationMap, NotificationType } from "./notifications";
 
 const log = rawLog.scope('renderer/utilityconnection');
 
-type Listener = (input: any) => void;
+type Listener<T extends NotificationType = NotificationType> = (
+  input: NotificationMap[T]
+) => void;
 type Message = {
   handlerName: string,
   args: any,
@@ -131,7 +134,10 @@ export class UtilityConnection {
     })
   }
 
-  public addListener(type: string, listener: Listener): string {
+  public addListener<T extends NotificationType>(
+    type: T,
+    listener: Listener<T>
+  ): string {
     const id = uuidv4();
     this.listeners.push({ type, id, listener });
     log.info('ADDED LISTENER: ', type, id);

--- a/apps/studio/src/lib/utility/notifications.ts
+++ b/apps/studio/src/lib/utility/notifications.ts
@@ -1,0 +1,26 @@
+import type { Notification } from "@/lib/db/BaseCommandClient";
+import type { ExportProgress } from "@/lib/export/models";
+import type { DownloadProgress } from "@/services/driverDeps/types";
+import type { CallHookMap } from "@/services/plugin/Module";
+
+/**
+ * Messages the utility process pushes to a window without being asked. Keys
+ * ending in an id are per-tab or per-job; the rest go to the whole window.
+ */
+export interface NotificationMap {
+  enumFileChanged: void;
+  backupNotif: Notification;
+  backupLog: string;
+  [key: `onExportProgress/${string}`]: ExportProgress;
+  [key: `onDriverDepProgress/${string}`]: DownloadProgress;
+  [key: `transactionTimeoutWarning/${number}`]: void;
+  [key: `transactionTimedOut/${number}`]: void;
+
+  // Plugin system notifications
+  afterInitializePluginManager: Parameters<CallHookMap["afterInitialize"]>;
+};
+
+export type NotificationType = keyof NotificationMap;
+
+export type NotificationPayload<T extends NotificationType> =
+  NotificationMap[T];

--- a/apps/studio/src/services/plugin/Hookable.ts
+++ b/apps/studio/src/services/plugin/Hookable.ts
@@ -1,5 +1,10 @@
 import type PluginManager from "./PluginManager";
-import { type Module, type ModuleClass, type ModuleHookMap } from "./Module";
+import {
+  type Module,
+  type ModuleClass,
+  type ApplyHookMap,
+  type CallHookMap,
+} from "./Module";
 
 export abstract class Hookable {
   private modules: Module[] = [];
@@ -9,9 +14,9 @@ export abstract class Hookable {
   }
 
   /** Run all handlers for a side-effect hook (no return value). */
-  protected async callHook<K extends keyof ModuleHookMap>(
+  protected async notify<K extends keyof CallHookMap>(
     name: K,
-    ...args: Parameters<ModuleHookMap[K]>
+    ...args: Parameters<CallHookMap[K]>
   ) {
     for (const module of this.modules) {
       for (const hook of module.hooks) {
@@ -23,9 +28,9 @@ export abstract class Hookable {
   }
 
   /** Run all handlers for a waterfall hook, piping data through each handler. */
-  protected async applyHook<K extends keyof ModuleHookMap>(
+  protected async pipe<K extends keyof ApplyHookMap>(
     name: K,
-    ...args: Parameters<ModuleHookMap[K]>
+    ...args: Parameters<ApplyHookMap[K]>
   ) {
     let value = args[0];
     const rest = args.slice(1);
@@ -36,6 +41,6 @@ export abstract class Hookable {
         }
       }
     }
-    return value as ReturnType<ModuleHookMap[K]>;
+    return value as Awaited<ReturnType<ApplyHookMap[K]>>;
   }
 }

--- a/apps/studio/src/services/plugin/Module.ts
+++ b/apps/studio/src/services/plugin/Module.ts
@@ -7,13 +7,28 @@ export type PluginSourcePathParams = {
   removeSourceDir: boolean;
 };
 
-export interface ModuleHookMap {
-  "before-initialize": () => void | Promise<void>;
-  "before-install-plugin": (pluginId: string) => void | Promise<void>;
-  "plugin-snapshots": (
+/** Hooks that run for side effects. */
+export interface CallHookMap {
+  /** Before initializing the plugin manager */
+  beforeInitialize: () => void | Promise<void>;
+
+  /** After the plugin manager is ready to be used */
+  afterInitialize: () => void | Promise<void>;
+
+  /** Also triggered before updating a plugin */
+  beforeInstallPlugin: (pluginId: string) => void | Promise<void>;
+}
+
+/** Hooks that pipe a value through each handler. */
+export interface ApplyHookMap {
+  /** Use it to adjust the state of a plugin — e.g. marking one as
+   * disabled — or to add and remove entries. */
+  pluginSnapshots: (
     snapshots: PluginSnapshot[]
   ) => PluginSnapshot[] | Promise<PluginSnapshot[]>;
 }
+
+export type ModuleHookMap = CallHookMap & ApplyHookMap;
 
 export type ModuleHook = {
   [K in keyof ModuleHookMap]: {

--- a/apps/studio/src/services/plugin/PluginManager.ts
+++ b/apps/studio/src/services/plugin/PluginManager.ts
@@ -53,7 +53,7 @@ export default class PluginManager extends Hookable {
     // FIXME: Migrate to full ini file configuration
     await this.loadPluginSettings();
 
-    await this.callHook("before-initialize");
+    await this.notify("beforeInitialize");
 
     const installedPlugins = this.fileManager.scanPlugins().map(convertToManifestV1);
     this.manifests = installedPlugins;
@@ -61,6 +61,8 @@ export default class PluginManager extends Hookable {
     log.debug("Installed plugins:", installedPlugins);
 
     this.initialized = true;
+
+    await this.notify("afterInitialize");
 
     for (const plugin of installedPlugins) {
       if (!this.pluginSettings[plugin.id]?.autoUpdate) {
@@ -146,7 +148,7 @@ export default class PluginManager extends Hookable {
       });
     }
 
-    return await this.applyHook("plugin-snapshots", snapshots);
+    return await this.pipe("pluginSnapshots", snapshots);
   }
 
   /** Plugin is not loadable if the **current app version** is lower than the
@@ -162,7 +164,7 @@ export default class PluginManager extends Hookable {
   async installPlugin(id: string): Promise<Manifest> {
     this.initializeGuard();
 
-    await this.callHook("before-install-plugin", id);
+    await this.notify("beforeInstallPlugin", id);
 
     let update = false;
 

--- a/apps/studio/src/services/plugin/web/ReadyState.ts
+++ b/apps/studio/src/services/plugin/web/ReadyState.ts
@@ -1,0 +1,59 @@
+import type { UtilityConnection } from "@/lib/utility/UtilityConnection";
+import { PluginSystemError } from "@/lib/errors";
+import globals from "@/common/globals";
+
+/**
+ * Tracks whether the backend's plugin manager has finished initializing.
+ *
+ * @example
+ *
+ * ```ts
+ * const state = new ReadyState(utilityConnection);
+ * await state.wait();
+ * ```
+ **/
+export default class ReadyState {
+  private ready = false;
+  private readonly readySignal = Promise.withResolvers<void>();
+
+  constructor(private readonly util: UtilityConnection) {
+    this.util.addListener("afterInitializePluginManager", () =>
+      this.markReady()
+    );
+  }
+
+  /** Resolves once the backend's plugin manager is ready.
+   * @throws if it is not ready within `globals.plugins.initTimeout` */
+  async wait() {
+    if (this.ready) {
+      return;
+    }
+
+    // The event may have fired before this window's port was attached.
+    if (await this.util.send("plugin/initialized")) {
+      this.markReady();
+      return;
+    }
+
+    const timeout = Promise.withResolvers<never>();
+    const timeoutId = setTimeout(() => {
+      timeout.reject(
+        new PluginSystemError(
+          "INIT_TIMEOUT",
+          "Plugin initialization timed out"
+        )
+      );
+    }, globals.plugins.initTimeout);
+
+    try {
+      await Promise.race([this.readySignal.promise, timeout.promise]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private markReady() {
+    this.ready = true;
+    this.readySignal.resolve();
+  }
+}

--- a/apps/studio/src/services/plugin/web/WebPluginManager.ts
+++ b/apps/studio/src/services/plugin/web/WebPluginManager.ts
@@ -10,6 +10,7 @@ import { FileHelpers } from "@/types";
 import type Noty from "noty";
 import { AppEvent } from "@/common/AppEvent";
 import { WebPluginCommandExecutor } from "./WebPluginCommandExecutor";
+import ReadyState from "./ReadyState";
 
 const log = rawLog.scope("WebPluginManager");
 
@@ -56,20 +57,24 @@ export default class WebPluginManager {
   loaders: Map<string, WebPluginLoader> = new Map();
 
   private initialized = false;
-  private utilityConnection: UtilityConnection;
+  private util: UtilityConnection;
   public readonly pluginStore: PluginStoreService;
   public readonly appVersion: string;
   public readonly fileHelpers: FileHelpers;
   private readonly noty: WebPluginManagerParams['noty'];
   private readonly confirm: WebPluginManagerParams['confirm'];
 
+  private readyState: ReadyState;
+
   constructor(params: WebPluginManagerParams) {
-    this.utilityConnection = params.utilityConnection;
+    this.util = params.utilityConnection;
     this.pluginStore = params.pluginStore;
     this.appVersion = params.appVersion;
     this.fileHelpers = params.fileHelpers;
     this.noty = params.noty;
     this.confirm = params.confirm;
+
+    this.readyState = new ReadyState(this.util);
   }
 
   async initialize() {
@@ -78,7 +83,12 @@ export default class WebPluginManager {
       return;
     }
 
-    await this.utilityConnection.send("plugin/waitForInit");
+    log.info("Waiting for the backend's plugin manager...");
+
+    await this.readyState.wait();
+
+    log.info("Backend's plugin manager is ready. Initializing web plugin manager...");
+
     await this.pluginStore.initialize();
 
     for (const snapshot of this.pluginStore.getSnapshots()) {
@@ -98,12 +108,14 @@ export default class WebPluginManager {
       }
     }
 
+    log.info("Web plugin manager is ready.");
+
     this.initialized = true;
   }
 
   /** Install a plugin by its id */
   async install(id: string) {
-    await this.utilityConnection.send("plugin/install", { id });
+    await this.util.send("plugin/install", { id });
     await this.pluginStore.loadSnapshots();
     const snapshot = this.pluginStore.getSnapshot(id)!;
     await this.loadPlugin(snapshot);
@@ -112,7 +124,7 @@ export default class WebPluginManager {
 
   /** Update a plugin by its id */
   async update(id: string) {
-    await this.utilityConnection.send("plugin/update", { id });
+    await this.util.send("plugin/update", { id });
     await this.pluginStore.loadSnapshots();
     const snapshot = this.pluginStore.getSnapshot(id)!;
     await this.reloadPlugin(snapshot);
@@ -121,7 +133,7 @@ export default class WebPluginManager {
 
   /** Uninstall a plugin by its id */
   async uninstall(id: string) {
-    await this.utilityConnection.send("plugin/uninstall", { id });
+    await this.util.send("plugin/uninstall", { id });
     await this.unloadPlugin(id);
     await this.pluginStore.loadSnapshots();
   }
@@ -186,7 +198,7 @@ export default class WebPluginManager {
   }
 
   async viewEntrypointExists(pluginId: string, viewId: string): Promise<boolean> {
-    return await this.utilityConnection.send("plugin/viewEntrypointExists", {
+    return await this.util.send("plugin/viewEntrypointExists", {
       pluginId,
       viewId,
     });
@@ -275,7 +287,7 @@ export default class WebPluginManager {
     const loader = new WebPluginLoader({
       manifest: snapshot.manifest,
       store: this.pluginStore,
-      utility: this.utilityConnection,
+      utility: this.util,
       log: rawLog.scope(`Plugin:${snapshot.manifest.id}`),
       appVersion: this.appVersion,
       fileHelpers: this.fileHelpers,

--- a/apps/studio/tests/integration/plugins/utils/WebHost.ts
+++ b/apps/studio/tests/integration/plugins/utils/WebHost.ts
@@ -26,8 +26,8 @@ export class WebHost {
 
   private mockUtilityConnection = {
     send: jest.fn().mockImplementation((event: string, data?: any) => {
-      if (event === "plugin/waitForInit") {
-        return Promise.resolve();
+      if (event === "plugin/initialized") {
+        return Promise.resolve(true);
       }
       if (event === "plugin/plugins") {
         return Promise.resolve(Array.from(this.plugins.values()));
@@ -37,6 +37,8 @@ export class WebHost {
       }
       return Promise.resolve();
     }),
+    addListener: jest.fn().mockReturnValue("mock-listener-id"),
+    removeListener: jest.fn(),
   } as any as UtilityConnection;
 
   private mockAppEventBus = {


### PR DESCRIPTION
- Plugin events are now camelCased, matching the convention.
- Plugin events can now be sent to renderer process via `NotificationModule`.
- We used `plugin/waitForInit` because we weren't able to send notifications from utility to renderer. Now this is removed, and replaced by `ReadyState`, which uses a notification.

Other than `ReadyState`, being able to send notifications to renderer allows us to get notified of processes that are running in the backend, for example, finished installing/updating a plugin.