### PR TITLE
Migrate 10 more unit specs from jest to vitest

### DIFF
--- a/apps/studio/tests/VITEST_MIGRATION.md
+++ b/apps/studio/tests/VITEST_MIGRATION.md
@@ -225,3 +225,16 @@ When the legacy trees are empty:
     the helper stays at `tests/unit/codemirror/helpers.js` and the moved
     spec now imports it as `@tests/unit/codemirror/helpers`. Verified
     `completions.spec.js` still passes unmodified under jest (27 tests).
+- **2026-09-10, ten more unit canaries**: `pluralize.spec.ts`,
+  `structureCopy.spec.ts`, `structureFilter.spec.ts`, `menuItems.spec.ts`,
+  `folderTree.spec.ts`, `enumParsers.spec.ts`, `partiqlFormatter.spec.ts`,
+  `duckdb_change_builder.spec.ts`, `stringify_range_data.spec.js`,
+  `vimrc.spec.js` — 2512 test cases total, identical pass count before
+  (jest) and after (vitest). `jest.fn()` → `vi.fn()` was the only API swap
+  needed (`structureCopy.spec.ts`, `structureFilter.spec.ts`,
+  `menuItems.spec.ts`). `pluralize.spec.ts`'s `@jest-environment node`
+  became `@vitest-environment node`. `stringify_range_data.spec.js` and
+  `vimrc.spec.js` used depth-counted relative imports into `src`
+  (`../../../src/...`, `../../../../studio/src/...`) that were correct from
+  the old tree depth but wrong after the move; swapped for the `@/` alias.
+  `jest --listTests` dropped by exactly these 10 files afterward.

