### PR TITLE
Connection import

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -31,6 +31,7 @@
     <workspace-delete-modal />
     <import-queries-modal />
     <import-connections-modal />
+    <connection-files-import-modal />
     <plugin-controller :editor-font-size="editorFontSize" />
     <plugin-manager-modal />
     <keyboard-shortcuts-modal />
@@ -96,6 +97,7 @@ import InputEphemeralModal from "@/components/common/modals/InputEphemeralModal.
 import ShareModal from "@/components/common/modals/ShareModal.vue";
 import MoveItemModal from "@/components/common/modals/MoveItemModal.vue";
 import MoveFolderModal from "@/components/common/modals/MoveFolderModal.vue";
+import ConnectionFilesImportModal from '@/components/common/modals/ConnectionFilesImportModal.vue'
 
 import rawLog from '@bksLogger'
 import { assignContextMenuToAllInputs } from './mixins/assignContextMenuToAllInputs'
@@ -114,6 +116,7 @@ export default Vue.extend({
     WorkspaceCreateModal, WorkspaceRenameModal, WorkspaceDeleteModal,
     PluginManagerModal, ConfigurationWarningModal, PluginController, LockManager, KeyboardShortcutsModal,
     InputEphemeralModal, ShareModal, MoveItemModal, MoveFolderModal,
+    ConnectionFilesImportModal
   },
   data() {
     return {

--- a/apps/studio/src/assets/styles/app/modals.scss
+++ b/apps/studio/src/assets/styles/app/modals.scss
@@ -19,7 +19,7 @@
     max-width: 520px;
   }
 
-  &.sql-files-import-modal, &.wait-sso-modal {
+  &.sql-files-import-modal, &.wait-sso-modal, &.connection-files-import-modal {
     .v--modal {
       width: auto !important;
       min-height: 0px;

--- a/apps/studio/src/assets/styles/app/sidebar/favorite-list.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/favorite-list.scss
@@ -40,11 +40,6 @@
   .list-heading {
     .actions {
       display: flex;
-      x-button {
-        height: auto;
-        padding: 0;
-        box-shadow: none;
-      }
     }
   }
   .list-title {

--- a/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
+++ b/apps/studio/src/assets/styles/app/sidebar/sidebar.scss
@@ -282,7 +282,16 @@
       cursor: pointer;
     }
     x-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
       height: auto;
+      min-width: 0;
+      flex-shrink: 0;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+      overflow: visible;
     }
     & > * {
       visibility: hidden;

--- a/apps/studio/src/backend/lib/objectimport/connection.ts
+++ b/apps/studio/src/backend/lib/objectimport/connection.ts
@@ -4,13 +4,14 @@ import { IFolder } from "@/common/interfaces/IQueryFolder";
 import { AppDbHandlers } from "@/handlers/appDbHandlers";
 import { promises as fs } from "fs";
 import path from "path";
+import { camelCaseObjectKeys } from "@/common/utils";
 
 export class ConnectionImporter extends ObjectImporter<ICloudSavedConnection> {
     async importFolders(folders: IFolder[]): Promise<IFolder[]> {
       if (this.client) {
         return await this.client.connectionFolders.import(folders);
       } else {
-        return await AppDbHandlers['appdb/connectionFolders/save']({ obj: folders, options: {} });
+        return await AppDbHandlers['appdb/connectionFolder/save']({ obj: folders, options: {} });
       }
     }
     async importItems(items: ICloudSavedConnection[]): Promise<ICloudSavedConnection[]> {
@@ -46,6 +47,7 @@ export class ConnectionImporter extends ObjectImporter<ICloudSavedConnection> {
 
       try {
         obj = JSON.parse(fileContents);
+        obj = camelCaseObjectKeys(obj);
       } catch (e) {
         this.stats.warnings.push(`Failed to parse json for ${filePath}. ${e.message ?? ''}`);
         return;

--- a/apps/studio/src/backend/lib/objectimport/connection.ts
+++ b/apps/studio/src/backend/lib/objectimport/connection.ts
@@ -1,0 +1,66 @@
+import { ICloudSavedConnection } from "@/common/interfaces/IConnection";
+import { MAX_BATCH_BYTES, MAX_BATCH_ROWS, ObjectDescriptor, ObjectImporter } from "./import";
+import { IFolder } from "@/common/interfaces/IQueryFolder";
+import { AppDbHandlers } from "@/handlers/appDbHandlers";
+import { promises as fs } from "fs";
+import path from "path";
+
+export class ConnectionImporter extends ObjectImporter<ICloudSavedConnection> {
+    async importFolders(folders: IFolder[]): Promise<IFolder[]> {
+      if (this.client) {
+        return await this.client.connectionFolders.import(folders);
+      } else {
+        return await AppDbHandlers['appdb/connectionFolders/save']({ obj: folders, options: {} });
+      }
+    }
+    async importItems(items: ICloudSavedConnection[]): Promise<ICloudSavedConnection[]> {
+      if (this.client) {
+        return await this.client.connections.import(items);
+      } else {
+        return await AppDbHandlers['appdb/saved/save']({ obj: items, options: {} });
+      }
+    }
+
+    async readObjectFromPath(dir: string, name: string, parentId?: number): Promise<ObjectDescriptor<ICloudSavedConnection>> {
+      const filePath = path.join(dir, name);
+      const stat = await fs.stat(filePath);
+
+      if(!stat.isFile()) {
+        this.stats.warnings.push(`Skipping ${filePath}, is not a file`);
+        return;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      if (ext !== '.json') {
+        this.stats.warnings.push(`Skipping ${filePath}, only .json files are allowed for connection import. Got "${ext || '(none)'}"`);
+        return;
+      }
+
+      if (this.currentBatch.length && (stat.size + this.currentBatchBytes > MAX_BATCH_BYTES || this.currentBatch.length + 1 > MAX_BATCH_ROWS)) {
+        this.batchFull = true;
+      }
+
+      const fileContents = await fs.readFile(filePath, { encoding: 'utf-8' });
+
+      let obj: ICloudSavedConnection;
+
+      try {
+        obj = JSON.parse(fileContents);
+      } catch (e) {
+        this.stats.warnings.push(`Failed to parse json for ${filePath}. ${e.message ?? ''}`);
+        return;
+      }
+
+      if (parentId) {
+        obj.connectionFolderId = parentId;
+      }
+
+      const desc: ObjectDescriptor<ICloudSavedConnection> = {
+        obj: obj,
+        size: stat.size
+      };
+
+      return desc;
+    }
+
+}

--- a/apps/studio/src/backend/lib/objectimport/import.ts
+++ b/apps/studio/src/backend/lib/objectimport/import.ts
@@ -1,0 +1,174 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+import { IObjectImportStats } from '@/common/interfaces/IObjectImportStats';
+import { IFolder } from '@/common/interfaces/IQueryFolder';
+import rawLog from '@bksLogger';
+import { CloudClient } from '@/lib/cloud/CloudClient';
+
+const log = rawLog.scope('ObjectImporter');
+
+export const MAX_SQL_FILE_LENGTH = 2_000_000;
+export const MAX_SQL_FILE_BYTES = 4 * MAX_SQL_FILE_LENGTH;
+export const SQL_FILE_EXTENSIONS = new Set(['.sql', '.txt']);
+
+export const SKIP_DIR_NAMES = new Set(['.git']);
+
+// I am just assuming that big batches might be an issue, so we have the ability to cap here
+// as well as cap the amount of rows so we don't piss off the active record transaction
+// I'm also not sure what size the cloud can actually handle
+export const MAX_BATCH_BYTES = 50 * 1024 * 1024;
+export const MAX_BATCH_ROWS = 100;
+
+export interface ObjectDescriptor<T> {
+  obj: T,
+  size: number
+}
+
+export abstract class ObjectImporter<T> {
+  stats: IObjectImportStats = {
+    warnings: [],
+    directories: 0,
+    items: 0
+  };
+  protected currentBatch: T[] = [];
+  protected currentBatchBytes: number = 0;
+  protected batchFull: boolean = false;
+
+  constructor(protected client?: CloudClient) {
+
+  }
+
+  abstract importFolders(folders: IFolder[]): Promise<IFolder[]>;
+  abstract importItems(items: T[]): Promise<T[]>;
+  abstract readObjectFromPath(dir: string, name: string, parentId?: number): Promise<ObjectDescriptor<T>>;
+
+  async importSelections(paths: string[], parentId: number): Promise<IObjectImportStats> {
+    this.stats = {
+      warnings: [],
+      directories: 0,
+      items: 0
+    };
+
+    this.currentBatch = [];
+    this.currentBatchBytes = 0;
+
+    for (const filePath of paths) {
+      const dir = path.dirname(filePath);
+      const name = path.basename(filePath);
+      const desc = await this.readObjectFromPath(dir, name, parentId);
+
+      if (this.batchFull) {
+        await this.importCurrentBatch();
+        this.batchFull = false;
+      }
+
+      await this.maybeAddToBatch(desc);
+    }
+
+    return this.stats;
+  }
+
+  async importDirectory(dir: string, parentId: number | null, importDir: boolean = true): Promise<IObjectImportStats> {
+    this.stats = {
+      warnings: [],
+      directories: 0,
+      items: 0
+    };
+
+    await this._import(dir, parentId, importDir);
+
+    return this.stats;
+  }
+
+  private async _import(dir: string, parentId: number | null, importDir: boolean = true): Promise<void> {
+    if (importDir) {
+      let parent: IFolder = {
+        id: null,
+        name: path.basename(dir),
+        parentId
+      } as IFolder;
+
+      try {
+        [parent] = await this.importFolders([parent]);
+
+        this.stats.directories += 1;
+        parentId = parent.id;
+      } catch (e) {
+        log.error(e);
+        this.stats.warnings.push(`Failed to import directory ${parent.name}. ${e.message}`);
+        return;
+      }
+    }
+
+    await this.importLevel(dir, parentId);
+
+    const childDirNames = await this.getDirChildren(dir, true);
+
+    for (const child of childDirNames) {
+      if (!SKIP_DIR_NAMES.has(child)) {
+        const dirPath = path.join(dir, child);
+
+        await this._import(dirPath, parentId);
+      } else {
+        this.stats.warnings.push(`Skipping folder: ${child}`);
+      }
+    }
+  }
+
+  async getDirChildren(dir: string, isDir: boolean): Promise<string[]> {
+    const children: string[] = []
+    for await (const d of await fs.opendir(dir)) {
+      if (d.isDirectory() === isDir) {
+        children.push(d.name);
+      } else if (d.isFile() === !isDir) {
+        children.push(d.name)
+      }
+    }
+
+    return children;
+  }
+
+
+  private async importLevel(dir: string, parentId?: number): Promise<void> {
+    const childFileNames = await this.getDirChildren(dir, false);
+
+    this.currentBatch = [];
+    this.currentBatchBytes = 0;
+
+    for (const fileName of childFileNames) {
+      const desc = await this.readObjectFromPath(dir, fileName, parentId);
+
+      if (this.batchFull) {
+        await this.importCurrentBatch();
+        this.batchFull = false;
+      }
+
+      await this.maybeAddToBatch(desc);
+    }
+
+    if (this.currentBatch && this.currentBatch.length > 0) {
+      await this.importCurrentBatch();
+    }
+  }
+
+  private async importCurrentBatch() {
+    try {
+      await this.importItems(this.currentBatch);
+      this.stats.items += this.currentBatch.length;
+    } catch (e) {
+      this.stats.warnings.push(`Failed to import ${this.currentBatch.length} items: ${e.message}`);
+    }
+
+    this.currentBatch = [];
+    this.currentBatchBytes = 0;
+  }
+
+  private async maybeAddToBatch(desc: ObjectDescriptor<T>) {
+    if (!_.isNil(desc)) {
+      this.currentBatch.push(desc.obj);
+
+      this.currentBatchBytes += desc.size;
+    }
+  }
+
+}

--- a/apps/studio/src/backend/lib/objectimport/import.ts
+++ b/apps/studio/src/backend/lib/objectimport/import.ts
@@ -4,6 +4,7 @@ import { IObjectImportStats } from '@/common/interfaces/IObjectImportStats';
 import { IFolder } from '@/common/interfaces/IQueryFolder';
 import rawLog from '@bksLogger';
 import { CloudClient } from '@/lib/cloud/CloudClient';
+import _ from 'lodash';
 
 const log = rawLog.scope('ObjectImporter');
 
@@ -63,6 +64,10 @@ export abstract class ObjectImporter<T> {
       }
 
       await this.maybeAddToBatch(desc);
+    }
+
+    if (this.currentBatch && this.currentBatch.length > 0) {
+      await this.importCurrentBatch();
     }
 
     return this.stats;

--- a/apps/studio/src/backend/lib/objectimport/query.ts
+++ b/apps/studio/src/backend/lib/objectimport/query.ts
@@ -1,0 +1,74 @@
+import ISavedQuery from "@/common/interfaces/ISavedQuery";
+import { MAX_BATCH_BYTES, MAX_BATCH_ROWS, MAX_SQL_FILE_BYTES, MAX_SQL_FILE_LENGTH, ObjectDescriptor, ObjectImporter, SQL_FILE_EXTENSIONS } from "./import";
+import { IFolder } from "@/common/interfaces/IQueryFolder";
+import { promises as fs } from "fs";
+import path from "path";
+import _ from "lodash";
+import { AppDbHandlers } from "@/handlers/appDbHandlers";
+
+
+export class QueryImporter extends ObjectImporter<ISavedQuery> {
+  async importFolders(folders: IFolder[]): Promise<IFolder[]> {
+    if (this.client) {
+      return this.client.queryFolders.import(folders);
+    } else {
+      return AppDbHandlers[`appdb/queryFolder/save`]({ obj: folders, options: {} });
+    }
+  }
+
+  async importItems(items: ISavedQuery[]): Promise<ISavedQuery[]> {
+    if (this.client) {
+      return await this.client.queries.import(items);
+    } else {
+      return await AppDbHandlers[`appdb/query/save`]({ obj: items, options: {} });
+    }
+  }
+
+  async readObjectFromPath(dir: string, name: string, parentId?: number): Promise<ObjectDescriptor<ISavedQuery>> {
+    const filePath = path.join(dir, name);
+
+    const stat = await fs.stat(filePath);
+
+    if (!stat.isFile()) {
+      this.stats.warnings.push(`Skipping ${filePath}, is not a file`)
+      return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+    if (!SQL_FILE_EXTENSIONS.has(ext)) {
+      const allowed = [...SQL_FILE_EXTENSIONS].join(', ');
+      this.stats.warnings.push(`Skipping ${filePath}, only ${allowed} files are allowed, got "${ext || '(none)'}"`);
+      return;
+    }
+
+    if (stat.size > MAX_SQL_FILE_BYTES) {
+      this.stats.warnings.push(`Skipping ${filePath}, target exceeds ${MAX_SQL_FILE_BYTES} bytes`)
+      return;
+    }
+
+    if (this.currentBatch.length && (stat.size + this.currentBatchBytes > MAX_BATCH_BYTES || this.currentBatch.length + 1 > MAX_BATCH_ROWS)) {
+      this.batchFull = true;
+    }
+
+    const fileContents = await fs.readFile(filePath, { encoding: 'utf-8'});
+
+    if (fileContents.length > MAX_SQL_FILE_LENGTH) {
+      this.stats.warnings.push(`Skipping ${filePath}, target exceeds length ${MAX_SQL_FILE_LENGTH} characters`);
+      return;
+    }
+
+    const query: ISavedQuery = {
+      queryFolderId: parentId,
+      title: name,
+      text: fileContents
+    } as ISavedQuery;
+
+    const desc: ObjectDescriptor<ISavedQuery> = {
+      obj: query,
+      size: stat.size
+    };
+
+    return desc;
+  }
+
+}

--- a/apps/studio/src/backend/lib/objectimport/query.ts
+++ b/apps/studio/src/backend/lib/objectimport/query.ts
@@ -60,7 +60,8 @@ export class QueryImporter extends ObjectImporter<ISavedQuery> {
     const query: ISavedQuery = {
       queryFolderId: parentId,
       title: name,
-      text: fileContents
+      text: fileContents,
+      excerpt: fileContents.slice(0, 250)
     } as ISavedQuery;
 
     const desc: ObjectDescriptor<ISavedQuery> = {

--- a/apps/studio/src/background/NativeMenuActionHandlers.ts
+++ b/apps/studio/src/background/NativeMenuActionHandlers.ts
@@ -213,6 +213,10 @@ export default class NativeMenuActionHandlers implements IMenuActionHandler {
     if (win) win.webContents.send(AppEvent.promptSqlFilesImport);
   }
 
+  importConnectionFiles = (_menuItem: Electron.MenuItem, win: ElectronWindow) => {
+    if (win) win.webContents.send(AppEvent.promptConnectionFilesImport);
+  }
+
   toggleMinimalMode = async (): Promise<void> => {
     this.settings.minimalMode.value = !this.settings.minimalMode.value
     await this.settings.minimalMode.save()

--- a/apps/studio/src/background/NativeMenuBuilder.ts
+++ b/apps/studio/src/background/NativeMenuBuilder.ts
@@ -37,30 +37,49 @@ export default class NativeMenuBuilder {
   }
 
   toggleConnectionMenuItems(action:"enable"|"disable") {
-      if(!this.menu){
-        return;
-      }
+    if(!this.menu){
+      return;
+    }
 
-      const isEnabled = action === "enable" ? true : false;
+    const isEnabled = action === "enable" ? true : false;
 
-      const getMenuItems = (label: string) => this.menu?.items.find(item => item.label === label)?.submenu?.items ?? [];
+    const pluginItemIds = this.pluginMenuItems.map((item) => item.id);
 
-      const pluginItemIds = this.pluginMenuItems.map((item) => item.id);
+    const toggleMenuMap = {
+      File: ["new-query-menu", "go-to", "disconnect", "import-sql-files", "close-tab"],
+      View: ["menu-toggle-sidebar", "menu-secondary-sidebar"],
+      Tools: ["backup-database", "restore-database", "export-tables", ...pluginItemIds],
+    };
 
-      const toggleMenuMap = {
-        File: ["new-query-menu", "go-to", "disconnect", "import-sql-files", "close-tab"],
-        View: ["menu-toggle-sidebar", "menu-secondary-sidebar"],
-        Tools: ["backup-database", "restore-database", "export-tables", ...pluginItemIds],
-      };
+    for(const [menuLabel, toggleMenuIds] of Object.entries(toggleMenuMap)){
+      const menuItems = this.getMenuItems(menuLabel);
+      menuItems.forEach(menuItem=>{
+        if(toggleMenuIds.includes(menuItem.id)){
+          menuItem.enabled = isEnabled;
+        }
+      })
+    }
+  }
 
-      for(const [menuLabel, toggleMenuIds] of Object.entries(toggleMenuMap)){
-        const menuItems = getMenuItems(menuLabel);
-        menuItems.forEach(menuItem=>{
-          if(toggleMenuIds.includes(menuItem.id)){
-            menuItem.enabled = isEnabled;
-          }
-        })
-      }
+  toggleAppMenuItems(action: "enable" | "disable") {
+    if (!this.menu) {
+      return;
+    }
+
+    const isEnabled = action === "enable" ? true : false;
+
+    const toggleMenuMap = {
+      File: ["import-connection-files"]
+    };
+
+    for (const [menuLabel, toggleMenuIds] of Object.entries(toggleMenuMap)) {
+      const menuItems = this.getMenuItems(menuLabel);
+      menuItems.forEach(menuItem => {
+        if (toggleMenuIds.includes(menuItem.id)) {
+          menuItem.enabled = isEnabled;
+        }
+      })
+    }
   }
 
   listenForClicks(): void {
@@ -79,8 +98,14 @@ export default class NativeMenuBuilder {
   }
 
   listenForToggleConnectionMenuItems(): void {
-    ipcMain.on("enable-connection-menu-items", (_event ) => this.toggleConnectionMenuItems("enable"));
-    ipcMain.on("disable-connection-menu-items", (_event ) => this.toggleConnectionMenuItems("disable"));
+    ipcMain.on("enable-connection-menu-items", (_event ) => {
+      this.toggleConnectionMenuItems("enable");
+      this.toggleAppMenuItems("disable");
+    });
+    ipcMain.on("disable-connection-menu-items", (_event ) => {
+      this.toggleConnectionMenuItems("disable");
+      this.toggleAppMenuItems("enable");
+    });
   }
 
   listenForPluginMenuChanges(): void {
@@ -106,6 +131,10 @@ export default class NativeMenuBuilder {
         this.rebuildMenu();
       }
     });
+  }
+
+  private getMenuItems(label: string) {
+    return this.menu?.items.find(item => item.label === label)?.submenu?.items ?? []
   }
 
   private rebuildMenu(): void {

--- a/apps/studio/src/common/AppEvent.ts
+++ b/apps/studio/src/common/AppEvent.ts
@@ -34,6 +34,7 @@ export enum AppEvent {
   promptQueryExport = 'q_export',
   promptConnectionImport = 'cloud_c_import',
   promptSqlFilesImport = 'q_files_import',
+  promptConnectionFilesImport = 'c_files_import',
   openCreateCollectionModal = 'create_collection_modal',
   openAddFieldModal = 'add_field_modal',
   enterLicense = 'enter_license',

--- a/apps/studio/src/common/interfaces/IDirectoryImportStats.ts
+++ b/apps/studio/src/common/interfaces/IDirectoryImportStats.ts
@@ -1,6 +1,0 @@
-export interface IDirectoryImportStats {
-  warnings: string[];
-  directories: number;
-  queries: number;
-}
-

--- a/apps/studio/src/common/interfaces/IMenuActionHandler.ts
+++ b/apps/studio/src/common/interfaces/IMenuActionHandler.ts
@@ -47,6 +47,7 @@ export interface IMenuActionHandler {
   upgradeModal: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   checkForUpdates: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   importSqlFiles: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
+  importConnectionFiles: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   toggleMinimalMode: (menuItem: Electron.MenuItem, win: ElectronWindow) => void
   switchLicenseState: (menuItem: Electron.MenuItem, win: ElectronWindow, state: DevLicenseState) => void
   simulatePlatform: (menuItem: Electron.MenuItem, win: ElectronWindow, platform: string) => void

--- a/apps/studio/src/common/interfaces/IObjectImportStats.ts
+++ b/apps/studio/src/common/interfaces/IObjectImportStats.ts
@@ -1,0 +1,6 @@
+export interface IObjectImportStats {
+  warnings: string[];
+  directories: number;
+  items: number;
+}
+

--- a/apps/studio/src/common/menus/MenuBuilder.ts
+++ b/apps/studio/src/common/menus/MenuBuilder.ts
@@ -111,6 +111,7 @@ export default class extends DefaultMenu {
         this.menuItems.closeTab,
         { type: 'separator' },
         this.menuItems.importSqlFiles,
+        this.menuItems.importConnectionFiles,
         this.menuItems.quickSearch,
         this.menuItems.disconnect,
         // Moved to Beekeeper Studio menu for mac

--- a/apps/studio/src/common/menus/MenuItems.ts
+++ b/apps/studio/src/common/menus/MenuItems.ts
@@ -214,6 +214,12 @@ export function menuItems(actionHandler: IMenuActionHandler, settings: IGroupedU
       showWhenConnected: true,
       enabled: false,
     },
+    importConnectionFiles: {
+      id: 'import-connection-files',
+      label: "Import Saved Connections",
+      click: actionHandler.importConnectionFiles,
+      enabled: true
+    },
     quickSearch: {
       id: 'go-to',
       label: "Quick Search",

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -288,7 +288,7 @@
       </template>
     </confirmation-modal>
 
-    <sql-files-import-modal @submit="importSqlFiles" />
+    <sql-files-import-modal />
     <create-collection-modal />
   </div>
 </template>
@@ -918,72 +918,6 @@ export default Vue.extend({
       }
 
       noty.close()
-    },
-    async importSqlFiles(importConfig: { paths: string[], parentId: number }) {
-      const { paths, parentId } = importConfig;
-      const files = paths.map((path) => ({
-        path,
-        name: path.replace(/^.*[\\/]/, '').replace(/\.sql$/, ''),
-        error: false,
-      }))
-
-      let readerAbort: () => void;
-      let aborted  = false;
-
-      function abort() {
-        if (typeof readerAbort === 'function') {
-          readerAbort()
-        }
-        aborted = true
-      }
-
-      const notyQueue = 'load-queries'
-      const notyText = `Loading <span class="counter">1</span> of ${files.length} files`
-
-      const noty = this.$noty.info(notyText,  {
-        queue: notyQueue,
-        allowRawHtml: true,
-        buttons: [
-          Noty.button('Abort', 'btn btn-danger', abort)
-        ],
-      })
-
-      const counter = noty.barDom.querySelector('.counter')
-
-      for (let i = 0; i < files.length; i++) {
-        if (aborted) {
-          break
-        }
-
-        const file = files[i]
-
-        counter.textContent = `${i + 1}`
-
-        try {
-          // TODO (azmi): this process can take longer by accident. Consider
-          // an ability to cancel reading file.
-          const text = await this.$util.send('file/readSqlFile', { path: file.path })
-          if (text) {
-            const query = await this.$util.send('appdb/query/new');
-            query.title = file.name
-            query.text = text
-            query.queryFolderId = parentId
-            await this.$store.dispatch('data/queries/save', query)
-          } else {
-            files[i].error = true
-          }
-        } catch (e) {
-            files[i].error = true
-        }
-      }
-
-      if (aborted) {
-        this.$noty.info('Loading aborted', { killer: notyQueue })
-      } else if (files.some(({ error }) => error)) {
-        this.$noty.error('Some files could not be loaded', { killer: notyQueue })
-      } else {
-        this.$noty.success('All files loaded', { killer: notyQueue })
-      }
     },
     async handlePromptQueryExport(query) {
       const safeFilename = query.title.replace(/[/\\?%*:|"<>]/g, '_');

--- a/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
+++ b/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
@@ -20,49 +20,43 @@
           id="import-type"
         >
           <option value="single">Individual Files</option>
-          <option value="recursive">Recursive Directory*</option>
+          <option value="recursive">Recursive Directory</option>
         </select>
       </div>
-      <template v-if="isIndividual || isUltimate">
-        <div class="form-group">
-          <label for="importFiles">{{importType === 'single' ? 'Files' : 'Directory'}}</label>
-          <file-picker
-            v-model="files"
-            :multiple="isIndividual"
-            :directory="!isIndividual"
-            :button-text="buttonText"
-            :options="dialogOptions"
-          />
-        </div>
-        <div class="form-group">
-          <label>Parent Folder</label>
-          <in-app-folder-picker
-            v-model="parentId"
-            folder-path="data/connectionFolders"
-          />
-        </div>
-        <div v-if="!isIndividual" class="form-group">
-          <label class="checkbox form-row">
-            <input
-              v-model="preserveRoot"
-              type="checkbox"
-            >
-            Preserve Root
-            <i
-              class="material-icons"
-              v-tooltip="{
-                content: `Import Root directory, otherwise import children at the root of the parent folder`
-              }"
-            >
-            help_outlined
-            </i>
-          </label>
-        </div>
-      </template>
-      <upgrade-panel v-else
-        standalone
-        :feature-name="'Recursive Import'"
-      />
+      <div class="form-group">
+        <label for="importFiles">{{importType === 'single' ? 'Files' : 'Directory'}}</label>
+        <file-picker
+          v-model="files"
+          :multiple="isIndividual"
+          :directory="!isIndividual"
+          :button-text="buttonText"
+          :options="dialogOptions"
+        />
+      </div>
+      <div class="form-group">
+        <label>Parent Folder</label>
+        <in-app-folder-picker
+          v-model="parentId"
+          folder-path="data/connectionFolders"
+        />
+      </div>
+      <div v-if="!isIndividual" class="form-group">
+        <label class="checkbox form-row">
+          <input
+            v-model="preserveRoot"
+            type="checkbox"
+          >
+          Preserve Root
+          <i
+            class="material-icons"
+            v-tooltip="{
+              content: `Import Root directory, otherwise import children at the root of the parent folder`
+            }"
+          >
+          help_outlined
+          </i>
+        </label>
+      </div>
     </div>
     <div v-else>
       <div v-if="!importFinished" class="importing-state">
@@ -73,7 +67,7 @@
         <p class="stats-summary">
           Successfully imported
           {{ $pluralize('directory', importStats.directories, true) }}
-          and {{ $pluralize('query', importStats.items, true) }}
+          and {{ $pluralize('connection', importStats.items, true) }}
         </p>
         <div class="warnings">
           <button
@@ -105,7 +99,7 @@
         type="button"
         @click="close"
       >
-        Cancel
+        {{ importFinished ? "Close" : "Cancel" }}
       </button>
       <button
         v-if="!importing"
@@ -123,7 +117,6 @@
 <script lang="ts">
 import FilePicker from "@/components/common/form/FilePicker.vue";
 import InAppFolderPicker from "@/components/common/form/InAppFolderPicker.vue";
-import UpgradePanel from "@/components/upsell/UpgradePanel.vue";
 import BaseModal from "@/components/common/modals/BaseModal.vue";
 import { AppEvent } from "@/common/AppEvent";
 import { mapState, mapGetters } from 'vuex'
@@ -137,7 +130,6 @@ export default {
   components: {
     FilePicker,
     InAppFolderPicker,
-    UpgradePanel,
     BaseModal
   },
   props: ["name"],
@@ -155,7 +147,7 @@ export default {
   },
   computed: {
     ...mapState('data/connectionFolders', {'folders': 'items'}),
-    ...mapGetters(["isCloud", "isUltimate"]),
+    ...mapGetters(["isCloud"]),
     modalName() {
       return this.name || "connection-files-import";
     },
@@ -201,29 +193,37 @@ export default {
       this.$modal.hide(this.modalName);
     },
     async submit() {
-    },
-    async importIndividual() {
-
-    },
-    async importDirectory() {
       this.importing = true;
-      const dir = _.isArray(this.files) ? this.files[0] : this.files;
       try {
-        const stats: IObjectImportStats = await this.$util.send('workspace/importConnectionsDirectory', {
-          dir,
-          parentId: this.parentId,
-          preserveRoot: this.preserveRoot
-        });
+        const stats: IObjectImportStats = this.isIndividual ?
+          await this.importSelection() :
+          await this.importDirectory();
 
         await this.$store.dispatch('refreshConnections');
 
         this.importStats = stats;
         this.importFinished = true;
       } catch (e) {
-        this.$noty.error(`Error importing queries: ${e?.message ?? e}`)
+        this.$noty.error(`Error importing connections: ${e?.message ?? e}`)
         log.error(e);
         this.close();
       }
+    },
+    async importSelection() {
+      const files = _.isArray(this.files) ? this.files : [this.files];
+
+      return await this.$util.send('workspace/importConnections', {
+        paths: files,
+        parentId: this.parentId
+      });
+    },
+    async importDirectory() {
+      const dir = _.isArray(this.files) ? this.files[0] : this.files;
+      return await this.$util.send('workspace/importConnectionsDirectory', {
+        dir,
+        parentId: this.parentId,
+        preserveRoot: this.preserveRoot
+      });
     }
   },
   mounted() {

--- a/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
+++ b/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
@@ -1,16 +1,14 @@
 <template>
   <base-modal
     :name="modalName"
-    class="sql-files-import-modal"
+    class="connection-files-import-modal"
     @submit="submit"
   >
     <template #title>
-      Import SQL Files into Saved Queries
+      Import Connections from JSON files
     </template>
     <div v-if="!importing" class="message">
-      This will make a copy of your .sql files and add them to your Beekeeper
-      Studio saved queries. Any changes to the original .sql files will not be
-      reflected in Beekeeper Studio.
+      This will import connections exported from Beekeeper Studio Cloud
     </div>
     <div v-if="!importing" class="form-group">
       <div class="form-group">
@@ -40,7 +38,7 @@
           <label>Parent Folder</label>
           <in-app-folder-picker
             v-model="parentId"
-            folder-path="data/queryFolders"
+            folder-path="data/connectionFolders"
           />
         </div>
         <div v-if="!isIndividual" class="form-group">
@@ -126,7 +124,7 @@
 import FilePicker from "@/components/common/form/FilePicker.vue";
 import InAppFolderPicker from "@/components/common/form/InAppFolderPicker.vue";
 import UpgradePanel from "@/components/upsell/UpgradePanel.vue";
-import BaseModal from '@/components/common/modals/BaseModal.vue'
+import BaseModal from "@/components/common/modals/BaseModal.vue";
 import { AppEvent } from "@/common/AppEvent";
 import { mapState, mapGetters } from 'vuex'
 import _ from 'lodash';
@@ -156,13 +154,13 @@ export default {
     };
   },
   computed: {
-    ...mapState('data/queryFolders', {'folders': 'items'}),
+    ...mapState('data/connectionFolders', {'folders': 'items'}),
     ...mapGetters(["isCloud", "isUltimate"]),
     modalName() {
-      return this.name || "sql-files-import";
+      return this.name || "connection-files-import";
     },
     rootBindings() {
-      return [{ event: AppEvent.promptSqlFilesImport, handler: this.open }];
+      return [{ event: AppEvent.promptConnectionFilesImport, handler: this.open }];
     },
     buttonText() {
       return this.importType === 'single' ? 'Choose Files' : 'Choose Directory'
@@ -174,7 +172,7 @@ export default {
       if (this.isIndividual) {
         return {
           filters: [
-            { name: 'SQL files (*.sql, *.txt)', extensions: ['sql', 'txt'] },
+            { name: 'Connection files (*.json)', extensions: ['json'] },
             { name: 'All files', extensions: ['*'] },
           ]
         }
@@ -202,30 +200,22 @@ export default {
     close() {
       this.$modal.hide(this.modalName);
     },
-    submit() {
-      if (this.importType === 'single') {
-        const files = _.isArray(this.files) ? this.files : [this.files];
-        const config = {
-          parentId: this.parentId,
-          paths: files
-        };
-        this.$emit("submit", config);
-        this.close();
-      } else {
-        this.importDirectory();
-      }
+    async submit() {
+    },
+    async importIndividual() {
+
     },
     async importDirectory() {
       this.importing = true;
       const dir = _.isArray(this.files) ? this.files[0] : this.files;
       try {
-        const stats: IObjectImportStats = await this.$util.send('workspace/importDirectory', {
+        const stats: IObjectImportStats = await this.$util.send('workspace/importConnectionsDirectory', {
           dir,
           parentId: this.parentId,
           preserveRoot: this.preserveRoot
         });
 
-        await this.$store.dispatch('refreshQueries');
+        await this.$store.dispatch('refreshConnections');
 
         this.importStats = stats;
         this.importFinished = true;

--- a/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
+++ b/apps/studio/src/components/common/modals/ConnectionFilesImportModal.vue
@@ -104,9 +104,8 @@
       <button
         v-if="!importing"
         class="btn btn-primary"
-        type="button"
+        type="submit"
         :disabled="files.length === 0 || (isCloud && parentId === null)"
-        @click="submit"
       >
         Import
       </button>

--- a/apps/studio/src/components/common/modals/SqlFilesImportModal.vue
+++ b/apps/studio/src/components/common/modals/SqlFilesImportModal.vue
@@ -22,49 +22,43 @@
           id="import-type"
         >
           <option value="single">Individual Files</option>
-          <option value="recursive">Recursive Directory*</option>
+          <option value="recursive">Recursive Directory</option>
         </select>
       </div>
-      <template v-if="isIndividual || isUltimate">
-        <div class="form-group">
-          <label for="importFiles">{{importType === 'single' ? 'Files' : 'Directory'}}</label>
-          <file-picker
-            v-model="files"
-            :multiple="isIndividual"
-            :directory="!isIndividual"
-            :button-text="buttonText"
-            :options="dialogOptions"
-          />
-        </div>
-        <div class="form-group">
-          <label>Parent Folder</label>
-          <in-app-folder-picker
-            v-model="parentId"
-            folder-path="data/queryFolders"
-          />
-        </div>
-        <div v-if="!isIndividual" class="form-group">
-          <label class="checkbox form-row">
-            <input
-              v-model="preserveRoot"
-              type="checkbox"
-            >
-            Preserve Root
-            <i
-              class="material-icons"
-              v-tooltip="{
-                content: `Import Root directory, otherwise import children at the root of the parent folder`
-              }"
-            >
-            help_outlined
-            </i>
-          </label>
-        </div>
-      </template>
-      <upgrade-panel v-else
-        standalone
-        :feature-name="'Recursive Import'"
-      />
+      <div class="form-group">
+        <label for="importFiles">{{importType === 'single' ? 'Files' : 'Directory'}}</label>
+        <file-picker
+          v-model="files"
+          :multiple="isIndividual"
+          :directory="!isIndividual"
+          :button-text="buttonText"
+          :options="dialogOptions"
+        />
+      </div>
+      <div class="form-group">
+        <label>Parent Folder</label>
+        <in-app-folder-picker
+          v-model="parentId"
+          folder-path="data/queryFolders"
+        />
+      </div>
+      <div v-if="!isIndividual" class="form-group">
+        <label class="checkbox form-row">
+          <input
+            v-model="preserveRoot"
+            type="checkbox"
+          >
+          Preserve Root
+          <i
+            class="material-icons"
+            v-tooltip="{
+              content: `Import Root directory, otherwise import children at the root of the parent folder`
+            }"
+          >
+          help_outlined
+          </i>
+        </label>
+      </div>
     </div>
     <div v-else>
       <div v-if="!importFinished" class="importing-state">
@@ -107,7 +101,7 @@
         type="button"
         @click="close"
       >
-        Cancel
+        {{ importFinished ? "Close" : "Cancel" }}
       </button>
       <button
         v-if="!importing"
@@ -125,7 +119,6 @@
 <script lang="ts">
 import FilePicker from "@/components/common/form/FilePicker.vue";
 import InAppFolderPicker from "@/components/common/form/InAppFolderPicker.vue";
-import UpgradePanel from "@/components/upsell/UpgradePanel.vue";
 import BaseModal from '@/components/common/modals/BaseModal.vue'
 import { AppEvent } from "@/common/AppEvent";
 import { mapState, mapGetters } from 'vuex'
@@ -139,7 +132,6 @@ export default {
   components: {
     FilePicker,
     InAppFolderPicker,
-    UpgradePanel,
     BaseModal
   },
   props: ["name"],
@@ -157,7 +149,7 @@ export default {
   },
   computed: {
     ...mapState('data/queryFolders', {'folders': 'items'}),
-    ...mapGetters(["isCloud", "isUltimate"]),
+    ...mapGetters(["isCloud"]),
     modalName() {
       return this.name || "sql-files-import";
     },
@@ -202,28 +194,12 @@ export default {
     close() {
       this.$modal.hide(this.modalName);
     },
-    submit() {
-      if (this.importType === 'single') {
-        const files = _.isArray(this.files) ? this.files : [this.files];
-        const config = {
-          parentId: this.parentId,
-          paths: files
-        };
-        this.$emit("submit", config);
-        this.close();
-      } else {
-        this.importDirectory();
-      }
-    },
-    async importDirectory() {
+    async submit() {
       this.importing = true;
-      const dir = _.isArray(this.files) ? this.files[0] : this.files;
       try {
-        const stats: IObjectImportStats = await this.$util.send('workspace/importDirectory', {
-          dir,
-          parentId: this.parentId,
-          preserveRoot: this.preserveRoot
-        });
+        const stats: IObjectImportStats = this.importType === 'single' ?
+          await this.importSelection() :
+          await this.importDirectory();
 
         await this.$store.dispatch('refreshQueries');
 
@@ -234,6 +210,22 @@ export default {
         log.error(e);
         this.close();
       }
+    },
+    async importSelection() {
+      const files = _.isArray(this.files) ? this.files : [this.files];
+
+      return await this.$util.send('workspace/importQueries', {
+        paths: files,
+        parentId: this.parentId
+      });
+    },
+    async importDirectory() {
+      const dir = _.isArray(this.files) ? this.files[0] : this.files;
+      return await this.$util.send('workspace/importQueryDirectory', {
+        dir,
+        parentId: this.parentId,
+        preserveRoot: this.preserveRoot
+      });
     }
   },
   mounted() {

--- a/apps/studio/src/components/common/modals/SqlFilesImportModal.vue
+++ b/apps/studio/src/components/common/modals/SqlFilesImportModal.vue
@@ -106,9 +106,8 @@
       <button
         v-if="!importing"
         class="btn btn-primary"
-        type="button"
+        type="submit"
         :disabled="files.length === 0 || (isCloud && parentId === null)"
-        @click="submit"
       >
         Import
       </button>

--- a/apps/studio/src/components/data/ImportConnectionsModal.vue
+++ b/apps/studio/src/components/data/ImportConnectionsModal.vue
@@ -96,7 +96,7 @@ export default Vue.extend({
       }
     },
     async findLocal(id: number) {
-      return await this.$util.send('appdb/connection/findOneBy', { options: { id }});
+      return await this.$util.send('appdb/saved/findOneBy', { options: { id }});
     }
   }
 })

--- a/apps/studio/src/components/menu/NewAppMenu.vue
+++ b/apps/studio/src/components/menu/NewAppMenu.vue
@@ -126,7 +126,7 @@ export default {
     menuElements() {
       return Array.from(this.$refs.nav.getElementsByTagName("*"))
     },
-    ...mapGetters('menuBar', ['menus', 'connectionMenuItems']),
+    ...mapGetters('menuBar', ['menus', 'connectionMenuItems', 'appMenuItems']),
     ...mapState(['connected']),
     ...mapState('tabs', { activeTab: 'active' })
   },
@@ -145,6 +145,7 @@ export default {
   methods: {
     isMenuItemDisabled(itemId){
       if (this.connectionMenuItems.includes(itemId) && !this.connected) return true;
+      if (this.appMenuItems.includes(itemId) && this.connected) return true;
       if (itemId === 'paste-as-new-rows') return this.activeTab?.tabType !== 'table';
       return false;
     },

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -769,7 +769,7 @@ export default {
       }
     },
     async deleteFolder(folder) {
-      if (await this.$confirm(`Delete folder "${folder.name}"?`)) {
+      if (await this.$confirm(`Delete folder "${folder.name}"?`, undefined, { variant: "danger" })) {
         try {
           await this.$store.dispatch('data/connectionFolders/remove', folder)
         } catch (e) {

--- a/apps/studio/src/components/sidebar/ConnectionSidebar.vue
+++ b/apps/studio/src/components/sidebar/ConnectionSidebar.vue
@@ -93,47 +93,43 @@
           ref="savedConnectionList"
         >
           <div class="list-group">
-            <div class="list-heading">
-              <div class="flex">
-                <div class="sub row flex-middle noselect">
+            <div class="list-heading row">
+              <div class="sub row flex-middle expand">
+                <div class="expand noselect">
                   Saved <span class="badge">{{ (filteredConnections || []).length }}</span>
                 </div>
-                <span class="expand" />
                 <div class="actions">
-                  <a
-                    v-if="isCloud"
-                    @click.prevent="importFromLocal"
-                    title="Import connections from local workspace"
-                  >
-                    <i class="material-icons">save_alt</i>
-                  </a>
                   <a
                     @click.prevent="createFolder"
                     title="New Folder"
                   >
                     <i class="material-icons-outlined">create_new_folder</i>
                   </a>
-                  <a @click.prevent="refresh"><i class="material-icons">refresh</i></a>
+                  <x-button
+                    title="Import Connections"
+                  >
+                    <i class="material-icons">save_alt</i>
+                    <x-menu style="--align: end;">
+                      <x-menuitem @click.prevent="importFromComputer">
+                        <x-label>Import .json files into Saved Connections</x-label>
+                      </x-menuitem>
+                      <x-menuitem
+                        v-if="isCloud"
+                        @click.prevent="importFromLocal"
+                      >
+                        <x-label>Import connections from local workspace</x-label>
+                      </x-menuitem>
+                    </x-menu>
+                  </x-button>
+                  <a @click.prevent="refresh">
+                    <i class="material-icons">refresh</i>
+                  </a>
                   <sidebar-sort-buttons
                     v-if="!isCloud"
                     v-model="sort"
                     :sort-options="sortables"
                   />
                 </div>
-                <!-- <x-button class="actions-btn btn btn-link btn-small" v-tooltip="`Sorted by ${sortables[sortOrder]}`">
-                  <i class="material-icons-outlined">sort</i>
-                  <x-menu style="--target-align: right;">
-                    <x-menuitem
-                      v-for="i in Object.keys(sortables)"
-                      :key="i"
-                      :toggled="i === sortOrder"
-                      togglable
-                      @click="sortConnections(i)"
-                    >
-                      <x-label>{{ sortables[i] }}</x-label>
-                    </x-menuitem>
-                  </x-menu>
-                </x-button> -->
               </div>
             </div>
             <expired-folder-alert
@@ -570,8 +566,10 @@ export default {
         sizes: this.sizes
       })
     },
+    importFromComputer() {
+      this.$root.$emit(AppEvent.promptConnectionFilesImport)
+    },
     importFromLocal() {
-      console.log("triggering import")
       this.$root.$emit(AppEvent.promptConnectionImport)
     },
     async refresh() {

--- a/apps/studio/src/handlers/workspaceHandlers.ts
+++ b/apps/studio/src/handlers/workspaceHandlers.ts
@@ -7,11 +7,15 @@ import { IObjectImportStats } from "@/common/interfaces/IObjectImportStats";
 import { LocalWorkspace } from "@/common/interfaces/IWorkspace";
 import { QueryImporter } from "@/backend/lib/objectimport/query";
 import { ConnectionImporter } from "@/backend/lib/objectimport/connection";
+import rawLog from "@bksLogger";
+
+const log = rawLog.scope('workspaceHandlers')
 
 
 export interface IWorkspaceHandlers {
   "workspace/setActive": ({ sId, wId, credentialId }: { sId: string, wId: number, credentialId: number }) => Promise<void>,
-  "workspace/importDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IObjectImportStats>,
+  "workspace/importQueryDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IObjectImportStats>,
+  "workspace/importQueries": ({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }) => Promise<IObjectImportStats>,
   "workspace/importConnectionsDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IObjectImportStats>,
   "workspace/importConnections": ({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }) => Promise<IObjectImportStats>
 }
@@ -41,7 +45,7 @@ export const WorkspaceHandlers: IWorkspaceHandlers = {
     const client = new CloudClient(options);
     state(sId).cloudClient = client;
   },
-  'workspace/importDirectory': async function({ dir, parentId, sId, preserveRoot }: { dir: string, parentId: number, sId: string, preserveRoot: boolean }): Promise<IObjectImportStats> {
+  'workspace/importQueryDirectory': async function({ dir, parentId, sId, preserveRoot }: { dir: string, parentId: number, sId: string, preserveRoot: boolean }): Promise<IObjectImportStats> {
     if (typeof dir !== 'string' || dir.length === 0) {
       throw new Error('workspace/importDirectory called with no directory path')
     }
@@ -55,6 +59,14 @@ export const WorkspaceHandlers: IWorkspaceHandlers = {
     const importer = new QueryImporter(client);
 
     const stats = await importer.importDirectory(dir, parentId, preserveRoot);
+
+    return stats;
+  },
+  'workspace/importQueries': async function({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }): Promise<IObjectImportStats> {
+    const client = state(sId).cloudClient;
+    const importer = new QueryImporter(client);
+
+    const stats = await importer.importSelections(paths, parentId);
 
     return stats;
   },
@@ -78,6 +90,7 @@ export const WorkspaceHandlers: IWorkspaceHandlers = {
   'workspace/importConnections': async function({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }): Promise<IObjectImportStats> {
     const client = state(sId).cloudClient;
     const importer = new ConnectionImporter(client);
+    log.info("paths: ", paths);
 
     const stats = await importer.importSelections(paths, parentId);
 

--- a/apps/studio/src/handlers/workspaceHandlers.ts
+++ b/apps/studio/src/handlers/workspaceHandlers.ts
@@ -2,38 +2,18 @@ import { CloudCredential } from "@/common/appdb/models/CloudCredential"
 import { CloudClient, CloudClientOptions } from "@/lib/cloud/CloudClient";
 import platformInfo from '@/common/platform_info';
 import { state } from "./handlerState";
-import ISavedQuery from "@/common/interfaces/ISavedQuery";
-import path from 'path';
 import { promises as fs } from 'fs';
-import { IQueryFolder } from "@/common/interfaces/IQueryFolder";
-import { IDirectoryImportStats } from "@/common/interfaces/IDirectoryImportStats";
-import rawLog from "@bksLogger";
-import { AppDbHandlers } from "./appDbHandlers";
+import { IObjectImportStats } from "@/common/interfaces/IObjectImportStats";
 import { LocalWorkspace } from "@/common/interfaces/IWorkspace";
+import { QueryImporter } from "@/backend/lib/objectimport/query";
+import { ConnectionImporter } from "@/backend/lib/objectimport/connection";
 
-const log = rawLog.scope("workspaceHandlers")
-
-// TEMP (@day): we need a better place for these
-// queries are limited to 2_000_000 characters, so the upper limit is 4x that amount
-const MAX_SQL_FILE_BYTES = 4 * 2_000_000;
-const SQL_FILE_EXTENSIONS = new Set(['.sql', '.txt']);
-
-const SKIP_DIR_NAMES = new Set(['.git']);
-
-// I am just assuming that big batches might be an issue, so we have the ability to cap here
-// as well as cap the amount of rows so we don't piss off the active record transaction
-// I'm also not sure what size the cloud can actually handle
-const MAX_BATCH_BYTES = 50 * 1024 * 1024;
-const MAX_BATCH_ROWS = 100;
-
-interface ImportFunctions {
-  importFolders(folders: IQueryFolder[]): Promise<IQueryFolder[]>,
-  importQueries(queries: ISavedQuery[]): Promise<ISavedQuery[]>,
-}
 
 export interface IWorkspaceHandlers {
   "workspace/setActive": ({ sId, wId, credentialId }: { sId: string, wId: number, credentialId: number }) => Promise<void>,
-  "workspace/importDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IDirectoryImportStats>
+  "workspace/importDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IObjectImportStats>,
+  "workspace/importConnectionsDirectory": ({ sId, dir, parentId, preserveRoot }: { sId: string, dir: string, parentId: number, preserveRoot: boolean }) => Promise<IObjectImportStats>,
+  "workspace/importConnections": ({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }) => Promise<IObjectImportStats>
 }
 
 export const WorkspaceHandlers: IWorkspaceHandlers = {
@@ -61,177 +41,46 @@ export const WorkspaceHandlers: IWorkspaceHandlers = {
     const client = new CloudClient(options);
     state(sId).cloudClient = client;
   },
-  'workspace/importDirectory': async function({ dir, parentId, sId, preserveRoot }: { dir: string, parentId: number, sId: string, preserveRoot: boolean }): Promise<IDirectoryImportStats> {
+  'workspace/importDirectory': async function({ dir, parentId, sId, preserveRoot }: { dir: string, parentId: number, sId: string, preserveRoot: boolean }): Promise<IObjectImportStats> {
     if (typeof dir !== 'string' || dir.length === 0) {
-      // throw?
+      throw new Error('workspace/importDirectory called with no directory path')
     }
 
     const stat = await fs.stat(dir);
     if (!stat.isDirectory()) {
-      throw new Error('file/importDirectory called with non directory path');
+      throw new Error('workspace/importDirectory called with non directory path');
     }
 
-    const funcs = getImportFuncs(sId);
+    const client = state(sId).cloudClient;
+    const importer = new QueryImporter(client);
 
-    const stats = await importDirectory(funcs, dir, parentId, preserveRoot);
+    const stats = await importer.importDirectory(dir, parentId, preserveRoot);
+
+    return stats;
+  },
+  'workspace/importConnectionsDirectory': async function({ dir, parentId, sId, preserveRoot }: { dir: string, parentId: number, sId: string, preserveRoot: boolean }): Promise<IObjectImportStats> {
+    if (typeof dir !== 'string' || dir.length === 0) {
+      throw new Error('workspace/importConnectionsDirectory called with no directory path')
+    }
+
+    const stat = await fs.stat(dir);
+    if (!stat.isDirectory()) {
+      throw new Error('workspace/importConnectionsDirectory called with non directory path');
+    }
+
+    const client = state(sId).cloudClient;
+    const importer = new ConnectionImporter(client);
+
+    const stats = await importer.importDirectory(dir, parentId, preserveRoot);
+
+    return stats;
+  },
+  'workspace/importConnections': async function({ sId, paths, parentId }: { sId: string, paths: string[], parentId: number }): Promise<IObjectImportStats> {
+    const client = state(sId).cloudClient;
+    const importer = new ConnectionImporter(client);
+
+    const stats = await importer.importSelections(paths, parentId);
 
     return stats;
   }
-}
-
-function getImportFuncs(sId: string): ImportFunctions {
-  const client = state(sId).cloudClient;
-  if (client) {
-    return {
-      importFolders: (folders: IQueryFolder[]) => {
-        return client.queryFolders.import(folders);
-      },
-      importQueries: (queries: ISavedQuery[]) => {
-        return client.queries.import(queries)
-      }
-    }
-  } else {
-    return {
-      importFolders: (folders: IQueryFolder[]) => {
-        return AppDbHandlers["appdb/queryFolder/save"]({ obj: folders, options: {} })
-      },
-      importQueries: (queries: ISavedQuery[]) => {
-        return AppDbHandlers["appdb/query/save"]({ obj: queries, options: {} })
-      }
-    }
-  }
-}
-
-async function importDirectory(funcs: ImportFunctions, dir: string, parentId: number | null, importDir: boolean = true): Promise<IDirectoryImportStats> {
-  const stats: IDirectoryImportStats = {
-    warnings: [],
-    directories: 0,
-    queries: 0
-  }
-
-  if (importDir) {
-    let parent: IQueryFolder = {
-      id: null,
-      name: path.basename(dir),
-      parentId
-    } as IQueryFolder;
-
-
-    try {
-      log.info('IMPORTING: ', parent);
-      [parent] = await funcs.importFolders([parent]);
-
-      stats.directories += 1;
-      parentId = parent.id;
-    } catch (e) {
-      log.error(e);
-      stats.warnings.push(`Failed to import directory ${parent.name}. ${e.message}`);
-      return stats;
-    }
-  }
-
-  {
-    const childFileNames = await getDirChildren(dir, false);
-
-    let currentBatchBytes = 0;
-    let currentBatchRows = 0;
-    let currentQueries: ISavedQuery[] = []
-
-    for (const fileName of childFileNames) {
-      const filePath = path.join(dir, fileName);
-
-      const stat = await fs.stat(filePath);
-
-      if (!stat.isFile()) {
-        stats.warnings.push(`Skipping ${filePath}, is not a file`)
-        continue;
-      }
-
-      const ext = path.extname(filePath).toLowerCase();
-      if (!SQL_FILE_EXTENSIONS.has(ext)) {
-        const allowed = [...SQL_FILE_EXTENSIONS].join(', ');
-        stats.warnings.push(`Skipping ${filePath}, only ${allowed} files are allowed, got "${ext || '(none)'}"`);
-        continue;
-      }
-
-      if (stat.size > MAX_SQL_FILE_BYTES) {
-        stats.warnings.push(`Skipping ${filePath}, target exceeds ${MAX_SQL_FILE_BYTES} bytes`)
-        continue;
-      }
-
-      if (currentQueries.length && (stat.size + currentBatchBytes > MAX_BATCH_BYTES || currentBatchRows + 1 > MAX_BATCH_ROWS)) {
-        try {
-          await funcs.importQueries(currentQueries);
-          stats.queries += currentQueries.length;
-        } catch (e) {
-          stats.warnings.push(`Failed to import ${currentQueries.length} queries: ${e.message}`)
-        }
-        currentBatchBytes = 0;
-        currentBatchRows = 0;
-        currentQueries = [];
-      }
-
-      const fileContents = await fs.readFile(filePath, { encoding: 'utf-8' });
-
-      if (fileContents.length > 2_000_000) {
-        stats.warnings.push(`Skipping ${filePath}, target exceeds length 2000000 characters`);
-        continue;
-      }
-
-      const query: ISavedQuery = {
-        queryFolderId: parentId,
-        title: fileName,
-        text: fileContents
-      } as ISavedQuery;
-
-      currentQueries.push(query);
-      currentBatchBytes += stat.size;
-      currentBatchRows += 1;
-    }
-
-    if (currentQueries && currentQueries.length > 0) {
-      try {
-        await funcs.importQueries(currentQueries);
-        stats.queries += currentQueries.length;
-      } catch (e) {
-        stats.warnings.push(`Failed to import ${currentQueries.length} queries: ${e.message}`)
-      }
-
-    }
-  }
-
-  {
-    const childDirNames = await getDirChildren(dir, true);
-
-    for (const child of childDirNames) {
-      if (!SKIP_DIR_NAMES.has(child)) {
-        const dirPath = path.join(dir, child);
-
-        const childStats = await importDirectory(funcs, dirPath, parentId);
-
-        stats.queries += childStats.queries;
-        stats.directories += childStats.directories;
-        if (childStats.warnings.length) {
-          stats.warnings.push(...childStats.warnings);
-        }
-      } else {
-        stats.warnings.push(`Skipping folder: ${child}`);
-      }
-    }
-  }
-
-  return stats;
-}
-
-async function getDirChildren(dir: string, isDir: boolean): Promise<string[]>{
-  const children: string[] = []
-  for await (const d of await fs.opendir(dir)) {
-    if (d.isDirectory() === isDir) {
-      children.push(d.name);
-    } else if (d.isFile() === !isDir) {
-      children.push(d.name)
-    }
-  }
-
-  return children;
 }

--- a/apps/studio/src/lib/events/AppEventHandler.js
+++ b/apps/studio/src/lib/events/AppEventHandler.js
@@ -30,6 +30,7 @@ export default class {
     this.forward(AppEvent.exportTables);
     this.forward(AppEvent.upgradeModal)
     this.forward(AppEvent.promptSqlFilesImport)
+    this.forward(AppEvent.promptConnectionFilesImport)
     this.forward(AppEvent.updatePin)
     this.forward(AppEvent.settingsChanged)
     this.forward(AppEvent.openPluginManager)

--- a/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
+++ b/apps/studio/src/lib/menu/ClientMenuActionHandler.ts
@@ -57,6 +57,7 @@ export default class ClientMenuActionHandler implements IMenuActionHandler {
   exportTables = () => send('exportTables')
   checkForUpdates = () => send('checkForUpdates')
   importSqlFiles = () => send('importSqlFiles')
+  importConnectionFiles = () => send('importConnectionFiles')
   toggleMinimalMode = () => send('toggleMinimalMode')
   togglePrivacyMode = () => send('togglePrivacyMode')
   switchLicenseState = (_menuItem, _win, type) => send('switchLicenseState', type)

--- a/apps/studio/src/plugins/BeekeeperPlugin.ts
+++ b/apps/studio/src/plugins/BeekeeperPlugin.ts
@@ -223,7 +223,7 @@ export default {
     Vue.prototype.$bks = BeekeeperPlugin
     Vue.prototype.$pluralize = pluralize;
 
-    Vue.prototype.$confirm = function(title?: string, message?: string, options?: { confirmLabel?: string, cancelLabel?: string }): Promise<boolean> {
+    Vue.prototype.$confirm = function(title?: string, message?: string, options?: { confirmLabel?: string, cancelLabel?: string, variant?: string }): Promise<boolean> {
       return new Promise<boolean>((resolve, reject) => {
         try {
           this.trigger(AppEvent.createConfirmModal, {

--- a/apps/studio/src/store/modules/MenuBarModule.ts
+++ b/apps/studio/src/store/modules/MenuBarModule.ts
@@ -43,6 +43,13 @@ export const MenuBarModule: Module<State, RootState> = {
 
       return result;
     },
+    appMenuItems() {
+      const result = [
+        "import-connection-files"
+      ];
+
+      return result;
+    },
     menus(state, _getters, _rootState, rootGetters) {
       const builder = new MenuBuilder(
         rootGetters["settings/settings"],

--- a/apps/studio/tests/init/setup.js
+++ b/apps/studio/tests/init/setup.js
@@ -1,5 +1,5 @@
 // This is for the camelCaseObjectKeys helper for cloud (connection import)
-const _ = require('lodash')
+import _ from 'lodash'
 if (!_.deepMapKeys) {
   _.mixin({
     deepMapKeys: function (obj, fn) {

--- a/apps/studio/tests/init/setup.js
+++ b/apps/studio/tests/init/setup.js
@@ -1,3 +1,23 @@
+// This is for the camelCaseObjectKeys helper for cloud (connection import)
+const _ = require('lodash')
+if (!_.deepMapKeys) {
+  _.mixin({
+    deepMapKeys: function (obj, fn) {
+      const x = {}
+      _.forOwn(obj, function (rawV, k) {
+        let v = rawV
+        if (_.isPlainObject(v)) {
+          v = _.deepMapKeys(v, fn)
+        } else if (_.isArray(v)) {
+          v = v.map((item) => _.deepMapKeys(item, fn))
+        }
+        x[fn(v, k)] = v
+      })
+      return x
+    },
+  })
+}
+
 if (typeof global.document !== 'undefined') {
   global.document.createRange = () => ({
     setStart: () => undefined,

--- a/apps/studio/tests/unit/backend/lib/objectimport/connectionImporter.spec.ts
+++ b/apps/studio/tests/unit/backend/lib/objectimport/connectionImporter.spec.ts
@@ -1,0 +1,166 @@
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+import { ConnectionImporter } from '@/backend/lib/objectimport/connection'
+import { SavedConnection } from '@/common/appdb/models/saved_connection'
+import { ConnectionFolder } from '@/common/appdb/models/ConnectionFolder'
+
+let tmpDir: string
+
+async function writeConn(dir: string, fileName: string, overrides: Record<string, any> = {}) {
+  const contents = JSON.stringify({
+    name: path.parse(fileName).name,
+    connectionType: 'sqlite',
+    defaultDatabase: ':memory:',
+    ...overrides,
+  })
+  const filePath = path.join(dir, fileName)
+  await fs.writeFile(filePath, contents, 'utf-8')
+  return filePath
+}
+
+describe('ConnectionImporter (local)', () => {
+  beforeEach(async () => {
+    await TestOrmConnection.connect()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'conn-import-'))
+  })
+
+  afterEach(async () => {
+    await TestOrmConnection.disconnect()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('importSelections', () => {
+    it('imports selected .json files into the database', async () => {
+      const a = await writeConn(tmpDir, 'alpha.json', { name: 'Alpha' })
+      const b = await writeConn(tmpDir, 'beta.json', { name: 'Beta' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importSelections([a, b], null)
+
+      expect(stats.items).toBe(2)
+      expect(stats.warnings).toEqual([])
+      expect(await SavedConnection.count()).toBe(2)
+
+      const names = (await SavedConnection.find()).map((c) => c.name).sort()
+      expect(names).toEqual(['Alpha', 'Beta'])
+    })
+
+    it('links imported connections to the given parent folder', async () => {
+      const folder = new ConnectionFolder()
+      folder.name = 'Imported'
+      await folder.save()
+
+      const a = await writeConn(tmpDir, 'alpha.json', { name: 'Alpha' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importSelections([a], folder.id)
+
+      expect(stats.items).toBe(1)
+      const fromDb = await SavedConnection.findOneBy({ name: 'Alpha' })
+      expect(fromDb.connectionFolderId).toBe(folder.id)
+    })
+
+    it('skips non-.json files with a warning', async () => {
+      const good = await writeConn(tmpDir, 'good.json', { name: 'Good' })
+      const badPath = path.join(tmpDir, 'notes.txt')
+      await fs.writeFile(badPath, 'not a connection', 'utf-8')
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importSelections([good, badPath], null)
+
+      expect(stats.items).toBe(1)
+      expect(stats.warnings).toHaveLength(1)
+      expect(stats.warnings[0]).toContain('only .json files are allowed')
+      expect(await SavedConnection.count()).toBe(1)
+    })
+
+    it('warns and skips files that are not valid json', async () => {
+      const good = await writeConn(tmpDir, 'good.json', { name: 'Good' })
+      const brokenPath = path.join(tmpDir, 'broken.json')
+      await fs.writeFile(brokenPath, '{ not valid json', 'utf-8')
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importSelections([good, brokenPath], null)
+
+      expect(stats.items).toBe(1)
+      expect(stats.warnings).toHaveLength(1)
+      expect(stats.warnings[0]).toContain('Failed to parse json')
+      expect(await SavedConnection.count()).toBe(1)
+    })
+  })
+
+  describe('importDirectory', () => {
+    it('creates a folder for the directory and imports its files into it', async () => {
+      await writeConn(tmpDir, 'alpha.json', { name: 'Alpha' })
+      await writeConn(tmpDir, 'beta.json', { name: 'Beta' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.directories).toBe(1)
+      expect(stats.items).toBe(2)
+      expect(stats.warnings).toEqual([])
+
+      const folder = await ConnectionFolder.findOneBy({ name: path.basename(tmpDir) })
+      expect(folder).toBeTruthy()
+
+      const conns = await SavedConnection.find()
+      expect(conns).toHaveLength(2)
+      for (const conn of conns) {
+        expect(conn.connectionFolderId).toBe(folder.id)
+      }
+    })
+
+    it('recurses into subdirectories, creating nested folders', async () => {
+      await writeConn(tmpDir, 'top.json', { name: 'Top' })
+      const subDir = path.join(tmpDir, 'nested')
+      await fs.mkdir(subDir)
+      await writeConn(subDir, 'child.json', { name: 'Child' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.directories).toBe(2)
+      expect(stats.items).toBe(2)
+
+      const topFolder = await ConnectionFolder.findOneBy({ name: path.basename(tmpDir) })
+      const nestedFolder = await ConnectionFolder.findOneBy({ name: 'nested' })
+      expect(topFolder).toBeTruthy()
+      expect(nestedFolder).toBeTruthy()
+      expect(nestedFolder.parentId).toBe(topFolder.id)
+
+      const child = await SavedConnection.findOneBy({ name: 'Child' })
+      expect(child.connectionFolderId).toBe(nestedFolder.id)
+    })
+
+    it('imports files directly under the parent when importDir is false', async () => {
+      await writeConn(tmpDir, 'alpha.json', { name: 'Alpha' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importDirectory(tmpDir, null, false)
+
+      expect(stats.directories).toBe(0)
+      expect(stats.items).toBe(1)
+      expect(await ConnectionFolder.count()).toBe(0)
+
+      const conn = await SavedConnection.findOneBy({ name: 'Alpha' })
+      expect(conn.connectionFolderId).toBeNull()
+    })
+
+    it('skips .git directories with a warning', async () => {
+      await writeConn(tmpDir, 'alpha.json', { name: 'Alpha' })
+      const gitDir = path.join(tmpDir, '.git')
+      await fs.mkdir(gitDir)
+      await writeConn(gitDir, 'ignored.json', { name: 'Ignored' })
+
+      const importer = new ConnectionImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.items).toBe(1)
+      expect(stats.warnings).toContain('Skipping folder: .git')
+      expect(await SavedConnection.findOneBy({ name: 'Ignored' })).toBeNull()
+    })
+  })
+})

--- a/apps/studio/tests/unit/backend/lib/objectimport/queryImporter.spec.ts
+++ b/apps/studio/tests/unit/backend/lib/objectimport/queryImporter.spec.ts
@@ -1,0 +1,155 @@
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+import { QueryImporter } from '@/backend/lib/objectimport/query'
+import { FavoriteQuery } from '@/common/appdb/models/favorite_query'
+import { QueryFolder } from '@/common/appdb/models/QueryFolder'
+
+let tmpDir: string
+
+async function writeQuery(dir: string, fileName: string, text = 'SELECT 1;') {
+  const filePath = path.join(dir, fileName)
+  await fs.writeFile(filePath, text, 'utf-8')
+  return filePath
+}
+
+describe('QueryImporter (local)', () => {
+  beforeEach(async () => {
+    await TestOrmConnection.connect()
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'query-import-'))
+  })
+
+  afterEach(async () => {
+    await TestOrmConnection.disconnect()
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('importSelections', () => {
+    it('imports selected .sql and .txt files into the database', async () => {
+      const a = await writeQuery(tmpDir, 'first.sql', 'SELECT * FROM users;')
+      const b = await writeQuery(tmpDir, 'second.txt', 'SELECT * FROM orders;')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importSelections([a, b], null)
+
+      expect(stats.items).toBe(2)
+      expect(stats.warnings).toEqual([])
+      expect(await FavoriteQuery.count()).toBe(2)
+
+      const titles = (await FavoriteQuery.find()).map((q) => q.title).sort()
+      expect(titles).toEqual(['first.sql', 'second.txt'])
+    })
+
+    it('stores the file title and contents on the saved query', async () => {
+      const a = await writeQuery(tmpDir, 'greeting.sql', 'SELECT 42;')
+
+      const importer = new QueryImporter()
+      await importer.importSelections([a], null)
+
+      // text has select: false, so fetch it explicitly
+      const saved = await FavoriteQuery.createQueryBuilder('q')
+        .addSelect('q.text')
+        .where('q.title = :title', { title: 'greeting.sql' })
+        .getOne()
+      expect(saved.text).toBe('SELECT 42;')
+    })
+
+    it('links imported queries to the given parent folder', async () => {
+      const folder = new QueryFolder()
+      folder.name = 'Imported'
+      await folder.save()
+
+      const a = await writeQuery(tmpDir, 'first.sql')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importSelections([a], folder.id)
+
+      expect(stats.items).toBe(1)
+      const fromDb = await FavoriteQuery.findOneBy({ title: 'first.sql' })
+      expect(fromDb.queryFolderId).toBe(folder.id)
+    })
+
+    it('skips files whose extension is not allowed with a warning', async () => {
+      const good = await writeQuery(tmpDir, 'good.sql')
+      const badPath = path.join(tmpDir, 'data.json')
+      await fs.writeFile(badPath, '{}', 'utf-8')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importSelections([good, badPath], null)
+
+      expect(stats.items).toBe(1)
+      expect(stats.warnings).toHaveLength(1)
+      expect(stats.warnings[0]).toContain('files are allowed')
+      expect(await FavoriteQuery.count()).toBe(1)
+    })
+  })
+
+  describe('importDirectory', () => {
+    it('creates a folder for the directory and imports its files into it', async () => {
+      await writeQuery(tmpDir, 'a.sql')
+      await writeQuery(tmpDir, 'b.sql')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.directories).toBe(1)
+      expect(stats.items).toBe(2)
+      expect(stats.warnings).toEqual([])
+
+      const folder = await QueryFolder.findOneBy({ name: path.basename(tmpDir) })
+      expect(folder).toBeTruthy()
+
+      const queries = await FavoriteQuery.find()
+      expect(queries).toHaveLength(2)
+      for (const query of queries) {
+        expect(query.queryFolderId).toBe(folder.id)
+      }
+    })
+
+    it('recurses into subdirectories, creating nested folders', async () => {
+      await writeQuery(tmpDir, 'top.sql')
+      const subDir = path.join(tmpDir, 'nested')
+      await fs.mkdir(subDir)
+      await writeQuery(subDir, 'child.sql')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.directories).toBe(2)
+      expect(stats.items).toBe(2)
+
+      const topFolder = await QueryFolder.findOneBy({ name: path.basename(tmpDir) })
+      const nestedFolder = await QueryFolder.findOneBy({ name: 'nested' })
+      expect(nestedFolder.parentId).toBe(topFolder.id)
+
+      const child = await FavoriteQuery.findOneBy({ title: 'child.sql' })
+      expect(child.queryFolderId).toBe(nestedFolder.id)
+    })
+
+    it('imports files directly under the parent when importDir is false', async () => {
+      await writeQuery(tmpDir, 'a.sql')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importDirectory(tmpDir, null, false)
+
+      expect(stats.directories).toBe(0)
+      expect(stats.items).toBe(1)
+      expect(await QueryFolder.count()).toBe(0)
+
+      const query = await FavoriteQuery.findOneBy({ title: 'a.sql' })
+      expect(query.queryFolderId).toBeNull()
+    })
+
+    it('skips non-sql files in the directory with a warning', async () => {
+      await writeQuery(tmpDir, 'a.sql')
+      await fs.writeFile(path.join(tmpDir, 'readme.md'), '# hi', 'utf-8')
+
+      const importer = new QueryImporter()
+      const stats = await importer.importDirectory(tmpDir, null)
+
+      expect(stats.items).toBe(1)
+      expect(stats.warnings.some((w) => w.includes('files are allowed'))).toBe(true)
+    })
+  })
+})

--- a/bin/allowed-console-logs.txt
+++ b/bin/allowed-console-logs.txt
@@ -16,7 +16,6 @@ apps/studio/src/components/data/WorkspaceSignInModal.vue::console.log("open moda
 apps/studio/src/components/editor/MergeManager.vue::console.log("Apply Patch", this.unsavedText, patch)
 apps/studio/src/components/editor/MergeManager.vue::console.log("Make Patch: ", this.originalText, this.query.text)
 apps/studio/src/components/editor/MergeManager.vue::console.log("post patch value:", final)
-apps/studio/src/components/sidebar/ConnectionSidebar.vue::console.log("triggering import")
 apps/studio/src/components/sidebar/core/ConnectionButton.vue::console.log('Missing id or workspaceId:', {
 apps/studio/src/components/tableinfo/TableRelations.vue::console.log("getcolumns", result)
 apps/studio/src/components/TabQueryEditor.vue::console.log("non empty result", nonEmptyResult)


### PR DESCRIPTION
Adds a connection importer: 
<img width="1015" height="633" alt="image" src="https://github.com/user-attachments/assets/b5e44d4f-127d-47b4-9f55-6be506a50b19" />

Also refactored the query import system so that we could use it for connections and queries. Both now support single and recursive import, and recursive import isn't ult-only anymore.

Importing to a cloud workspace is also possible. Requires: https://github.com/beekeeper-studio/cloud/pull/187