### PR TITLE
Finally fixing connection race conditions and ghost connects

### DIFF
--- a/apps/studio/e2e/tests/connectionErrorHandling.test.ts
+++ b/apps/studio/e2e/tests/connectionErrorHandling.test.ts
@@ -1,0 +1,81 @@
+import { test, expect, ElectronApplication, Page } from '@playwright/test';
+import { launchElectron } from 'e2e/helpers/launchElectron';
+import { userActions } from '../pageActions/index';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+let electronApp: ElectronApplication;
+let window: Page;
+let userAttemptsTo: ReturnType<typeof userActions>;
+
+const coreInterface = () => window.locator('#interface.interface');
+const errorAlert = () => window.getByText('There was a problem', { exact: false });
+
+test.describe('Connection error handling', () => {
+  test.beforeEach(async () => {
+    electronApp = await launchElectron();
+    window = await electronApp.firstWindow();
+    userAttemptsTo = userActions(window);
+  });
+
+  test.afterEach(async () => {
+    if (electronApp) await electronApp.close();
+  });
+
+  test('sqlite: nonexistent file stays on the connection screen with an error', async () => {
+    const dbFile = path.join(os.tmpdir(), `bks-missing-${Date.now()}.db`);
+    await userAttemptsTo.selectNewConnection('sqlite');
+    await window.locator('#Database').fill(dbFile);
+    await window.getByRole('button', { name: 'Connect', exact: false }).click();
+
+    await expect(errorAlert()).toBeVisible();
+    await expect(window.getByText('Database file not found', { exact: false })).toBeVisible();
+    expect(await coreInterface().count()).toBe(0);
+    // connecting must not create the file as a side effect
+    expect(fs.existsSync(dbFile)).toBe(false);
+  });
+
+  test('sqlite: nonexistent directory stays on the connection screen with an error', async () => {
+    const dbFile = path.join(os.tmpdir(), `bks-no-dir-${Date.now()}`, 'foo.db');
+    await userAttemptsTo.selectNewConnection('sqlite');
+    await window.locator('#Database').fill(dbFile);
+    await window.getByRole('button', { name: 'Connect', exact: false }).click();
+
+    await expect(errorAlert()).toBeVisible();
+    expect(await coreInterface().count()).toBe(0);
+  });
+
+  test('overlapping connect attempts cannot land in the core interface', async () => {
+    test.setTimeout(150000);
+
+    // save a working sqlite connection to double-click later
+    const goodDb = path.join(os.tmpdir(), `bks-good-${Date.now()}.db`);
+    fs.writeFileSync(goodDb, '');
+    await userAttemptsTo.selectNewConnection('sqlite');
+    await window.locator('#Database').fill(goodDb);
+    await window.getByPlaceholder('Connection Name').fill('goodsqlite');
+    await window.getByRole('button', { name: 'Save', exact: true }).click();
+    await window.waitForTimeout(1000);
+
+    // start a slow, failing postgres connect (non-routable host)
+    await userAttemptsTo.selectNewConnection('postgresql');
+    await window.waitForTimeout(500);
+    const hostGroup = window.locator('.form-group')
+      .filter({ has: window.locator('label', { hasText: /^Host$/ }) }).first();
+    await hostGroup.locator('input').fill('10.255.255.1');
+    await window.getByRole('button', { name: 'Connect', exact: false }).first().click();
+    await window.waitForTimeout(1500);
+
+    // while the postgres attempt is pending, double-click the saved
+    // connection; the attempt in progress must not be raced
+    await window.getByText('goodsqlite', { exact: false }).first().dblclick();
+    await window.waitForTimeout(5000);
+    expect(await coreInterface().count()).toBe(0);
+
+    // the pending postgres attempt eventually fails; its error belongs on the
+    // connection screen, not on top of the core interface
+    await expect(errorAlert()).toBeVisible({ timeout: 60000 });
+    expect(await coreInterface().count()).toBe(0);
+  });
+});

--- a/apps/studio/e2e/tests/savedQueryRestore.test.ts
+++ b/apps/studio/e2e/tests/savedQueryRestore.test.ts
@@ -1,6 +1,8 @@
 import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test';
