### PR TITLE
fix(cassandra): convert the remaining driver types, in both directions

### DIFF
--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -15,7 +15,7 @@ import { identify } from "sql-query-identifier";
 import { errors } from "@/lib/errors";
 import { CassandraData as D } from "@shared/lib/dialects/cassandra";
 import { CassandraCursor } from "./cassandra/CassandraCursor";
-import { convertValueByType, dataTypeName } from "./cassandra/valueConverter";
+import { convertValueByType, dataTypeName, toDriverValue, CassandraType, ColumnTypes } from "./cassandra/valueConverter";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import _ from "lodash";
 import { IdentifyResult } from "sql-query-identifier/lib/defines";
@@ -378,22 +378,27 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     let results = [];
     let batchedChanges = [];
 
+    // Values arrive from the grid in the flattened form parseRows produced, so
+    // they have to be rebuilt into what the driver's encoder accepts. That
+    // needs the column types, which are looked up once per table here.
+    const types = await this.columnTypesForChanges(changes);
+
     if (changes.inserts) {
-      batchedChanges = [...batchedChanges, ...this.insertRows(changes.inserts)];
+      batchedChanges = [...batchedChanges, ...this.insertRows(changes.inserts, types)];
     }
 
     if (changes.updates) {
-      batchedChanges = [...batchedChanges, ...await this.updateValues(changes.updates)];
+      batchedChanges = [...batchedChanges, ...await this.updateValues(changes.updates, types)];
     }
 
     if (changes.deletes) {
-      batchedChanges = [...batchedChanges, ...this.deleteRows(changes.deletes)];
+      batchedChanges = [...batchedChanges, ...this.deleteRows(changes.deletes, types)];
     }
 
     await this.driverExecuteBatch(batchedChanges);
 
     if (changes.updates) {
-      results = await this.getSelectUpdatedValues(changes.updates);
+      results = await this.getSelectUpdatedValues(changes.updates, types);
     }
 
     return results;
@@ -630,31 +635,78 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     }
   }
 
