### PR TITLE
fix(updater): clean up leftover update files on startup

### DIFF
--- a/apps/studio/src/background/update_housekeeping.ts
+++ b/apps/studio/src/background/update_housekeeping.ts
@@ -1,0 +1,131 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import semver from 'semver'
+
+// electron-updater and Squirrel.Mac both leave files behind after an update is
+// installed. electron-updater only empties its `pending` folder when it starts
+// downloading a *different* update, so the last installer (hundreds of MB)
+// stays on disk indefinitely, and forever if update checks are later turned
+// off.
+//
+// Squirrel.Mac's ShipIt runs as root when installing into /Applications, which
+// leaves root-owned log files it can't reopen later. Each install then writes
+// to the next free ShipIt_stdout.log.N, nothing deletes the old ones, and once
+// N reaches 100 updates stop applying
+// (https://github.com/Squirrel/Squirrel.Mac/issues/322). Deleting the logs
+// resets the numbering. ShipIt can also leave staged app bundles behind when
+// an install is interrupted.
+
+interface Logger {
+  info(...args: any[]): void
+  warn(...args: any[]): void
+}
+
+export interface UpdateHousekeepingOptions {
+  // electron-updater cache, e.g. ~/Library/Caches/beekeeper-studio-updater
+  updaterCacheDir?: string
+  // Squirrel.Mac cache, e.g. ~/Library/Caches/io.beekeeperstudio.desktop.ShipIt
+  shipItCacheDir?: string
+  currentVersion: string
+  // false when update checks are turned off, so nothing will reuse the cache
+  updatesEnabled: boolean
+  log: Logger
+}
+
+const VERSION_IN_FILENAME = /\d+\.\d+\.\d+(?:-(?:alpha|beta|rc)(?:\.\d+)*)?/
+const TEMP_DOWNLOAD = /^(\d+-)?temp-/
+const SHIPIT_LOG = /^ShipIt_std(out|err)\.log(\.\d+)?$/
+const STAGED_SHIPIT_BUNDLE = /^update\./
+
+export function versionFromFileName(fileName: string): string | null {
+  const match = fileName.match(VERSION_IN_FILENAME)
+  return match && semver.valid(match[0]) ? match[0] : null
+}
+
+async function readDir(dir: string): Promise<string[]> {
+  try {
+    return await fs.readdir(dir)
+  } catch {
+    return []
+  }
+}
+
+async function remove(target: string, log: Logger): Promise<void> {
+  try {
+    await fs.rm(target, { recursive: true, force: true })
+    log.info(`removed ${target}`)
+  } catch (e) {
+    log.warn(`could not remove ${target}: ${e.message}`)
+  }
+}
+
+async function pendingUpdateVersion(pendingDir: string, entries: string[]): Promise<string | null> {
+  try {
+    const info = JSON.parse(await fs.readFile(path.join(pendingDir, 'update-info.json'), 'utf8'))
+    const version = info?.fileName && versionFromFileName(info.fileName)
+    if (version) return version
+  } catch {
+    // no update-info.json; fall back to the downloaded file names
+  }
+  const versions = entries.map(versionFromFileName).filter(Boolean)
+  return versions.length ? semver.rsort(versions)[0] : null
+}
+
+async function cleanUpdaterCache(opts: UpdateHousekeepingOptions): Promise<void> {
+  const { updaterCacheDir, currentVersion, updatesEnabled, log } = opts
+
+  if (!updatesEnabled) {
+    if ((await readDir(updaterCacheDir)).length) await remove(updaterCacheDir, log)
+    return
+  }
+
+  const pendingDir = path.join(updaterCacheDir, 'pending')
+  const entries = await readDir(pendingDir)
+  if (!entries.length) return
+
+  // No download runs before startup housekeeping finishes, so any temp file is
+  // left over from a download that was interrupted.
+  for (const entry of entries.filter((e) => TEMP_DOWNLOAD.test(e))) {
+    await remove(path.join(pendingDir, entry), log)
+  }
+
+  const pendingVersion = await pendingUpdateVersion(pendingDir, entries)
+  if (pendingVersion && semver.valid(currentVersion) && semver.lte(pendingVersion, currentVersion)) {
+    log.info(`pending update ${pendingVersion} is already installed (running ${currentVersion})`)
+    await remove(pendingDir, log)
+  }
+}
+
+async function cleanShipItCache(shipItCacheDir: string, log: Logger): Promise<void> {
+  const entries = await readDir(shipItCacheDir)
+  if (!entries.length) return
+
+  // ShipIt records the bundle it is about to install (as JSON, despite the
+  // extension). Leave that one alone in case an install is still in flight;
+  // anything else is an orphan. Without a readable state file there is no way
+  // to tell, so bundles are kept.
+  let activeBundle: string | null | undefined
+  try {
+    const state = JSON.parse(await fs.readFile(path.join(shipItCacheDir, 'ShipItState.plist'), 'utf8'))
+    const bundlePath = decodeURIComponent(new URL(state.updateBundleURL).pathname)
+    activeBundle = path.relative(shipItCacheDir, bundlePath).split(path.sep)[0]
+  } catch (e) {
+    if (e.code === 'ENOENT') activeBundle = null
+  }
+
+  for (const entry of entries) {
+    const orphanBundle = activeBundle !== undefined && STAGED_SHIPIT_BUNDLE.test(entry) && entry !== activeBundle
+    if (orphanBundle || SHIPIT_LOG.test(entry)) {
+      await remove(path.join(shipItCacheDir, entry), log)
+    }
+  }
+}
+
+export async function cleanUpUpdateFiles(opts: UpdateHousekeepingOptions): Promise<void> {
+  try {
+    if (opts.updaterCacheDir) await cleanUpdaterCache(opts)
+    if (opts.shipItCacheDir) await cleanShipItCache(opts.shipItCacheDir, opts.log)
+  } catch (e) {
+    opts.log.warn(`update housekeeping failed: ${e.message}`)
+  }
+}

