### PR TITLE
SQL Server first time connection issue fixes

### DIFF
--- a/apps/studio/src/common/appdb/models/saved_connection.ts
+++ b/apps/studio/src/common/appdb/models/saved_connection.ts
@@ -257,9 +257,13 @@ export class DbConnectionBase extends ApplicationEntity {
   @Column({ type: 'simple-json', nullable: false, transformer: [snowflakeTransformer] })
   snowflakeOptions: SnowflakeOptions = {};
 
-  // this is only for SQL Server.
+  // this is only for SQL Server. Defaults on: every stock install presents a self-signed
+  // certificate and tedious validates by default, so a new connection with a correct host and
+  // password fails without it. The integrated-auth path already trusts self-signed certs
+  // (encryptionMode 'on' -> TrustServerCertificate=yes), so this keeps the two consistent.
+  // Class-field default: applies to newly constructed entities only, saved rows keep theirs.
   @Column({ type: 'boolean', nullable: false })
-  trustServerCertificate = false
+  trustServerCertificate = true
 
   // SQL Server only. Integrated authentication (SSPI/Kerberos/NTLM) via msnodesqlv8.
   @Column({ type: 'boolean', nullable: false })

--- a/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
+++ b/apps/studio/src/frontend/utils/FriendlyErrorHelper.ts
@@ -1,11 +1,21 @@
 import { ConnectionType } from "@/lib/db/types"
 
 interface HelpInfo {
-  help: string
+  // Optional: an entry may carry only a link, when the message already states the remedy
+  // and this side is just adding somewhere to read more.
+  help?: string
   link?: string
   pattern?: string
 }
+
+const SQL_SERVER_DOCS = 'https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/'
 const errorMappings = {
+  // Errors are rebuilt as `new Error(message)` when they cross the utility-process boundary
+  // (see UtilityConnection.ts), so only the top-level message reaches this side -- the nested
+  // originalError / precedingErrors and the error code are already gone. Failures that need
+  // those, or need the driver config, are classified in the client itself and arrive with the
+  // remedy already in the message; sqlserver.ts does that for certificate and SQL Server
+  // Browser failures. Add a pattern here when the top-level text alone identifies the fault.
   'sqlserver': [
     {
       pattern: "login failed for user <token-identified principal>",
@@ -13,31 +23,39 @@ const errorMappings = {
       link: "https://learn.microsoft.com/en-us/answers/questions/133709/login-failed-for-user"
     },
     {
-      pattern: 'self signed certificate',
-      help: "You might need to check 'Trust Server Certificate'"
+      // Certificate and SQL Server Browser failures are already annotated with the remedy by
+      // sqlserver.ts, so these add the docs link and no help text -- a second copy of the
+      // advice would render right after the first in ErrorAlert. Keyed on the wording those
+      // hints guarantee; sqlserverConfig.spec.ts asserts the two stay in step.
+      pattern: 'self-signed certificate',
+      link: `${SQL_SERVER_DOCS}#certificates`
+    },
+    {
+      pattern: 'sql server browser',
+      link: `${SQL_SERVER_DOCS}#named-instances-and-the-sql-server-browser`
     },
     {
       // Integrated auth: the ODBC driver (and unixODBC on Linux/macOS) is missing.
       pattern: 'odbc driver',
       help: "Integrated authentication needs the Microsoft ODBC Driver 18 for SQL Server installed (plus unixODBC on Linux/macOS).",
-      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+      link: SQL_SERVER_DOCS
     },
     {
       // Integrated auth: the native driver module failed to load.
       pattern: 'msnodesqlv8',
       help: "The native driver for integrated authentication could not load. On Linux/macOS install unixODBC and the Microsoft ODBC Driver 18 for SQL Server.",
-      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+      link: SQL_SERVER_DOCS
     },
     {
       // Integrated auth: SSPI/Kerberos handshake failed or timed out.
       pattern: 'sspi',
       help: "Integrated (Kerberos/NTLM) authentication failed. Check for a valid Kerberos ticket (kinit) and that the server's SPN is registered. Connect by hostname/FQDN so Kerberos can match the SPN.",
-      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+      link: SQL_SERVER_DOCS
     },
     {
       pattern: 'kerberos',
       help: "Kerberos authentication failed. Check for a valid ticket (kinit), a registered server SPN, and a client clock in sync with the KDC.",
-      link: "https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/"
+      link: SQL_SERVER_DOCS
     }
   ],
   'oracle': [

--- a/apps/studio/src/lib/db/clients/sqlserver.ts
+++ b/apps/studio/src/lib/db/clients/sqlserver.ts
@@ -22,6 +22,7 @@ import {
 import logRaw from '@bksLogger'
 import { SqlServerCursor } from './sqlserver/SqlServerCursor'
 import { buildWindowsAuthConnStr } from './sqlserverWinAuth'
+import { parseSqlServerHost } from './sqlserverHost'
 import { SqlServerData } from '@shared/lib/dialects/sqlserver'
 import { SqlServerChangeBuilder } from '@shared/lib/sql/change_builder/SqlServerChangeBuilder'
 import { joinFilters } from '@/common/utils';
@@ -58,6 +59,71 @@ function withDeadline<T>(promise: Promise<T>, ms: number, message: string): Prom
     timer = setTimeout(() => reject(new Error(message)), ms);
   });
   return Promise.race([promise, deadline]).finally(() => clearTimeout(timer)) as Promise<T>;
+}
+
+// Flatten every nested message out of an mssql/msnodesqlv8 error: mssql wraps driver
+// errors and exposes the real cause via originalError / precedingErrors, so the outermost
+// message alone is rarely enough to classify a failure.
+export function flattenErrorText(err: any): string {
+  const parts: string[] = []
+  const visit = (e: any) => {
+    if (!e) return
+    if (typeof e === 'string') { parts.push(e); return }
+    if (typeof e.message === 'string') parts.push(e.message)
+    if (typeof e.code === 'string') parts.push(e.code)
+    if (e.originalError) visit(e.originalError)
+    if (Array.isArray(e.precedingErrors)) e.precedingErrors.forEach(visit)
+  }
+  if (Array.isArray(err)) err.forEach(visit); else visit(err)
+  return parts.join('; ')
+}
+
+// Every stock SQL Server presents a self-signed certificate and tedious has validated by
+// default since v16, so this is the first wall a correct host + password hits.
+const SELF_SIGNED_CERT_PATTERN =
+  /self[-\s]?signed certificate|unable to verify the first certificate|SELF_SIGNED_CERT_IN_CHAIN/i
+
+export const sqlServerConnectHints = {
+  selfSignedCertificate:
+    'The server presented a self-signed certificate. Enable "Trust Server Certificate" in the ' +
+    'SQL Server options, or configure the server with a certificate the OS trusts.',
+  browserUnreachable: (host: string, instanceName: string): string =>
+    `No response from the SQL Server Browser service on ${host} (UDP 1434), required to resolve ` +
+    `instance ${instanceName}. Start the SQL Server Browser service, allow UDP 1434 through the ` +
+    `firewall, or enter the instance's static TCP port in the Port field.`,
+}
+
+// Both failure modes reach the user as something they cannot act on: a self-signed
+// certificate reads as a bare TLS error with no hint that the fix is a checkbox, and an
+// unreachable SQL Server Browser as a flat 15s timeout that never mentions UDP 1434.
+// The browser case is keyed off the built config rather than the driver's text -- that text
+// is inconsistent (a generic "Failed to connect ... in 15000ms" in testing, not tedious's
+// "Failed to get response from SQL Server Browser") and options.instanceName is set exactly
+// when the connection depends on a browser lookup.
+export function sqlServerConnectHint(err: any, config: any): string | null {
+  if (SELF_SIGNED_CERT_PATTERN.test(flattenErrorText(err))) {
+    return sqlServerConnectHints.selfSignedCertificate
+  }
+
+  const instanceName = config?.options?.instanceName
+  if (instanceName) return sqlServerConnectHints.browserUnreachable(config.server, instanceName)
+
+  return null
+}
+
+// Keep the driver's own text (and the original error) and append the remedy, so logs lose
+// nothing and the connection screen gains the one sentence that resolves the failure.
+function withConnectHint(err: any, config: any): any {
+  const hint = sqlServerConnectHint(err, config)
+  if (!hint) return err
+
+  const message = ((err instanceof Error && err.message) || flattenErrorText(err) || String(err)).trim()
+  // The connection screen renders this as one line, so join rather than stack.
+  const separator = /[.!?]$/.test(message) ? ' ' : '. '
+  const decorated: any = new Error(`${message}${separator}${hint}`)
+  decorated.originalError = err
+  if (err?.code) decorated.code = err.code
+  return decorated
 }
 
 type SQLServerVersion = {
@@ -1127,10 +1193,14 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
 
     this.dbConfig = await this.configDatabase(this.server, this.database, signal)
 
-    if (this.server.config.windowsAuthEnabled) {
-      this.pool = await this.connectWindowsAuth()
-    } else {
-      this.pool = await new ConnectionPool(this.dbConfig).connect();
+    try {
+      if (this.server.config.windowsAuthEnabled) {
+        this.pool = await this.connectWindowsAuth()
+      } else {
+        this.pool = await new ConnectionPool(this.dbConfig).connect();
+      }
+    } catch (err) {
+      throw withConnectHint(err, this.dbConfig)
     }
 
     this.pool.on('error', (err) => {
@@ -1330,21 +1400,6 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       candidates.push({ driver: 'SQL Server', legacy: true })
     }
 
-    // Flatten every nested message out of an mssql/msnodesqlv8 error so a missing
-    // driver can be told apart from a real auth/connect failure (mssql wraps native
-    // errors and exposes them via originalError / precedingErrors).
-    const errorText = (err: any): string => {
-      const parts: string[] = []
-      const visit = (e: any) => {
-        if (!e) return
-        if (typeof e === 'string') { parts.push(e); return }
-        if (typeof e.message === 'string') parts.push(e.message)
-        if (e.originalError) visit(e.originalError)
-        if (Array.isArray(e.precedingErrors)) e.precedingErrors.forEach(visit)
-      }
-      if (Array.isArray(err)) err.forEach(visit); else visit(err)
-      return parts.join('; ')
-    }
     const isDriverMissing = (text: string): boolean =>
       /IM002|IM003|data source name not found|specified driver could not be loaded|can'?t open lib|file not found/i.test(text)
 
@@ -1392,11 +1447,11 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
         // A missing driver is not fatal while other candidates remain; advance to
         // the next. Any other failure (auth, unreachable, or the withDeadline
         // timeout above) is real and already carries a useful message.
-        if (isDriverMissing(errorText(err))) {
+        if (isDriverMissing(flattenErrorText(err))) {
           if (i < candidates.length - 1) continue
           throw driverMissingError()
         }
-        throw err instanceof Error ? err : new Error(errorText(err))
+        throw err instanceof Error ? err : new Error(flattenErrorText(err))
       }
     }
 
@@ -1404,9 +1459,15 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     throw driverMissingError()
   }
 
-  private async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, signal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes
+  // Exposed (not private) so the built driver config can be asserted in unit tests without a
+  // live server -- the host/port/instance decisions below are the whole fix for named instances.
+  async configDatabase(server: IDbConnectionServer, database: IDbConnectionDatabase, signal?: AbortSignal): Promise<any> { // changed to any for now, might need to make some changes
+    // `.`/`(local)` and stray whitespace never reach the driver, and the instance name is
+    // split off here so config.server holds a bare host -- see parseSqlServerHost.
+    const { host, instanceName } = parseSqlServerHost(server.config.host)
+
     const config: any = {
-      server: server.config.host,
+      server: host,
       database: database.database,
       requestTimeout: Infinity,
       appName: 'beekeeperstudio',
@@ -1433,9 +1494,15 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     if (server.config.windowsAuthEnabled) {
       config.port = Number(server.config.port);
 
+      // msnodesqlv8 rebuilds Server=host\instance from server + options.instanceName and the
+      // ODBC driver runs its own browser lookup, so the instance is passed straight through.
+      let winAuthInstance = instanceName;
+
       if (server.sshTunnel) {
         config.server = server.config.localHost;
         config.port = server.config.localPort;
+        // A tunnel forwards one TCP port; a UDP 1434 browser lookup cannot follow it.
+        winAuthInstance = undefined;
       }
 
       // trustedConnection delegates auth to the OS (SSPI -> Kerberos/NTLM) via msnodesqlv8.
@@ -1444,6 +1511,7 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       const sqlServerOptions = server.config.sqlServerOptions || {};
       config.options = {
         trustedConnection: true,
+        instanceName: winAuthInstance,
         encryptionMode: sqlServerOptions.encryptionMode || 'on',
         serverCertificate: sqlServerOptions.serverCertificate || undefined,
         serverSpn: sqlServerOptions.serverSpn || undefined,
@@ -1454,7 +1522,24 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
 
     config.user = server.config.user;
     config.password = server.config.password;
-    config.port = Number(server.config.port);
+
+    const port = Number(server.config.port);
+    // mssql drops the port whenever an instance name is set, forcing a SQL Browser lookup.
+    // Treat the client default of 1433 as "unspecified" so a user who knows the instance's
+    // static port can bypass the browser, which is often stopped or firewalled. The Port
+    // field cannot be left blank today, which is why the default doubles as the signal.
+    let browserLookupInstance: string | undefined = undefined;
+
+    if (instanceName) {
+      if (Number.isFinite(port) && port > 0 && port !== 1433) {
+        config.port = port;
+      } else {
+        browserLookupInstance = instanceName;
+        delete config.port;
+      }
+    } else {
+      config.port = port;
+    }
 
     if (server.config.domain) {
       config.domain = server.config.domain
@@ -1463,6 +1548,8 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
     if (server.sshTunnel) {
       config.server = server.config.localHost;
       config.port = server.config.localPort;
+      // A tunnel forwards one TCP port; a UDP 1434 browser lookup cannot follow it.
+      browserLookupInstance = undefined;
     }
 
     config.options = { trustServerCertificate: server.config.trustServerCertificate }
@@ -1494,6 +1581,11 @@ export class SQLServerClient extends BasicDatabaseClient<SQLServerResult, Transa
       }
 
       config.options = options;
+    }
+
+    // Set last: both branches above assign config.options wholesale.
+    if (browserLookupInstance) {
+      config.options.instanceName = browserLookupInstance;
     }
 
     return config;

--- a/apps/studio/src/lib/db/clients/sqlserverHost.ts
+++ b/apps/studio/src/lib/db/clients/sqlserverHost.ts
@@ -1,0 +1,34 @@
+// Pure helpers for normalising what a user types into the SQL Server Host field.
+// Extracted so the exact values handed to the driver can be unit-tested without a live
+// server -- see tests/vitest/unit, and sqlserverWinAuth.ts for the same pattern.
+//
+// mssql splits `host\instance` itself and then throws the port away
+// (lib/tedious/connection-pool.js), which forces a SQL Browser lookup. Parsing here keeps
+// config.server free of backslashes so that split never runs and the client decides.
+
+export interface ParsedSqlServerHost {
+  host: string
+  instanceName?: string
+}
+
+// SSMS accepts these as "this machine". They reach the driver untranslated and die at DNS
+// resolution (getaddrinfo ENOTFOUND .), so map them onto a name the resolver knows.
+const LOCAL_MACHINE_ALIASES = ['.', '(local)', '(localdb)']
+
+export function parseSqlServerHost(raw: string): ParsedSqlServerHost {
+  const value = (raw || '').trim()
+
+  // Split on the FIRST backslash: `host\a\b` has no valid reading other than instance
+  // `a\b`, and letting it through unchanged produces a worse error than the driver's.
+  const separator = value.indexOf('\\')
+  const rawHost = separator === -1 ? value : value.slice(0, separator)
+  const rawInstance = separator === -1 ? '' : value.slice(separator + 1)
+
+  const host = rawHost.trim()
+  const instanceName = rawInstance.trim()
+
+  return {
+    host: LOCAL_MACHINE_ALIASES.includes(host.toLowerCase()) ? 'localhost' : host,
+    instanceName: instanceName || undefined,
+  }
+}

--- a/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
+++ b/apps/studio/tests/integration/lib/db/clients/sqlserver.spec.ts
@@ -2,6 +2,9 @@ import { GenericContainer, Wait } from 'testcontainers'
 import { DBTestUtil, dbtimeout } from '../../../../lib/db'
 import { runCommonTests, runReadOnlyTests } from './all'
 import { DatabaseElement, IDbConnectionServerConfig } from '@/lib/db/types'
+import { IDbConnectionServer } from '@/lib/db/backendTypes'
+import { SQLServerClient } from '@/lib/db/clients/sqlserver'
+import { SavedConnection } from '@/common/appdb/models/saved_connection'
 import fs from 'fs';
 import path from 'path';
 
@@ -140,6 +143,43 @@ function testWith(dockerTag: string, readonly: boolean) {
     describe("Param tests", () => {
       it("Should be able to handle named (:name) params", async () => {
         await util.paramTest([':param1', ':param2', ':param3']);
+      })
+    })
+
+    // Regression guard: tedious has defaulted encrypt to true since v16 and every stock
+    // SQL Server presents a self-signed certificate, so a form the user only typed host,
+    // port, username and password into used to fail certificate validation.
+    describe("Stock install defaults", () => {
+      it("connects without the certificate checkbox being touched", async () => {
+        // Whatever an untouched connection form carries -- notably trustServerCertificate.
+        const defaults = new SavedConnection()
+        expect(defaults.trustServerCertificate).toBe(true)
+
+        const config = {
+          client: 'sqlserver',
+          host: container.getHost(),
+          port: container.getMappedPort(1433),
+          user: 'sa',
+          password: 'Example*1',
+          trustServerCertificate: defaults.trustServerCertificate,
+          readOnlyMode: readonly,
+        } as IDbConnectionServerConfig
+
+        // Built directly rather than through DBTestUtil so this cannot disturb the shared
+        // ORM connection the rest of the suite runs on.
+        const client = new SQLServerClient(
+          { db: {}, sshTunnel: null, config } as IDbConnectionServer,
+          { database: 'master', connected: false, connecting: false, namespace: null }
+        )
+
+        let connected = false
+        try {
+          await client.connect()
+          connected = true
+          expect(await client.versionString()).toBeTruthy()
+        } finally {
+          if (connected) await client.disconnect()
+        }
       })
     })
 

--- a/apps/studio/tests/unit/frontend/utils/FriendlyErrorHelper.spec.ts
+++ b/apps/studio/tests/unit/frontend/utils/FriendlyErrorHelper.spec.ts
@@ -32,12 +32,26 @@ describe('FriendlyErrorHelper', () => {
       expect(result).toBeNull()
     })
 
-    it('returns help text for SQL Server self-signed certificate error', () => {
-      const error = new Error('Connection error: self signed certificate')
+    it('returns help text and link for an integrated-auth ODBC driver error', () => {
+      const error = new Error('Connection error: ODBC Driver not found')
       const result = FriendlyErrorHelper.getHelpText('sqlserver', error)
       expect(result).not.toBeNull()
-      expect(result.help).toBe("You might need to check 'Trust Server Certificate'")
-      expect(result.link).toBeUndefined()
+      expect(result.help).toContain('ODBC Driver 18 for SQL Server')
+      expect(result.link).toBe('https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/')
+    })
+
+    // Certificate failures are classified in sqlserver.ts and arrive with the remedy already
+    // in the message, so this side contributes the docs link only -- help text here would
+    // print the advice twice in ErrorAlert.
+    it('adds a link but no help text to a message the driver already annotated', () => {
+      const error = new Error(
+        'Failed to connect to localhost:14330 - self signed certificate. The server presented ' +
+        'a self-signed certificate. Enable "Trust Server Certificate" in the SQL Server ' +
+        'options, or configure the server with a certificate the OS trusts.'
+      )
+      const result = FriendlyErrorHelper.getHelpText('sqlserver', error)
+      expect(result.help).toBeUndefined()
+      expect(result.link).toBe('https://docs.beekeeperstudio.io/user_guide/connecting/sql-server/#certificates')
     })
 
     it('returns help text and link for SQL Server login failed error', () => {
@@ -57,23 +71,22 @@ describe('FriendlyErrorHelper', () => {
     })
 
     it('matches partial error messages', () => {
-      const error = new Error('Failed to connect: self signed certificate detected in the connection')
+      const error = new Error('Failed to connect: kerberos ticket could not be acquired')
       const result = FriendlyErrorHelper.getHelpText('sqlserver', error)
       expect(result).not.toBeNull()
-      expect(result.help).toBe("You might need to check 'Trust Server Certificate'")
-      expect(result.link).toBeUndefined()
+      expect(result.help).toContain('Kerberos authentication failed')
     })
     
     it('handles errors with message property other than string', () => {
       // In rare cases, an error object might have a non-string message property
-      const customError = { message: { toString: () => 'self signed certificate' } } as unknown as Error
+      const customError = { message: { toString: () => 'kerberos' } } as unknown as Error
       const result = FriendlyErrorHelper.getHelpText('sqlserver', customError)
       expect(result).toBeNull() // Since we're expecting a string message, this should return null
     })
     
     it('returns the first matching pattern when multiple patterns match', () => {
       // Let's create a complex error message that could match multiple patterns
-      const error = new Error('Login failed for user <token-identified principal> due to self signed certificate')
+      const error = new Error('Login failed for user <token-identified principal> during kerberos negotiation')
       const result = FriendlyErrorHelper.getHelpText('sqlserver', error)
       expect(result).not.toBeNull()
       // It should match the first pattern in the errorMappings array for sqlserver

--- a/apps/studio/tests/vitest/unit/common/appdb/models/savedConnectionDefaults.spec.ts
+++ b/apps/studio/tests/vitest/unit/common/appdb/models/savedConnectionDefaults.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { TestOrmConnection } from '@tests/lib/TestOrmConnection'
+import { SavedConnection } from '@/common/appdb/models/saved_connection'
+
+// trustServerCertificate defaults to true so a stock SQL Server -- which always presents a
+// self-signed certificate -- connects from an untouched form. That is a class-field default,
+// so it must reach new connections only: silently re-enabling certificate trust on a
+// connection a user deliberately saved with it off would be a security regression.
+
+describe('SavedConnection trustServerCertificate', () => {
+  beforeAll(async () => {
+    await TestOrmConnection.connect()
+  })
+
+  afterAll(async () => {
+    await TestOrmConnection.disconnect()
+  })
+
+  it('defaults to trusting the certificate on a new connection', () => {
+    expect(new SavedConnection().trustServerCertificate).toBe(true)
+  })
+
+  it('keeps the stored value when an existing connection is loaded back', async () => {
+    const saved = new SavedConnection()
+    saved.connectionType = 'sqlserver'
+    saved.name = 'validates the certificate'
+    saved.host = 'db.example.com'
+    saved.trustServerCertificate = false
+    await saved.save()
+
+    const reloaded = await SavedConnection.findOneBy({ id: saved.id })
+    expect(reloaded.trustServerCertificate).toBe(false)
+  })
+
+  it('persists the default for a connection the user never touched', async () => {
+    const saved = new SavedConnection()
+    saved.connectionType = 'sqlserver'
+    saved.name = 'stock install'
+    saved.host = 'db.example.com'
+    await saved.save()
+
+    const reloaded = await SavedConnection.findOneBy({ id: saved.id })
+    expect(reloaded.trustServerCertificate).toBe(true)
+  })
+})

--- a/apps/studio/tests/vitest/unit/lib/db/clients/sqlserverConfig.spec.ts
+++ b/apps/studio/tests/vitest/unit/lib/db/clients/sqlserverConfig.spec.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { SQLServerClient, sqlServerConnectHint, sqlServerConnectHints } from '@/lib/db/clients/sqlserver'
+import { IDbConnectionDatabase, IDbConnectionServerConfig } from '@/lib/db/types'
+import { IDbConnectionServer } from '@/lib/db/backendTypes'
+import { FriendlyErrorHelper } from '@/frontend/utils/FriendlyErrorHelper'
+
+// Pins the driver config configDatabase() hands to mssql, without needing a live server.
+// The port/instanceName decision is the whole fix for named instances: mssql deletes the
+// port whenever options.instanceName is set (lib/tedious/connection-pool.js), so exactly one
+// of the two may be present or the user's static port is silently discarded.
+
+const DATABASE: IDbConnectionDatabase = {
+  database: 'master',
+  connected: false,
+  connecting: false,
+  namespace: null,
+}
+
+function buildServer(config: Partial<IDbConnectionServerConfig>, sshTunnel: any = null): IDbConnectionServer {
+  return {
+    db: {},
+    sshTunnel,
+    config: {
+      client: 'sqlserver',
+      host: 'localhost',
+      port: 1433,
+      user: 'sa',
+      password: 'Example*1',
+      ...config,
+    },
+  } as IDbConnectionServer
+}
+
+async function buildConfig(config: Partial<IDbConnectionServerConfig>, sshTunnel: any = null) {
+  const server = buildServer(config, sshTunnel)
+  const client = new SQLServerClient(server, DATABASE)
+  return await client.configDatabase(server, DATABASE)
+}
+
+describe('configDatabase - host and instance', () => {
+  it('sets options.instanceName and omits the port for an instance on the default port', async () => {
+    const config = await buildConfig({ host: 'localhost\\SQL2019', port: 1433 })
+    expect(config.server).toBe('localhost')
+    expect(config.options.instanceName).toBe('SQL2019')
+    // Present-but-undefined would still make mssql delete nothing, but tedious would try to
+    // dial it -- the key must be gone entirely.
+    expect('port' in config).toBe(false)
+  })
+
+  it('sets the port and omits options.instanceName for an instance on a static port', async () => {
+    const config = await buildConfig({ host: 'localhost\\SQL2019', port: 14330 })
+    expect(config.server).toBe('localhost')
+    expect(config.port).toBe(14330)
+    expect(config.options.instanceName).toBeUndefined()
+  })
+
+  it('sets the port and leaves options.instanceName undefined with no instance', async () => {
+    const config = await buildConfig({ host: 'localhost', port: 14330 })
+    expect(config.server).toBe('localhost')
+    expect(config.port).toBe(14330)
+    expect(config.options.instanceName).toBeUndefined()
+  })
+
+  it('never leaves a backslash in config.server, so mssql does not re-split it', async () => {
+    const config = await buildConfig({ host: '  .\\SQL2019 ', port: 1433 })
+    expect(config.server).toBe('localhost')
+    expect(config.options.instanceName).toBe('SQL2019')
+  })
+
+  it('uses the tunnel host and port and drops the instance name for an SSH tunnel', async () => {
+    // A tunnel forwards a single TCP port; a UDP 1434 browser lookup cannot follow it.
+    const config = await buildConfig(
+      { host: 'localhost\\SQL2019', port: 1433, localHost: '127.0.0.1', localPort: 15551 },
+      { localHost: '127.0.0.1', localPort: 15551 }
+    )
+    expect(config.server).toBe('127.0.0.1')
+    expect(config.port).toBe(15551)
+    expect(config.options.instanceName).toBeUndefined()
+  })
+
+  it('keeps options.instanceName through the ssl branch, which reassigns options wholesale', async () => {
+    const config = await buildConfig({ host: 'localhost\\SQL2019', port: 1433, ssl: true })
+    expect(config.options.encrypt).toBe(true)
+    expect(config.options.instanceName).toBe('SQL2019')
+    expect('port' in config).toBe(false)
+  })
+
+  it('passes the instance through on the integrated-auth path', async () => {
+    // msnodesqlv8 rebuilds Server=host\instance from server + options.instanceName, and the
+    // ODBC driver runs its own browser lookup.
+    const config = await buildConfig({ host: '(local)\\SQL2022', port: 1433, windowsAuthEnabled: true })
+    expect(config.server).toBe('localhost')
+    expect(config.options.trustedConnection).toBe(true)
+    expect(config.options.instanceName).toBe('SQL2022')
+  })
+})
+
+describe('configDatabase - certificate trust', () => {
+  it('passes trustServerCertificate straight through to the driver', async () => {
+    const trusted = await buildConfig({ trustServerCertificate: true })
+    expect(trusted.options.trustServerCertificate).toBe(true)
+
+    const untrusted = await buildConfig({ trustServerCertificate: false })
+    expect(untrusted.options.trustServerCertificate).toBe(false)
+  })
+})
+
+describe('sqlServerConnectHint', () => {
+  it('names the certificate checkbox for a self-signed certificate failure', () => {
+    const hint = sqlServerConnectHint(new Error('Failed to connect to localhost:1433 - self-signed certificate'), {})
+    expect(hint).toBe(sqlServerConnectHints.selfSignedCertificate)
+  })
+
+  it('matches the other certificate-validation wordings and the error code', () => {
+    expect(sqlServerConnectHint(new Error('unable to verify the first certificate'), {}))
+      .toBe(sqlServerConnectHints.selfSignedCertificate)
+    // Older node/openssl wording, plus the code-only shape mssql wraps.
+    expect(sqlServerConnectHint(new Error('self signed certificate in certificate chain'), {}))
+      .toBe(sqlServerConnectHints.selfSignedCertificate)
+    const wrapped: any = new Error('Failed to connect')
+    wrapped.originalError = { code: 'SELF_SIGNED_CERT_IN_CHAIN' }
+    expect(sqlServerConnectHint(wrapped, {})).toBe(sqlServerConnectHints.selfSignedCertificate)
+  })
+
+  it('names SQL Browser and the Port field when the connection depends on a browser lookup', () => {
+    // The driver's own text is unreliable here -- a stopped browser surfaces as a bare
+    // timeout -- so the hint keys off the config that required the lookup.
+    const hint = sqlServerConnectHint(new Error('Failed to connect to localhost\\SQL2019 in 15000ms'), {
+      server: 'localhost',
+      options: { instanceName: 'SQL2019' },
+    })
+    expect(hint).toBe(sqlServerConnectHints.browserUnreachable('localhost', 'SQL2019'))
+    expect(hint).toContain('UDP 1434')
+    expect(hint).toContain('Port field')
+  })
+
+  it('leaves the frontend helper adding a docs link and no second copy of the advice', () => {
+    // Only one layer states the remedy. These failures are classified here because the
+    // frontend only ever sees a flat message (UtilityConnection rebuilds errors as
+    // `new Error(message)`), so help text there would render right after this one in
+    // ErrorAlert. The helper still contributes the link, keyed on the wording below.
+    const cert = new Error(`Failed to connect to localhost:1433 - self signed certificate. ${sqlServerConnectHints.selfSignedCertificate}`)
+    const certHelp = FriendlyErrorHelper.getHelpText('sqlserver', cert)
+    expect(certHelp?.help).toBeUndefined()
+    expect(certHelp?.link).toContain('#certificates')
+
+    const browser = new Error(`Failed to connect to localhost\\SQL2019 in 15000ms. ${sqlServerConnectHints.browserUnreachable('localhost', 'SQL2019')}`)
+    const browserHelp = FriendlyErrorHelper.getHelpText('sqlserver', browser)
+    expect(browserHelp?.help).toBeUndefined()
+    expect(browserHelp?.link).toContain('#named-instances-and-the-sql-server-browser')
+  })
+
+  it('stays quiet when neither failure mode applies', () => {
+    expect(sqlServerConnectHint(new Error('Login failed for user \'sa\''), { server: 'localhost', options: {} }))
+      .toBeNull()
+    // An instance with a static port never touches the browser, so the browser hint is wrong.
+    expect(sqlServerConnectHint(new Error('Failed to connect to localhost:14330 in 15000ms'), {
+      server: 'localhost',
+      port: 14330,
+      options: {},
+    })).toBeNull()
+  })
+})

--- a/apps/studio/tests/vitest/unit/lib/db/clients/sqlserverHost.spec.ts
+++ b/apps/studio/tests/vitest/unit/lib/db/clients/sqlserverHost.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { parseSqlServerHost } from '@/lib/db/clients/sqlserverHost'
+
+// Verifies how the SQL Server Host field is normalised before it reaches the driver, without
+// needing a live server. The integration suite (sqlserver.spec.ts) proves the end-to-end
+// behaviour; this pins the host/instance split so a regression in driver inputs is caught in
+// the fast unit run.
+
+describe('parseSqlServerHost', () => {
+  it('splits host from instance on the backslash', () => {
+    expect(parseSqlServerHost('localhost\\SQL2019')).toEqual({
+      host: 'localhost',
+      instanceName: 'SQL2019',
+    })
+  })
+
+  it("maps the SSMS local-machine shorthands '.' and '(local)' to localhost", () => {
+    expect(parseSqlServerHost('.\\SQL2019')).toEqual({ host: 'localhost', instanceName: 'SQL2019' })
+    expect(parseSqlServerHost('(local)\\SQL2019')).toEqual({ host: 'localhost', instanceName: 'SQL2019' })
+    expect(parseSqlServerHost('(localdb)\\SQL2019')).toEqual({ host: 'localhost', instanceName: 'SQL2019' })
+  })
+
+  it('matches the local-machine shorthands case-insensitively', () => {
+    expect(parseSqlServerHost('(LOCAL)\\SQL2019')).toEqual({ host: 'localhost', instanceName: 'SQL2019' })
+    expect(parseSqlServerHost('.\\sql2019')).toEqual({ host: 'localhost', instanceName: 'sql2019' })
+  })
+
+  it('leaves every other host untouched', () => {
+    expect(parseSqlServerHost('db.example.com')).toEqual({ host: 'db.example.com', instanceName: undefined })
+    expect(parseSqlServerHost('10.0.0.4\\SQL2022')).toEqual({ host: '10.0.0.4', instanceName: 'SQL2022' })
+    // Only the exact shorthands map -- a real host that merely starts with one does not.
+    expect(parseSqlServerHost('localdb.example.com').host).toBe('localdb.example.com')
+  })
+
+  it('trims whitespace around the whole value and around each part', () => {
+    expect(parseSqlServerHost('  localhost\\SQL2019  ')).toEqual({
+      host: 'localhost',
+      instanceName: 'SQL2019',
+    })
+    // A copy-pasted trailing space otherwise lands inside the instance name and the lookup
+    // fails with "Port for SQL2019  not found".
+    expect(parseSqlServerHost('localhost\\SQL2019 ')).toEqual({
+      host: 'localhost',
+      instanceName: 'SQL2019',
+    })
+    expect(parseSqlServerHost(' localhost \\ SQL2019 ')).toEqual({
+      host: 'localhost',
+      instanceName: 'SQL2019',
+    })
+  })
+
+  it('yields no instance name when there is no backslash', () => {
+    expect(parseSqlServerHost('localhost').instanceName).toBeUndefined()
+    expect(parseSqlServerHost('localhost').host).toBe('localhost')
+  })
+
+  it('yields no instance name for an empty instance segment', () => {
+    expect(parseSqlServerHost('localhost\\')).toEqual({ host: 'localhost', instanceName: undefined })
+    expect(parseSqlServerHost('localhost\\   ')).toEqual({ host: 'localhost', instanceName: undefined })
+  })
+
+  it('splits on the first backslash only', () => {
+    expect(parseSqlServerHost('localhost\\SQL2019\\extra')).toEqual({
+      host: 'localhost',
+      instanceName: 'SQL2019\\extra',
+    })
+  })
+
+  it('handles an empty or missing value without throwing', () => {
+    expect(parseSqlServerHost('')).toEqual({ host: '', instanceName: undefined })
+    expect(parseSqlServerHost(undefined as unknown as string)).toEqual({ host: '', instanceName: undefined })
+  })
+})

--- a/docs/user_guide/connecting/sql-server.md
+++ b/docs/user_guide/connecting/sql-server.md
@@ -43,6 +43,54 @@ prerequisites.
     Authentication feature set. SQL Login and Domain (NTLM) are available in all
     editions.
 
+## Host, instance, and port
+
+The **Host** field accepts the same forms SSMS does. Surrounding whitespace is trimmed,
+so a pasted value with a stray space still works.
+
+| Host | Connects to |
+| --- | --- |
+| `db.example.com` | The default instance, on the port in the **Port** field. |
+| `localhost` | The default instance on this machine. |
+| `.` | Shorthand for `localhost`. |
+| `(local)` | Shorthand for `localhost`. |
+| `db.example.com\SQLEXPRESS` | The named instance `SQLEXPRESS`. |
+
+### Named instances and the SQL Server Browser
+
+A named instance normally listens on a **dynamic port**, so its port has to be looked up
+from the **SQL Server Browser** service over **UDP 1434**. Leave **Port** at the default
+`1433` and that lookup happens automatically.
+
+The browser service is often stopped, or UDP 1434 is blocked by a firewall, and the
+lookup then fails with a timeout. Either:
+
+- Start the SQL Server Browser service and allow **UDP 1434** through the firewall, or
+- Give the instance a **static TCP port** in SQL Server Configuration Manager and enter
+  that port in the **Port** field. Any port other than `1433` connects directly and skips
+  the browser lookup entirely.
+
+To read the port an instance is currently listening on, run this from any tool already
+connected to it:
+
+```sql
+SELECT local_tcp_port FROM sys.dm_exec_connections WHERE session_id = @@SPID;
+```
+
+## Certificates
+
+Every stock SQL Server presents a **self-signed certificate**, and the driver validates
+certificates by default. New connections therefore have **Trust Server Certificate**
+enabled, so a default install connects with no extra setup.
+
+Clear the checkbox to validate the certificate against the operating system's trust
+store. The server then needs a certificate issued by a certificate authority the machine
+already trusts — a self-signed one is rejected.
+
+!!! note "Integrated authentication"
+    **Kerberos / Windows (via ODBC)** ignores this checkbox. Certificate handling for
+    that mode is the **Encryption** setting under [ODBC Options](#odbc-options).
+
 ## Kerberos vs NTLM
 
 "Integrated Authentication" (SSPI) is an umbrella over two wire protocols. The same
@@ -140,6 +188,12 @@ The **ODBC Options** section exposes the settings specific to integrated authent
 
 ## Troubleshooting
 
+- **"The server presented a self-signed certificate"** — the server's certificate is not
+  signed by a CA this machine trusts. Enable **Trust Server Certificate**, or install a
+  trusted certificate on the server. See [Certificates](#certificates).
+- **"No response from the SQL Server Browser service ... (UDP 1434)"** — the instance
+  name could not be resolved to a port. See
+  [Named instances and the SQL Server Browser](#named-instances-and-the-sql-server-browser).
 - **"Integrated authentication requires ... ODBC Driver 18 for SQL Server"** — the ODBC
   driver (and unixODBC on Linux/macOS) is not installed. See the prerequisites above.
 - **The connection times out during login** — TCP reached the server but the


### PR DESCRIPTION
- default to trust server certificate for new users
- better parsing of host name
- better error capture and display to the users

This came from several testimonials where new users complain that they were `totally unable to connect to SQL Server`.