### PR TITLE
Move to the renamed @trinodb/trino-js-client

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -139,7 +139,7 @@
     "surrealdb": "^2.0.3",
     "tabulator-tables": "^6.5.2",
     "tinyduration": "^3.2.4",
-    "trino-client": "^0.2.9",
+    "@trinodb/trino-js-client": "^0.3.2",
     "typeface-roboto": "^0.0.75",
     "typeface-source-code-pro": "^1.1.3",
     "typeorm": "^0.3.31",

--- a/apps/studio/src-commercial/backend/lib/db/clients/trino.ts
+++ b/apps/studio/src-commercial/backend/lib/db/clients/trino.ts
@@ -7,7 +7,7 @@ import {
   QueryResult,
   ConnectionOptions as TrinoConnectionOptions,
   SecureContextOptions
-} from 'trino-client'
+} from '@trinodb/trino-js-client'
 import {
   BaseQueryResult,
   BasicDatabaseClient,
@@ -441,7 +441,7 @@ export class TrinoClient extends BasicDatabaseClient<TrinoResult> {
       const rows: any[] = []
 
       for await (const r of result) {
-        // The trino-client iterator doesn't throw on query failure - it
+        // The client iterator doesn't throw on query failure - it
         // yields the error response as a normal value, so without this
         // check a failed query looks like a successful 0-row result.
         if (r.error) {

--- a/apps/studio/tests/unit/lib/db/clients/trino.spec.ts
+++ b/apps/studio/tests/unit/lib/db/clients/trino.spec.ts
@@ -3,7 +3,7 @@ const capturedQueries: string[] = []
 // default single-row result. Reset it in beforeEach.
 const mockQueryResults: Record<string, any>[] = []
 
-jest.mock('trino-client', () => {
+jest.mock('@trinodb/trino-js-client', () => {
   const mockQuery = jest.fn().mockImplementation((sql: string) => {
     capturedQueries.push(sql)
     const results = mockQueryResults.length
@@ -30,7 +30,7 @@ jest.mock('trino-client', () => {
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { Trino as TrinoNodeClient } from 'trino-client'
+import { Trino as TrinoNodeClient } from '@trinodb/trino-js-client'
 import { TrinoClient } from '@commercial/backend/lib/db/clients/trino'
 import { IDbConnectionServer } from '@/lib/db/backendTypes'
 import { IDbConnectionDatabase } from '@/lib/db/types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,6 +4365,13 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
+"@trinodb/trino-js-client@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@trinodb/trino-js-client/-/trino-js-client-0.3.2.tgz#d0484d24281cf01700c49f83c50c496fff36936f"
+  integrity sha512-TNFOXkk2wp/SSgNtRdfArKZSR78ebYR7zxTobu+o01C+KJO7ELWcti90DeCw4WJDh0YbjZGT0XuXV48n7TEyoQ==
+  dependencies:
+    axios "1.19.0"
+
 "@tybys/wasm-util@^0.10.1":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
@@ -5639,7 +5646,7 @@ axios-retry@^3.2.4:
     "@babel/runtime" "^7.15.4"
     is-retry-allowed "^2.2.0"
 
-axios@1.13.2, axios@^1.15.0, axios@^1.15.1, axios@^1.18.0:
+axios@1.19.0, axios@^1.15.0, axios@^1.15.1, axios@^1.18.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.19.0.tgz#ddf864d4c8233c0e6873746ab59361537d05ad39"
   integrity sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==
@@ -13212,13 +13219,6 @@ tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
-
-trino-client@^0.2.9:
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/trino-client/-/trino-client-0.2.9.tgz#0f5dbdb920177402cb1a614c4bfda6e3a1bf56af"
-  integrity sha512-bINcQxDH5v9DR1zqXtoNqnRJ5leYMyYzRuFZLsoqg4irWYPDh/4wBndC8c2x+QfNIOr6c35BtHKOwotelqSATg==
-  dependencies:
-    axios "1.13.2"
 
 triple-beam@^1.3.0:
   version "1.4.1"


### PR DESCRIPTION
The Trino client was republished under the `trinodb` scope. Versions up to 0.2.9 shipped as the unscoped `trino-client`; the scoped `@trinodb/trino-js-client` starts at 0.3.0. The unscoped package is no longer maintained and will not receive further updates.

I am a Trino maintainer, and we are working through the downstream consumers of the client as part of that move. Happy to open an issue first if you would rather discuss it, per CONTRIBUTING.md — this seemed small enough to just show.

## Risk

Low. The declaration files of `trino-client@0.2.9` and `@trinodb/trino-js-client@0.3.2` are identical byte for byte:

```
$ npm pack trino-client@0.2.9 && tar xzf trino-client-0.2.9.tgz
$ diff -u package/dist/index.d.ts node_modules/@trinodb/trino-js-client/dist/index.d.ts
$ echo $?
0
```

Same twenty exports, same shapes, so this is a rename of the dependency and its import specifiers with no API change.

## Changes

- `apps/studio/package.json` — the dependency
- `apps/studio/src-commercial/backend/lib/db/clients/trino.ts` — the import, and one comment that names the package
- `apps/studio/tests/unit/lib/db/clients/trino.spec.ts` — the import and the `jest.mock` specifier
- `yarn.lock`

## A note on the lockfile

The change also removes an inconsistency that was already there. The old entry read:

```
axios@1.13.2, axios@^1.15.0, axios@^1.15.1, axios@^1.18.0:
  version "1.19.0"
```

The old client pinned axios `1.13.2` exactly, but yarn deduplicated that request against the newer ranges and resolved the whole group to 1.19.0, so the lockfile claimed to satisfy an exact pin with a version that does not match it. 0.3.2 pins 1.19.0, so the range key and the resolved version now agree. No axios version actually changes.

## Verification

I did not run the Trino integration suite, which needs a live coordinator. Beyond the declaration comparison above, I verified 0.3.2 against a real Trino using a harness built from this driver's call patterns, including the `next()` iteration and the error handling your client comments describe. All checks pass. That harness now runs in the client's own CI (trinodb/trino-js-client#970).