### PR TITLE
Migrate 10 simple unit specs to vitest

### DIFF
--- a/apps/studio/tests/VITEST_MIGRATION.md
+++ b/apps/studio/tests/VITEST_MIGRATION.md
@@ -207,3 +207,21 @@ When the legacy trees are empty:
   explicit vitest import. Pure function, no mocks, no jsdom. Both test
   cases (10 `expect` calls total) pass unchanged; jest collection dropped
   by exactly this file.
+- **2026-09-10, nine more unit canaries**: `LanguageData.spec.js`,
+  `lib/dialects/models.spec.js`, `shared/lib/dialects/sqlserver.spec.js`,
+  `shared/lib/dialects/bigquery.spec.js`, `mainPlatformInfo.spec.js`,
+  `mixins/data_converter.spec.js`, `lib/data/mutators.spec.js`,
+  `lib/db/clients/sqlite.spec.js` (unit version), `codemirror/quotes.spec.js`
+  — 16 test cases total, all passing unchanged under vitest. Two shapes
+  worth noting:
+  - `data_converter.spec.js`, `mutators.spec.js`, and the unit
+    `sqlite.spec.js` used deep relative imports into `src`
+    (`../../../src/...`) that were correct from the old `tests/unit/...`
+    depth but would resolve one directory too high after the move; swapped
+    for the `@/` alias instead of recomputing `../` counts.
+  - `codemirror/quotes.spec.js` imports a helper (`helpers.js`) shared with
+    `codemirror/completions.spec.js`, which stays on jest for now. This is
+    the `@tests/` alias case from the "How to migrate a spec" section:
+    the helper stays at `tests/unit/codemirror/helpers.js` and the moved
+    spec now imports it as `@tests/unit/codemirror/helpers`. Verified
+    `completions.spec.js` still passes unmodified under jest (27 tests).

--- a/apps/studio/tests/VITEST_MIGRATION.md
+++ b/apps/studio/tests/VITEST_MIGRATION.md
@@ -203,3 +203,7 @@ When the legacy trees are empty:
   matrix still passes with docker (mysql.spec.js, 642 tests) and jest
   collection dropped by exactly the migrated files
   (`internal:integration --listTests` = 44).
+- **2026-09-10, formatSeconds.spec.ts (unit)**: only change needed was the
+  explicit vitest import. Pure function, no mocks, no jsdom. Both test
+  cases (10 `expect` calls total) pass unchanged; jest collection dropped
+  by exactly this file.

--- a/apps/studio/tests/vitest/unit/codemirror/quotes.spec.js
+++ b/apps/studio/tests/vitest/unit/codemirror/quotes.spec.js
@@ -1,5 +1,6 @@
+import { describe } from "vitest";
 import { Pos } from "codemirror";