--- a/apps/studio/src/background/update_manager.ts
+++ b/apps/studio/src/background/update_manager.ts
@@ -1,5 +1,9 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import { autoUpdater } from 'electron-updater'
+import { getAppCacheDir } from 'electron-updater/out/AppAdapter'
+import { readFileSync } from 'fs'
+import path from 'path'
+import { cleanUpUpdateFiles } from './update_housekeeping'
 import { getActiveWindows } from './WindowBuilder'
 import rawlog from '@bksLogger'
 
@@ -42,6 +46,33 @@ function checkForUpdates() {
   }
 }
 
+function readResource(file: string, pattern: RegExp): string | null {
+  try {
+    const value = readFileSync(path.join(process.resourcesPath, file), 'utf8').match(pattern)?.[1]
+    return value?.trim().replace(/^(['"])(.*)\1$/, '$2') || null
+  } catch {
+    return null
+  }
+}
+
+function housekeepUpdateFiles(updatesEnabled: boolean): Promise<void> {
+  // Portable and installed Windows builds share one updater cache, and a
+  // portable build never downloads, so it leaves the cache to the installed one.
+  const cacheDirName = readResource('app-update.yml', /^updaterCacheDirName:\s*(.+)$/m)
+  const bundleId = platformInfo.isMac
+    ? readResource(path.join('..', 'Info.plist'), /<key>CFBundleIdentifier<\/key>\s*<string>([^<]+)<\/string>/)
+    : null
+  return cleanUpUpdateFiles({
+    updaterCacheDir: platformInfo.isPortable
+      ? undefined
+      : path.join(getAppCacheDir(), cacheDirName || 'beekeeper-studio-updater'),
+    shipItCacheDir: bundleId ? path.join(getAppCacheDir(), `${bundleId}.ShipIt`) : undefined,
+    currentVersion: app.getVersion(),
+    updatesEnabled,
+    log,
+  })
+}
+
 export function setAllowBeta(allowBeta: boolean) {
   autoUpdater.allowPrerelease = allowBeta;
   autoUpdater.channel = allowBeta ? 'beta' : 'latest';
@@ -56,8 +87,11 @@ export function manageUpdates(allowBeta: boolean, debug?: boolean): void {
 
   if (BksConfig.general.checkForUpdatesDisabled) {
     log.info("automatic update checks are disabled")
+    housekeepUpdateFiles(false)
     return
   }
+
+  const housekeeping = housekeepUpdateFiles(true)
 
   setAllowBeta(allowBeta);
 
@@ -70,7 +104,8 @@ export function manageUpdates(allowBeta: boolean, debug?: boolean): void {
 
   autoUpdater.logger?.debug?.(JSON.stringify(process.env))
 
-  ipcMain.on('updater-ready', () => {
+  ipcMain.on('updater-ready', async () => {
+    await housekeeping
     checkForUpdates()
     if (debug) {
       getActiveWindows().forEach(beeWin => beeWin.send('update-available'))
@@ -82,7 +117,8 @@ export function manageUpdates(allowBeta: boolean, debug?: boolean): void {
     getActiveWindows().forEach(beeWin => beeWin.send(message))
   })
 
-  ipcMain.on('download-update', () => {
+  ipcMain.on('download-update', async () => {
+    await housekeeping
     autoUpdater.downloadUpdate()
   })
 

--- a/apps/studio/tests/vitest/unit/background/update_housekeeping.spec.ts
+++ b/apps/studio/tests/vitest/unit/background/update_housekeeping.spec.ts
@@ -1,0 +1,146 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { cleanUpUpdateFiles, versionFromFileName } from "@/background/update_housekeeping";
+
+const log = { info: () => undefined, warn: () => undefined };
+
+function touch(file: string, content = "") {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+}
+
+describe("versionFromFileName", () => {
+  it.each([
+    ["Beekeeper-Studio-5.3.0-arm64-mac.zip", "5.3.0"],
+    ["Beekeeper-Studio-Setup-5.3.0.exe", "5.3.0"],
+    ["Beekeeper-Studio-5.4.0-beta.2.AppImage", "5.4.0-beta.2"],
+    ["Beekeeper-Studio-5.4.0-beta.2-arm64-mac.zip", "5.4.0-beta.2"],
+    ["update-info.json", null],
+  ])("%s -> %s", (fileName, expected) => {
+    expect(versionFromFileName(fileName)).toBe(expected);
+  });
+});
+
+describe("cleanUpUpdateFiles", () => {
+  let root: string;
+  let updaterCacheDir: string;
+  let pendingDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "bks-update-housekeeping-"));
+    updaterCacheDir = path.join(root, "app-updater");
+    pendingDir = path.join(updaterCacheDir, "pending");
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function pendingUpdate(fileName: string) {
+    touch(path.join(pendingDir, fileName));
+    touch(path.join(pendingDir, "update-info.json"), JSON.stringify({ fileName, sha512: "x" }));
+  }
+
+  const run = (overrides = {}) =>
+    cleanUpUpdateFiles({ updaterCacheDir, currentVersion: "5.3.0", updatesEnabled: true, log, ...overrides });
+
+  it("removes a pending update that is already installed", async () => {
+    pendingUpdate("App-Setup-5.3.0.exe");
+    touch(path.join(updaterCacheDir, "update.zip"));
+
+    await run();
+
+    expect(existsSync(pendingDir)).toBe(false);
+    // kept as the base for differential downloads
+    expect(existsSync(path.join(updaterCacheDir, "update.zip"))).toBe(true);
+  });
+
+  it("removes a pending update older than the running version", async () => {
+    pendingUpdate("App-5.2.1.AppImage");
+    await run();
+    expect(existsSync(pendingDir)).toBe(false);
+  });
+
+  it("keeps a pending update that has not been installed yet", async () => {
+    pendingUpdate("App-5.4.0-beta.1-arm64-mac.zip");
+    await run();
+    expect(readdirSync(pendingDir).sort()).toEqual(["App-5.4.0-beta.1-arm64-mac.zip", "update-info.json"]);
+  });
+
+  it("falls back to file names when update-info.json is missing", async () => {
+    touch(path.join(pendingDir, "App-Setup-5.2.0.exe"));
+    touch(path.join(pendingDir, "App-Setup-5.3.0.exe"));
+    await run();
+    expect(existsSync(pendingDir)).toBe(false);
+  });
+
+  it("removes interrupted temp downloads but keeps a newer pending update", async () => {
+    pendingUpdate("App-Setup-5.4.0.exe");
+    touch(path.join(pendingDir, "temp-App-Setup-5.4.0.exe"));
+    touch(path.join(pendingDir, "0-temp-App-Setup-5.4.0.exe"));
+
+    await run();
+
+    expect(readdirSync(pendingDir).sort()).toEqual(["App-Setup-5.4.0.exe", "update-info.json"]);
+  });
+
+  it("removes the whole updater cache when updates are disabled", async () => {
+    pendingUpdate("App-Setup-5.4.0.exe");
+    touch(path.join(updaterCacheDir, "current.blockmap"));
+
+    await run({ updatesEnabled: false });
+
+    expect(existsSync(updaterCacheDir)).toBe(false);
+  });
+
+  describe("ShipIt cache", () => {
+    let shipItCacheDir: string;
+
+    beforeEach(() => {
+      shipItCacheDir = path.join(root, "com.example.app.ShipIt");
+      for (const name of ["ShipIt_stderr.log", "ShipIt_stdout.log", "ShipIt_stderr.log.1", "ShipIt_stdout.log.12"]) {
+        touch(path.join(shipItCacheDir, name));
+      }
+      touch(path.join(shipItCacheDir, "update.active", "App.app", "Contents", "Info.plist"));
+      touch(path.join(shipItCacheDir, "update.orphan", "App.app", "Contents", "Info.plist"));
+    });
+
+    function writeState() {
+      const bundle = path.join(shipItCacheDir, "update.active", "App.app");
+      touch(
+        path.join(shipItCacheDir, "ShipItState.plist"),
+        JSON.stringify({ updateBundleURL: `file://${encodeURI(bundle)}/` })
+      );
+    }
+
+    it("removes logs and orphaned bundles, keeping the active one", async () => {
+      writeState();
+      await run({ shipItCacheDir });
+      expect(readdirSync(shipItCacheDir).sort()).toEqual(["ShipItState.plist", "update.active"]);
+    });
+
+    it("removes all staged bundles when there is no state file", async () => {
+      await run({ shipItCacheDir });
+      expect(readdirSync(shipItCacheDir)).toEqual([]);
+    });
+
+    it("cleans ShipIt without an updater cache", async () => {
+      pendingUpdate("App-Setup-5.2.0.exe");
+      await run({ updaterCacheDir: undefined, shipItCacheDir });
+      expect(existsSync(path.join(pendingDir, "App-Setup-5.2.0.exe"))).toBe(true);
+      expect(readdirSync(shipItCacheDir)).not.toContain("ShipIt_stderr.log");
+    });
+
+    it("keeps staged bundles when the state file cannot be parsed", async () => {
+      touch(path.join(shipItCacheDir, "ShipItState.plist"), "bplist00");
+      await run({ shipItCacheDir });
+      expect(readdirSync(shipItCacheDir)).toEqual(
+        expect.arrayContaining(["update.active", "update.orphan"])
+      );
+      expect(readdirSync(shipItCacheDir)).not.toContain("ShipIt_stdout.log.12");
+    });
+  });
+});


### PR DESCRIPTION
Update files are never cleaned up after an install, so they pile up on disk. This adds a cleanup pass that runs when `manageUpdates` starts. Update checks and downloads wait for it to finish.

**electron-updater cache** (`<cache>/beekeeper-studio-updater`)

electron-updater only empties `pending/` when it starts downloading a different update, so the last installer stays on disk after it's installed (on macOS there's also a second copy at `update.zip`). If update checks are later disabled, it stays forever.

- `pending/` is removed when the update in it (version read from `update-info.json`, or from the file names) is the same as or older than the running version. A newer, not yet installed update is kept.
- Leftover `temp-*` files from interrupted downloads are removed.
- The whole cache folder is removed when `checkForUpdatesDisabled` is set.
- `update.zip` and `current.blockmap` at the cache root are kept, since the updater uses them for differential downloads.
- Portable builds skip this entirely, because they share the cache folder with the installed Windows build and never download anything themselves.

**Squirrel.Mac ShipIt** (`~/Library/Caches/<bundleId>.ShipIt`)

When ShipIt installs into `/Applications` as root, it leaves root-owned log files it can't reopen. On the next install it writes to `ShipIt_stdout.log.1`, then `.2`, and so on, and nothing deletes the old ones. Once the count hits 100, updates stop applying: Squirrel/Squirrel.Mac#322, electron/electron#52284.

- All `ShipIt_std{out,err}.log*` files are deleted, so the numbering starts over.
- `update.*` bundles are removed unless `ShipItState.plist` points at them. That file is JSON (written by `SQRLShipItRequest`). If it exists but can't be parsed, all bundles are kept.

**Worth a look**

- The version is parsed from installer file names with `\d+\.\d+\.\d+(-(alpha|beta|rc)(\.\d+)*)?`. That covers the current artifact names and tags, but it would need updating if the naming changes.
- `updaterCacheDirName` is read from `app-update.yml` and the bundle id from `Info.plist`, with a fallback to electron-builder's default `beekeeper-studio-updater`.
- Unit tests run against temp directories. I haven't tested this on a packaged build.