+import { userActions } from '../pageActions/index';
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 
 async function launch(): Promise<{ app: ElectronApplication; win: Page }> {
   const app = await electron.launch({
@@ -18,16 +20,23 @@ async function launch(): Promise<{ app: ElectronApplication; win: Page }> {
 
 test('restores in-progress edits to a SAVED query after relaunch', async () => {
   const dbFile = path.join(os.tmpdir(), `bks-restore-${Date.now()}.db`);
-  const dbName = path.basename(dbFile);
+  fs.writeFileSync(dbFile, '');
+  const CONN_NAME = 'RestoreTestConn';
   const SAVED = 'select 1 as original_saved_text;';
   const EDITED = 'select 999 as restored_after_relaunch;';
 
   // ---------- First launch: connect, save a query, edit it, let it autosave ----------
   let { app, win } = await launch();
 
-  await win.getByLabel('Connection Type').selectOption('sqlite');
+  await userActions(win).selectNewConnection('sqlite');
   await win.locator('#Database').fill(dbFile);
-  await win.getByRole('button', { name: 'Connect' }).click();
+  // Tabs are keyed on a saved_connection id, so only a saved connection
+  // restores them. An unsaved session always opens an empty core interface -
+  // see isConnectionScope in src/handlers/utils.ts.
+  await win.getByPlaceholder('Connection Name').fill(CONN_NAME);
+  await win.getByRole('button', { name: 'Save', exact: true }).click();
+  await win.waitForTimeout(1000);
+  await win.getByRole('button', { name: 'Connect', exact: false }).first().click();
 
   const editor = win.locator('#tab-0').getByRole('textbox');
   await expect(editor).toBeVisible({ timeout: 30000 });
@@ -53,10 +62,10 @@ test('restores in-progress edits to a SAVED query after relaunch', async () => {
   // ---------- Second launch: reconnect to the same DB, expect the edits restored ----------
   ({ app, win } = await launch());
 
-  // Recent connections connect on double-click; the item shows the db file name
-  const recent = win.locator('.recent-connection-list').getByText(dbName, { exact: false }).first();
-  await expect(recent).toBeVisible({ timeout: 15000 });
-  await recent.dblclick();
+  // Saved connections connect on double-click
+  const saved = win.getByText(CONN_NAME, { exact: false }).first();
+  await expect(saved).toBeVisible({ timeout: 15000 });
+  await saved.dblclick();
 
   const editor2 = win.locator('#tab-0').getByRole('textbox');
   await expect(editor2).toBeVisible({ timeout: 30000 });

--- a/apps/studio/e2e/tests/tabConnectionScope.test.ts
+++ b/apps/studio/e2e/tests/tabConnectionScope.test.ts
@@ -1,0 +1,95 @@
+import { test, expect, _electron as electron, ElectronApplication, Page } from '@playwright/test';
+import { userActions } from '../pageActions/index';
+import * as path from 'path';
+import * as os from 'os';
+import * as fs from 'fs';
+
+async function launch(): Promise<{ app: ElectronApplication; win: Page }> {
+  const app = await electron.launch({
+    args: ['dist/main.js'],
+    env: { ...process.env, TEST_MODE: '1' },
+  });
+  const win = await app.firstWindow();
+  await win.setViewportSize({ width: 1600, height: 1000 });
+  await win.waitForTimeout(1500);
+  try {
+    await win.getByText("Don't show again", { exact: false }).click({ timeout: 800 });
+  } catch (e) { /* no dialog */ }
+  return { app, win };
+}
+
+// Tabs, pins, hidden entities and query history are keyed on a saved_connection
+// id (isConnectionScope in src/handlers/utils.ts). A session on a connection
+// that was never saved has no such id, so it must always open an empty core
+// interface - nothing is persisted for it and nothing is restored.
+const MARKER = 'select 1 as tab_scope_marker;';
+
+async function typeIntoFirstTab(win: Page) {
+  const editor = win.locator('#tab-0').getByRole('textbox');
+  await expect(editor).toBeVisible({ timeout: 30000 });
+  await editor.click();
+  await editor.fill(MARKER);
+  await expect(editor).toContainText('tab_scope_marker');
+  await win.waitForTimeout(2500); // past the 1s autosave debounce
+}
+
+test('anonymous connection: tabs do NOT come back', async () => {
+  test.setTimeout(180000);
+  const dbFile = path.join(os.tmpdir(), `bks-anon-${Date.now()}.db`);
+  fs.writeFileSync(dbFile, '');
+  const dbName = path.basename(dbFile);
+
+  let { app, win } = await launch();
+  await userActions(win).selectNewConnection('sqlite');
+  await win.locator('#Database').fill(dbFile);
+  await win.getByRole('button', { name: 'Connect', exact: false }).click();
+  await typeIntoFirstTab(win);
+  await app.close();
+
+  // Reconnect via the recent-connections list - the path that used to smuggle
+  // a used_connection id into the core interface.
+  ({ app, win } = await launch());
+  const recent = win.locator('.recent-connection-list').getByText(dbName, { exact: false }).first();
+  await expect(recent).toBeVisible({ timeout: 15000 });
+  await recent.dblclick();
+
+  const editor = win.locator('#tab-0').getByRole('textbox');
+  await expect(editor).toBeVisible({ timeout: 30000 });
+  await win.waitForTimeout(4000);
+  const text = await editor.textContent();
+  const tabCount = await win.locator('.tabs-header .nav-item').count();
+  console.log(`[ANON] editor text: ${JSON.stringify(text)} tabCount=${tabCount}`);
+  await app.close();
+
+  expect(text).not.toContain('tab_scope_marker');
+});
+
+test('saved connection: tabs DO come back', async () => {
+  test.setTimeout(180000);
+  const dbFile = path.join(os.tmpdir(), `bks-saved-${Date.now()}.db`);
+  fs.writeFileSync(dbFile, '');
+
+  let { app, win } = await launch();
+  await userActions(win).selectNewConnection('sqlite');
+  await win.locator('#Database').fill(dbFile);
+  await win.getByPlaceholder('Connection Name').fill('SavedScopeConn');
+  await win.getByRole('button', { name: 'Save', exact: true }).click();
+  await win.waitForTimeout(1000);
+  await win.getByRole('button', { name: 'Connect', exact: false }).first().click();
+  await typeIntoFirstTab(win);
+  await app.close();
+
+  ({ app, win } = await launch());
+  const saved = win.getByText('SavedScopeConn', { exact: false }).first();
+  await expect(saved).toBeVisible({ timeout: 15000 });
+  await saved.dblclick();
+
+  const editor = win.locator('#tab-0').getByRole('textbox');
+  await expect(editor).toBeVisible({ timeout: 30000 });
+  await win.waitForTimeout(4000);
+  const text = await editor.textContent();
+  console.log(`[SAVED] editor text: ${JSON.stringify(text)}`);
+  await app.close();
+
+  expect(text).toContain('tab_scope_marker');
+});

--- a/apps/studio/src-commercial/backend/handlers/connHandlers.ts
+++ b/apps/studio/src-commercial/backend/handlers/connHandlers.ts
@@ -14,6 +14,9 @@ import { AzureAuthService } from "@/lib/db/authentication/azure";
 import bksConfig from "@/common/bksConfig";
 import { UserPin } from "@/common/appdb/models/UserPin";
 import { waitPromise } from "@/common/utils";
+import rawLog from "@bksLogger";
+
+const log = rawLog.scope('ConnHandlers');
 
 export interface IConnectionHandlers {
   // Connection management from the store **************************************
@@ -177,7 +180,20 @@ export const ConnHandlers: IConnectionHandlers = {
     const settings = await UserSetting.all();
     const server = ConnectionProvider.for(config, osUser, settings);
     const connection = server.createConnection(database);
-    await connection.connect(abortController.signal);
+    try {
+      await connection.connect(abortController.signal);
+    } catch (e) {
+      // A failed connect can still have opened sockets, pools or an ssh tunnel.
+      // Nothing else holds a reference to `server` yet, so tear it down here or
+      // it leaks for every failed attempt.
+      try {
+        server.disconnect();
+      } catch (disconnectError) {
+        log.error('Error cleaning up after a failed connection', disconnectError);
+      }
+      state(sId).connectionAbortController = null;
+      throw e;
+    }
     // HACK (@day): this is because of type fuckery, need to actually just recreate the object but I'm lazy rn and it's late
     connection.connectionType = config.connectionType ?? (config as any)._connectionType;
     await UsedConnection.recordUse(config);
@@ -274,7 +290,14 @@ export const ConnHandlers: IConnectionHandlers = {
   },
 
   'conn/connect': getDriverHandler('connect'),
-  'conn/disconnect': getDriverHandler('disconnect'),
+  // Not `getDriverHandler` - the renderer always holds a connection client, so it
+  // sends this even when nothing is open (disconnecting, or rolling back a failed
+  // connect). Blowing up on a missing connection would mask the error that caused
+  // the disconnect.
+  'conn/disconnect': async function({ sId }: { sId: string }) {
+    if (!state(sId).connection) return;
+    await state(sId).connection.disconnect();
+  },
 
   'conn/listTables': async function({ filter, sId }: { filter?: FilterOptions, sId: string }) {
     checkConnection(sId);

--- a/apps/studio/src/components/ConnectionInterface.vue
+++ b/apps/studio/src/components/ConnectionInterface.vue
@@ -592,6 +592,12 @@ export default Vue.extend({
 
     },
     async submit() {
+      // Ignore re-entrant submits (e.g. a sidebar double-click while a
+      // connection attempt is pending) - the Connect button is disabled, but
+      // sidebar and quicksearch entry points are not.
+      if (this.connecting) {
+        return
+      }
       if (!this.isUltimate && isUltimateType(this.config.connectionType)) {
         return
       }

--- a/apps/studio/src/components/CoreInterface.vue
+++ b/apps/studio/src/components/CoreInterface.vue
@@ -137,8 +137,14 @@
       },
     },
     watch: {
-      async usedConfig(){
-        await this.$store.dispatch('pins/loadPins');
+      // immediate: usedConfig is committed before the interface flips to
+      // connected, so it is already set when this component mounts
+      usedConfig: {
+        immediate: true,
+        async handler() {
+          if (!this.usedConfig) return
+          await this.$store.dispatch('pins/loadPins');
+        }
       },
       initializing() {
         if (this.initializing) return;

--- a/apps/studio/src/components/CoreTabs.vue
+++ b/apps/studio/src/components/CoreTabs.vue
@@ -377,12 +377,18 @@ export default Vue.extend({
     }
   },
   watch: {
-    async usedConfig() {
-      await this.$store.dispatch('tabs/load')
-      if (!this.tabItems?.length) {
-        await this.createQuery()
+    // immediate: usedConfig is committed before the interface flips to
+    // connected, so it is already set when this component mounts
+    usedConfig: {
+      immediate: true,
+      async handler() {
+        if (!this.usedConfig) return
+        await this.$store.dispatch('tabs/load')
+        if (!this.tabItems?.length) {
+          await this.createQuery()
+        }
+        wait(800).then(() => this.$tour.start("connectedScreen"));
       }
-      wait(800).then(() => this.$tour.start("connectedScreen"));
     }
   },
   filters: {

--- a/apps/studio/src/components/quicksearch/QuickSearch.vue
+++ b/apps/studio/src/components/quicksearch/QuickSearch.vue
@@ -272,13 +272,13 @@ export default Vue.extend({
             return
           }
 
-          await this.$store.dispatch('disconnect')
           try {
+            await this.$store.dispatch('disconnect')
             const { auth, cancelled } = await this.$bks.unlock();
             if (cancelled) return;
             await this.$store.dispatch('connect', { config: result.item, auth })
           } catch (ex) {
-            this.$noty.error("Error establishing a connection")
+            this.$noty.error(`Error establishing a connection: ${ex?.message ?? ex}`)
             console.error(ex)
           }
           break;

--- a/apps/studio/src/components/sidebar/core/ConnectionButton.vue
+++ b/apps/studio/src/components/sidebar/core/ConnectionButton.vue
@@ -285,14 +285,14 @@ export default {
         return;
       }
 
-      await this.$store.dispatch('disconnect')
       try {
+        await this.$store.dispatch('disconnect')
         const { auth, cancelled } = await this.$bks.unlock();
         if (cancelled) return;
         await this.$store.dispatch('connect', { config, auth });
       } catch (ex) {
         log.error(ex)
-        this.$noty.error("Error establishing a connection")
+        this.$noty.error(`Error establishing a connection: ${ex?.message ?? ex}`)
       }
       this.isQuickSwitcherVisible = false
     },

--- a/apps/studio/src/lib/db/clients/sqlite.ts
+++ b/apps/studio/src/lib/db/clients/sqlite.ts
@@ -11,6 +11,7 @@ import { BasicDatabaseClient, ExecutionContext, QueryLogOptions } from "./BasicD
 import { identify } from "sql-query-identifier";
 import { IdentifyResult, Statement } from "sql-query-identifier/lib/defines";
 import * as path from 'path';
+import * as fs from 'fs';
 import _ from 'lodash';
 import { SqliteCursor } from "./sqlite/SqliteCursor";
 import { createSQLiteKnex } from "./sqlite/utils";
@@ -88,6 +89,13 @@ export class SqliteClient extends BasicDatabaseClient<SqliteResult> {
 
   async connect(): Promise<void> {
     await super.connect();
+
+    // better-sqlite3 silently creates missing files, which turns a typo'd or
+    // deleted path into a "successful" connection to an empty database.
+    // Creating new databases is handled explicitly via createDatabase.
+    if (!this.isTempDB && !fs.existsSync(this.databasePath)) {
+      throw new Error(`Database file not found: ${this.databasePath}`);
+    }
 
     // verify that the connection is valid
     await this.driverExecuteSingle('PRAGMA schema_version', { overrideReadonly: true });

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -93,6 +93,7 @@ export interface State {
   usedConfig: Nullable<IConnection>,
   server: Nullable<IDbConnectionPublicServer>,
   connected: boolean,
+  connecting: boolean,
   connectionType: Nullable<string>,
   supportedFeatures: Nullable<SupportedFeatures>,
   database: Nullable<string>,
@@ -161,6 +162,7 @@ const store = new Vuex.Store<State>({
     usedConfig: null,
     server: null,
     connected: false,
+    connecting: false,
     sshConfigWarnings: [],
     connectionType: null,
     supportedFeatures: null,
@@ -379,6 +381,9 @@ const store = new Vuex.Store<State>({
       state.supportedFeatures = null
       state.server = null
       state.database = null
+      state.connectionType = null
+      state.defaultSchema = null
+      state.versionString = null
       state.databaseList = []
       state.namespace = null
       state.namespaceList = []
@@ -459,6 +464,9 @@ const store = new Vuex.Store<State>({
     connected(state, connected: boolean) {
       state.connected = connected;
     },
+    connecting(state, connecting: boolean) {
+      state.connecting = connecting;
+    },
     supportedFeatures(state, features: SupportedFeatures) {
       state.supportedFeatures = features;
     },
@@ -523,50 +531,111 @@ const store = new Vuex.Store<State>({
     },
 
     async connect(context, { config, auth }: { config: IConnection, auth?: { input: string; mode: 'pin'; }}) {
-      context.commit('sshConfigWarnings', []);
-      const resolvedConfig = await resolveEphemeralValues(config);
-      if (!resolvedConfig) return false;
-
-      if (context.state.username) {
-        await Vue.prototype.$util.send('conn/create', { config: resolvedConfig, auth, osUser: context.state.username })
-        const defaultSchema = await context.state.connection.defaultSchema();
-        const supportedFeatures = await context.state.connection.supportedFeatures();
-        const versionString = await context.state.connection.versionString();
-
-        const serverConfig = await Vue.prototype.$util.send('conn/getServerConfig');
-        context.commit('sshConfigWarnings', serverConfig?.sshConfigWarnings || []);
-
-        if (supportedFeatures.backups) {
-          context.dispatch('backups/setConnectionConfigs', { config: resolvedConfig, supportedFeatures, serverConfig });
-        }
-
-        window.main.enableConnectionMenuItems();
-
-        context.commit('defaultSchema', defaultSchema);
-        context.commit('connectionType', config.connectionType);
-        context.commit('connected', true);
-        context.commit('supportedFeatures', supportedFeatures);
-        context.commit('versionString', versionString);
-        // conn/create recorded the use; pick up the new/updated recent row
-        await context.dispatch('data/usedconnections/load')
-        context.commit('newConnection', resolvedConfig)
-
-        if (context.state.usedConfig.connectionType === 'surrealdb' &&
-          context.state.usedConfig.surrealDbOptions?.authType === SurrealAuthType.Root) {
-          await context.dispatch('updateNamespaceList');
-        }
-        await context.dispatch('updateDatabaseList')
-        await context.dispatch('updateTables')
-        await context.dispatch('updateRoutines')
-        context.dispatch('updateWindowTitle', resolvedConfig)
-
-        await Vue.prototype.$util.send('appdb/tabhistory/clearDeletedTabs', { workspaceId: context.state.usedConfig.workspaceId, connectionId: context.state.usedConfig.id })
-
-        await context.dispatch('checkVersion');
-        return true;
-      } else {
-        throw "No username provided"
+      // A second connect while one is pending would race it for the single
+      // utility-process connection slot: whichever attempt finishes last wins
+      // state, and a stale failure surfaces its error over the winner's session.
+      if (context.state.connecting) {
+        throw new Error('A connection attempt is already in progress');
       }
+      context.commit('connecting', true);
+      try {
+        context.commit('sshConfigWarnings', []);
+        const resolvedConfig = await resolveEphemeralValues(config);
+        if (!resolvedConfig) return false;
+
+        if (!context.state.username) {
+          throw new Error("No username provided")
+        }
+
+        await Vue.prototype.$util.send('conn/create', { config: resolvedConfig, auth, osUser: context.state.username })
+
+        // The server connection exists from here on: any bootstrap failure
+        // below must tear it down and rethrow, so the caller stays on the
+        // connection screen with the error instead of landing in a
+        // half-connected core interface.
+        try {
+          const defaultSchema = await context.state.connection.defaultSchema();
+          const supportedFeatures = await context.state.connection.supportedFeatures();
+          const versionString = await context.state.connection.versionString();
+
+          const serverConfig = await Vue.prototype.$util.send('conn/getServerConfig');
+          context.commit('sshConfigWarnings', serverConfig?.sshConfigWarnings || []);
+
+          // conn/create recorded the use; pick up the new/updated recent row
+          await context.dispatch('data/usedconnections/load')
+
+          context.commit('defaultSchema', defaultSchema);
+          context.commit('connectionType', config.connectionType);
+          context.commit('supportedFeatures', supportedFeatures);
+          context.commit('versionString', versionString);
+          // `usedConfig` is what the connected UI is keyed on (the connection
+          // button, the window title, tab history), so it is committed before
+          // `connected` - otherwise the core interface renders with no
+          // connection. Watchers on it must be `immediate` for the same reason.
+          context.commit('newConnection', resolvedConfig)
+
+          // `connected` is the switch between the connection screen and the
+          // core interface. Entity loading below deliberately runs after it so
+          // the sidebar can show its own "Loading tables..." state instead of
+          // stalling on the connection screen; a failure there still rolls the
+          // whole connection back.
+          window.main.enableConnectionMenuItems();
+          context.commit('connected', true);
+          context.dispatch('updateWindowTitle', resolvedConfig)
+
+          if (supportedFeatures.backups) {
+            context.dispatch('backups/setConnectionConfigs', { config: resolvedConfig, supportedFeatures, serverConfig });
+          }
+
+          if (resolvedConfig.connectionType === 'surrealdb' &&
+            resolvedConfig.surrealDbOptions?.authType === SurrealAuthType.Root) {
+            await context.dispatch('updateNamespaceList');
+          }
+          await context.dispatch('updateDatabaseList')
+          await context.dispatch('updateTables')
+          await context.dispatch('updateRoutines')
+        } catch (ex) {
+          log.error("Connection failed after the connection was opened, disconnecting", ex)
+          await context.dispatch('rollbackConnection')
+          throw ex
+        }
+
+        // Post-connect housekeeping - failures here shouldn't kick the user
+        // back out of an otherwise working connection.
+        try {
+          await Vue.prototype.$util.send('appdb/tabhistory/clearDeletedTabs', { workspaceId: context.state.usedConfig.workspaceId, connectionId: context.state.usedConfig.id })
+          await context.dispatch('checkVersion');
+        } catch (ex) {
+          log.error('post-connect housekeeping failed', ex)
+        }
+        return true;
+      } finally {
+        context.commit('connecting', false);
+      }
+    },
+    /**
+     * Return the app to a clean disconnected state after `connect` fails partway
+     * through. Closes the backend connection that `conn/create` already opened and
+     * undoes any commits made, so the user lands back on the connection screen
+     * instead of an empty core interface.
+     */
+    async rollbackConnection(context) {
+      try {
+        await Vue.prototype.$util.send('conn/disconnect');
+      } catch (ex) {
+        log.error("Error disconnecting a failed connection", ex)
+      }
+
+      try {
+        await Vue.prototype.$util.send('conn/clearConnection');
+      } catch (ex) {
+        log.error("Error clearing a failed connection", ex)
+      }
+
+      window.main.disableConnectionMenuItems();
+      context.commit('clearConnection')
+      context.commit('newConnection', null)
+      await context.dispatch('updateWindowTitle')
     },
     async checkVersion(context) {
       const data = context.getters['dialectData'];
@@ -583,7 +652,7 @@ const store = new Vuex.Store<State>({
     },
     async reconnect(context) {
       if (context.state.connection) {
-        if (shouldPromptForCockroachJwt(context.state.usedConfig)) {
+        if (shouldPromptCockroachJwt(context.state.usedConfig)) {
           return await context.dispatch('connect', { config: context.state.usedConfig });
         }
 

--- a/apps/studio/tests/vitest/integration/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/vitest/integration/lib/db/clients/sqlite.spec.js
@@ -1,6 +1,8 @@
 import { describe, it, test, expect, beforeAll, afterAll } from "vitest";
 import { DBTestUtil } from "@tests/lib/db";
-import { writeFileSync } from "fs";
+import { writeFileSync, existsSync } from "fs";
+import path from "path";
+import os from "os";
 import tmp from "tmp";
 import { runCommonTests, runReadOnlyTests } from "@tests/integration/lib/db/clients/all";
 import knex from "knex";
@@ -293,5 +295,38 @@ describe('SQLite - invalid db file', () => {
   test('should throw error on connecting', () => {
     expect.assertions(1)
     return expect(util.connection.connect()).rejects.toHaveProperty('message', 'file is not a database')
+  })
+})
+
+describe('SQLite - missing db file', () => {
+  let dbName
+  /** @type {DBTestUtil} */
+  let util
+
+  beforeAll(() => {
+    dbName = path.join(os.tmpdir(), `bks-missing-${Date.now()}.db`)
+
+    util = new DBTestUtil({
+      client: 'sqlite',
+    },
+    dbName,
+    {
+      dialect: "sqlite",
+      knex: knex({
+        client: "better-sqlite3",
+        connection: {
+          filename: dbName,
+        },
+      }),
+    })
+  })
+
+  afterAll(async () => {
+    await util?.disconnect()
+  })
+
+  test('should throw error on connecting instead of creating the file', async () => {
+    await expect(util.connection.connect()).rejects.toThrow(/Database file not found/)
+    expect(existsSync(dbName)).toBe(false)
   })
 })

--- a/apps/studio/tests/vitest/unit/store/connectAction.spec.ts
+++ b/apps/studio/tests/vitest/unit/store/connectAction.spec.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Vue from 'vue'
+import store from '@/store'
+
+// The connect action talks to the utility process via `$util.send` and to the
+// main process via `window.main`. Both are stubbed so the action's own
+// sequencing - what it commits, in what order, and what it tears down on
+// failure - is what's under test.
+const sent: string[] = []
+let sendImpl: (channel: string, args?: any) => Promise<any>
+
+function stubConnectionClient(overrides: Record<string, any> = {}) {
+  Object.assign(store.state.connection, {
+    defaultSchema: async () => 'public',
+    supportedFeatures: async () => ({ backups: false, customRoutines: false }),
+    versionString: async () => '1.0.0',
+    listDatabases: async () => ['mydb'],
+    listTables: async () => [],
+    listViews: async () => [],
+    listMaterializedViews: async () => [],
+    listRoutines: async () => [],
+    listSchemas: async () => [],
+    ...overrides,
+  })
+}
+
+const CONFIG: any = { connectionType: 'sqlite', defaultDatabase: '/tmp/x.db', workspaceId: -1, id: 1 }
+
+describe('store connect action', () => {
+  beforeEach(() => {
+    sent.length = 0
+    sendImpl = async () => undefined
+
+    Vue.prototype.$util = {
+      send: (channel: string, args?: any) => {
+        sent.push(channel)
+        return sendImpl(channel, args)
+      }
+    }
+
+    // partial stub of the preload bridge - only what connect/rollback touch
+    window.main = {
+      enableConnectionMenuItems: vi.fn(),
+      disableConnectionMenuItems: vi.fn(),
+      setWindowTitle: vi.fn(),
+      basename: (p: string) => p.split('/').pop(),
+    } as any
+
+    store.commit('setUsername', 'tester')
+    store.commit('clearConnection')
+    store.commit('newConnection', null)
+    store.commit('connecting', false)
+
+    stubConnectionClient()
+
+    // conn/create records the use backend-side; the renderer only reloads the
+    // recent-connection rows. Registered under the literal slashed name, the
+    // way DataManager does it.
+    store.registerModule('data/usedconnections', {
+      namespaced: true,
+      state: { items: [] },
+      actions: { load: async () => undefined },
+    } as any, { preserveState: false })
+  })
+
+  afterEach(() => {
+    store.unregisterModule('data/usedconnections')
+    store.commit('clearConnection')
+    store.commit('connecting', false)
+  })
+
+  it('commits connected and usedConfig on success', async () => {
+    const result = await store.dispatch('connect', { config: CONFIG })
+
+    expect(result).toBe(true)
+    expect(store.state.connected).toBe(true)
+    expect(store.state.usedConfig).toBeTruthy()
+    expect(store.state.connecting).toBe(false)
+  })
+
+  it('commits usedConfig before connected so the core interface never renders without one', async () => {
+    // Watchers keyed on usedConfig (initial query tab, pins) rely on this
+    // ordering, and the connection button renders `v-if="config"`.
+    const order: string[] = []
+    const unsubscribe = store.subscribe((mutation) => {
+      if (mutation.type === 'newConnection' || mutation.type === 'connected') {
+        order.push(mutation.type)
+      }
+    })
+
+    await store.dispatch('connect', { config: CONFIG })
+    unsubscribe()
+
+    expect(order).toEqual(['newConnection', 'connected'])
+  })
+
+  it('stays disconnected and tears down the backend when bootstrap fails', async () => {
+    stubConnectionClient({
+      listTables: async () => { throw new Error('permission denied for schema public') }
+    })
+
+    await expect(store.dispatch('connect', { config: CONFIG }))
+      .rejects.toThrow('permission denied for schema public')
+
+    expect(store.state.connected).toBe(false)
+    expect(store.state.usedConfig).toBeNull()
+    // the connection conn/create opened must not be left dangling
+    expect(sent).toContain('conn/disconnect')
+    expect(sent).toContain('conn/clearConnection')
+    expect(store.state.connecting).toBe(false)
+  })
+
+  it('propagates a failure from conn/create without committing anything', async () => {
+    sendImpl = async (channel) => {
+      if (channel === 'conn/create') throw new Error('Database file not found: /tmp/x.db')
+      return undefined
+    }
+
+    await expect(store.dispatch('connect', { config: CONFIG }))
+      .rejects.toThrow('Database file not found')
+
+    expect(store.state.connected).toBe(false)
+    expect(store.state.usedConfig).toBeNull()
+    expect(store.state.connecting).toBe(false)
+  })
+
+  it('rejects a second connect while one is still in flight', async () => {
+    let releaseCreate: () => void
+    const createStarted = new Promise<void>((resolveStarted) => {
+      sendImpl = async (channel) => {
+        if (channel === 'conn/create') {
+          resolveStarted()
+          await new Promise<void>((r) => { releaseCreate = r })
+        }
+        return undefined
+      }
+    })
+
+    const first = store.dispatch('connect', { config: CONFIG })
+    await createStarted
+
+    // A sidebar double-click or quick-search pick lands here mid-flight. Both
+    // attempts share one utility-process connection slot, so the second must be
+    // refused rather than race the first.
+    await expect(store.dispatch('connect', { config: CONFIG }))
+      .rejects.toThrow('already in progress')
+
+    releaseCreate()
+    await expect(first).resolves.toBe(true)
+    expect(store.state.connected).toBe(true)
+  })
+
+  it('keeps a working connection when post-connect housekeeping fails', async () => {
+    sendImpl = async (channel) => {
+      if (channel === 'appdb/tabhistory/clearDeletedTabs') throw new Error('tab history unavailable')
+      return undefined
+    }
+
+    await expect(store.dispatch('connect', { config: CONFIG })).resolves.toBe(true)
+    expect(store.state.connected).toBe(true)
+  })
+})


### PR DESCRIPTION
- track 'connecting' status
- Don't let two separate connection attempts stomp each other
- Special file system check for sqlite

