### PR TITLE
Show the trial/license-expired dialogs at launch

### DIFF
--- a/apps/studio/src/App.vue
+++ b/apps/studio/src/App.vue
@@ -166,6 +166,14 @@ export default Vue.extend({
     clearInterval(this.licenseInterval)
   },
   async mounted() {
+    // The store loads licenses before this component exists, so the
+    // `licensesInitialized` and `status` watchers never see the initial
+    // values. Without this, a trial or license that lapsed while the app was
+    // closed never surfaces its dialog on the next launch.
+    if (this.licensesInitialized) {
+      await this.$nextTick()
+      this.validateLicenseExpiry()
+    }
     this.notifyFreeTrial()
     this.interval = setInterval(this.notifyFreeTrial, globals.trialNotificationInterval)
     this.$store.dispatch('licenses/updateAll');

--- a/apps/studio/src/components/license/LifetimeLicenseExpiredModal.vue
+++ b/apps/studio/src/components/license/LifetimeLicenseExpiredModal.vue
@@ -6,8 +6,8 @@
           Your license has ended
         </div>
         <div>
-          Your license has ended. But you can continue using all features using
-          Beekeeper Studio version {{ maxAllowedVersion }} or later.
+          Your license has ended. All paid features keep working in
+          Beekeeper Studio version {{ maxAllowedVersion }} or earlier.
         </div>
       </div>
       <div class="vue-dialog-buttons">
@@ -35,7 +35,9 @@ import type { LicenseStatus } from "@/lib/license";
 
 export default {
   computed: {
-    modalName: () => "license-expired-modal",
+    // Distinct from LicenseExpiredModal's name: vue-js-modal opens every
+    // <modal> that shares a name, so a collision showed both dialogs at once.
+    modalName: () => "lifetime-license-expired-modal",
     maxAllowedVersion() {
       const version = this.$store.state.licenses.status.maxAllowedVersion;
       return `${version.major}.${version.minor}.${version.patch}`;

--- a/apps/studio/tests/unit/components/AppLicenseExpiry.spec.ts
+++ b/apps/studio/tests/unit/components/AppLicenseExpiry.spec.ts
@@ -1,0 +1,121 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import Vuex from 'vuex'
+import App from '@/App.vue'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+const FLAG = 'expiredLicenseEventsEmitted'
+
+// Enough store for App.vue to mount: the license module's status and
+// initialized flag drive the expiry check, everything else is inert.
+function buildStore(options: { initialized: boolean; expired: boolean }) {
+  return new Vuex.Store({
+    state: { storeInitialized: false, connected: false, database: null } as any,
+    getters: {
+      isTrial: () => false,
+      isUltimate: () => false,
+    },
+    actions: { updateWindowTitle: jest.fn() },
+    modules: {
+      licenses: {
+        namespaced: true,
+        state: {
+          initialized: options.initialized,
+          status: {
+            edition: 'community',
+            condition: options.expired ? ['Expired valid date'] : ['No license found'],
+            isTrial: options.expired,
+            isValidDateExpired: options.expired,
+            isSupportDateExpired: false,
+            fromFile: false,
+          },
+        },
+        mutations: {
+          setInitialized(state: any, b: boolean) { state.initialized = b },
+        },
+        actions: { updateAll: jest.fn() },
+      },
+      settings: {
+        namespaced: true,
+        state: { settings: {} },
+        getters: { themeValue: () => null },
+      },
+    },
+  })
+}
+
+function mountApp(store: any) {
+  return shallowMount(App, {
+    localVue,
+    store,
+    mocks: {
+      $config: { isDevelopment: false, isMac: false },
+      $util: { send: jest.fn() },
+      $noty: { error: jest.fn(), success: jest.fn(), warning: jest.fn(), info: jest.fn() },
+      $bks: { unlock: jest.fn() },
+    },
+    stubs: ['portal-target'],
+  })
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+describe('App license expiry check', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    ;(window as any).main = { isReady: jest.fn(), setWindowTitle: jest.fn() }
+    jest.useFakeTimers({ doNotFake: ['setImmediate', 'nextTick'] })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('runs the expiry check on mount when the store loaded licenses first', async () => {
+    // The real boot order: initRootStates() finishes (licenses initialized,
+    // status final) before App.vue is created, so its watchers never fire.
+    const wrapper = mountApp(buildStore({ initialized: true, expired: true }))
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem(FLAG)).toBe('true')
+    wrapper.destroy()
+  })
+
+  it('does not report an expiry that has not happened', async () => {
+    const wrapper = mountApp(buildStore({ initialized: true, expired: false }))
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem(FLAG)).toBeNull()
+    wrapper.destroy()
+  })
+
+  it('still reacts when licenses finish loading after mount', async () => {
+    const store = buildStore({ initialized: false, expired: true })
+    const wrapper = mountApp(store)
+    await wrapper.vm.$nextTick()
+    expect(localStorage.getItem(FLAG)).toBeNull()
+
+    store.commit('licenses/setInitialized', true)
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(localStorage.getItem(FLAG)).toBe('true')
+    wrapper.destroy()
+  })
+
+  it('reports once: a second mount with the flag set stays quiet', async () => {
+    localStorage.setItem(FLAG, 'true')
+    const store = buildStore({ initialized: true, expired: true })
+    const emitted: string[] = []
+    const wrapper = mountApp(store)
+    wrapper.vm.$root.$on('licenseValidDateExpired', () => emitted.push('licenseValidDateExpired'))
+    await wrapper.vm.$nextTick()
+    await wrapper.vm.$nextTick()
+
+    expect(emitted).toEqual([])
+    wrapper.destroy()
+  })
+})


### PR DESCRIPTION
Two small, independent bug fixes for the license-expiry dialogs, split out so they can merge ahead of the larger conversion work on `claude/beekeeper-conversion-optimization-1dmw34`.

## 1. The expiry check never ran at startup

`initRootStates()` loads the license store before `App.vue` is created, so App.vue's `licensesInitialized` and `status` watchers never fire for the initial values. The check only ran when a license lapsed while the app was open (the 10-minute refresh). A trial that ended while the app was closed, which is the common case, produced no dialog on the next launch: the app silently reverted to the free version.

Fix: `App.vue` runs `validateLicenseExpiry()` on mount when the store is already initialized. The existing watcher path is unchanged for the case where initialization finishes after mount, and the one-shot `expiredLicenseEventsEmitted` marker still prevents repeat reports.

## 2. Two dialogs opened at once

`LicenseExpiredModal` and `LifetimeLicenseExpiredModal` both registered the modal name `license-expired-modal`. vue-js-modal opens every `<modal>` sharing a name, so showing either one showed both, stacked. The lifetime dialog now has its own name.

While there, its copy said the license covers "version X or later". The version cap is an upper bound, so it now reads "or earlier".

## Test

`tests/unit/components/AppLicenseExpiry.spec.ts` mounts `App.vue` against a pre-initialized store and checks that the expiry marker is set (this case fails without the fix), that a non-expired license stays quiet, that the post-mount watcher path still works, and that an already-reported expiry is not reported again.

Verified end to end under Xvfb with an expired trial in the app database: before the fix, launch showed nothing; after, the trial-ended dialog appears on launch and the lifetime dialog no longer stacks behind the license-ended one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KSbTV9LLY5r6vYkRuYJaiT

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSbTV9LLY5r6vYkRuYJaiT)_