-import { testAutoquotes as test } from "./helpers";
+import { testAutoquotes as test } from "@tests/unit/codemirror/helpers";
 
 describe("Codemirror autoquotes", () => {
   test("Lowercased identifier", {

--- a/apps/studio/tests/vitest/unit/common/platform_info/mainPlatformInfo.spec.js
+++ b/apps/studio/tests/vitest/unit/common/platform_info/mainPlatformInfo.spec.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import { resolveAppVersion } from "@/common/platform_info/mainPlatformInfo"
 
 

--- a/apps/studio/tests/vitest/unit/lib/data/mutators.spec.js
+++ b/apps/studio/tests/vitest/unit/lib/data/mutators.spec.js
@@ -1,4 +1,5 @@
-import { Mutators } from "../../../../src/lib/data/tools";
+import { describe, it, expect } from "vitest";
+import { Mutators } from "@/lib/data/tools";
 
 describe("Mutators", () => {
   describe("Error handling", () => {

--- a/apps/studio/tests/vitest/unit/lib/db/clients/sqlite.spec.js
+++ b/apps/studio/tests/vitest/unit/lib/db/clients/sqlite.spec.js
@@ -1,4 +1,5 @@
-import { SqliteClient } from "../../../../../src/lib/db/clients/sqlite"
+import { describe, it, expect } from "vitest"
+import { SqliteClient } from "@/lib/db/clients/sqlite"
 
 describe("SQLite UNIT test (no connection)", () => {
   it("Should build alter table statements", async () => {

--- a/apps/studio/tests/vitest/unit/lib/dialects/models.spec.js
+++ b/apps/studio/tests/vitest/unit/lib/dialects/models.spec.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import { FormatterDialect } from "@shared/lib/dialects/models"
 
 

--- a/apps/studio/tests/vitest/unit/lib/editor/LanguageData.spec.js
+++ b/apps/studio/tests/vitest/unit/lib/editor/LanguageData.spec.js
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest"
 import { Languages } from "@/lib/editor/languageData"
 
 

--- a/apps/studio/tests/vitest/unit/lib/time/formatSeconds.spec.ts
+++ b/apps/studio/tests/vitest/unit/lib/time/formatSeconds.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import formatSeconds from "@/lib/time/formatSeconds"
 
 describe("formatSeconds", () => {

--- a/apps/studio/tests/vitest/unit/mixins/data_converter.spec.js
+++ b/apps/studio/tests/vitest/unit/mixins/data_converter.spec.js
@@ -1,4 +1,5 @@
-import data_converter from "../../../src/mixins/data_converter"
+import { describe, it, expect } from "vitest"
+import data_converter from "@/mixins/data_converter"
 
 
 describe("data converter", () => {

--- a/apps/studio/tests/vitest/unit/shared/lib/dialects/bigquery.spec.js
+++ b/apps/studio/tests/vitest/unit/shared/lib/dialects/bigquery.spec.js
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import { BigQueryData } from "@/shared/lib/dialects/bigquery"
 
 

--- a/apps/studio/tests/vitest/unit/shared/lib/dialects/sqlserver.spec.js
+++ b/apps/studio/tests/vitest/unit/shared/lib/dialects/sqlserver.spec.js
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest"
 import { SqlServerData } from "@/shared/lib/dialects/sqlserver"
 
 


### PR DESCRIPTION
## Summary
Moves 10 simple, self-contained unit specs from Jest to Vitest per `VITEST_MIGRATION.md`, all with matching before/after test coverage:

- `tests/unit/lib/time/formatSeconds.spec.ts` (2 tests, 10 assertions) — pure function, no mocks
- `tests/unit/lib/editor/LanguageData.spec.js` (1 test)
- `tests/unit/lib/dialects/models.spec.js` (1 test, 5 assertions)
- `tests/unit/shared/lib/dialects/sqlserver.spec.js` (1 test, 2 assertions)
- `tests/unit/shared/lib/dialects/bigquery.spec.js` (1 test, 3 assertions)
- `tests/unit/common/platform_info/mainPlatformInfo.spec.js` (5 tests)
- `tests/unit/mixins/data_converter.spec.js` (1 test)
- `tests/unit/lib/data/mutators.spec.js` (1 test, 6 assertions)
- `tests/unit/lib/db/clients/sqlite.spec.js` — unit version, no real DB connection (1 test)
- `tests/unit/codemirror/quotes.spec.js` (4 tests)

All were picked for having zero `jest.mock`/`jest.fn`/`require()`/jsdom-pragma usage, so each needed only the explicit vitest import — except three:

- `mixins/data_converter.spec.js`, `lib/data/mutators.spec.js`, and `lib/db/clients/sqlite.spec.js` used deep relative imports into `src` (`../../../src/...`) that would resolve one directory too shallow once moved a level deeper under `tests/vitest/`. Switched these to the `@/` alias instead of recomputing `../` counts.
- `codemirror/quotes.spec.js` shares a helper (`helpers.js`) with `codemirror/completions.spec.js`, which stays on Jest for now. Per the migration guide, the helper stays put at `tests/unit/codemirror/helpers.js`, and the moved spec now imports it via the `@tests/` alias. Verified `completions.spec.js` still passes unmodified under Jest (27 tests, untouched).

Findings logged in `VITEST_MIGRATION.md`.

## Verification (same coverage before/after, each spec)
- **Before (Jest)**: all 10 files run together — `Test Suites: 10 passed, 10 total`, `Tests: 18 passed, 18 total` (2 from formatSeconds + 16 from the other 9).
- **After (Vitest)**: same 10 files — `Test Files 10 passed (10)`, `Tests 18 passed (18)`, identical test names and assertions.
- Confirmed Jest no longer collects any of the 10 files (`internal:unit --listTests`).
- `npx eslint` clean on all moved files.

## Test plan
- [x] `yarn test:unit <paths>` (pre-migration) — 10/10 suites, 18/18 tests passed
- [x] `yarn vitest:unit <paths>` (post-migration) — 10/10 suites, 18/18 tests passed
- [x] `yarn test:unit tests/unit/codemirror/completions.spec.js` — confirms the shared helper still works for the file staying on Jest (27/27 passed)
- [x] `npx eslint` on all moved files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pnhyga7hjg3JseV3VVULsn