### PR TITLE
fix: pin ER diagram menu item and disable plugin items when disconnected

### DIFF
--- a/apps/studio/src/background/NativeMenuBuilder.ts
+++ b/apps/studio/src/background/NativeMenuBuilder.ts
@@ -16,6 +16,7 @@ export default class NativeMenuBuilder {
   private menu?: Electron.Menu
   /** Array of native menu items from plugins */
   private pluginMenuItems: MenuItemConstructorOptions[] = []
+  private connected = false
 
   constructor(private electron: any, settings: IGroupedUserSettings, bksConfig: IBksConfig){
     this.handler = new NativeMenuActionHandlers(settings)
@@ -99,10 +100,12 @@ export default class NativeMenuBuilder {
 
   listenForToggleConnectionMenuItems(): void {
     ipcMain.on("enable-connection-menu-items", (_event ) => {
+      this.connected = true;
       this.toggleConnectionMenuItems("enable");
       this.toggleAppMenuItems("disable");
     });
     ipcMain.on("disable-connection-menu-items", (_event ) => {
+      this.connected = false;
       this.toggleConnectionMenuItems("disable");
       this.toggleAppMenuItems("enable");
     });
@@ -145,6 +148,8 @@ export default class NativeMenuBuilder {
     this.injectPluginMenuItems(template);
     this.menu = this.electron.Menu.buildFromTemplate(template);
     this.electron.Menu.setApplicationMenu(this.menu);
+    this.toggleConnectionMenuItems(this.connected ? "enable" : "disable");
+    this.toggleAppMenuItems(this.connected ? "disable" : "enable");
   }
 
   private injectPluginMenuItems(template: Electron.MenuItemConstructorOptions[]): void {
@@ -153,6 +158,11 @@ export default class NativeMenuBuilder {
     if (!toolsMenu || !Array.isArray(toolsMenu.submenu)) {
       return;
     }
-    toolsMenu.submenu.push(...this.pluginMenuItems);
+    const [pinned, rest] = _.partition(
+      this.pluginMenuItems,
+      item => item.id.startsWith('bks-er-diagram')
+    );
+    toolsMenu.submenu.unshift(...pinned);
+    toolsMenu.submenu.push(...rest);
   }
 }

--- a/apps/studio/src/components/TabTableProperties.vue
+++ b/apps/studio/src/components/TabTableProperties.vue
@@ -24,6 +24,14 @@
           >
             {{ pill.name }} {{ pill.dirty ? '*' : '' }}
           </a>
+          <a
+            v-if="erDiagramAvailable"
+            class="nav-pill er-diagram-pill"
+            title="Open ER Diagram in a new tab"
+            @click.prevent="openErDiagram"
+          >
+            ER Diagram <i class="material-icons">open_in_new</i>
+          </a>
         </div>
       </div>
       <div
@@ -248,7 +256,7 @@ export default {
   },
   computed: {
     ...mapState(['tables', 'tablesInitialLoaded', 'supportedFeatures', 'connection']),
-    ...mapGetters(['dialectData', 'dialect']),
+    ...mapGetters(['dialectData', 'dialect', 'erDiagramAvailable']),
     ...mapGetters('popupMenu', ['getExtraPopupMenu']),
     shouldInitialize() {
       // TODO (matthew): Move this to the wrapper TabWithTable
@@ -389,6 +397,15 @@ export default {
     handleExtraStatusbarMenuClick(event, item) {
       item.handler({ event, item: this.table });
     },
+    openErDiagram() {
+      this.$bksPlugin.execute("bks-er-diagram", "showOneTable", {
+        entity: {
+          type: this.table.entityType,
+          name: this.table.name,
+          schema: this.table.schema,
+        },
+      });
+    },
   },
   async mounted() {
     if (this.shouldInitialize) this.initialize()
@@ -397,6 +414,16 @@ export default {
 </script>
 
 <style scoped>
+.er-diagram-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.er-diagram-pill .material-icons {
+  font-size: 14px;
+}
+
 .permission-warning {
   cursor: pointer;
   color: #f39c12;

--- a/apps/studio/src/services/plugin/web/PluginStoreService.ts
+++ b/apps/studio/src/services/plugin/web/PluginStoreService.ts
@@ -354,7 +354,10 @@ export default class PluginStoreService {
   }
 
   addMenuBarItem(item: ExternalMenuItem<PluginTabContext>) {
-    this.store.commit("menuBar/add", item);
+    this.store.commit("menuBar/add", {
+      disableWhenDisconnected: true,
+      ...item,
+    });
   }
 
   removeMenuBarItem(id: string) {

--- a/apps/studio/src/store/index.ts
+++ b/apps/studio/src/store/index.ts
@@ -328,6 +328,10 @@ const store = new Vuex.Store<State>({
       return getters["tabs/newTabDropdownItems"].some(
         ({ config }) => config.pluginId === "bks-ai-shell"
       );
+    },
+    erDiagramAvailable(_state, getters) {
+      const items = getters["popupMenu/getExtraPopupMenu"]("structure.statusbar");
+      return items.some((item) => item.slug === "bks-er-diagram-showOneTable");
     }
   },
   mutations: {

--- a/apps/studio/src/store/modules/MenuBarModule.ts
+++ b/apps/studio/src/store/modules/MenuBarModule.ts
@@ -14,8 +14,6 @@ const log = RawLog.scope("MenuBarModule");
 
 const actionHandler = new ClientMenuActionHandler();
 
-const erDiagramMenuItemId = "bks-er-diagram-showAllEntities";
-
 export const MenuBarModule: Module<State, RootState> = {
   namespaced: true,
   state: () => ({
@@ -82,7 +80,7 @@ export const MenuBarModule: Module<State, RootState> = {
           accelerator: externalItem.accelerator,
         };
 
-        if (externalItem.id === erDiagramMenuItemId) {
+        if (externalItem.id.startsWith("bks-er-diagram")) {
           submenu.unshift(item);
         } else {
           submenu.push(item);

--- a/apps/studio/src/store/modules/MenuBarModule.ts
+++ b/apps/studio/src/store/modules/MenuBarModule.ts
@@ -14,6 +14,8 @@ const log = RawLog.scope("MenuBarModule");
 
 const actionHandler = new ClientMenuActionHandler();
 
+const erDiagramMenuItemId = "bks-er-diagram-showAllEntities";
+
 export const MenuBarModule: Module<State, RootState> = {
   namespaced: true,
   state: () => ({
@@ -34,6 +36,8 @@ export const MenuBarModule: Module<State, RootState> = {
         "export-tables",
       ];
 
+      // These are menu items from plugins. They can only be used when the app
+      // is connected to a database.
       for (const id of Object.keys(state.externalMenu)) {
         const menuItem = state.externalMenu[id];
         if (menuItem.disableWhenDisconnected) {
@@ -68,14 +72,21 @@ export const MenuBarModule: Module<State, RootState> = {
           continue;
         }
 
-        (parent.submenu as Electron.MenuItemConstructorOptions[]).push({
+        const submenu = parent.submenu as Electron.MenuItemConstructorOptions[];
+        const item = {
           id: externalItem.id,
           label: externalItem.label,
           click: () => {
             actionHandler.handleAction(externalItem.action);
           },
           accelerator: externalItem.accelerator,
-        });
+        };
+
+        if (externalItem.id === erDiagramMenuItemId) {
+          submenu.unshift(item);
+        } else {
+          submenu.push(item);
+        }
       }
 
       return menus;


### PR DESCRIPTION
- Move the "Open ER Diagram" item to the top

<img width="238" height="188" alt="Screenshot 2026-09-10 at 23 07 50" src="https://github.com/user-attachments/assets/e58a1e29-62f7-4ee8-adc1-ebeef0401ca8" />

- Add `ER Diagram` pill to the table structure

<img width="509" height="148" alt="Screenshot 2026-09-10 at 23 08 09" src="https://github.com/user-attachments/assets/39fc4d80-a19c-45f6-954a-11de3344f332" />