-  private insertRows(rows) {
+  /**
+   * Column type descriptors for every table a set of changes touches, keyed by
+   * `keyspace.table`. The driver's table metadata carries the same descriptors
+   * parseRows works from, so the two directions stay in step without having to
+   * parse the CQL type strings in system_schema.
+   */
+  private async columnTypesForChanges(changes: TableChanges): Promise<ColumnTypes> {
+    const changed = [
+      ...(changes.inserts ?? []),
+      ...(changes.updates ?? []),
+      ...(changes.deletes ?? []),
+    ];
+
+    const types: ColumnTypes = {};
+    for (const { table, schema } of changed) {
+      const key = this.tableTypeKey(table, schema);
+      if (key in types) continue;
+
+      try {
+        const meta = await this.client.metadata.getTable(schema || this.db, table);
+        types[key] = (meta?.columns ?? []).reduce((acc, column) => {
+          acc[column.name] = column.type;
+          return acc;
+        }, {});
+      } catch (err) {
+        // A missing keyspace or a metadata hiccup should not block the write.
+        // Without types the values go out as they came in, which is what
+        // happened before any of this existed.
+        logger().error(`Could not read column types for ${key}`, err);
+        types[key] = {};
+      }
+    }
+
+    return types;
+  }
+
+  private tableTypeKey(table: string, schema?: string) {
+    return `${schema || this.db}.${table}`;
+  }
+
+  private typesFor(change: { table: string; schema?: string }, types: ColumnTypes) {
+    return types[this.tableTypeKey(change.table, change.schema)] ?? {};
+  }
+
+  private insertRows(rows, types: ColumnTypes) {
     return rows.map(row => {
       const [data] = row.data
+      const columnTypes = this.typesFor(row, types)
       const columns = Object.keys(data)
       return {
         query: `INSERT INTO ${row.table} (${columns.join(', ')}) VALUES (${Array(columns.length).fill('?', 0, columns.length)})`,
-        params: columns.map(c => data[c] || null)
+        params: columns.map(c => toDriverValue(data[c] ?? null, columnTypes[c]))
       }
     })
   }
 
-  private deleteRows(rows) {
+  private deleteRows(rows, types: ColumnTypes) {
     return rows.map(row => {
       const [data] = row.primaryKeys
+      const columnTypes = this.typesFor(row, types)
       return {
         query: `DELETE FROM ${row.table} where ${this.wrapIdentifier(data.column)} = ?`,
-        params: [data.value]
+        params: [toDriverValue(data.value, columnTypes[data.column])]
       }
     })
   }
 
-  private async updateValues(updates) {
+  private async updateValues(updates, types: ColumnTypes) {
     return updates.map(update => {
-      const value = update.value
-      const [updateParams, updateWhereList] = this.getParamsAndWhereList(update.primaryKeys, value)
+      const columnTypes = this.typesFor(update, types)
+      const value = toDriverValue(update.value, columnTypes[update.column])
+      const [updateParams, updateWhereList] = this.getParamsAndWhereList(update.primaryKeys, columnTypes, value)
       const where = updateWhereList.join(' AND ')
       return {
         query: `UPDATE ${this.wrapIdentifier(update.table)} SET ${this.wrapIdentifier(update.column)} = ? WHERE ${where}`,
@@ -663,20 +715,23 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
     })
   }
 
-  private getParamsAndWhereList(primaryKeys, initialValue = undefined) {
+  private getParamsAndWhereList(primaryKeys, columnTypes: Record<string, CassandraType>, initialValue = undefined) {
     const params = initialValue !== undefined ? [initialValue] : [];
     const whereList = [];
     primaryKeys.forEach(({ column, value }) => {
       whereList.push(`${this.wrapIdentifier(column)} = ?`);
-      params.push(value);
+      // a primary key can be a frozen tuple, which the encoder will not take
+      // as the plain array parseRows turned it into
+      params.push(toDriverValue(value, columnTypes[column]));
     });
 
     return [params, whereList];
   }
 
-  private async getSelectUpdatedValues(updates): Promise<Array<any>> {
+  private async getSelectUpdatedValues(updates, types: ColumnTypes): Promise<Array<any>> {
     const updatePromises = updates.map(update => {
-      const [updateParams, updateWhereList] = this.getParamsAndWhereList(update.primaryKeys);
+      const columnTypes = this.typesFor(update, types);
+      const [updateParams, updateWhereList] = this.getParamsAndWhereList(update.primaryKeys, columnTypes);
       const query = `SELECT * FROM ${this.wrapIdentifier(update.table)} WHERE ${updateWhereList.join(' AND ')}`;
 
       return this.driverExecuteSingle(query, { params: updateParams });

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -13,9 +13,9 @@ import rawLog from "@bksLogger";
 import { createCancelablePromise } from "@/common/utils";
 import { identify } from "sql-query-identifier";
 import { errors } from "@/lib/errors";
-import { dataTypesToMatchTypeCode, CassandraData as D } from "@shared/lib/dialects/cassandra";
+import { CassandraData as D } from "@shared/lib/dialects/cassandra";
 import { CassandraCursor } from "./cassandra/CassandraCursor";
-import { convertValueByType } from "./cassandra/valueConverter";
+import { convertValueByType, dataTypeName } from "./cassandra/valueConverter";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import _ from "lodash";
 import { IdentifyResult } from "sql-query-identifier/lib/defines";
@@ -595,7 +595,7 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
 
   private parseFields(fields, _row) {
     return fields.map((field) => {
-      field.dataType = dataTypesToMatchTypeCode[field?.type?.code] || 'user-defined'
+      field.dataType = dataTypeName(field?.type)
       field.id = field.name
       return field
     })

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -15,6 +15,7 @@ import { identify } from "sql-query-identifier";
 import { errors } from "@/lib/errors";
 import { dataTypesToMatchTypeCode, CassandraData as D } from "@shared/lib/dialects/cassandra";
 import { CassandraCursor } from "./cassandra/CassandraCursor";
+import { convertValueByType } from "./cassandra/valueConverter";
 import { IDbConnectionServer } from "@/lib/db/backendTypes";
 import _ from "lodash";
 import { IdentifyResult } from "sql-query-identifier/lib/defines";
@@ -808,55 +809,9 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
 
     return rows?.map((row) => {
       Object.keys(row).forEach((key) => {
-        const value = row[key];
-        const typeCode = typeByColumn[key].code;
-
-        if (typeCode == cassandra.types.dataTypes.list || typeCode == cassandra.types.dataTypes.set) {
-          row[key] = value?.map((v) => this.convertValueByType(v, typeByColumn[key].info.code));
-          return;
-        }
-
-        if (typeCode == cassandra.types.dataTypes.map) {
-          const [keyType, valueType] = typeByColumn[key].info;
-          const converted = {};
-          if (value) {
-            Object.entries(value).forEach(([k, v]) => {
-              const convertedKey = this.convertValueByType(k, keyType.code);
-              converted[convertedKey as string] = this.convertValueByType(v, valueType.code);
-            });
-          }
-          row[key] = converted;
-          return;
-        }
-
-        row[key] = this.convertValueByType(value, typeCode);
+        row[key] = convertValueByType(row[key], typeByColumn[key]);
       });
       return row;
     });
-  }
-
-  private convertValueByType(value, type) {
-    if (value == null || value === undefined) {
-      return null;
-    }
-
-    switch (type) {
-      case cassandra.types.dataTypes.bigint:
-        return String(value);
-      case cassandra.types.dataTypes.timestamp:
-        return value ? value.toISOString() : null;
-      case cassandra.types.dataTypes.time:
-      case cassandra.types.dataTypes.date:
-        return value ? String(value) : null;
-      case cassandra.types.dataTypes.uuid:
-      case cassandra.types.dataTypes.timeuuid:
-        return value?.buffer
-          ? new cassandra.types.Uuid(Buffer.from(value.buffer)).toString()
-          : value;
-      case cassandra.types.dataTypes.inet:
-        return value ? value.toString() : null;
-      default:
-        return value;
-    }
   }
 }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra.ts
@@ -661,8 +661,11 @@ export class CassandraClient extends BasicDatabaseClient<CassandraResult> {
         }, {});
       } catch (err) {
         // A missing keyspace or a metadata hiccup should not block the write.
-        // Without types the values go out as they came in, which is what
-        // happened before any of this existed.
+        // Values then go out as they came in, which is fine for every type the
+        // encoder takes as a string, and fails the same way it did before any
+        // of this existed for a duration, vector or tuple column - so log the
+        // real cause, since all the user would otherwise see is the encoder's
+        // "Not a valid duration" further down.
         logger().error(`Could not read column types for ${key}`, err);
         types[key] = {};
       }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
@@ -8,19 +8,43 @@ import * as cassandra from 'cassandra-driver';
  *  - map:       a two element tuple, [keyType, valueType]
  *  - tuple:     an array of descriptors, one per position
  *  - udt:       { name, keyspace, fields: [{ name, type }] }
+ *  - custom:    the fully qualified Java class name, or for a vector,
+ *               [elementType, dimensions] alongside customTypeName: 'vector'
  *  - scalars:   unused
  */
 export type CassandraType = {
   code: number;
   info?: any;
+  customTypeName?: string;
 };
 
 const dataTypes = cassandra.types.dataTypes;
 
+/**
+ * Duration: months, days and a nanoseconds Long. toString() gives back the CQL
+ * literal, e.g. 1mo2d3s - except for a zero duration, where it appends nothing
+ * for each zero component and returns an empty string. A blank cell would be
+ * indistinguishable from an unset value, so spell zero out as `0s`, which is
+ * what Cassandra accepts back.
+ */
+function durationToString(value: any) {
+  return String(value) || '0s';
+}
+
 function convertScalar(value: any, code: number) {
   switch (code) {
+    // Long, or a native BigInt when the driver is configured for it. A counter
+    // decodes to a Long too, so it needs the same treatment as a bigint.
     case dataTypes.bigint:
+    case dataTypes.counter:
+    // Integer, the driver's arbitrary precision integer (a CQL varint is a Java
+    // BigInteger). Backed by an int array, so its raw form is meaningless.
+    case dataTypes.varint:
+    // BigDecimal, an Integer plus a scale.
+    case dataTypes.decimal:
       return String(value);
+    case dataTypes.duration:
+      return durationToString(value);
     case dataTypes.timestamp:
       // Map keys reach us already coerced to strings: the driver builds plain
       // object maps with `map[key] = value`, which stringifies a Date key.
@@ -36,19 +60,54 @@ function convertScalar(value: any, code: number) {
     case dataTypes.inet:
       return value.toString();
     default:
+      // blob decodes to a Buffer, which the grid renders as binary. Left alone
+      // on purpose.
       return value;
   }
+}
+
+/** A driver Vector: an elements array plus the subtype it was decoded with. */
+function isVector(value: any) {
+  return Array.isArray(value?.elements) && typeof value?.subtype === 'string';
+}
+
+/**
+ * `custom` covers what the driver decodes outside the CQL type codes: vectors,
+ * DSE geometry (Point, LineString, Polygon), DateRange, and duration on older
+ * protocol versions. Anything the driver cannot decode stays a Buffer.
+ */
+function convertCustom(value: any, info: any) {
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+
+  if (isVector(value)) {
+    // A Vector is a Proxy over its elements and throws on structured clone, so
+    // it has to become a plain array.
+    const elementType = Array.isArray(info) ? info[0] : undefined;
+    return value.elements.map((v: any) => convertValueByType(v, elementType));
+  }
+
+  // A real server sends duration as a custom type rather than under its own
+  // type code, so this - not the `duration` case above - is the path it takes.
+  if (value instanceof cassandra.types.Duration) {
+    return durationToString(value);
+  }
+
+  // The rest are class instances whose toString() is the literal form.
+  return typeof value.toString === 'function' ? value.toString() : value;
 }
 
 /**
  * Convert a driver-decoded value into something that survives the trip to the
  * renderer and reads sensibly in the grid.
  *
- * Driver types like Uuid, Long and InetAddress are class instances, so once
- * they cross the process boundary they arrive as their raw internals - a UUID
- * turns into `{ buffer: { type: "Buffer", data: [...] } }`. Containers are
- * walked recursively so a driver type is converted no matter how deeply it is
- * nested: set<frozen<udt>>, a udt holding a list, a udt inside a udt, and so on.
+ * Driver types like Uuid, Long, Integer, BigDecimal, Duration and InetAddress
+ * are class instances, so once they cross the process boundary they arrive as
+ * their raw internals - a UUID turns into `{ buffer: { type: "Buffer", data:
+ * [...] } }`, a varint into `{ bits_: [...], sign_: 0 }`. Containers are walked
+ * recursively so a driver type is converted no matter how deeply it is nested:
+ * set<frozen<udt>>, a udt holding a list, a udt inside a udt, and so on.
  */
 export function convertValueByType(value: any, type: CassandraType) {
   if (value == null) {
@@ -88,5 +147,42 @@ export function convertValueByType(value: any, type: CassandraType) {
     return Array.from(elements).map((v, i) => convertValueByType(v, info?.[i]));
   }
 
+  if (code === dataTypes.custom) {
+    return convertCustom(value, info);
+  }
+
   return convertScalar(value, code);
+}
+
+/**
+ * The CQL name for a column's type, e.g. `varint`, `duration`, `list<uuid>`,
+ * `map<text, int>`, or a udt's own name.
+ *
+ * The driver derives this from the same descriptor `convertValueByType` walks,
+ * including the nested subtypes. The previous hand-maintained array indexed
+ * names by type code, which only holds while the codes are contiguous: they
+ * are not (list is 32, udt 48), so every collection came back `user-defined`
+ * and duration - code 21, one past tinyint - came back `list`.
+ */
+export function dataTypeName(type: CassandraType): string {
+  // Exported by the driver but missing from its type definitions.
+  const getName: (type: CassandraType) => string =
+    (cassandra.types as any).getDataTypeNameByCode;
+
+  // The driver names every custom type `custom`, but a real server sends
+  // duration and the DSE geometry types this way, identified by a Java class
+  // name. `org.apache.cassandra.db.marshal.DurationType` -> `duration`.
+  if (type?.code === dataTypes.custom && typeof type.info === 'string') {
+    const className = type.info.split('.').pop() ?? '';
+    const name = className.replace(/Type$/, '').toLowerCase();
+    if (name) {
+      return name;
+    }
+  }
+
+  try {
+    return getName(type);
+  } catch {
+    return 'user-defined';
+  }
 }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
@@ -102,6 +102,31 @@ function convertCustom(value: any, info: any) {
 }
 
 /**
+ * The driver builds plain object maps with `map[key] = value`, which stringifies
+ * any key that is not already a primitive - a Tuple key arrives as `(1,2)`, a
+ * Date key as its toString form. Feeding one of those back through the walker
+ * destroys it: the tuple branch would call Array.from on the string and shred it
+ * into `(,1,,,2,)`. A key that is already a string is left as it is.
+ *
+ * A key can only be a comparable frozen type, so duration and vector are ruled
+ * out by Cassandra itself ("Durations are not allowed as map keys"), but a
+ * frozen tuple is legal, which is the case this guards.
+ */
+function convertMapKey(key: any, keyType: CassandraType) {
+  const isContainer = keyType?.code === dataTypes.tuple
+    || keyType?.code === dataTypes.udt
+    || keyType?.code === dataTypes.list
+    || keyType?.code === dataTypes.set
+    || keyType?.code === dataTypes.map;
+
+  if (isContainer && typeof key === 'string') {
+    return key;
+  }
+
+  return convertValueByType(key, keyType);
+}
+
+/**
  * Convert a driver-decoded value into something that survives the trip to the
  * renderer and reads sensibly in the grid.
  *
@@ -128,7 +153,7 @@ export function convertValueByType(value: any, type: CassandraType) {
     const entries = value instanceof Map ? value.entries() : Object.entries(value);
     const converted = {};
     for (const [k, v] of entries) {
-      const convertedKey = convertValueByType(k, keyType);
+      const convertedKey = convertMapKey(k, keyType);
       converted[convertedKey as string] = convertValueByType(v, valueType);
     }
     return converted;
@@ -215,8 +240,10 @@ export function toDriverValue(value: any, type: CassandraType) {
   }
 
   if (code === dataTypes.map) {
-    // Keys are left alone: Cassandra only allows comparable frozen types as map
-    // keys, which rules out every type this function has to rebuild.
+    // Keys are left alone. Cassandra rejects duration and vector as map keys
+    // outright, but a frozen tuple is legal - and the driver hands those to us
+    // already stringified to `(1,2)`, which Tuple offers no way back from. Such
+    // a map reads fine and is not writable; nothing here can change that.
     const valueType = (info ?? [])[1];
     const entries = value instanceof Map ? value.entries() : Object.entries(value);
     const converted = {};

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
@@ -18,6 +18,9 @@ export type CassandraType = {
   customTypeName?: string;
 };
 
+/** Column type descriptors per table, keyed by `keyspace.table` then column. */
+export type ColumnTypes = Record<string, Record<string, CassandraType>>;
+
 const dataTypes = cassandra.types.dataTypes;
 
 /**
@@ -185,4 +188,107 @@ export function dataTypeName(type: CassandraType): string {
   } catch {
     return 'user-defined';
   }
+}
+
+/**
+ * The inverse of `convertValueByType`, for values on their way back to the
+ * server as bound parameters.
+ *
+ * `convertValueByType` flattens driver classes so they survive the trip to the
+ * renderer, but the driver's encoder is stricter than its decoder: it takes a
+ * string for the numeric types "for historical reasons", yet insists on the
+ * real class for a duration, a vector and the DSE geometry types, and on a
+ * Tuple for a tuple. Encoding a plain value for one of those throws, so every
+ * one has to be rebuilt from the string or array the grid hands back.
+ *
+ * Anything the encoder already accepts is passed through untouched.
+ */
+export function toDriverValue(value: any, type: CassandraType) {
+  if (value == null) {
+    return null;
+  }
+
+  const { code, info } = type ?? {};
+
+  if (code === dataTypes.list || code === dataTypes.set) {
+    return Array.from(value).map((v) => toDriverValue(v, info));
+  }
+
+  if (code === dataTypes.map) {
+    // Keys are left alone: Cassandra only allows comparable frozen types as map
+    // keys, which rules out every type this function has to rebuild.
+    const valueType = (info ?? [])[1];
+    const entries = value instanceof Map ? value.entries() : Object.entries(value);
+    const converted = {};
+    for (const [k, v] of entries) {
+      converted[k as string] = toDriverValue(v, valueType);
+    }
+    return converted;
+  }
+
+  if (code === dataTypes.udt) {
+    const converted = {};
+    (info?.fields ?? []).forEach((field) => {
+      converted[field.name] = toDriverValue(value[field.name], field.type);
+    });
+    return converted;
+  }
+
+  if (code === dataTypes.tuple) {
+    // encodeTuple calls value.get(i), so a plain array will not do.
+    if (value instanceof cassandra.types.Tuple) {
+      return value;
+    }
+    const elements = Array.from(value).map((v, i) => toDriverValue(v, info?.[i]));
+    return cassandra.types.Tuple.fromArray(elements);
+  }
+
+  if (code === dataTypes.custom) {
+    return customToDriverValue(value, type);
+  }
+
+  if (code === dataTypes.duration) {
+    return toDuration(value);
+  }
+
+  return value;
+}
+
+function toDuration(value: any) {
+  return value instanceof cassandra.types.Duration
+    ? value
+    : cassandra.types.Duration.fromString(String(value));
+}
+
+/** Rebuilders for the custom types, keyed by their Java class name. */
+const customFromString = {
+  DurationType: (v: string) => cassandra.types.Duration.fromString(v),
+  PointType: (v: string) => cassandra.geometry.Point.fromString(v),
+  LineStringType: (v: string) => cassandra.geometry.LineString.fromString(v),
+  PolygonType: (v: string) => cassandra.geometry.Polygon.fromString(v),
+  DateRangeType: (v: string) => cassandra.datastax.search.DateRange.fromString(v),
+};
+
+function customToDriverValue(value: any, type: CassandraType) {
+  const { info, customTypeName } = type;
+
+  if (isVector(value)) {
+    return value;
+  }
+
+  if (customTypeName === 'vector') {
+    // encodeVector reads the element type off the column rather than off the
+    // Vector, so the subtype here is only a label.
+    const elementType = Array.isArray(info) ? info[0] : undefined;
+    const elements = Array.from(value).map((v) => toDriverValue(v, elementType));
+    return new cassandra.types.Vector(elements, dataTypeName(elementType));
+  }
+
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const className = typeof info === 'string' ? info.split('.').pop() : '';
+  const rebuild = customFromString[className];
+  return rebuild ? rebuild(value) : value;
 }

--- a/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/cassandra/valueConverter.ts
@@ -1,0 +1,92 @@
+import * as cassandra from 'cassandra-driver';
+
+/**
+ * A column/field type descriptor as handed to us by the driver.
+ *
+ * The shape of `info` depends on `code`:
+ *  - list/set:  a single nested descriptor (the element type)
+ *  - map:       a two element tuple, [keyType, valueType]
+ *  - tuple:     an array of descriptors, one per position
+ *  - udt:       { name, keyspace, fields: [{ name, type }] }
+ *  - scalars:   unused
+ */
+export type CassandraType = {
+  code: number;
+  info?: any;
+};
+
+const dataTypes = cassandra.types.dataTypes;
+
+function convertScalar(value: any, code: number) {
+  switch (code) {
+    case dataTypes.bigint:
+      return String(value);
+    case dataTypes.timestamp:
+      // Map keys reach us already coerced to strings: the driver builds plain
+      // object maps with `map[key] = value`, which stringifies a Date key.
+      return typeof value.toISOString === 'function' ? value.toISOString() : String(value);
+    case dataTypes.time:
+    case dataTypes.date:
+      return String(value);
+    case dataTypes.uuid:
+    case dataTypes.timeuuid:
+      return value?.buffer
+        ? new cassandra.types.Uuid(Buffer.from(value.buffer)).toString()
+        : value;
+    case dataTypes.inet:
+      return value.toString();
+    default:
+      return value;
+  }
+}
+
+/**
+ * Convert a driver-decoded value into something that survives the trip to the
+ * renderer and reads sensibly in the grid.
+ *
+ * Driver types like Uuid, Long and InetAddress are class instances, so once
+ * they cross the process boundary they arrive as their raw internals - a UUID
+ * turns into `{ buffer: { type: "Buffer", data: [...] } }`. Containers are
+ * walked recursively so a driver type is converted no matter how deeply it is
+ * nested: set<frozen<udt>>, a udt holding a list, a udt inside a udt, and so on.
+ */
+export function convertValueByType(value: any, type: CassandraType) {
+  if (value == null) {
+    return null;
+  }
+
+  const { code, info } = type ?? {};
+
+  if (code === dataTypes.list || code === dataTypes.set) {
+    return Array.from(value).map((v) => convertValueByType(v, info));
+  }
+
+  if (code === dataTypes.map) {
+    const [keyType, valueType] = info ?? [];
+    const entries = value instanceof Map ? value.entries() : Object.entries(value);
+    const converted = {};
+    for (const [k, v] of entries) {
+      const convertedKey = convertValueByType(k, keyType);
+      converted[convertedKey as string] = convertValueByType(v, valueType);
+    }
+    return converted;
+  }
+
+  if (code === dataTypes.udt) {
+    const converted = {};
+    (info?.fields ?? []).forEach((field) => {
+      converted[field.name] = convertValueByType(value[field.name], field.type);
+    });
+    return converted;
+  }
+
+  if (code === dataTypes.tuple) {
+    // A driver Tuple is not iterable and exposes no indexed properties, so
+    // Array.from(tuple) yields a same-length array of undefined. Read the
+    // backing array instead.
+    const elements = value.elements ?? value;
+    return Array.from(elements).map((v, i) => convertValueByType(v, info?.[i]));
+  }
+
+  return convertScalar(value, code);
+}

--- a/apps/studio/src/shared/lib/dialects/cassandra.ts
+++ b/apps/studio/src/shared/lib/dialects/cassandra.ts
@@ -8,37 +8,6 @@ const types = [
 
 const supportsLength = []
 
-// Couldn't find a function in the cassandra-driver api which found these, so ripped it out and can map it using the type.code.
-// https://github.com/datastax/nodejs-driver/blob/388418dd7d9cf7c0e1e8a803a7791458268c9ad6/lib/types/index.js#L48
-export const dataTypesToMatchTypeCode = [
-  'custom',
-  'ascii',
-  'bigint',
-  'blob',
-  'boolean',
-  'counter',
-  'decimal',
-  'double',
-  'float',
-  'int',
-  'text',
-  'timestamp',
-  'uuid',
-  'varchar',
-  'varint',
-  'timeuuid',
-  'inet',
-  'date',
-  'time',
-  'smallint',
-  'tinyint',
-  'list',
-  'map',
-  'set',
-  'udt',
-  'tuple'
-]
-
 const defaultLength = (t: string) => t.startsWith('var') ? 255 : 8
 
 const UNWRAPPER = /^`(.*)`$/

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -322,6 +322,99 @@ describe("Cassandra Tests", () => {
     expect(structuredClone(counterRow)).toEqual(counterRow)
   })
 
+  it("Should write back the values the grid was shown", async () => {
+    // The read side flattens driver classes so they survive IPC, which leaves
+    // the grid holding strings and arrays the driver's encoder rejects.
+    const keyspace = 'write_back_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.editable (
+        id UUID PRIMARY KEY,
+        window DURATION,
+        zero_window DURATION,
+        pair FROZEN<TUPLE<UUID, INT>>,
+        huge VARINT,
+        amount DECIMAL,
+        total BIGINT,
+        windows LIST<DURATION>
+      )
+    `)
+
+    const rowId = '77777777-8888-9999-aaaa-bbbbbbbbbbbb'
+    const pairId = '99999999-8888-7777-6666-555555555555'
+    const huge = '123456789012345678901234567890'
+    const amount = '0.10000000000000000001'
+    const total = '9007199254740993'
+
+    await connection.executeQuery(`
+      INSERT INTO ${keyspace}.editable (id, window, zero_window, pair, huge, amount, total, windows)
+      VALUES (
+        ${rowId}, 1mo2d3s, 0s, (${pairId}, 3), ${huge}, ${amount}, ${total}, [1mo2d3s]
+      )
+    `)
+
+    const writeConnection = server.createConnection(keyspace)
+    await writeConnection.connect()
+
+    try {
+      const before = await writeConnection.executeQuery(
+        `SELECT * FROM ${keyspace}.editable WHERE id = ${rowId}`
+      )
+      const row = before[0].rows[0]
+
+      // exactly what the grid holds, fed straight back as an edit
+      await writeConnection.applyChanges({
+        inserts: [],
+        updates: [
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'window', value: row.window },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'zero_window', value: row.zero_window },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'pair', value: row.pair },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'huge', value: row.huge },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'amount', value: row.amount },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'total', value: row.total },
+          { table: 'editable', schema: keyspace, primaryKeys: [{ column: 'id', value: row.id }], column: 'windows', value: row.windows },
+        ],
+        deletes: [],
+      })
+
+      const after = await writeConnection.executeQuery(
+        `SELECT * FROM ${keyspace}.editable WHERE id = ${rowId}`
+      )
+      expect(after[0].rows[0]).toEqual(row)
+
+      // and an insert built from the same flattened shapes
+      const newId = '66666666-5555-4444-3333-222222222222'
+      await writeConnection.applyChanges({
+        inserts: [{
+          table: 'editable',
+          schema: keyspace,
+          data: [{
+            id: newId,
+            window: '1mo2d3s',
+            zero_window: '0s',
+            pair: [pairId, 3],
+            huge,
+            amount,
+            total,
+            windows: ['1mo2d3s'],
+          }],
+        }],
+        updates: [],
+        deletes: [],
+      })
+
+      const inserted = await writeConnection.executeQuery(
+        `SELECT * FROM ${keyspace}.editable WHERE id = ${newId}`
+      )
+      expect(inserted[0].rows[0]).toEqual({ ...row, id: newId })
+    } finally {
+      await writeConnection.disconnect()
+    }
+  })
+
   it("Should report CQL type names for columns", async () => {
     const keyspace = 'type_name_test'
 

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -171,6 +171,32 @@ describe("Cassandra Tests", () => {
     expect(row.text_uuid_map.first).toBe(textVal)
   })
 
+  it("Should keep a tuple map key intact", async () => {
+    // a frozen tuple is a legal map key, and the driver hands the key over
+    // already stringified as '(1,2)'. Walking that through the tuple branch
+    // shreds it character by character into '(,1,,,2,)'.
+    const keyspace = 'tuple_map_key_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.tuple_keys (
+        id INT PRIMARY KEY,
+        lookup MAP<FROZEN<TUPLE<INT, INT>>, TEXT>
+      )
+    `)
+    await connection.executeQuery(
+      `INSERT INTO ${keyspace}.tuple_keys (id, lookup) VALUES (1, {(1,2): 'hello'})`
+    )
+
+    const results = await connection.executeQuery(`SELECT * FROM ${keyspace}.tuple_keys WHERE id = 1`)
+    const row = results[0].rows[0]
+
+    expect(row.lookup).toEqual({ '(1,2)': 'hello' })
+    expect(structuredClone(row)).toEqual(row)
+  })
+
   it("Should convert UUIDs nested inside user defined types to strings", async () => {
     const keyspace = 'uuid_udt_test'
 

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -239,4 +239,121 @@ describe("Cassandra Tests", () => {
     // performs on its way to the renderer
     expect(structuredClone(row)).toEqual(row)
   })
+
+  it("Should convert numeric and duration types to strings", async () => {
+    const keyspace = 'numeric_type_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.metrics_type (
+        huge VARINT,
+        amount DECIMAL,
+        window DURATION
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.numerics (
+        name TEXT PRIMARY KEY,
+        total BIGINT,
+        huge VARINT,
+        amount DECIMAL,
+        window DURATION,
+        zero_window DURATION,
+        varint_list LIST<VARINT>,
+        metrics FROZEN<metrics_type>
+      )
+    `)
+
+    // values chosen to be unrepresentable as a JS number
+    const huge = '123456789012345678901234567890'
+    const amount = '0.10000000000000000001'
+    const total = '9007199254740993'
+
+    await connection.executeQuery(`
+      INSERT INTO ${keyspace}.numerics (name, total, huge, amount, window, zero_window, varint_list, metrics)
+      VALUES (
+        'row1',
+        ${total},
+        ${huge},
+        ${amount},
+        1mo2d3s,
+        0s,
+        [${huge}],
+        {huge: ${huge}, amount: ${amount}, window: 1mo2d3s}
+      )
+    `)
+
+    const results = await connection.executeQuery(
+      `SELECT * FROM ${keyspace}.numerics WHERE name = 'row1'`
+    )
+    expect(results[0].rows).toHaveLength(1)
+    const row = results[0].rows[0]
+
+    expect(row.total).toBe(total)
+    expect(row.huge).toBe(huge)
+    expect(row.amount).toBe(amount)
+    expect(row.window).toBe('1mo2d3s')
+    // a zero duration stringifies to '' in the driver, which would read as unset
+    expect(row.zero_window).toBe('0s')
+    expect(row.varint_list).toEqual([huge])
+    expect(row.metrics).toEqual({ huge, amount, window: '1mo2d3s' })
+
+    expect(structuredClone(row)).toEqual(row)
+
+    // counters live in their own table: Cassandra will not mix them with
+    // non-counter columns
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.counters (
+        name TEXT PRIMARY KEY,
+        hits COUNTER
+      )
+    `)
+    await connection.executeQuery(
+      `UPDATE ${keyspace}.counters SET hits = hits + ${total} WHERE name = 'row1'`
+    )
+
+    const counterResults = await connection.executeQuery(
+      `SELECT * FROM ${keyspace}.counters WHERE name = 'row1'`
+    )
+    const counterRow = counterResults[0].rows[0]
+    expect(counterRow.hits).toBe(total)
+    expect(structuredClone(counterRow)).toEqual(counterRow)
+  })
+
+  it("Should report CQL type names for columns", async () => {
+    const keyspace = 'type_name_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.name_ref (
+        id UUID
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.typed (
+        name TEXT PRIMARY KEY,
+        window DURATION,
+        tags LIST<TEXT>,
+        lookup MAP<TEXT, UUID>,
+        ref FROZEN<name_ref>
+      )
+    `)
+
+    const results = await connection.executeQuery(`SELECT * FROM ${keyspace}.typed`)
+    const byName = {}
+    results[0].fields.forEach((f) => { byName[f.name] = f.dataType })
+
+    // text and varchar are aliases in CQL and the protocol carries both under
+    // the varchar type code, so that is the name that comes back
+    expect(byName.name).toBe('varchar')
+    // duration used to come back as 'list', collections as 'user-defined'
+    expect(byName.window).toBe('duration')
+    expect(byName.tags).toBe('list<varchar>')
+    expect(byName.lookup).toBe('map<varchar, uuid>')
+    expect(byName.ref).toBe('name_ref')
+  })
 })

--- a/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
+++ b/apps/studio/tests/integration/lib/db/clients/cassandra.spec.js
@@ -170,4 +170,73 @@ describe("Cassandra Tests", () => {
     expect(typeof row.text_uuid_map).toBe('object')
     expect(row.text_uuid_map.first).toBe(textVal)
   })
+
+  it("Should convert UUIDs nested inside user defined types to strings", async () => {
+    const keyspace = 'uuid_udt_test'
+
+    await connection.executeQuery(
+      `CREATE KEYSPACE IF NOT EXISTS ${keyspace} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}`
+    )
+    // a udt with a uuid field, used both as a bare column and as the element
+    // type of a collection, plus a udt nested inside another udt
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.item_ref (
+        id UUID,
+        position INT
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TYPE IF NOT EXISTS ${keyspace}.wrapper_type (
+        label TEXT,
+        inner FROZEN<item_ref>
+      )
+    `)
+    await connection.executeQuery(`
+      CREATE TABLE IF NOT EXISTS ${keyspace}.nested_udt (
+        username TEXT PRIMARY KEY,
+        single FROZEN<item_ref>,
+        item_list SET<FROZEN<item_ref>>,
+        nested FROZEN<wrapper_type>
+      )
+    `)
+
+    const singleId = '660e8400-e29b-41d4-a716-446655440000'
+    const setIdA = '660e8400-e29b-41d4-a716-446655440001'
+    const setIdB = '660e8400-e29b-41d4-a716-446655440002'
+    const nestedId = '660e8400-e29b-41d4-a716-446655440003'
+
+    await connection.executeQuery(`
+      INSERT INTO ${keyspace}.nested_udt (username, single, item_list, nested)
+      VALUES (
+        'test_user',
+        {id: ${singleId}, position: 1},
+        {{id: ${setIdA}, position: 2}, {id: ${setIdB}, position: 3}},
+        {label: 'wrapped', inner: {id: ${nestedId}, position: 4}}
+      )
+    `)
+
+    const results = await connection.executeQuery(
+      `SELECT * FROM ${keyspace}.nested_udt WHERE username = 'test_user'`
+    )
+    expect(results[0].rows).toHaveLength(1)
+    const row = results[0].rows[0]
+
+    // bare FROZEN<udt> column
+    expect(row.single).toEqual({ id: singleId, position: 1 })
+    expect(typeof row.single.id).toBe('string')
+
+    // SET<FROZEN<udt>> (order is not guaranteed)
+    expect(Array.isArray(row.item_list)).toBe(true)
+    expect([...row.item_list].sort((a, b) => a.position - b.position)).toEqual([
+      { id: setIdA, position: 2 },
+      { id: setIdB, position: 3 },
+    ])
+
+    // udt nested inside a udt
+    expect(row.nested).toEqual({ label: 'wrapped', inner: { id: nestedId, position: 4 } })
+
+    // nothing driver-internal survives the structured clone the IPC boundary
+    // performs on its way to the renderer
+    expect(structuredClone(row)).toEqual(row)
+  })
 })

--- a/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
@@ -147,6 +147,20 @@ describe("cassandra valueConverter", () => {
         .toEqual([[ID_A, 1]])
     })
 
+    it("does not shred a tuple map key the driver already stringified", () => {
+      // a frozen tuple is a legal map key, and the driver hands it over as
+      // "(1,2)". Walking that string with the tuple branch yields "(,1,,,2,)".
+      const value = { "(1,2)": driverUuid(ID_A) }
+
+      expect(convertValueByType(value, map(tuple(int, int), uuid())))
+        .toEqual({ "(1,2)": ID_A })
+    })
+
+    it("still converts scalar map keys", () => {
+      const value = { [ID_A]: "x" }
+      expect(convertValueByType(value, map(uuid(), text))).toEqual({ [ID_A]: "x" })
+    })
+
     it("does not stringify an already stringified timestamp map key", () => {
       // The driver builds plain object maps with `map[key] = value`, so a Date
       // key arrives as a string and must not be handed toISOString()

--- a/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
@@ -1,0 +1,188 @@
+import * as cassandra from "cassandra-driver"
+import { convertValueByType } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
+
+const dataTypes = cassandra.types.dataTypes
+
+const uuid = (code = dataTypes.uuid) => ({ code })
+const text = { code: dataTypes.text }
+const int = { code: dataTypes.int }
+const boolean = { code: dataTypes.boolean }
+
+const list = (info) => ({ code: dataTypes.list, info })
+const set = (info) => ({ code: dataTypes.set, info })
+const map = (keyType, valueType) => ({ code: dataTypes.map, info: [keyType, valueType] })
+const tuple = (...info) => ({ code: dataTypes.tuple, info })
+const udt = (name, fields) => ({
+  code: dataTypes.udt,
+  info: {
+    name,
+    keyspace: "mtm",
+    fields: Object.entries(fields).map(([fieldName, type]) => ({ name: fieldName, type })),
+  },
+})
+
+// The driver hands back Uuid instances. Once they cross the process boundary
+// they arrive as their raw internals, which is what the grid used to render.
+const driverUuid = (value: string) => cassandra.types.Uuid.fromString(value)
+
+const ID_A = "b7e4e35c-1a05-4c93-8a3f-9d2fd6a1f001"
+const ID_B = "0f2b6c1e-9d4a-4e21-8b70-3c1a5e7d2002"
+
+describe("cassandra valueConverter", () => {
+  describe("scalars", () => {
+    it("converts a top level uuid to a string", () => {
+      expect(convertValueByType(driverUuid(ID_A), uuid())).toBe(ID_A)
+    })
+
+    it("converts a timeuuid to a string", () => {
+      const value = cassandra.types.TimeUuid.now()
+      expect(convertValueByType(value, uuid(dataTypes.timeuuid))).toBe(value.toString())
+    })
+
+    it("converts a bigint to a string", () => {
+      expect(convertValueByType(cassandra.types.Long.fromString("9007199254740993"), { code: dataTypes.bigint }))
+        .toBe("9007199254740993")
+    })
+
+    it("converts a timestamp to an ISO string", () => {
+      const date = new Date("2026-08-28T10:11:12.000Z")
+      expect(convertValueByType(date, { code: dataTypes.timestamp })).toBe("2026-08-28T10:11:12.000Z")
+    })
+
+    it("leaves plain types alone", () => {
+      expect(convertValueByType("hello", text)).toBe("hello")
+      expect(convertValueByType(7, int)).toBe(7)
+      expect(convertValueByType(false, boolean)).toBe(false)
+    })
+
+    it("returns null for null and undefined", () => {
+      expect(convertValueByType(null, uuid())).toBeNull()
+      expect(convertValueByType(undefined, uuid())).toBeNull()
+    })
+  })
+
+  describe("collections", () => {
+    it("converts uuids in a list", () => {
+      expect(convertValueByType([driverUuid(ID_A), driverUuid(ID_B)], list(uuid())))
+        .toEqual([ID_A, ID_B])
+    })
+
+    it("converts uuids in a set", () => {
+      expect(convertValueByType([driverUuid(ID_A), driverUuid(ID_B)], set(uuid())))
+        .toEqual([ID_A, ID_B])
+    })
+
+    it("converts uuid keys and values in a map", () => {
+      const value = { [ID_A]: driverUuid(ID_B) }
+      expect(convertValueByType(value, map(uuid(), uuid()))).toEqual({ [ID_A]: ID_B })
+    })
+
+    it("converts a map decoded as an ES6 Map", () => {
+      const value = new Map([[ID_A, driverUuid(ID_B)]])
+      expect(convertValueByType(value, map(uuid(), uuid()))).toEqual({ [ID_A]: ID_B })
+    })
+
+    it("converts values in a tuple position by position", () => {
+      // A real driver Tuple, not a plain array: Tuple is not iterable and has no
+      // indexed properties, so Array.from(tuple) silently yields [undefined, ...]
+      const value = cassandra.types.Tuple.fromArray([driverUuid(ID_A), 3])
+      expect(convertValueByType(value, tuple(uuid(), int))).toEqual([ID_A, 3])
+    })
+
+    it("converts a tuple nested inside a collection", () => {
+      const value = [cassandra.types.Tuple.fromArray([driverUuid(ID_A), 1])]
+      expect(convertValueByType(value, list(tuple(uuid(), int))))
+        .toEqual([[ID_A, 1]])
+    })
+
+    it("does not stringify an already stringified timestamp map key", () => {
+      // The driver builds plain object maps with `map[key] = value`, so a Date
+      // key arrives as a string and must not be handed toISOString()
+      const key = new Date("2026-08-28T10:11:12.000Z").toString()
+      const value = { [key]: driverUuid(ID_A) }
+
+      expect(convertValueByType(value, map({ code: dataTypes.timestamp }, uuid())))
+        .toEqual({ [key]: ID_A })
+    })
+  })
+
+  describe("user defined types", () => {
+    // a udt with a uuid field: the shape at the heart of this bug
+    const itemRef = udt("item_ref", { id: uuid(), position: int })
+
+    it("converts a uuid inside a bare udt column", () => {
+      const ownerRef = udt("owner_ref", { id: uuid(), name: text, description: text })
+      const value = { id: driverUuid(ID_A), name: "Acme", description: null }
+
+      expect(convertValueByType(value, ownerRef))
+        .toEqual({ id: ID_A, name: "Acme", description: null })
+    })
+
+    it("converts uuids inside a set of udts", () => {
+      const value = [
+        { id: driverUuid(ID_A), position: 1 },
+        { id: driverUuid(ID_B), position: 2 },
+      ]
+
+      expect(convertValueByType(value, set(itemRef))).toEqual([
+        { id: ID_A, position: 1 },
+        { id: ID_B, position: 2 },
+      ])
+    })
+
+    it("converts uuids inside a list of udts", () => {
+      const value = [{ id: driverUuid(ID_A), position: 1 }]
+      expect(convertValueByType(value, list(itemRef))).toEqual([{ id: ID_A, position: 1 }])
+    })
+
+    it("converts a collection nested inside a udt", () => {
+      const memberType = udt("member_type", { username: text, roles: set(text), blocked: boolean })
+      const value = { username: "test_user", roles: ["admin", "editor"], blocked: false }
+
+      expect(convertValueByType(value, memberType))
+        .toEqual({ username: "test_user", roles: ["admin", "editor"], blocked: false })
+    })
+
+    it("converts a uuid in a udt nested inside a udt inside a list", () => {
+      // a udt holding another udt, inside a list
+      const meta = udt("note_meta_type", { authorId: uuid() })
+      const comment = udt("note_type", { id: uuid(), meta })
+      const value = [{ id: driverUuid(ID_A), meta: { authorId: driverUuid(ID_B) } }]
+
+      expect(convertValueByType(value, list(comment)))
+        .toEqual([{ id: ID_A, meta: { authorId: ID_B } }])
+    })
+
+    it("converts uuids in a map whose values are udts", () => {
+      const value = { first: { id: driverUuid(ID_A), position: 1 } }
+      expect(convertValueByType(value, map(text, itemRef)))
+        .toEqual({ first: { id: ID_A, position: 1 } })
+    })
+
+    it("keeps null udt fields null", () => {
+      expect(convertValueByType({ id: null, position: null }, itemRef))
+        .toEqual({ id: null, position: null })
+    })
+
+    it("returns null for a null udt column", () => {
+      expect(convertValueByType(null, itemRef)).toBeNull()
+    })
+
+    it("returns null for a null element inside a collection of udts", () => {
+      expect(convertValueByType([null], list(itemRef))).toEqual([null])
+    })
+  })
+
+  it("does not leave driver internals anywhere in a nested value", () => {
+    const itemRef = udt("item_ref", { id: uuid(), position: int })
+    const converted = convertValueByType(
+      [{ id: driverUuid(ID_A), position: 1 }],
+      set(itemRef)
+    )
+
+    // The bug: an unconverted Uuid instance survives the structured clone the
+    // IPC boundary performs and reaches the grid as { buffer: ... }.
+    // (JSON.stringify would hide this - Uuid defines toJSON.)
+    expect(structuredClone(converted)).toEqual([{ id: ID_A, position: 1 }])
+  })
+})

--- a/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
@@ -1,5 +1,5 @@
 import * as cassandra from "cassandra-driver"
-import { convertValueByType } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
+import { convertValueByType, dataTypeName } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
 
 const dataTypes = cassandra.types.dataTypes
 
@@ -42,6 +42,58 @@ describe("cassandra valueConverter", () => {
     it("converts a bigint to a string", () => {
       expect(convertValueByType(cassandra.types.Long.fromString("9007199254740993"), { code: dataTypes.bigint }))
         .toBe("9007199254740993")
+    })
+
+    it("converts a counter to a string", () => {
+      // a counter decodes to a Long, same as a bigint, but under its own code
+      const value = cassandra.types.Long.fromString("9007199254740993")
+      expect(convertValueByType(value, { code: dataTypes.counter })).toBe("9007199254740993")
+    })
+
+    it("converts a varint to a string", () => {
+      // Integer is backed by an int array, so it has no meaningful raw form
+      const value = cassandra.types.Integer.fromString("123456789012345678901234567890")
+      expect(convertValueByType(value, { code: dataTypes.varint }))
+        .toBe("123456789012345678901234567890")
+    })
+
+    it("converts a negative varint to a string", () => {
+      const value = cassandra.types.Integer.fromString("-123456789012345678901234567890")
+      expect(convertValueByType(value, { code: dataTypes.varint }))
+        .toBe("-123456789012345678901234567890")
+    })
+
+    it("converts a decimal to a string, keeping its scale", () => {
+      const value = cassandra.types.BigDecimal.fromString("1234.5678")
+      expect(convertValueByType(value, { code: dataTypes.decimal })).toBe("1234.5678")
+    })
+
+    it("converts a decimal with more precision than a double can hold", () => {
+      const value = cassandra.types.BigDecimal.fromString("0.10000000000000000001")
+      expect(convertValueByType(value, { code: dataTypes.decimal })).toBe("0.10000000000000000001")
+    })
+
+    it("converts a duration to its CQL literal", () => {
+      const value = new cassandra.types.Duration(1, 2, cassandra.types.Long.fromNumber(3000000000))
+      expect(convertValueByType(value, { code: dataTypes.duration })).toBe("1mo2d3s")
+    })
+
+    it("spells out a zero duration rather than rendering a blank cell", () => {
+      // Duration.toString() appends nothing per zero component, so an all-zero
+      // duration stringifies to "" and is indistinguishable from unset
+      const value = new cassandra.types.Duration(0, 0, cassandra.types.Long.ZERO)
+      expect(String(value)).toBe("")
+      expect(convertValueByType(value, { code: dataTypes.duration })).toBe("0s")
+      // and it has to be something Cassandra reads back
+      expect(String(cassandra.types.Duration.fromString("0s"))).toBe("")
+    })
+
+    it("does not apply the zero duration fallback to other numeric types", () => {
+      // guards the switch fallthrough: a zero varint/decimal/bigint is "0"
+      expect(convertValueByType(cassandra.types.Integer.fromString("0"), { code: dataTypes.varint })).toBe("0")
+      expect(convertValueByType(cassandra.types.BigDecimal.fromString("0"), { code: dataTypes.decimal })).toBe("0")
+      expect(convertValueByType(cassandra.types.Long.ZERO, { code: dataTypes.bigint })).toBe("0")
+      expect(convertValueByType(cassandra.types.Long.ZERO, { code: dataTypes.counter })).toBe("0")
     })
 
     it("converts a timestamp to an ISO string", () => {
@@ -173,6 +225,87 @@ describe("cassandra valueConverter", () => {
     })
   })
 
+  describe("custom types", () => {
+    it("converts a vector to a plain array", () => {
+      // Vector is a Proxy over its elements and throws on structured clone
+      const value = new cassandra.types.Vector(new Float32Array([1, 2, 3]), "float")
+      const type = {
+        code: dataTypes.custom,
+        customTypeName: "vector",
+        info: [{ code: dataTypes.float }, 3],
+      }
+
+      const converted = convertValueByType(value, type)
+      expect(converted).toEqual([1, 2, 3])
+      expect(structuredClone(converted)).toEqual([1, 2, 3])
+    })
+
+    it("converts a duration sent as a custom type", () => {
+      // how a real server sends duration: custom, not type code 21
+      const value = new cassandra.types.Duration(1, 2, cassandra.types.Long.fromNumber(3000000000))
+      const type = { code: dataTypes.custom, info: "org.apache.cassandra.db.marshal.DurationType" }
+
+      expect(convertValueByType(value, type)).toBe("1mo2d3s")
+      expect(convertValueByType(
+        new cassandra.types.Duration(0, 0, cassandra.types.Long.ZERO), type
+      )).toBe("0s")
+    })
+
+    it("leaves an undecodable custom value as a buffer", () => {
+      const value = Buffer.from([1, 2, 3])
+      expect(convertValueByType(value, { code: dataTypes.custom, info: "com.example.Whatever" }))
+        .toBe(value)
+    })
+  })
+
+  describe("dataTypeName", () => {
+    it("names scalars", () => {
+      expect(dataTypeName({ code: dataTypes.varint })).toBe("varint")
+      expect(dataTypeName({ code: dataTypes.decimal })).toBe("decimal")
+      expect(dataTypeName({ code: dataTypes.counter })).toBe("counter")
+    })
+
+    it("names duration, which the old code-indexed array reported as list", () => {
+      expect(dataTypeName({ code: dataTypes.duration })).toBe("duration")
+    })
+
+    it("names a custom type after its Java class", () => {
+      // a real server sends duration as a custom type, not as code 21
+      expect(dataTypeName({
+        code: dataTypes.custom,
+        info: "org.apache.cassandra.db.marshal.DurationType",
+      })).toBe("duration")
+      expect(dataTypeName({
+        code: dataTypes.custom,
+        info: "org.apache.cassandra.db.marshal.PointType",
+      })).toBe("point")
+    })
+
+    it("names a vector with its subtype and dimensions", () => {
+      expect(dataTypeName({
+        code: dataTypes.custom,
+        customTypeName: "vector",
+        info: [{ code: dataTypes.float }, 3],
+      })).toBe("vector<float, 3>")
+    })
+
+    it("names collections with their subtypes", () => {
+      expect(dataTypeName(list(uuid()))).toBe("list<uuid>")
+      expect(dataTypeName(set(text))).toBe("set<text>")
+      expect(dataTypeName(map(text, int))).toBe("map<text, int>")
+      expect(dataTypeName(tuple(uuid(), int))).toBe("tuple<uuid, int>")
+    })
+
+    it("names a udt after the type itself", () => {
+      expect(dataTypeName(udt("item_ref", { id: uuid(), position: int }))).toBe("item_ref")
+    })
+
+    it("falls back for a descriptor it cannot read", () => {
+      expect(dataTypeName(undefined as any)).toBe("user-defined")
+      expect(dataTypeName({ code: 9999 })).toBe("user-defined")
+    })
+  })
+
   it("does not leave driver internals anywhere in a nested value", () => {
     const itemRef = udt("item_ref", { id: uuid(), position: int })
     const converted = convertValueByType(
@@ -184,5 +317,35 @@ describe("cassandra valueConverter", () => {
     // IPC boundary performs and reaches the grid as { buffer: ... }.
     // (JSON.stringify would hide this - Uuid defines toJSON.)
     expect(structuredClone(converted)).toEqual([{ id: ID_A, position: 1 }])
+  })
+
+  it("converts every driver class type nested inside a udt", () => {
+    // one udt holding each of the types that decode to a class instance
+    const metrics = udt("metrics_type", {
+      total: { code: dataTypes.bigint },
+      hits: { code: dataTypes.counter },
+      huge: { code: dataTypes.varint },
+      amount: { code: dataTypes.decimal },
+      window: { code: dataTypes.duration },
+    })
+    const value = {
+      total: cassandra.types.Long.fromString("9007199254740993"),
+      hits: cassandra.types.Long.fromString("42"),
+      huge: cassandra.types.Integer.fromString("123456789012345678901234567890"),
+      amount: cassandra.types.BigDecimal.fromString("1234.5678"),
+      window: new cassandra.types.Duration(1, 2, cassandra.types.Long.fromNumber(3000000000)),
+    }
+
+    const expected = {
+      total: "9007199254740993",
+      hits: "42",
+      huge: "123456789012345678901234567890",
+      amount: "1234.5678",
+      window: "1mo2d3s",
+    }
+
+    const converted = convertValueByType([value], list(metrics))
+    expect(converted).toEqual([expected])
+    expect(structuredClone(converted)).toEqual([expected])
   })
 })

--- a/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/cassandraValueConverter.spec.ts
@@ -1,5 +1,5 @@
 import * as cassandra from "cassandra-driver"
-import { convertValueByType, dataTypeName } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
+import { convertValueByType, dataTypeName, toDriverValue } from "@commercial/backend/lib/db/clients/cassandra/valueConverter"
 
 const dataTypes = cassandra.types.dataTypes
 
@@ -347,5 +347,123 @@ describe("cassandra valueConverter", () => {
     const converted = convertValueByType([value], list(metrics))
     expect(converted).toEqual([expected])
     expect(structuredClone(converted)).toEqual([expected])
+  })
+})
+
+describe("cassandra toDriverValue", () => {
+  // The encoder is stricter than the decoder, so assert against the encoder
+  // itself rather than against a shape we assume it wants.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Encoder = require("cassandra-driver/lib/encoder")
+  const encoder = new Encoder(4, {})
+  const encodes = (value, type) => {
+    expect(() => encoder.encode(toDriverValue(value, type), type)).not.toThrow()
+  }
+
+  const durationType = { code: dataTypes.duration }
+  const customDuration = {
+    code: dataTypes.custom,
+    info: "org.apache.cassandra.db.marshal.DurationType",
+  }
+  const vectorType = {
+    code: dataTypes.custom,
+    customTypeName: "vector",
+    info: [{ code: dataTypes.float }, 3],
+  }
+
+  it("rebuilds a duration from the string the grid holds", () => {
+    const converted = toDriverValue("1mo2d3s", durationType)
+    expect(converted).toBeInstanceOf(cassandra.types.Duration)
+    expect(String(converted)).toBe("1mo2d3s")
+    encodes("1mo2d3s", durationType)
+  })
+
+  it("rebuilds a duration sent as a custom type", () => {
+    expect(toDriverValue("1mo2d3s", customDuration)).toBeInstanceOf(cassandra.types.Duration)
+    encodes("1mo2d3s", customDuration)
+  })
+
+  it("round trips the zero duration the reader spells out as 0s", () => {
+    const zero = new cassandra.types.Duration(0, 0, cassandra.types.Long.ZERO)
+    const displayed = convertValueByType(zero, durationType)
+
+    expect(displayed).toBe("0s")
+    const back = toDriverValue(displayed, durationType)
+    expect(back.months).toBe(0)
+    expect(back.days).toBe(0)
+    expect(String(back.nanoseconds)).toBe("0")
+    encodes(displayed, durationType)
+  })
+
+  it("rebuilds a tuple, which the encoder will not take as a plain array", () => {
+    const type = tuple(uuid(), int)
+    const displayed = convertValueByType(cassandra.types.Tuple.fromArray([driverUuid(ID_A), 3]), type)
+
+    expect(displayed).toEqual([ID_A, 3])
+    expect(toDriverValue(displayed, type)).toBeInstanceOf(cassandra.types.Tuple)
+    encodes(displayed, type)
+  })
+
+  it("rebuilds a vector, which the encoder will not take as a plain array", () => {
+    const converted = toDriverValue([1, 2, 3], vectorType)
+    expect(converted).toBeInstanceOf(cassandra.types.Vector)
+    encodes([1, 2, 3], vectorType)
+  })
+
+  it("rebuilds durations nested in collections and udts", () => {
+    const metrics = udt("metrics_type", { window: durationType, name: text })
+
+    const inList = toDriverValue(["1mo2d3s"], list(durationType))
+    expect(inList[0]).toBeInstanceOf(cassandra.types.Duration)
+    encodes(["1mo2d3s"], list(durationType))
+
+    const inUdt = toDriverValue({ window: "1mo2d3s", name: "x" }, metrics)
+    expect(inUdt.window).toBeInstanceOf(cassandra.types.Duration)
+    expect(inUdt.name).toBe("x")
+    encodes({ window: "1mo2d3s", name: "x" }, metrics)
+
+    const inMap = toDriverValue({ first: "1mo2d3s" }, map(text, durationType))
+    expect(inMap.first).toBeInstanceOf(cassandra.types.Duration)
+    encodes({ first: "1mo2d3s" }, map(text, durationType))
+  })
+
+  it("passes through the types the encoder already accepts as strings", () => {
+    // these were never broken and must not be touched
+    expect(toDriverValue("123456789012345678901234567890", { code: dataTypes.varint }))
+      .toBe("123456789012345678901234567890")
+    expect(toDriverValue("1234.5678", { code: dataTypes.decimal })).toBe("1234.5678")
+    expect(toDriverValue("9007199254740993", { code: dataTypes.bigint })).toBe("9007199254740993")
+    expect(toDriverValue(ID_A, uuid())).toBe(ID_A)
+    expect(toDriverValue("hello", text)).toBe("hello")
+    expect(toDriverValue(7, int)).toBe(7)
+    expect(toDriverValue(false, boolean)).toBe(false)
+
+    encodes("123456789012345678901234567890", { code: dataTypes.varint })
+    encodes("1234.5678", { code: dataTypes.decimal })
+    encodes(ID_A, uuid())
+  })
+
+  it("leaves a blob buffer alone", () => {
+    const value = Buffer.from([1, 2, 3])
+    expect(toDriverValue(value, { code: dataTypes.blob })).toBe(value)
+  })
+
+  it("returns null for null, and for a null element inside a collection", () => {
+    expect(toDriverValue(null, durationType)).toBeNull()
+    expect(toDriverValue(undefined, durationType)).toBeNull()
+    expect(toDriverValue([null], list(durationType))).toEqual([null])
+  })
+
+  it("passes a value through when the column type is unknown", () => {
+    // metadata lookup can fail; the write should still go out as it used to
+    expect(toDriverValue("1mo2d3s", undefined as any)).toBe("1mo2d3s")
+  })
+
+  it("accepts a value that is already a driver instance", () => {
+    const d = cassandra.types.Duration.fromString("1mo2d3s")
+    expect(toDriverValue(d, durationType)).toBe(d)
+
+    const t = cassandra.types.Tuple.fromArray([ID_A, 3])
+    expect(toDriverValue(t, tuple(uuid(), int))).toBe(t)
   })
 })


### PR DESCRIPTION
Builds on #4701 — until that merges, the diff here also shows its commit. The three commits on top of it are the ones to review.

#4701 fixed UUIDs nested inside UDTs. Working on it turned up more types with the same underlying problem, plus two bugs on the way back out.

## Types that never reached the grid intact

`convertValueByType` only converted `bigint`, `timestamp`, `time`, `date`, `uuid`, `timeuuid` and `inet`. Everything else fell through untouched, so any type the driver decodes into a class instance arrived in the renderer as raw internals after the structured clone:

| Type | Driver class | What the grid rendered |
| --- | --- | --- |
| `varint` | `Integer` | `{"bits_":[1312754386,-1015815954,…],"sign_":0}` |
| `decimal` | `BigDecimal` | `{"_intVal":{"bits_":[12345678],…},"_scale":4}` |
| `counter` | `Long` — same class as `bigint`, different type code, so it missed that case | `{"low":1,"high":2097152,"unsigned":false}` |
| `duration` | `Duration` | `{"months":1,"days":2,"nanoseconds":{…}}` |
| `custom` (vector, DSE geometry) | `Vector` etc. | `Vector` is a Proxy — `structuredClone` throws, so the query failed outright |

All four scalars have a correct `toString()`, so they're handled the same way `bigint` already was. Vectors become plain arrays.

Worth knowing for review: **a real server sends `duration` as a `custom` type, not under type code 21.** The custom branch is what actually fixes duration in practice; the code-21 case is kept because some protocol versions do use it.

`blob` deliberately stays a `Buffer` — `parseTableColumn` tags those `bksType: 'BINARY'` and the grid renders binary itself.

## Column type names

`dataTypesToMatchTypeCode` was a positional array indexed by driver type code, but the codes aren't contiguous — `list` is 32, `udt` is 48. So `duration` (21) landed on the array slot holding `list`, and every collection/UDT/tuple ran off the end into `user-defined`. Replaced with the driver's own `getDataTypeNameByCode`, which also handles subtypes (`list<uuid>`, `map<text, uuid>`) and returns a UDT's real name. It reports custom types as a flat `custom`, so the CQL name is derived from the Java class (`…marshal.DurationType` → `duration`).

Note `text` columns report as `varchar` — CQL aliases them and the protocol carries both under the varchar code. Unchanged from before.

## Values couldn't be written back

The read side flattens driver classes so they survive IPC, which leaves the grid holding strings and arrays the driver's encoder rejects. The encoder is stricter than the decoder — it takes a string for the numeric types "for historical reasons" but insists on the real class elsewhere:

```
list/set/map/udt as plain arrays & objects → OK
varint/decimal/bigint/counter as strings   → OK
tuple as a plain array   → FAIL  value.get is not a function
duration as a string     → FAIL  Not a valid duration
vector as a plain array  → FAIL  only supports Vector type
```

So editing any duration, vector or tuple cell and hitting Apply threw a raw `TypeError`. Tuples were broken by #4701 itself; the rest predate it.

`toDriverValue` is the inverse walker. It rebuilds only what the encoder actually rejects and passes everything else through untouched. Column types come from `client.metadata.getTable()` rather than from parsing the CQL strings in `system_schema` — the driver builds those descriptors with the same `parseTypeName` that produces the ones `parseRows` consumes, so both directions read identical shapes instead of two separate notions of what a column's type is. Looked up once per table per `applyChanges`. Primary key params go through it too, since a frozen tuple can be a partition key.

If the metadata lookup fails the values go out unconverted, which is what happened before any of this existed. That's deliberate — blocking every write because metadata is briefly unavailable would be worse — but it means a duration write can still fail with the encoder's opaque error, so the real cause is logged.

## Two smaller bugs

**A zero duration rendered as a blank cell.** `Duration.toString()` appends nothing per zero component, so `0s` stringified to `""` — indistinguishable from unset. Now `0s`, which parses back correctly.

**Tuple map keys were shredded.** A frozen tuple is a legal map key, and the driver hands those over already stringified as `(1,2)`. The tuple branch ran `Array.from` over that *string* and produced `(,1,,,2,)`. `list`, `set`, `map` and `udt` keys were mangled the same way. Keys that arrive pre-stringified are now left alone. Such a map still can't be written back — `Tuple` has no `fromString` — which is documented in the code rather than papered over.

**Not fixable here:** a `map` or `udt` used as a map key arrives collapsed to the literal string `"[object Object]"`, so two different keys overwrite each other. The driver destroys the key before this code sees it; it'd need `encoding.map` and real `Map` support. Pre-existing and out of scope.

## One behaviour change worth a look

`insertRows` had `params: columns.map(c => data[c] || null)`, which coerced `0`, `''` and `false` to null on insert. Changed to `??`.

`''` is the interesting one. Cassandra columns are configured `allowEmpty: true`, and `NullableInputEditor` treats `''` and `null` as deliberately distinct — `(EMPTY)` vs `(NULL)` placeholders, a separate "Nullify Value" control that emits real `null`, and a Delete-key path that explicitly sets `''`. So the grid does produce a literal empty string meaning "empty, not null", and it was being silently discarded. `updateValues` never had the coercion, so inserts and updates already disagreed, and the shared `buildInsertQuery` every other client uses applies no such coercion either.

## Testing

Unit tests assert against the driver's encoder directly rather than against an assumed shape. Integration tests run on a real `cassandra:4.1` container and cover the round trip — read a row, feed the grid's exact values back through `applyChanges` as both an update and an insert, assert the row is unchanged.

I checked the round-trip test isn't vacuous by neutering `toDriverValue` to identity; it fails with `TypeError: Not a valid duration, expected Duration/Buffer obtained '1mo2d3s'`.

Vector is the one path with no integration coverage — CQL vectors need Cassandra 5.0 and the container is pinned to 4.1. It's covered in unit tests against a real `Vector` and the real encoder.