--- a/apps/studio/tests/vitest/unit/common/folderTree.spec.ts
+++ b/apps/studio/tests/vitest/unit/common/folderTree.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import {
   buildFolderNodes,
   buildItemNodes,

--- a/apps/studio/tests/vitest/unit/common/menus/menuItems.spec.ts
+++ b/apps/studio/tests/vitest/unit/common/menus/menuItems.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from "vitest";
 import { menuItems } from "@/common/menus/MenuItems";
 import { IMenuActionHandler } from "@/common/interfaces/IMenuActionHandler";
 import { IGroupedUserSettings } from "@/common/transport/TransportUserSetting";
@@ -6,7 +7,7 @@ import { IPlatformInfo } from "@/common/IPlatformInfo";
 // menuItems only dereferences handler properties, so a permissive proxy is
 // enough to build the full template.
 const actionHandler = new Proxy({} as IMenuActionHandler, {
-  get: () => jest.fn(),
+  get: () => vi.fn(),
 });
 
 const settings = {} as IGroupedUserSettings;

--- a/apps/studio/tests/vitest/unit/lib/db/clients/duckdb_change_builder.spec.ts
+++ b/apps/studio/tests/vitest/unit/lib/db/clients/duckdb_change_builder.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import { DuckDBChangeBuilder } from "@shared/lib/sql/change_builder/DuckDBChangeBuilder"
 
 describe("DuckDBChangeBuilder", () => {

--- a/apps/studio/tests/vitest/unit/lib/db/clients/enumParsers.spec.ts
+++ b/apps/studio/tests/vitest/unit/lib/db/clients/enumParsers.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest"
 import { parseQuotedEnumValues, parseClickHouseEnumValues } from "@/lib/db/clients/enumParsers"
 
 describe("parseQuotedEnumValues (MySQL / MariaDB / DuckDB)", () => {

--- a/apps/studio/tests/vitest/unit/mixins/structureCopy.spec.ts
+++ b/apps/studio/tests/vitest/unit/mixins/structureCopy.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import { StructureCopyMixin } from "@/mixins/structureCopy";
 
@@ -33,7 +34,7 @@ const Host = {
 };
 
 function mountHost(tabulator: any) {
-  const writeText = jest.fn();
+  const writeText = vi.fn();
   const wrapper = mount(Host, {
     propsData: { tabulator },
     mocks: {

--- a/apps/studio/tests/vitest/unit/mixins/structureFilter.spec.ts
+++ b/apps/studio/tests/vitest/unit/mixins/structureFilter.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, vi } from "vitest";
 import { mount, Wrapper } from "@vue/test-utils";
 import { StructureFilterMixin } from "@/mixins/structureFilter";
 
@@ -18,8 +19,8 @@ function fakeTabulator(initialColumns: any[] = COLUMNS) {
   const activeRows = [{ columnName: "user_name" }];
   return {
     activeRows,
-    setFilter: jest.fn(),
-    clearFilter: jest.fn(),
+    setFilter: vi.fn(),
+    clearFilter: vi.fn(),
     on(event: string, callback: (...args: any[]) => void) {
       listeners[event] = listeners[event] || [];
       listeners[event].push(callback);

--- a/apps/studio/tests/vitest/unit/mixins/vimrc.spec.js
+++ b/apps/studio/tests/vitest/unit/mixins/vimrc.spec.js
@@ -1,4 +1,5 @@
-import { parseVimrc } from "../../../../studio/src/lib/editor/vim"
+import { describe, it, expect } from "vitest"
+import { parseVimrc } from "@/lib/editor/vim"
 
 const mapping = (lhs, rhs, mode, noremap = false) => ({ lhs, rhs, mode, noremap })
 

--- a/apps/studio/tests/vitest/unit/shared/lib/dialects/partiqlFormatter.spec.ts
+++ b/apps/studio/tests/vitest/unit/shared/lib/dialects/partiqlFormatter.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from 'vitest'
 import { safeSqlFormat } from '@/common/utils'
 import { formatOptionsFor } from '@shared/lib/dialects/models'
 

--- a/apps/studio/tests/vitest/unit/utils/stringify_range_data.spec.js
+++ b/apps/studio/tests/vitest/unit/utils/stringify_range_data.spec.js
@@ -1,4 +1,5 @@
-import { stringifyRangeData } from "../../../src/common/utils";
+import { describe, it, expect } from "vitest";
+import { stringifyRangeData } from "@/common/utils";
 
 describe("stringifyRangeData", () => {
   it("Should convert array and objects to string", () => {

--- a/apps/studio/tests/vitest/unit/vendor/pluralize.spec.ts
+++ b/apps/studio/tests/vitest/unit/vendor/pluralize.spec.ts
@@ -1,6 +1,7 @@
 /**
- * @jest-environment node
+ * @vitest-environment node
  */
+import { describe, it, expect } from "vitest";
 import { pluralize } from "@/vendor/pluralize";
 
 /**


### PR DESCRIPTION
## Summary
- Moves 10 more unit specs into `tests/vitest/unit/`, following `apps/studio/tests/VITEST_MIGRATION.md`: `pluralize.spec.ts`, `structureCopy.spec.ts`, `structureFilter.spec.ts`, `menuItems.spec.ts`, `folderTree.spec.ts`, `enumParsers.spec.ts`, `partiqlFormatter.spec.ts`, `duckdb_change_builder.spec.ts`, `stringify_range_data.spec.js`, `vimrc.spec.js`
- Standard conversions only: explicit vitest imports, `jest.fn()` → `vi.fn()` (3 files), `@jest-environment node` → `@vitest-environment node` (`pluralize.spec.ts`), and depth-counted relative `../src` imports swapped for the `@/` alias (`stringify_range_data.spec.js`, `vimrc.spec.js`)
- Appended a findings-log entry to `VITEST_MIGRATION.md`

## Verification
- Baseline (jest, before move): 10 suites, **2512/2512** tests passing
- After move (vitest): 10 suites, **2512/2512** tests passing — same pass count, same test names
- `yarn internal:unit --listTests` no longer collects any of the 10 moved files (jest count dropped by exactly 10)
- `yarn lint`: 0 errors

## Test plan
- [x] `yarn test:unit <files>` on original jest paths recorded baseline (2512 passing)
- [x] `yarn vitest:unit <files>` on new vitest paths — 2512 passing, identical to baseline
- [x] Confirmed jest no longer collects the moved files
- [x] `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJmj1fvyEXnfSH4qd6Jkok

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJmj1fvyEXnfSH4qd6Jkok)_